### PR TITLE
Fixes what is likely a misspelling on the mcsadmin> prompt

### DIFF
--- a/oamapps/mcsadmin/mcsadmin.cpp
+++ b/oamapps/mcsadmin/mcsadmin.cpp
@@ -349,7 +349,7 @@ int main(int argc, char *argv[])
             }
 
             // read input
-            pcommand = readline("mscadmin> ");
+            pcommand = readline("mcsadmin> ");
 
             if (!pcommand)                        // user hit <Ctrl>-D
                 pcommand = strdup("exit");


### PR DESCRIPTION
Instead of mscadmin> this changes the prompt to mcsadmin> which is in-line with the name of the utility.