### PR TITLE
Fix casting issue for date truncation

### DIFF
--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -1100,7 +1100,7 @@ boost::any
 				}
 				else
 				{
-                    value = 0;
+                    value = (uint32_t) 0;
                     pushWarning = true;
 				}
 			}
@@ -1115,7 +1115,7 @@ boost::any
 				}
 				else
 				{
-                    value = 0;
+                    value = (uint64_t) 0;
                     pushWarning = true;
 				}
 			}


### PR DESCRIPTION
Boost::any is used for the value so it needs to be casted to a type