### PR TITLE
MCOL-611 backport of MCOL-353 Fix lag at end of cpimport

### DIFF
--- a/writeengine/splitter/we_sdhandler.cpp
+++ b/writeengine/splitter/we_sdhandler.cpp
@@ -994,7 +994,6 @@ void WESDHandler::onNakResponse(int PmId) {
 void WESDHandler::onEodResponse(int PmId) {
 	if (getDebugLvl())
 		cout << "Received a EOD from " << PmId << endl;
-	fWeSplClients[PmId]->setRdSecTo(fPmCount); //Set Rd T/O to 1 sec
 
 	if (fRef.fCmdArgs.getMode() == 0)
 	{


### PR DESCRIPTION
The end of a cpimport adds a delay which is 1 second multiplied by the
number of PMs. This in-turn is multipled up with the number of
connections/threads causing a long delay when you have several PMs.

The delay is not required as we already have a 20ms delay and we will
re-enter the recv() if there is no data and we are still connected.