### PR TITLE
MCOL-406 add table_usage() schema input

### DIFF
--- a/dbcon/mysql/columnstore_info.sql
+++ b/dbcon/mysql/columnstore_info.sql
@@ -25,13 +25,13 @@ BEGIN
         (SELECT format_filesize(sum(file_size)) TOTAL_DISK_USAGE FROM INFORMATION_SCHEMA.COLUMNSTORE_FILES) TOTAL_DISK_USAGE;
 END //
 
-CREATE PROCEDURE table_usage (IN t_name char(64))
+CREATE PROCEDURE table_usage (IN t_schema char(64), IN t_name char(64))
 BEGIN
     IF t_name IS NOT NULL THEN
     SELECT TABLE_SCHEMA, TABLE_NAME, format_filesize(sum(cf.file_size)) DATA_DISK_USAGE, format_filesize(sum(IFNULL(ccf.file_size, 0))) DICT_DISK_USAGE, format_filesize(sum(cf.file_size) + sum(IFNULL(ccf.file_size, 0))) TOTAL_USAGE FROM INFORMATION_SCHEMA.COLUMNSTORE_COLUMNS cc
 JOIN INFORMATION_SCHEMA.COLUMNSTORE_FILES cf ON cc.object_id = cf.object_id
 LEFT JOIN INFORMATION_SCHEMA.COLUMNSTORE_FILES ccf ON cc.dictionary_object_id = ccf.object_id
-WHERE table_name = t_name GROUP BY table_schema, table_name;
+WHERE table_name = t_name and (table_schema = t_schema or t_schema IS NULL) GROUP BY table_schema, table_name;
     ELSE
     SELECT TABLE_SCHEMA, TABLE_NAME, format_filesize(sum(cf.file_size)) DATA_DISK_USAGE, format_filesize(sum(IFNULL(ccf.file_size, 0))) DICT_DISK_USAGE, format_filesize(sum(cf.file_size) + sum(IFNULL(ccf.file_size, 0))) TOTAL_USAGE FROM INFORMATION_SCHEMA.COLUMNSTORE_COLUMNS cc
 JOIN INFORMATION_SCHEMA.COLUMNSTORE_FILES cf ON cc.object_id = cf.object_id
@@ -39,7 +39,7 @@ LEFT JOIN INFORMATION_SCHEMA.COLUMNSTORE_FILES ccf ON cc.dictionary_object_id = 
 GROUP BY table_schema, table_name;
     END IF;
 END //
-    
+
 CREATE PROCEDURE compression_ratio()
 BEGIN
 SELECT CONCAT(((sum(compressed_data_size) / sum(data_size)) * 100), '%') COMPRESSION_RATIO FROM INFORMATION_SCHEMA.COLUMNSTORE_EXTENTS ce


### PR DESCRIPTION
table_usage() is now called using:

* table_usage(NULL, NULL) - all tables
* table_usage(NULL, 'table') - match tables with the name 'table' in all
schemas
* table_usage('schema', 'table') - match a specific schema and table
combination