### PR TITLE
MCOL-433 Fix cross engine buffer underrun

### DIFF
--- a/utils/mysqlcl_idb/state.cc
+++ b/utils/mysqlcl_idb/state.cc
@@ -73,6 +73,12 @@ drizzle_return_t drizzle_state_packet_read(drizzle_con_st *con)
 
   con->packet_size= drizzle_get_byte3(con->buffer_ptr);
 
+  if (con->buffer_size < con->packet_size + 4)
+  {
+    drizzle_state_push(con, drizzle_state_read);
+    return DRIZZLE_RETURN_OK;
+  }
+
   if (con->packet_number != con->buffer_ptr[3])
   {
     drizzle_set_error(con->drizzle, "drizzle_state_packet_read",


### PR DESCRIPTION
If there is only one packet in the buffer it is possible that the read
doesn't contain the whole packet, the resulting in the buffer pointer
going less than 0 and bad things happening.