### PR TITLE
MCOL-298 Fix saturated date/datetime handling

### DIFF
--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -1100,16 +1100,8 @@ boost::any
 				}
 				else
 				{
-					if ( isUpdate) //@Bug 5222 set to null for ot of range value
-					{
-						uint32_t d = joblist::DATENULL;
-						value = d;
-						pushWarning = true;
-					}
-					else
-					{
-						throw QueryDataExcept("Invalid date", formatErr);
-					}
+                    value = 0;
+                    pushWarning = true;
 				}
 			}
 			break;
@@ -1123,14 +1115,8 @@ boost::any
 				}
 				else
 				{
-					if ( isUpdate) //@Bug 5222 set to null for ot of range value
-					{
-						uint64_t d = joblist::DATETIMENULL;
-						value = d;
-						pushWarning = true;
-					}
-					else
-						throw QueryDataExcept("Invalid datetime", formatErr);
+                    value = 0;
+                    pushWarning = true;
 				}
 			}
 			break;

--- a/writeengine/bulk/we_bulkloadbuffer.cpp
+++ b/writeengine/bulk/we_bulkloadbuffer.cpp
@@ -965,19 +965,8 @@ void BulkLoadBuffer::convert(char *field, int fieldLength,
                         bufStats.maxBufferVal = llDate;
                 }
                 else {
-					if(!column.fNotNull)
-					{
-                    	// @bug 3375: reset invalid date/time to NULL,
-                    	//            and track as a saturated value.
-                    	llDate = joblist::DATETIMENULL;
-                    	bufStats.satCount++;
-					}
-					else
-					{
-						//Bug5383 - 4.0@1400-01-01 00:00:00 Below it is 0000-01-01 00:00:00
-						llDate = 0x578104000000000;	//394082834458869760
-                    	bufStats.satCount++;
-					}
+                   	llDate = 0;
+                   	bufStats.satCount++;
                 }
 
                 pVal = &llDate;
@@ -1262,23 +1251,8 @@ void BulkLoadBuffer::convert(char *field, int fieldLength,
                         bufStats.maxBufferVal = iDate;
                 }
                 else {
-
-
-                	if (!column.fNotNull)
-					{
-                    	// @bug 3375: reset invalid date to NULL,
-                    	//            and track as a saturated value.
-                    	iDate = joblist::DATENULL;
-                    	bufStats.satCount++;
-					}
-					else
-					{
-						// Bug5383 - 1400-01-01 
-//                        iDate = 0x5781068;		// for versions below 4.0 it is 0x1068
-						// MariaDB bug 740
-						iDate = 0x578107E;
-						bufStats.satCount++; 	
-					}
+                   	iDate = 0;
+                    bufStats.satCount++;
                 }
 
                 pVal = &iDate;

--- a/writeengine/bulk/we_tableinfo.cpp
+++ b/writeengine/bulk/we_tableinfo.cpp
@@ -924,24 +924,15 @@ void TableInfo::reportTotals(double elapsedTime)
                 fColumns[i].column.colName << "; Number of ";
             if (fColumns[i].column.dataType == CalpontSystemCatalog::DATE)
 			{
-				//bug5383
-				if(!fColumns[i].column.fNotNull)
-                	ossSatCnt <<
-                    	"invalid dates replaced with null: ";
-				else
-					ossSatCnt <<
-						"invalid dates replaced with minimum value : ";
+				ossSatCnt <<
+					"invalid dates replaced with zero value : ";
 			}
             else if (fColumns[i].column.dataType ==
                      CalpontSystemCatalog::DATETIME)
 			{
 				//bug5383
-				if(!fColumns[i].column.fNotNull)
-                	ossSatCnt <<
-                    	"invalid date/times replaced with null: ";
-				else
-					ossSatCnt <<
-						"invalid date/times replaced with minimum value : ";
+				ossSatCnt <<
+					"invalid date/times replaced with zero value : ";
 			}
             else if (fColumns[i].column.dataType == CalpontSystemCatalog::CHAR)
                 ossSatCnt <<

--- a/writeengine/splitter/we_sdhandler.cpp
+++ b/writeengine/splitter/we_sdhandler.cpp
@@ -1669,10 +1669,10 @@ void WESDHandler::onCleanupResult(int PmId, messageqcpp::SBS& Sbs) {
 					switch ((*aIt).fColType)
 					{
 					case CalpontSystemCatalog::DATE:
-						ossSatCnt << "invalid dates replaced with null: ";
+						ossSatCnt << "invalid dates replaced with zero value: ";
 						break;
 					case CalpontSystemCatalog::DATETIME:
-						ossSatCnt << "invalid date/times replaced with null: ";
+						ossSatCnt << "invalid date/times replaced with zero value: ";
 						break;
 					case CalpontSystemCatalog::CHAR:
 						ossSatCnt << "character strings truncated: ";


### PR DESCRIPTION
Saturated DML updates would be set to NULL as were saturated cpimport
values. This sets them to the zero date/datetime value.