### PR TITLE
MCOL-457 Fix insert...select NULL bitmap

### DIFF
--- a/dbcon/mysql/ha_calpont_dml.cpp
+++ b/dbcon/mysql/ha_calpont_dml.cpp
@@ -729,17 +729,17 @@ int ha_calpont_impl_write_batch_row_(uchar *buf, TABLE* table, cal_impl_if::cal_
 			if (colpos == ci.columnTypes.size())
 				break;
 
-			if (ci.headerLength > 0 && headerByte >= ci.headerLength)
-			{
-				// We've used more null bits than allowed. Something is seriously wrong.
-				std::string errormsg = "Null bit header is wrong size";
-				setError(current_thd, ER_INTERNAL_ERROR, errormsg);
-				return -1;
-			}
-
 			//if a column has not null constraint, it will not be in the bit map
 			if (ci.columnTypes[colpos].constraintType != CalpontSystemCatalog::NOTNULL_CONSTRAINT)
 			{
+       			if (ci.headerLength > 0 && headerByte >= ci.headerLength)
+	    		{
+		    		// We've used more null bits than allowed. Something is seriously wrong.
+			    	std::string errormsg = "Null bit header is wrong size";
+    				setError(current_thd, ER_INTERNAL_ERROR, errormsg);
+	    			return -1;
+		    	}
+
 				nullVal = nullBits & 0x01;
 				nullBits = nullBits>>1;
 				++headerBit;


### PR DESCRIPTION
When a table has 8 columns that could be NULL and a NOT NULL column
after the NULLable columns the check to see if we have gone over the
NULL bitmap byte limit is run prematurely trigging an error.

This patch moves the check to only run when we are looking at NULLable
columns.