### PR TITLE
MCOL-303

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,10 @@ MESSAGE(STATUS "Running cmake version ${CMAKE_VERSION}")
 # custom packaging steps.
 OPTION(COMMUNITY_BUILD "Set to true if this is a community build" ON) 
 
-SET(CMAKE_BUILD_TYPE RELWITHDEBINFO CACHE STRING
-    "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel" FORCE)
+IF(NOT CMAKE_BUILD_TYPE)
+    SET(CMAKE_BUILD_TYPE RELWITHDEBINFO CACHE STRING
+        "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel" FORCE)
+ENDIF(NOT CMAKE_BUILD_TYPE)
 
 #set( CMAKE_VERBOSE_MAKEFILE on )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ MESSAGE(STATUS "Running cmake version ${CMAKE_VERSION}")
 OPTION(COMMUNITY_BUILD "Set to true if this is a community build" ON) 
 
 SET(CMAKE_BUILD_TYPE RELWITHDEBINFO CACHE STRING
-   "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel")
+    "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel" FORCE)
 
 #set( CMAKE_VERBOSE_MAKEFILE on )
 


### PR DESCRIPTION
It turns out if CMAKE_BUILD_TYPE is not already set the 'SET' command doesn't apply to the cache. This meant that CMAKE_BUILD_TYPE was not set by default and therefore no compiler flags were set.

With no compiler flags set we were using unoptimised builds which caused large performance regressions.

This fix tells CMAKE to set the default build to Release With Debug Info as intended but allows the user to change this.