### PR TITLE
MCOL-333 Fix subtime() for saturated values

### DIFF
--- a/utils/funcexp/func_add_time.cpp
+++ b/utils/funcexp/func_add_time.cpp
@@ -206,6 +206,7 @@ int64_t Func_add_time::getDatetimeIntVal(rowgroup::Row& row,
 		t2.hour = 838;
 		t2.minute = 59;
 		t2.second = 59;
+        t2.msecond = 999999;
 	}
 	else
 	{


### PR DESCRIPTION
In MariaDB (unlike MySQL) max/min time values include msec of 999999.
This means that subtime() with saturated values can be off by one
second.

For this calculation I have modified add_time (which also does
subtime()) to have a saturated value including 999999 msec. This fixes
the subtime test in the regression suite.