### PR TITLE
MCOL-460 fix -mp for postConfigure

### DIFF
--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -596,7 +596,7 @@ int main(int argc, char *argv[])
 
 				cout << endl << "===== Performing Configuration Setup and MariaDB Columnstore Startup =====" << endl;
 
-				cmd = installDir + "/bin/installer dummy.rpm dummy.rpm dummy.rpm dummy.rpm dummy.rpm initial dummy " + reuseConfig + " --nodeps ' ' 1 " + installDir;
+				cmd = installDir + "/bin/installer dummy.rpm dummy.rpm dummy.rpm dummy.rpm dummy.rpm initial dummy " + reuseConfig + " --nodeps '" + mysqlpw + "' 1 " + installDir;
 				system(cmd.c_str());
 				exit(0);
 			}


### PR DESCRIPTION
Allow postConfigure -mp to work for single server. For no password a space
is sent as before.