### PR TITLE
MCOL-350 Fix zero date comparison

### DIFF
--- a/dbcon/joblist/jlf_execplantojoblist.cpp
+++ b/dbcon/joblist/jlf_execplantojoblist.cpp
@@ -1674,12 +1674,7 @@ const JobStepVector doSimpleFilter(SimpleFilter* sf, JobInfo& jobInfo)
 			try
 			{
 				bool isNull = ConstantColumn::NULLDATA == cc->type();
-				if ((ct.colDataType == CalpontSystemCatalog::DATE ||
-					  ct.colDataType == CalpontSystemCatalog::DATETIME) &&
-					  constval == "0000-00-00")
-					value = 0;
-				else
-					value = convertValueNum(constval, ct, isNull, rf);
+				value = convertValueNum(constval, ct, isNull, rf);
 				if (ct.colDataType == CalpontSystemCatalog::FLOAT && !isNull)
 				{
 					float f = cc->getFloatVal();
@@ -1715,12 +1710,7 @@ const JobStepVector doSimpleFilter(SimpleFilter* sf, JobInfo& jobInfo)
 			}
 #else
 			bool isNull = ConstantColumn::NULLDATA == cc->type();
-			if ((ct.colDataType == CalpontSystemCatalog::DATE ||
-				   ct.colDataType == CalpontSystemCatalog::DATETIME) &&
-				   constval == "0000-00-00")
-					value = 0;
-			else
-				value = convertValueNum(constval, ct, isNull, rf);
+			value = convertValueNum(constval, ct, isNull, rf);
 
 			if (ct.colDataType == CalpontSystemCatalog::FLOAT && !isNull)
 			{


### PR DESCRIPTION
If a query uses '0000-00-00' the value to compare with is hard-coded to
0. With date types there are 6 unused bits set to 1 so a zero date is
stored as 3F 00 00 00.

This removes the hard-coded setting of '0000-00-00' to 0 and uses the
correct conversion routines instead.