### PR TITLE
MCOL-341 Fix DATETIME2 support in INSERT...SELECT

### DIFF
--- a/dbcon/mysql/ha_calpont_dml.cpp
+++ b/dbcon/mysql/ha_calpont_dml.cpp
@@ -774,7 +774,10 @@ int ha_calpont_impl_write_batch_row_(uchar *buf, TABLE* table, cal_impl_if::cal_
 					if (nullVal && (ci.columnTypes[colpos].constraintType != CalpontSystemCatalog::NOTNULL_CONSTRAINT))
 					{
 						fprintf(ci.filePtr, "%c", ci.delimiter);
-						buf += 8;
+                        if (table->field[colpos]->real_type() == MYSQL_TYPE_DATETIME2)
+                            buf += table->field[colpos]->pack_length();
+                        else
+                            buf += 8;
 					}
 					else
 					{


### PR DESCRIPTION
DATETIME2 has a variable pack length but we were using a constant length
of 8 if the value was NULL. This messed up the offset for the next
column.