### PR TITLE
MCOL-430 Fix memory corruption in cross-engine

### DIFF
--- a/dbcon/joblist/crossenginestep.h
+++ b/dbcon/joblist/crossenginestep.h
@@ -26,6 +26,9 @@
 #include "jobstep.h"
 #include "primitivestep.h"
 
+#include "libdrizzle-2.0/drizzle.h"
+#include "libdrizzle-2.0/drizzle_client.h"
+
 // forward reference
 namespace  execplan
 {
@@ -40,6 +43,30 @@ class FuncExp;
 
 namespace joblist
 {
+
+class DrizzleMySQL
+{
+public:
+	DrizzleMySQL();
+	~DrizzleMySQL();
+
+	// init:   host          port        username      passwd         db
+	int init(const char*, unsigned int, const char*, const char*, const char*);
+
+	// run the query
+	int run(const char* q);
+
+	int getFieldCount()      { return drizzle_result_column_count(fDrzrp); }
+	int getRowCount()        { return drizzle_result_row_count(fDrzrp); }
+	char** nextRow()   { return drizzle_row_next(fDrzrp); }
+	const string& getError() { return fErrStr; }
+
+private:
+	drizzle_st*        fDrzp;
+	drizzle_con_st*    fDrzcp;
+	drizzle_result_st* fDrzrp;
+	string             fErrStr;
+};
 
 /** @brief class CrossEngineStep
  *
@@ -138,6 +165,7 @@ protected:
 	// output rowgroup and row
 	rowgroup::RowGroup fRowGroupOut;
 	rowgroup::RowGroup fRowGroupDelivered;
+    rowgroup::RowGroup fRowGroupAdded;
 	rowgroup::Row fRowDelivered;
 
 	// for datalist
@@ -184,7 +212,7 @@ protected:
 	rowgroup::RowGroup fRowGroupFe3;
 
 	funcexp::FuncExp* fFeInstance;
-
+    DrizzleMySQL* drizzle;
 };
 
 


### PR DESCRIPTION
Cross engine was using fRowGroupDelivered for pulling the rows out of
libdrizzle and passing them on to the next step in the job list
simultaneously on different threads. Sometimes this is OK, but with
larger data sets it leads to data corruption and race conditions.

For pulling the rows out of libdrizzle this patch uses a new RowGroup
object instead to avoid the collision.

In addition this patch makes the DrizzleMySQL class a dynamically
allocated object. A first step into potentially using unbuffered row
results for performance and lower RAM usage at a later date.