### PR TITLE
MCOL-455: fix crash caused by rewind of unopened redistribute plan fi…

### DIFF
--- a/writeengine/redistribute/we_redistributecontrolthread.cpp
+++ b/writeengine/redistribute/we_redistributecontrolthread.cpp
@@ -501,7 +501,7 @@ void RedistributeControlThread::displayPlan()
 		if (!fControl->fPlanFilePtr)
 		{
 			ostringstream oss;
-			oss << "No data is schefuled to be moved" << endl;
+			oss << "No data is scheduled to be moved" << endl;
 			fControl->logMessage(oss.str());
 			return;
 		}


### PR DESCRIPTION
…le during display when no partitions have been planned to be moved.