### PR TITLE
MCOL-129 INSERT/UPDATE strict mode support

### DIFF
--- a/dbcon/dmlpackage/calpontdmlpackage.cpp
+++ b/dbcon/dmlpackage/calpontdmlpackage.cpp
@@ -40,7 +40,7 @@ namespace dmlpackage
         std::string dmlStatement, int sessionID )
         :fSchemaName(schemaName), fTableName( tableName ), fDMLStatement( dmlStatement ),
         fSessionID(sessionID), fPlan(new messageqcpp::ByteStream()), fTable(0), fHasFilter(false), fLogging(true), fIsInsertSelect(false), 
-		fIsBatchInsert(false), fIsAutocommitOn(false), fTableOid(0)
+		fIsBatchInsert(false), fIsAutocommitOn(false), fIsWarnToError(false), fTableOid(0)
     {
 
     }

--- a/dbcon/dmlpackage/calpontdmlpackage.h
+++ b/dbcon/dmlpackage/calpontdmlpackage.h
@@ -226,6 +226,10 @@ namespace dmlpackage
 
             bool get_isAutocommitOn() { return fIsAutocommitOn; }
             void set_isAutocommitOn( const bool isAutocommitOn ) { fIsAutocommitOn = isAutocommitOn; }
+
+            bool get_isWarnToError() { return fIsWarnToError; }
+            void set_isWarnToError( const bool isWarnToError ) { fIsWarnToError = isWarnToError; }
+
             uint32_t getTableOid() { return fTableOid; }
             void setTableOid( const uint32_t tableOid ) { fTableOid = tableOid; }
 
@@ -254,6 +258,7 @@ namespace dmlpackage
             bool fIsInsertSelect;
             bool fIsBatchInsert;
             bool fIsAutocommitOn;
+            bool fIsWarnToError;
             uint32_t fTableOid;
             WriteEngine::ChunkManager* fCM;
     };

--- a/dbcon/mysql/ha_calpont_dml.cpp
+++ b/dbcon/mysql/ha_calpont_dml.cpp
@@ -370,6 +370,11 @@ int doProcessInsertValues ( TABLE* table, uint32_t size, cal_connection_info& ci
 		{
 			pDMLPackage->set_isBatchInsert( true );
 		}
+        if (thd->is_strict_mode())
+        {
+            pDMLPackage->set_isWarnToError( true );
+        }
+
 		pDMLPackage->setTableOid (ci.tableOid);
 		if (lastBatch)
 		{
@@ -514,8 +519,11 @@ int doProcessInsertValues ( TABLE* table, uint32_t size, cal_connection_info& ci
 		}
 		if ( b == dmlpackageprocessor::DMLPackageProcessor::IDBRANGE_WARNING )
 		{
-			rc = 0;
-			push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 9999, errormsg.c_str());
+            if (!thd->is_strict_mode())
+            {
+    			rc = 0;
+            }
+   			push_warning(thd, Sql_condition::WARN_LEVEL_WARN, ER_WARN_DATA_OUT_OF_RANGE, errormsg.c_str());
 		}
 		
 		if ( rc != 0 )

--- a/writeengine/server/we_dmlcommandproc.cpp
+++ b/writeengine/server/we_dmlcommandproc.cpp
@@ -654,6 +654,14 @@ uint8_t WE_DMLCommandProc::processSingleInsert(messageqcpp::ByteStream& bs, std:
 		}
 		args.add(cols);
 		err = IDBErrorInfo::instance()->errorMsg(WARN_DATA_TRUNC,args);
+        // Strict mode enabled, so rollback on warning
+        if (insertPkg.get_isWarnToError())
+        {
+			string applName ("SingleInsert");
+			fWEWrapper.bulkRollback(tblOid,txnid.id,tableName.toString(),
+				applName, false, err);
+			BulkRollbackMgr::deleteMetaFile( tblOid );
+        }
 	}
 
 	return rc;
@@ -1243,7 +1251,15 @@ End-Disable use of MetaFile for bulk rollback support
 		}
 		args.add(cols);
 		err = IDBErrorInfo::instance()->errorMsg(WARN_DATA_TRUNC,args);
-		
+
+        // Strict mode enabled, so rollback on warning
+        if (insertPkg.get_isWarnToError())
+        {
+			string applName ("BatchInsert");
+			fWEWrapper.bulkRollback(tblOid,txnid.id,tableName.toString(),
+				applName, false, err);
+			BulkRollbackMgr::deleteMetaFile( tblOid );
+        }
 	}
 	//cout << "Batch insert return code " << rc << endl;
 	return rc;


### PR DESCRIPTION
This changes the warning for truncation to the correct MariaDB error
code (1264).

In addition it passes the strict mode up into the DML class to roll back
correctly.

It also sets the abort_on_warning flag for updates as this isn't set on
the rnd_init phase but is needed for strict mode to work.