### PR TITLE
MCOL-505 Performance improvements to ExeMgr

### DIFF
--- a/oam/oamcpp/liboamcpp.cpp
+++ b/oam/oamcpp/liboamcpp.cpp
@@ -278,11 +278,11 @@ namespace oam
         const string MODULE_TYPE = "ModuleType";
         systemmoduletypeconfig.moduletypeconfig.clear();
 
+        Config* sysConfig = Config::makeConfig(CalpontConfigFile.c_str());
+
         for (int moduleTypeID = 1; moduleTypeID < MAX_MODULE_TYPE+1; moduleTypeID++)
         {
         	ModuleTypeConfig moduletypeconfig;
-	
-            Config* sysConfig = Config::makeConfig(CalpontConfigFile.c_str());
 
             // get Module info
 
@@ -375,7 +375,7 @@ namespace oam
 
 				int moduleFound = 0;
 				//get NIC IP address/hostnames
-				for (int moduleID = 1; moduleID < MAX_MODULE ; moduleID++)
+				for (int moduleID = 1; moduleID <= moduletypeconfig.ModuleCount ; moduleID++)
 				{
 					DeviceNetworkConfig devicenetworkconfig;
 					HostConfig hostconfig;
@@ -385,7 +385,9 @@ namespace oam
 						string ModuleIpAddr = MODULE_IP_ADDR + itoa(moduleID) + "-" + itoa(nicID) + "-" + itoa(moduleTypeID);
 	
 						string ipAddr = sysConfig->getConfig(Section, ModuleIpAddr);
-						if (ipAddr.empty() || ipAddr == UnassignedIpAddr )
+						if (ipAddr.empty())
+                            break;
+                        else if (ipAddr == UnassignedIpAddr )
 							continue;
 	
 						string ModuleHostName = MODULE_SERVER_NAME + itoa(moduleID) + "-" + itoa(nicID) + "-" + itoa(moduleTypeID);
@@ -428,7 +430,7 @@ namespace oam
 
 				// get dbroot IDs
 				moduleFound = 0;
-				for (int moduleID = 1; moduleID < MAX_MODULE+1 ; moduleID++)
+				for (int moduleID = 1; moduleID <= moduletypeconfig.ModuleCount ; moduleID++)
 				{
 					string ModuleDBRootCount = MODULE_DBROOT_COUNT + itoa(moduleID) + "-" + itoa(moduleTypeID);
 					string temp = sysConfig->getConfig(Section, ModuleDBRootCount).c_str();
@@ -1925,11 +1927,11 @@ namespace oam
         const string SECTION_NAME = "PROCESSCONFIG";
         systemprocessconfig.processconfig.clear();
 
+        Config* proConfig = Config::makeConfig(ProcessConfigFile.c_str());
+
         for (int processID = 1; processID < MAX_PROCESS+1; processID++)
         {
 	        ProcessConfig processconfig;
-
-            Config* proConfig = Config::makeConfig(ProcessConfigFile.c_str());
 
             // get process info
 

--- a/utils/common/cgroupconfigurator.cpp
+++ b/utils/common/cgroupconfigurator.cpp
@@ -141,29 +141,7 @@ uint32_t CGroupConfigurator::getNumCoresFromProc()
 	GetSystemInfo(&siSysInfo);
 	return siSysInfo.dwNumberOfProcessors;
 #else
-	ifstream cpuinfo("/proc/cpuinfo");
-
-	if (!cpuinfo.good())
-		return 0;
-
-	unsigned nc = 0;
-
-	regex re("Processor\\s*:\\s*[0-9]+", regex::normal|regex::icase);
-
-	string line;
-
-	getline(cpuinfo, line);
-
-	unsigned i = 0;
-	while (i < 10000 && cpuinfo.good() && !cpuinfo.eof())
-	{
-		if (regex_match(line, re))
-			nc++;
-
-		getline(cpuinfo, line);
-
-		++i;
-	}
+    uint32_t nc = sysconf(_SC_NPROCESSORS_ONLN);
 
 	return nc;
 #endif

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -800,7 +800,14 @@ int64_t Row::getSignedNullValue(uint32_t colIndex) const
 
 RowGroup::RowGroup() : columnCount(0), data(NULL), rgData(NULL), strings(NULL),
 	useStringTable(true), hasLongStringField(false), sTableThreshold(20)
-{ }
+{
+    oldOffsets.reserve(1024);
+    oids.reserve(1024);
+    keys.reserve(1024);
+    types.reserve(1024);
+    scale.reserve(1024);
+    precision.reserve(1024);
+}
 
 RowGroup::RowGroup(uint32_t colCount,
 	const vector<uint32_t> &positions,


### PR DESCRIPTION
This fix improves the performance of ExeMgr by doing the following:

* Significantly reduces the amount of time the xml configuration is
scanned
* Uses a much faster way to determine the CPU core count
* Reduces the amount of times certain allocations are executed
* Rowgroup pre-allocates vectors for 1024 rows

This improves performance for the first query of a connection and the
performance for smaller result sets. It may well improve performance in
other areas too.