### PR TITLE
Make packages management optional

### DIFF
--- a/oam/install_scripts/performance_installer.sh
+++ b/oam/install_scripts/performance_installer.sh
@@ -29,6 +29,7 @@ set UNM [lindex $argv 13]
 if { $UNM != "" } {
 	set USERNAME $UNM
 }
+set DEPLOY_PACKAGES [lindex $argv 14]
 
 set BASH "/bin/bash "
 if { $DEBUG == "1" } {
@@ -40,162 +41,165 @@ set HOME "$env(HOME)"
 log_user $DEBUG
 spawn -noecho /bin/bash
 #
-if { $PKGTYPE == "rpm" } {
-	set PKGERASE "rpm -e --nodeps \$(rpm -qa | grep '^mariadb-columnstore')"
-	set PKGERASE1 "rpm -e --nodeps "
+if { $DEPLOY_PACKAGES } {
+    if { $PKGTYPE == "rpm" } {
+        set PKGERASE "rpm -e --nodeps \$(rpm -qa | grep '^mariadb-columnstore')"
+        set PKGERASE1 "rpm -e --nodeps "
 
-	set PKGINSTALL "rpm -ivh $NODEPS --force mariadb-columnstore*$VERSION*rpm"
-	set PKGUPGRADE "rpm -Uvh --noscripts mariadb-columnstore*$VERSION*rpm"
-} else {
-	if { $PKGTYPE == "deb" } {
-		set PKGERASE "dpkg -P \$(dpkg --get-selections | grep '^mariadb-columnstore')"
-		set PKGERASE1 "dpkg -P "
-		set PKGINSTALL "dpkg -i --force-confnew mariadb-columnstore*$VERSION*deb"
-		set PKGUPGRADE "dpkg -i --force-confnew mariadb-columnstore*$VERSION*deb"
-	} else {
-		if { $PKGTYPE != "bin" } {
-			send_user "Invalid Package Type of $PKGTYPE"
-			exit 1
-		}
-	}
-}
+        set PKGINSTALL "rpm -ivh $NODEPS --force mariadb-columnstore*$VERSION*rpm"
+        set PKGUPGRADE "rpm -Uvh --noscripts mariadb-columnstore*$VERSION*rpm"
+    } else {
+        if { $PKGTYPE == "deb" } {
+            set PKGERASE "dpkg -P \$(dpkg --get-selections | grep '^mariadb-columnstore')"
+            set PKGERASE1 "dpkg -P "
+            set PKGINSTALL "dpkg -i --force-confnew mariadb-columnstore*$VERSION*deb"
+            set PKGUPGRADE "dpkg -i --force-confnew mariadb-columnstore*$VERSION*deb"
+        } else {
+            if { $PKGTYPE != "bin" } {
+                send_user "Invalid Package Type of $PKGTYPE"
+                exit 1
+            }
+        }
+    }
 
-# check and see if remote server has ssh keys setup, set PASSWORD if so
-send_user " "
-send "ssh $USERNAME@$SERVER 'time'\n"
-set timeout 60
-expect {
-	"Host key verification failed" { send_user "FAILED: Host key verification failed\n" ; exit 1 }
-	"service not known" { send_user "FAILED: Invalid Host\n" ; exit 1 }
-	"authenticity" { send "yes\n" 
-						expect {
-							"word: " { send "$PASSWORD\n" }
-							"passphrase" { send "$PASSWORD\n" }
-						}
-	}
-	"sys" { set PASSWORD "ssh" }
-	"word: " { send "$PASSWORD\n" }
-	"passphrase" { send "$PASSWORD\n" }
-	"Permission denied, please try again"   { send_user "ERROR: Invalid password\n" ; exit 1 }
-	"Connection refused"   { send_user "ERROR: Connection refused\n" ; exit 1 }
-	"Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
-	"No route to host"   { send_user "ERROR: No route to host\n" ; exit 1 }
-	timeout { send_user "ERROR: Timeout to host\n" ; exit 1 }
-}
-set timeout 30
-expect {
-	-re {[$#] }        {  }
-	"sys" {  }
-}
-send_user "\n"
-#BUG 5749 - SAS: didn't work on their system until I added the sleep 60
+    # check and see if remote server has ssh keys setup, set PASSWORD if so
+    send_user " "
+    send "ssh $USERNAME@$SERVER 'time'\n"
+    set timeout 60
+    expect {
+        "Host key verification failed" { send_user "FAILED: Host key verification failed\n" ; exit 1 }
+        "service not known" { send_user "FAILED: Invalid Host\n" ; exit 1 }
+        "authenticity" { send "yes\n"
+                            expect {
+                                "word: " { send "$PASSWORD\n" }
+                                "passphrase" { send "$PASSWORD\n" }
+                            }
+        }
+        "sys" { set PASSWORD "ssh" }
+        "word: " { send "$PASSWORD\n" }
+        "passphrase" { send "$PASSWORD\n" }
+        "Permission denied, please try again"   { send_user "ERROR: Invalid password\n" ; exit 1 }
+        "Connection refused"   { send_user "ERROR: Connection refused\n" ; exit 1 }
+        "Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
+        "No route to host"   { send_user "ERROR: No route to host\n" ; exit 1 }
+        timeout { send_user "ERROR: Timeout to host\n" ; exit 1 }
+    }
+    set timeout 30
+    expect {
+        -re {[$#] }        {  }
+        "sys" {  }
+    }
+    send_user "\n"
+    #BUG 5749 - SAS: didn't work on their system until I added the sleep 60
 
-sleep 60
+    sleep 60
 
-if { $INSTALLTYPE == "initial" || $INSTALLTYPE == "uninstall" } {
-	# 
-	# erase package
-	#
-	send_user "Erase MariaDB Columnstore Packages on Module                 "
-	send "ssh $USERNAME@$SERVER '$PKGERASE ;$PKGERASE1 dummy'\n"
-	if { $PASSWORD != "ssh" } {
-		set timeout 30
-		expect {
-			"word: " { send "$PASSWORD\n" }
-			"passphrase" { send "$PASSWORD\n" }
-		}
-	}
-	set timeout 120
-	expect {
-		"package dummy" { send_user "DONE" }
-		"error: Failed dependencies" { send_user "ERROR: Failed dependencies\n" ; exit 1 }
-		"Permission denied, please try again"   { send_user "ERROR: Invalid password\n" ; exit 1 }
-		"Connection refused"   { send_user "ERROR: Connection refused\n" ; exit 1 }
-		"Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
-		"No route to host"   { send_user "ERROR: No route to host\n" ; exit 1 }
-	}
-	send_user "\n"
-}
-
-if { $INSTALLTYPE == "uninstall" } { exit 0 }
-
-# 
-# send the package
-#
-set timeout 30
-#expect -re {[$#] }
-send_user "Copy New MariaDB Columnstore Package to Module              "
-send "ssh $USERNAME@$SERVER 'rm -f /root/mariadb-columnstore-*.$PKGTYPE'\n"
-if { $PASSWORD != "ssh" } {
-	set timeout 30
-	expect {
-		"word: " { send "$PASSWORD\n" }
-		"passphrase" { send "$PASSWORD\n" }
-	}
-}
-expect {
-	-re {[$#] } { }
-	"Connection refused"   { send_user "ERROR: Connection refused\n" ; exit 1 }
-	"Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
-	"No route to host"   { send_user "ERROR: No route to host\n" ; exit 1 }
-}
-set timeout 30
-expect {
-        -re {[$#] } { }
-}
-
-send "scp $HOME/mariadb-columnstore*$VERSION*$PKGTYPE $USERNAME@$SERVER:.;$PKGERASE1 dummy\n"
-if { $PASSWORD != "ssh" } {
-        set timeout 30
-        expect {
+    if { $INSTALLTYPE == "initial" || $INSTALLTYPE == "uninstall" } {
+        #
+        # erase package
+        #
+        send_user "Erase MariaDB Columnstore Packages on Module                 "
+        send "ssh $USERNAME@$SERVER '$PKGERASE ;$PKGERASE1 dummy'\n"
+        if { $PASSWORD != "ssh" } {
+            set timeout 30
+            expect {
                 "word: " { send "$PASSWORD\n" }
                 "passphrase" { send "$PASSWORD\n" }
+            }
         }
+        set timeout 120
+        expect {
+            "package dummy" { send_user "DONE" }
+            "error: Failed dependencies" { send_user "ERROR: Failed dependencies\n" ; exit 1 }
+            "Permission denied, please try again"   { send_user "ERROR: Invalid password\n" ; exit 1 }
+            "Connection refused"   { send_user "ERROR: Connection refused\n" ; exit 1 }
+            "Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
+            "No route to host"   { send_user "ERROR: No route to host\n" ; exit 1 }
+        }
+        send_user "\n"
+    }
 }
-set timeout 180
-expect {
-        "package dummy"         { send_user "DONE" }
-        "directory"             { send_user "ERROR\n" ;
-                                        send_user "\n*** Installation ERROR\n" ;
-                                        exit 1 }
+if { $INSTALLTYPE == "uninstall" } { exit 0 }
+
+if { $DEPLOY_PACKAGES } {
+    #
+    # send the package
+    #
+    set timeout 30
+    #expect -re {[$#] }
+    send_user "Copy New MariaDB Columnstore Package to Module              "
+    send "ssh $USERNAME@$SERVER 'rm -f /root/mariadb-columnstore-*.$PKGTYPE'\n"
+    if { $PASSWORD != "ssh" } {
+        set timeout 30
+        expect {
+            "word: " { send "$PASSWORD\n" }
+            "passphrase" { send "$PASSWORD\n" }
+        }
+    }
+    expect {
+        -re {[$#] } { }
+        "Connection refused"   { send_user "ERROR: Connection refused\n" ; exit 1 }
         "Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
+        "No route to host"   { send_user "ERROR: No route to host\n" ; exit 1 }
+    }
+    set timeout 30
+    expect {
+            -re {[$#] } { }
+    }
+
+    send "scp $HOME/mariadb-columnstore*$VERSION*$PKGTYPE $USERNAME@$SERVER:.;$PKGERASE1 dummy\n"
+    if { $PASSWORD != "ssh" } {
+            set timeout 30
+            expect {
+                    "word: " { send "$PASSWORD\n" }
+                    "passphrase" { send "$PASSWORD\n" }
+            }
+    }
+    set timeout 180
+    expect {
+            "package dummy"         { send_user "DONE" }
+            "directory"             { send_user "ERROR\n" ;
+                                            send_user "\n*** Installation ERROR\n" ;
+                                            exit 1 }
+            "Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
+    }
+    send_user "\n"
+
+    #sleep to make sure it's finished
+    sleep 5
+
+    #
+    if { $INSTALLTYPE == "initial"} {
+        #
+        # install package
+        #
+        send_user "Install MariaDB Columnstore Packages on Module               "
+
+        send "ssh $USERNAME@$SERVER '$PKGINSTALL ;$PKGERASE1 dummy'\n"
+        if { $PASSWORD != "ssh" } {
+            set timeout 30
+            expect {
+                "word: " { send "$PASSWORD\n" }
+                "passphrase" { send "$PASSWORD\n" }
+            }
+        }
+        set timeout 180
+        expect {
+            "package dummy" 		  { send_user "DONE" }
+            "error: Failed dependencies" { send_user "ERROR: Failed dependencies\n" ;
+                                        send_user "\n*** Installation ERROR\n" ;
+                                            exit 1 }
+            "Permission denied, please try again"   { send_user "ERROR: Invalid password\n" ; exit 1 }
+            "Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
+            "needs"    { send_user "ERROR: disk space issue\n" ; exit 1 }
+            "conflicts"	   { send_user "ERROR: File Conflict issue\n" ; exit 1 }
+        }
+
+    }
+    send_user "\n"
+    #sleep to make sure it's finished
+    sleep 5
 }
-send_user "\n"
-
-#sleep to make sure it's finished
-sleep 5
-
-#
-if { $INSTALLTYPE == "initial"} {
-	#
-	# install package
-	#
-	send_user "Install MariaDB Columnstore Packages on Module               "
-
-	send "ssh $USERNAME@$SERVER '$PKGINSTALL ;$PKGERASE1 dummy'\n"
-	if { $PASSWORD != "ssh" } {
-		set timeout 30
-		expect {
-			"word: " { send "$PASSWORD\n" }
-			"passphrase" { send "$PASSWORD\n" }
-		}
-	}
-	set timeout 180
-	expect {
-		"package dummy" 		  { send_user "DONE" }
-		"error: Failed dependencies" { send_user "ERROR: Failed dependencies\n" ; 
-									send_user "\n*** Installation ERROR\n" ; 
-										exit 1 }
-		"Permission denied, please try again"   { send_user "ERROR: Invalid password\n" ; exit 1 }
-		"Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
-		"needs"    { send_user "ERROR: disk space issue\n" ; exit 1 }
-		"conflicts"	   { send_user "ERROR: File Conflict issue\n" ; exit 1 }
-	}
-
-}
-send_user "\n"
-#sleep to make sure it's finished
-sleep 5
 set timeout 30
 #expect -re {[$#] }
 if { $INSTALLTYPE == "initial"} {

--- a/oam/install_scripts/user_installer.sh
+++ b/oam/install_scripts/user_installer.sh
@@ -35,6 +35,7 @@ if { $UNM != "" } {
 if { $MYSQLPW == "none" } {
 	set MYSQLPW " "
 } 
+set DEPLOY_PACKAGES [lindex $argv 12]
 
 set BASH "/bin/bash "
 #if { $DEBUG == "1" } {
@@ -46,24 +47,25 @@ set HOME "$env(HOME)"
 log_user $DEBUG
 spawn -noecho /bin/bash
 #
-if { $PKGTYPE == "rpm" } {
-	set PKGERASE "rpm -e --nodeps \$(rpm -qa | grep '^mariadb-columnstore')"
-	set PKGERASE1 "rpm -e --nodeps "
+if { $DEPLOY_PACKAGES } {
+    if { $PKGTYPE == "rpm" } {
+        set PKGERASE "rpm -e --nodeps \$(rpm -qa | grep '^mariadb-columnstore')"
+        set PKGERASE1 "rpm -e --nodeps "
 
-	set PKGINSTALL "rpm -ivh $NODEPS --force mariadb-columnstore*$VERSION*rpm"
-	set PKGUPGRADE "rpm -Uvh --noscripts mariadb-columnstore*$VERSION*rpm"
-} else {
-	if { $PKGTYPE == "deb" } {
-		set PKGERASE "dpkg -P \$(dpkg --get-selections | grep '^mariadb-columnstore')"
-		set PKGERASE1 "dpkg -P "
-		set PKGINSTALL "dpkg -i --force-confnew mariadb-columnstore*$VERSION*deb"
-		set PKGUPGRADE "dpkg -i --force-confnew mariadb-columnstore*$VERSION*deb"
-	} else {
-		send_user "Invalid Package Type of $PKGTYPE"
-		exit 1
-	}
+        set PKGINSTALL "rpm -ivh $NODEPS --force mariadb-columnstore*$VERSION*rpm"
+        set PKGUPGRADE "rpm -Uvh --noscripts mariadb-columnstore*$VERSION*rpm"
+    } else {
+        if { $PKGTYPE == "deb" } {
+            set PKGERASE "dpkg -P \$(dpkg --get-selections | grep '^mariadb-columnstore')"
+            set PKGERASE1 "dpkg -P "
+            set PKGINSTALL "dpkg -i --force-confnew mariadb-columnstore*$VERSION*deb"
+            set PKGUPGRADE "dpkg -i --force-confnew mariadb-columnstore*$VERSION*deb"
+        } else {
+            send_user "Invalid Package Type of $PKGTYPE"
+            exit 1
+        }
+    }
 }
-
 # check and see if remote server has ssh keys setup, set PASSWORD if so
 send_user " "
 send "ssh $USERNAME@$SERVER 'time'\n"
@@ -71,7 +73,7 @@ set timeout 60
 expect {
 	"Host key verification failed" { send_user "FAILED: Host key verification failed\n" ; exit 1 }
 	"service not known" { send_user "FAILED: Invalid Host\n" ; exit 1 }
-	"authenticity" { send "yes\n" 
+	"authenticity" { send "yes\n"
 						expect {
 							"word: " { send "$PASSWORD\n" }
 							"passphrase" { send "$PASSWORD\n" }
@@ -95,109 +97,87 @@ send_user "\n"
 #BUG 5749 - SAS: didn't work on their system until I added the sleep 60
 sleep 60
 
-if { $INSTALLTYPE == "initial" || $INSTALLTYPE == "uninstall" } {
-	# 
-	# erase MariaDB Columnstore packages
-	#
-	send_user "Erase MariaDB Columnstore Packages on Module           "
-	send "ssh $USERNAME@$SERVER '$PKGERASE ;$PKGERASE1 dummy'\n"
-	if { $PASSWORD != "ssh" } {
-		set timeout 30
-		expect {
-			"word: " { send "$PASSWORD\n" }
-			"passphrase" { send "$PASSWORD\n" }
-		}
-	}
-	set timeout 120
-	expect {
-		"package dummy" { send_user "DONE" }
-		"error: Failed dependencies" { send_user "ERROR: Failed dependencies\n" ; exit 1 }
-		"Permission denied, please try again"   { send_user "ERROR: Invalid password\n" ; exit 1 }
-		"Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
-	}
-	send_user "\n"
+if { $DEPLOY_PACKAGES } {
+    if { $INSTALLTYPE == "initial" || $INSTALLTYPE == "uninstall" } {
+        #
+        # erase MariaDB Columnstore packages
+        #
+        send_user "Erase MariaDB Columnstore Packages on Module           "
+        send "ssh $USERNAME@$SERVER '$PKGERASE ;$PKGERASE1 dummy'\n"
+        if { $PASSWORD != "ssh" } {
+            set timeout 30
+            expect {
+                "word: " { send "$PASSWORD\n" }
+                "passphrase" { send "$PASSWORD\n" }
+            }
+        }
+        set timeout 120
+        expect {
+            "package dummy" { send_user "DONE" }
+            "error: Failed dependencies" { send_user "ERROR: Failed dependencies\n" ; exit 1 }
+            "Permission denied, please try again"   { send_user "ERROR: Invalid password\n" ; exit 1 }
+            "Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
+        }
+        send_user "\n"
+    }
 }
 
 if { $INSTALLTYPE == "uninstall" } { exit 0 }
 
-# 
-# send the MariaDB ColumnStore package
-#
-set timeout 30
-#expect -re {[$#] }
-send_user "Copy new MariaDB Columnstore Packages to Module              "
-send "ssh $USERNAME@$SERVER 'rm -f /root/mariadb-columnstore-*.$PKGTYPE'\n"
-if { $PASSWORD != "ssh" } {
-	set timeout 30
-	expect {
-		"word: " { send "$PASSWORD\n" }
-		"passphrase" { send "$PASSWORD\n" }
-		"Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
-	}
-}
-expect {
-        -re {[$#] } { }
-        "Connection refused"   { send_user "ERROR: Connection refused\n" ; exit 1 }
+if { $DEPLOY_PACKAGES } {
+
+    send "scp $HOME/mariadb-columnstore*$VERSION*$PKGTYPE $USERNAME@$SERVER:.;$PKGERASE1 dummy\n"
+    if { $PASSWORD != "ssh" } {
+        set timeout 30
+        expect {
+            "word: " { send "$PASSWORD\n" }
+            "passphrase" { send "$PASSWORD\n" }
+        }
+    }
+    set timeout 120
+    expect {
+        "package dummy" 	{ send_user "DONE" }
+        "directory"  		{ send_user "ERROR\n" ;
+                        send_user "\n*** Installation ERROR\n" ;
+                        exit 1 }
         "Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
-        "No route to host"   { send_user "ERROR: No route to host\n" ; exit 1 }
-}
-set timeout 30
-expect {
-	-re {[$#] } { }
-}
+    }
+    send_user "\n"
 
-send "scp $HOME/mariadb-columnstore*$VERSION*$PKGTYPE $USERNAME@$SERVER:.;$PKGERASE1 dummy\n"
-if { $PASSWORD != "ssh" } {
-	set timeout 30
-	expect {
-		"word: " { send "$PASSWORD\n" }
-		"passphrase" { send "$PASSWORD\n" }
-	}
+    #sleep to make sure it's finished
+    sleep 5
+    #
+    set timeout 30
+    expect -re {[$#] }
+    if { $INSTALLTYPE == "initial"} {
+        #
+        # install package
+        #
+        send_user "Install MariaDB ColumnStore Packages on Module               "
+        send "ssh $USERNAME@$SERVER '$PKGINSTALL ;$PKGERASE1 dummy'\n"
+        if { $PASSWORD != "ssh" } {
+            set timeout 30
+            expect {
+                "word: " { send "$PASSWORD\n" }
+                "passphrase" { send "$PASSWORD\n" }
+            }
+        }
+        set timeout 180
+        expect {
+            "package dummy" 	  { send_user "DONE" }
+            "error: Failed dependencies" { send_user "ERROR: Failed dependencies\n" ;
+                                send_user "\n*** Installation ERROR\n" ;
+                                exit 1 }
+            "Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
+            "needs"	   { send_user "ERROR: disk space issue\n" ; exit 1 }
+            "conflicts"	   { send_user "ERROR: File Conflict issue\n" ; exit 1 }
+        }
+        send_user "\n"
+        set timeout 30
+    }
+    #sleep to make sure it's finished
+    sleep 5
 }
-set timeout 120
-expect {
-	"package dummy" 	{ send_user "DONE" }
-	"directory"  		{ send_user "ERROR\n" ; 
-				 	send_user "\n*** Installation ERROR\n" ; 
-					exit 1 }
-	"Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
-}
-send_user "\n"
-
-#sleep to make sure it's finished
-sleep 5
-#
-set timeout 30
-expect -re {[$#] }
-if { $INSTALLTYPE == "initial"} {
-	#
-	# install package
-	#
-	send_user "Install MariaDB ColumnStore Packages on Module               "
-	send "ssh $USERNAME@$SERVER '$PKGINSTALL ;$PKGERASE1 dummy'\n"
-	if { $PASSWORD != "ssh" } {
-		set timeout 30
-		expect {
-			"word: " { send "$PASSWORD\n" }
-			"passphrase" { send "$PASSWORD\n" }
-		}
-	}
-	set timeout 180
-	expect {
-		"package dummy" 	  { send_user "DONE" }
-		"error: Failed dependencies" { send_user "ERROR: Failed dependencies\n" ; 
-							send_user "\n*** Installation ERROR\n" ; 
-							exit 1 }
-		"Connection closed"   { send_user "ERROR: Connection closed\n" ; exit 1 }
-		"needs"	   { send_user "ERROR: disk space issue\n" ; exit 1 }
-		"conflicts"	   { send_user "ERROR: File Conflict issue\n" ; exit 1 }
-	}
-	send_user "\n"
-
-	set timeout 30
-}
-#sleep to make sure it's finished
-sleep 5
 #
 if { $INSTALLTYPE == "initial"} {
 	#


### PR DESCRIPTION
Currently postConfigure requires deb or rpm packages to be copied on disk in /root
It also connect to each nodes using ssh to uninstall packages, push its own ones and install its own through expect scripts.
This makes MariaDB Columnstore very unfriendly with configuration management systems, and it's even worse with containers.

This patch aims to:
- add a new command line option to postConfigure: `-m` to tell postConfigure *not* to manage packages (default behaviour is still to manage them)
- pass a new option to expect scripts to reflect package management choice
- update expect scripts to respect this option

I have still to implement the same behaviour in one place at least: `processmanager.cpp` which check for package in `ProcessManager::addModule`.
I'll have a look at it asap.

Cheers