### PR TITLE
MCOL-454 Fix HWM edge case

### DIFF
--- a/dbcon/mysql/is_columnstore_extents.cpp
+++ b/dbcon/mysql/is_columnstore_extents.cpp
@@ -152,7 +152,15 @@ static int is_columnstore_extents_fill(THD *thd, TABLE_LIST *tables, COND *cond)
                 default:
                     table->field[14]->store("Unknown", strlen("Unknown"), cs);
             }
-            table->field[15]->store((iter->HWM - iter->blockOffset + 1) * 8192);
+            // MCOL-454: special case, sometimes blockOffset can be > 0 and HWM can be 0
+            if (iter->HWM == 0)
+            {
+                table->field[15]->store(8192);
+            }
+            else
+            {
+                table->field[15]->store((iter->HWM - iter->blockOffset + 1) * 8192);
+            }
 
             if (schema_table_store_record(thd, table))
             {


### PR DESCRIPTION
Sometimes block offset can be > 0 but HWM can be 0 this causes a
calculation error in the DATA_SIZE field of I_S.columnstore_extents