### PR TITLE
MCOL-334 Give joins in views highest priority

### DIFF
--- a/dbcon/joblist/jlf_execplantojoblist.cpp
+++ b/dbcon/joblist/jlf_execplantojoblist.cpp
@@ -1105,7 +1105,15 @@ const JobStepVector doJoin(
 	thj->sequence2(sc2->sequence());
 	thj->column1(sc1);
 	thj->column2(sc2);
-	thj->joinId((joinInfo == 0) ? (++jobInfo.joinNum) : 0);
+    // MCOL-334 joins in views need to have higher priority than SEMI/ANTI
+	if (!view1.empty() && view1 == view2)
+	{
+		thj->joinId(-1);
+	}
+	else
+	{
+		thj->joinId((joinInfo == 0) ? (++jobInfo.joinNum) : 0);
+	}
 
 	// Check if SEMI/ANTI join.
 	// INNER/OUTER join and SEMI/ANTI are mutually exclusive,


### PR DESCRIPTION
For "select * from {view} where {col} in ({subquery})" type queries the
join for 'in' was being processed before any joins in the view. This
patch changes the priority so joins in views are processed first.