### PR TITLE
Make date handling more in-line with MySQL

### DIFF
--- a/dbcon/ddlpackageproc/createindexprocessor.cpp
+++ b/dbcon/ddlpackageproc/createindexprocessor.cpp
@@ -31,9 +31,6 @@ using namespace std;
 #include <boost/algorithm/string/case_conv.hpp>
 using namespace boost::algorithm;
 
-#include <boost/date_time/gregorian/gregorian.hpp>
-using namespace boost::gregorian;
-
 using namespace execplan;
 using namespace ddlpackage;
 using namespace logging;

--- a/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
+++ b/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
@@ -45,9 +45,6 @@ using namespace WriteEngine;
 #include <boost/algorithm/string/case_conv.hpp>
 using namespace boost::algorithm;
 
-#include <boost/date_time/gregorian/gregorian.hpp>
-using namespace boost::gregorian;
-
 #include "cacheutils.h"
 using namespace cacheutils;
 

--- a/dbcon/dmlpackageproc/dmlpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/dmlpackageprocessor.cpp
@@ -28,8 +28,6 @@ using namespace std;
 #include <boost/algorithm/string/case_conv.hpp>
 using namespace boost::algorithm;
 #include <boost/tokenizer.hpp>
-#include <boost/date_time/gregorian/gregorian.hpp>
-using namespace boost::gregorian;
 #include <boost/shared_ptr.hpp>
 
 #include "we_messages.h"

--- a/oam/replaytxnlog/replaytxnlog.cpp
+++ b/oam/replaytxnlog/replaytxnlog.cpp
@@ -33,7 +33,6 @@ using namespace std;
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 namespace fs = boost::filesystem;
 

--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -31,8 +31,6 @@ using namespace std;
 #include <boost/algorithm/string/case_conv.hpp>
 using namespace boost::algorithm;
 #include <boost/tokenizer.hpp>
-#include <boost/date_time/gregorian/gregorian.hpp>
-using namespace boost::gregorian;
 #include "calpontsystemcatalog.h"
 #include "calpontselectexecutionplan.h"
 #include "columnresult.h"
@@ -644,24 +642,14 @@ bool mysql_str_to_datetime( const string& input, DateTime& output, bool& isDate 
 		return false;
 	}
 
-	try
-	{
-		boost::gregorian::date d(year, mon, day);
-		// one more check - boost allows year 10000 but we want to limit at 9999
-		if( year > 9999 )
-		{
-			output.reset();
-			return false;
-		}
-		output.year = d.year();
-		output.month = d.month();
-		output.day = d.day();
-	}
-	catch (...)
+	if (!isDateValid(day, mon, year))
 	{
 		output.reset();
 		return false;
 	}
