### PR TITLE
MCOL-494 Don't try to process BLOB/TEXT

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -2233,6 +2233,10 @@ CalpontSystemCatalog::ColType colType_MysqlToIDB (const Item* item)
 					ct.colDataType = CalpontSystemCatalog::DATETIME;
 					ct.colWidth = 8;
 				}
+                if (item->field_type() == MYSQL_TYPE_BLOB)
+                {
+                    throw runtime_error ("BLOB/TEXT data types are not supported by ColumnStore.");
+                }
 			}
 			break;
 /* FIXME:


### PR DESCRIPTION
It is possible for a BLOB/TEXT column to appear in a cross engine join.
This causes an ExeMgr crash later during execution. For now this patch
disable BLOB/TEXT support.