### PR TITLE
MCOL-173 Fix null handling for bulk inserts

### DIFF
--- a/dbcon/mysql/ha_calpont_impl.cpp
+++ b/dbcon/mysql/ha_calpont_impl.cpp
@@ -3397,8 +3397,8 @@ void ha_calpont_impl_start_bulk_insert(ha_rows rows, TABLE* table)
 			{
 				CalpontSystemCatalog::ColType ctype = csc->colType(colrids[j].objnum);
 				ci->columnTypes.push_back(ctype);
-//				if ((( ctype.colDataType == CalpontSystemCatalog::VARCHAR ) || ( ctype.colDataType == CalpontSystemCatalog::VARBINARY )) && !ci->useXbit )
-//					ci->useXbit = true;
+				if ((( ctype.colDataType == CalpontSystemCatalog::VARCHAR ) || ( ctype.colDataType == CalpontSystemCatalog::VARBINARY )) && !ci->useXbit )
+					ci->useXbit = true;
 				if (ctype.constraintType == CalpontSystemCatalog::NOTNULL_CONSTRAINT)
 					numberNotNull++;
 			}


### PR DESCRIPTION
When infinidb_use_import_for_batchinsert is enabled the NULL handling
for the batch insert was incorrect. This is due to an off-by-one on the
NULL bitmap. This also affects INSERT...SELECT.