### PR TITLE
Fix snmptrad

### DIFF
--- a/cpackEngineRPM.cmake
+++ b/cpackEngineRPM.cmake
@@ -81,11 +81,11 @@ IF (EXISTS "/etc/redhat-release")
     set(REDHAT_VERSION_NUMBER "${CMAKE_MATCH_1}")
 ENDIF ()
 if (${REDHAT_VERSION_NUMBER} EQUAL 6)
-    SETA(CPACK_RPM_platform_PACKAGE_REQUIRES "expect" "mariadb-columnstore-libs" "net-snmp-libs")
+    SETA(CPACK_RPM_platform_PACKAGE_REQUIRES "expect" "mariadb-columnstore-libs" "net-snmp-libs" "net-snmp" "net-tools")
     # Disable auto require as this will also try to pull Boost via RPM
     SET(CPACK_RPM_PACKAGE_AUTOREQPROV " no")
 else ()
-    SETA(CPACK_RPM_platform_PACKAGE_REQUIRES "expect" "boost >= 1.53.0" "mariadb-columnstore-libs" "net-snmp-libs")
+    SETA(CPACK_RPM_platform_PACKAGE_REQUIRES "expect" "boost >= 1.53.0" "mariadb-columnstore-libs" "net-snmp-libs" "net-snmp" "net-tools")
 endif()
 
 SETA(CPACK_RPM_storage-engine_PACKAGE_REQUIRES "mariadb-columnstore-libs")

--- a/oam/etc/ProcessConfig.xml
+++ b/oam/etc/ProcessConfig.xml
@@ -24,8 +24,8 @@
 	<PROCESSCONFIG3>
 		<ProcessName>SNMPTrapDaemon</ProcessName>
 		<ModuleType>ParentOAMModule</ModuleType>
-		<ProcessLocation>$INSTALLDIR/sbin/snmptrapd</ProcessLocation>
-		<ProcessArg1>$INSTALLDIR/sbin/snmptrapd</ProcessArg1>
+		<ProcessLocation>/sbin/snmptrapd</ProcessLocation>
+		<ProcessArg1>/sbin/snmptrapd</ProcessArg1>
 		<ProcessArg2>-M</ProcessArg2>
 		<ProcessArg3>$INSTALLDIR/share/snmp/mibs</ProcessArg3>
 		<ProcessArg4>-m</ProcessArg4>

--- a/oam/etc/ProcessConfig.xml.singleserver
+++ b/oam/etc/ProcessConfig.xml.singleserver
@@ -24,8 +24,8 @@
 	<PROCESSCONFIG3>
 		<ProcessName>SNMPTrapDaemon</ProcessName>
 		<ModuleType>ParentOAMModule</ModuleType>
-		<ProcessLocation>/usr/local/mariadb/columnstore/sbin/snmptrapd</ProcessLocation>
-		<ProcessArg1>/usr/local/mariadb/columnstore/sbin/snmptrapd</ProcessArg1>
+        <ProcessLocation>/sbin/snmptrapd</ProcessLocation>
+		<ProcessArg1>/sbin/snmptrapd</ProcessArg1>
 		<ProcessArg2>-M</ProcessArg2>
                 <ProcessArg3>/usr/local/mariadb/columnstore/share/snmp/mibs</ProcessArg3>
                 <ProcessArg4>-m</ProcessArg4>


### PR DESCRIPTION
The net-snmp that was removed also contained snmptrapd which is used by
ColumnStore. This fix makes sure the OS version is executed instead.

In addition it makes sure net-tools is installed as the 'netstat'
command is required by postConfigure

This fixes a problem mentioned in MCOL-308