+	output.year = year;
+	output.month = mon;
+	output.day = day;
 
 	/**
 	 *  Now we need to deal with the time portion.

--- a/utils/dataconvert/dataconvert.h
+++ b/utils/dataconvert/dataconvert.h
@@ -228,11 +228,17 @@ inline
 bool isDateValid ( int day, int month, int year)
 {
     bool valid = true;
+
+	if ( year == 0 && month == 0 && year == 0 )
+	{
+		return true;
+	}
+
     int daycheck = getDaysInMonth( month );
     if( month == 2 && isLeapYear( year ) )
         //  29 days in February in a leap year
         daycheck = 29;
-    if ( ( year < 1400 ) || ( year > 9999 ) )
+    if ( ( year < 1000 ) || ( year > 9999 ) )
         valid = false;
     else if ( month < 1 || month > 12 )
         valid = false;

--- a/utils/funcexp/timeextract.h
+++ b/utils/funcexp/timeextract.h
@@ -67,8 +67,7 @@ public:
 			if( dayOfWeek < 0 || !dataconvert::isDateValid( 1, 1, dateTime.year ) )
 				return returnError( dateTime );
 
-			boost::gregorian::date yearfirst( dateTime.year, 1, 1 );
-
+            uint32_t yearfirst = helpers::calc_mysql_daynr(dateTime.year, 1, 1);
 			// figure out which day of week Jan-01 is
 			uint32_t firstweekday = helpers::calc_mysql_weekday( dateTime.year, 1, 1, sundayFirst );
 
@@ -76,10 +75,8 @@ public:
 			uint32_t firstoffset = firstweekday ? ( 7 - firstweekday ) : 0;
 
 			firstoffset += ( ( weekOfYear - 1) * 7 ) + dayOfWeek - ( sundayFirst ? 0 : 1 );
-			yearfirst += boost::gregorian::date_duration( firstoffset );
-			dateTime.year = yearfirst.year();
-			dateTime.month = yearfirst.month();
-			dateTime.day = yearfirst.day();
+			yearfirst += firstoffset;
+            helpers::get_date_from_mysql_daynr(yearfirst, dateTime);
 		}
 
 		if( !dataconvert::isDateTimeValid( dateTime.hour, dateTime.minute, dateTime.second, dateTime.msecond ) )

--- a/writeengine/client/we_ddlcommandclient.cpp
+++ b/writeengine/client/we_ddlcommandclient.cpp
@@ -25,8 +25,6 @@ using namespace messageqcpp;
 #include "resourcemanager.h"
 #include "ddlpkg.h"
 #include "ddlpackageprocessor.h"
-#include <boost/date_time/gregorian/gregorian.hpp>
-using namespace boost::gregorian;
 #include "dataconvert.h"
 using namespace dataconvert;
 using namespace ddlpackage;

--- a/writeengine/client/we_ddlcommandclient.h
+++ b/writeengine/client/we_ddlcommandclient.h
@@ -34,7 +34,6 @@
 #define EXPORT
 #endif
 
-#include <boost/date_time/gregorian/gregorian.hpp>
 #include "dataconvert.h"
 
 namespace WriteEngine

--- a/writeengine/client/we_dmlcommandclient.cpp
+++ b/writeengine/client/we_dmlcommandclient.cpp
@@ -25,8 +25,6 @@ using namespace messageqcpp;
 #include "resourcemanager.h"
 #include "../../dbcon/dmlpackage/dmlpkg.h"
 #include "ddlpackageprocessor.h"
-#include <boost/date_time/gregorian/gregorian.hpp>
-using namespace boost::gregorian;
 #include "dataconvert.h"
 using namespace dataconvert;
 using namespace dmlpackage;

--- a/writeengine/client/we_dmlcommandclient.h
+++ b/writeengine/client/we_dmlcommandclient.h
@@ -34,7 +34,6 @@
 #define EXPORT
 #endif
 
-#include <boost/date_time/gregorian/gregorian.hpp>
 #include "dataconvert.h"
 
 namespace WriteEngine

--- a/writeengine/server/we_ddlcommandproc.cpp
+++ b/writeengine/server/we_ddlcommandproc.cpp
@@ -34,8 +34,7 @@ using namespace messageqcpp;
 #include "we_ddlcommandproc.h"
 #include "ddlpkg.h"
 using namespace ddlpackage;
-#include <boost/date_time/gregorian/gregorian.hpp>
-using namespace boost::gregorian;
+#include <ctime>
 #include "dataconvert.h"
 using namespace dataconvert;
 //#include "we_brm.h"
@@ -188,25 +187,15 @@ uint8_t WE_DDLCommandProc::writeSystable(ByteStream& bs, std::string &err)
 			}
 			else if (CREATEDATE_COL == column.tableColName.column)
 			{
-				date d(day_clock::universal_day());
-				std::string date = to_iso_string(d);
-				Date aDay;
-				int intvalue;
-				std::string s = date.substr(0, 4);
-				if (from_string<int>(intvalue, s, std::dec))
-				{
-					aDay.year = intvalue;
-				}
-				s = date.substr(4, 2);
-				if (from_string<int>(intvalue, s, std::dec))
-				{
-					aDay.month = intvalue;
-				}
-				s = date.substr(6, 2);
-				if (from_string<int>(intvalue, s, std::dec))
-				{
-					aDay.day = intvalue;
-				}
+                time_t t;
+                struct tm tmp;
+                Date aDay;
+
+                t = time(NULL);
+                gmtime_r(&t, &tmp);
+				aDay.year = tmp.tm_year;
+				aDay.month = tmp.tm_mon+1;
+				aDay.day = tmp.tm_mday;
 
 				colTuple.data = *(reinterpret_cast<int *> (&aDay));
 

--- a/writeengine/server/we_ddlcommandproc.h
+++ b/writeengine/server/we_ddlcommandproc.h
@@ -28,7 +28,6 @@
 #include "dbrm.h"
 #include "we_message_handlers.h"
 #include "liboamcpp.h"
-#include <boost/date_time/gregorian/gregorian.hpp>
 #include "dataconvert.h"
 #include "writeengine.h"
 

--- a/writeengine/server/we_dmlcommandproc.cpp
+++ b/writeengine/server/we_dmlcommandproc.cpp
@@ -30,8 +30,6 @@ using namespace messageqcpp;
 using namespace dmlpackage;
 #include "dmlpackageprocessor.h"
 using namespace dmlpackageprocessor;
-#include <boost/date_time/gregorian/gregorian.hpp>
-using namespace boost::gregorian;
 #include "dataconvert.h"
 using namespace dataconvert;
 #include "calpontsystemcatalog.h"

--- a/writeengine/server/we_dmlcommandproc.h
+++ b/writeengine/server/we_dmlcommandproc.h
@@ -33,7 +33,6 @@
 #include "calpontsystemcatalog.h"
 #include "insertdmlpackage.h"
 #include "liboamcpp.h"
-#include <boost/date_time/gregorian/gregorian.hpp>
 #include "dataconvert.h"
 #include "writeengine.h"
 #include "we_convertor.h"


### PR DESCRIPTION
Date limit of year 1400 was used due to Boost's limits.

This patch strips out the use of Boost for date handling and sets the
lower limit to year 1000.