### PR TITLE
Add the jemalloc install to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,4 +199,5 @@ ADD_SUBDIRECTORY(writeengine/server)
 ADD_SUBDIRECTORY(writeengine/bulk)
 ADD_SUBDIRECTORY(writeengine/splitter)
 
+INSTALL(FILES utils/jemalloc/libjemalloc.so.3.3.0 DESTINATION ${ENGINE_LIBDIR})
 


### PR DESCRIPTION
This puts the library in the right place, post-install creates the
symlink and the scripts run the LD_PRELOAD with it.