### PR TITLE
MCOL-240 Fix NULL handling on empty Having clause

### DIFF
--- a/dbcon/joblist/jlf_subquery.cpp
+++ b/dbcon/joblist/jlf_subquery.cpp
@@ -177,6 +177,7 @@ void ssfInHaving(ParseTree* pt, void* obj)
 			// not a scalar result
 			// replace simple scalar filter with simple filters
 			delete pt->data();
+			pt->data(NULL);
 			delete parseTree;
 			jobInfo->constantFalse = true;
 		}
@@ -677,6 +678,10 @@ void preprocessHavingClause(CalpontSelectExecutionPlan* csep, JobInfo& jobInfo)
 	ParseTree* correlatedFilters = NULL;
 	havings->walk(getCorrelatedFilters, &correlatedFilters);
 	trim(havings);
+	if (havings == NULL)
+	{
+		csep->having(NULL);
+	}
 
 	if (correlatedFilters != NULL)
 	{


### PR DESCRIPTION
During subquery processing it is possible to have an empty Having
clause. When this happens various tree elements are deleted but the
pointers to those tree elements are not set to NULL. So later on in
processing ExeMgr can crash.