### PR TITLE
MCOL-642 Separate TEXT from BLOB

### DIFF
--- a/dbcon/ddlpackage/ddl.y
+++ b/dbcon/ddlpackage/ddl.y
@@ -902,27 +902,27 @@ blob_type:
 text_type:
 	TEXT '(' ICONST ')'
 	{
-		$$ = new ColumnType(DDL_BLOB);
+		$$ = new ColumnType(DDL_TEXT);
 		$$->fLength = atol($3);
 	}
 	| TEXT
 	{
-		$$ = new ColumnType(DDL_BLOB);
+		$$ = new ColumnType(DDL_TEXT);
 		$$->fLength = 65535;
 	}
 	| TINYTEXT
 	{
-		$$ = new ColumnType(DDL_BLOB);
+		$$ = new ColumnType(DDL_TEXT);
 		$$->fLength = 255;
 	}
 	| MEDIUMTEXT
 	{
-		$$ = new ColumnType(DDL_BLOB);
+		$$ = new ColumnType(DDL_TEXT);
 		$$->fLength = 16777215;
 	}
 	| LONGTEXT
 	{
-		$$ = new ColumnType(DDL_BLOB);
+		$$ = new ColumnType(DDL_TEXT);
 		$$->fLength = 2100000000;
 	}
 	;

--- a/dbcon/ddlpackage/ddlpkg.h
+++ b/dbcon/ddlpackage/ddlpkg.h
@@ -229,6 +229,7 @@ enum DDL_DATATYPES {
     DDL_UNSIGNED_FLOAT,
     DDL_UNSIGNED_DOUBLE,
     DDL_UNSIGNED_NUMERIC,
+    DDL_TEXT,
     DDL_INVALID_DATATYPE
 };
 
@@ -265,6 +266,7 @@ const std::string DDLDatatypeString[] =
         "unsigned-float",
         "unsigned-double",
         "unsigned-numeric",
+        "text",
         ""
     };
 
@@ -318,7 +320,8 @@ const int  DDLDatatypeLength[] =
         2,      // UNSIGNED_DECIMAL, 
         4,      // UNSIGNED_FLOAT,   
         8,      // UNSIGNED_DOUBLE,  
-        2,      // UNSIGNED_NUMERIC, 
+        2,      // UNSIGNED_NUMERIC,
+        8,      // TEXT 
         -1		// INVALID LENGTH
     };
 

--- a/dbcon/ddlpackageproc/altertableprocessor.cpp
+++ b/dbcon/ddlpackageproc/altertableprocessor.cpp
@@ -174,6 +174,7 @@ bool typesAreSame(const CalpontSystemCatalog::ColType& colType, const ColumnType
 	case (CalpontSystemCatalog::CLOB):
 		break;
 	case (CalpontSystemCatalog::BLOB):
+	case (CalpontSystemCatalog::TEXT):
 		break;
 	default:
 		break;

--- a/dbcon/ddlpackageproc/createtableprocessor.cpp
+++ b/dbcon/ddlpackageproc/createtableprocessor.cpp
@@ -245,7 +245,8 @@ keepGoing:
 			if ( (dataType == CalpontSystemCatalog::CHAR && tableDef.fColumns[i]->fType->fLength > 8) ||
 				 (dataType == CalpontSystemCatalog::VARCHAR && tableDef.fColumns[i]->fType->fLength > 7) ||
 				 (dataType == CalpontSystemCatalog::VARBINARY && tableDef.fColumns[i]->fType->fLength > 7) ||
-                 (dataType == CalpontSystemCatalog::BLOB && tableDef.fColumns[i]->fType->fLength > 7) )			 
+                 (dataType == CalpontSystemCatalog::BLOB && tableDef.fColumns[i]->fType->fLength > 7) ||
+                 (dataType == CalpontSystemCatalog::TEXT && tableDef.fColumns[i]->fType->fLength > 7) )			 
 				 numDictCols++;
 		}
 		fStartingColOID = fObjectIDManager.allocOIDs(numColumns+numDictCols+1); //include column, oids,dictionary oids and tableoid
@@ -535,7 +536,8 @@ cout << fTxnid.id << " Create table WE_SVR_WRITE_CREATE_SYSCOLUMN: " << errorMsg
 			if ( (dataType == CalpontSystemCatalog::CHAR && colDefPtr->fType->fLength > 8) ||
 				 (dataType == CalpontSystemCatalog::VARCHAR && colDefPtr->fType->fLength > 7) ||
 				 (dataType == CalpontSystemCatalog::VARBINARY && colDefPtr->fType->fLength > 7) ||
-                 (dataType == CalpontSystemCatalog::BLOB && colDefPtr->fType->fLength > 7) )
+                 (dataType == CalpontSystemCatalog::BLOB && colDefPtr->fType->fLength > 7) ||
+                 (dataType == CalpontSystemCatalog::TEXT && colDefPtr->fType->fLength > 7) )
 			{
 				bytestream << (uint32_t) (fStartingColOID+numColumns+(dictNum++)+1);
 				bytestream << (uint8_t) dataType;

--- a/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
+++ b/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
@@ -238,6 +238,10 @@ execplan::CalpontSystemCatalog::ColDataType DDLPackageProcessor::convertDataType
 			colDataType = CalpontSystemCatalog::BLOB;
 			break;
 
+		case ddlpackage::DDL_TEXT:
+			colDataType = CalpontSystemCatalog::TEXT;
+			break;
+
 		default:
 			throw runtime_error("Unsupported datatype!");
 

--- a/dbcon/dmlpackageproc/dmlpackageprocessor.h
+++ b/dbcon/dmlpackageproc/dmlpackageprocessor.h
@@ -444,7 +444,8 @@ protected:
        || ((colType.colDataType == execplan::CalpontSystemCatalog::VARCHAR) && (colType.colWidth > 7)) 
        || ((colType.colDataType == execplan::CalpontSystemCatalog::DECIMAL) && (colType.precision > 18))
                || (colType.colDataType == execplan::CalpontSystemCatalog::VARBINARY)
-               || (colType.colDataType == execplan::CalpontSystemCatalog::BLOB))
+               || (colType.colDataType == execplan::CalpontSystemCatalog::BLOB)
+               || (colType.colDataType == execplan::CalpontSystemCatalog::TEXT))
              {
                     return true;
              }

--- a/dbcon/execplan/calpontsystemcatalog.cpp
+++ b/dbcon/execplan/calpontsystemcatalog.cpp
@@ -155,6 +155,9 @@ const string colDataTypeToString(CalpontSystemCatalog::ColDataType cdt)
 	case CalpontSystemCatalog::BLOB:
 		return "blob";
 		break;
+	case CalpontSystemCatalog::TEXT:
+		return "text";
+		break;
     case CalpontSystemCatalog::UTINYINT:
         return "utinyint";
         break;

--- a/dbcon/execplan/calpontsystemcatalog.h
+++ b/dbcon/execplan/calpontsystemcatalog.h
@@ -155,7 +155,8 @@ public:
 			UDOUBLE,		/*!< Unsigned DOUBLE type */
 			NUM_OF_COL_DATA_TYPE,
 			LONGDOUBLE,		/* @bug3241, dev and variance calculation only */
-			STRINT			/* @bug3532, string as int for fast comparison */
+			STRINT,			/* @bug3532, string as int for fast comparison */
+            TEXT            /*!< TEXT type */
 	};
 
 	/** the set of column constraint types
@@ -906,7 +907,8 @@ inline bool isCharType(const execplan::CalpontSystemCatalog::ColDataType type)
 {
 	return (execplan::CalpontSystemCatalog::VARCHAR == type ||
 			execplan::CalpontSystemCatalog::CHAR == type ||
-            execplan::CalpontSystemCatalog::BLOB == type);
+            execplan::CalpontSystemCatalog::BLOB == type ||
+            execplan::CalpontSystemCatalog::TEXT == type);
 }
 
 /** convenience function to determine if column type is an

--- a/dbcon/execplan/simplecolumn.cpp
+++ b/dbcon/execplan/simplecolumn.cpp
@@ -584,6 +584,7 @@ void SimpleColumn::evaluate(Row& row, bool& isNull)
 		}
 		case CalpontSystemCatalog::VARBINARY:
         case CalpontSystemCatalog::BLOB:
+        case CalpontSystemCatalog::TEXT:
 		{
 			fResult.strVal = row.getVarBinaryStringField(fInputIndex);
 			break;

--- a/dbcon/execplan/simplefilter.cpp
+++ b/dbcon/execplan/simplefilter.cpp
@@ -177,6 +177,7 @@ const string SimpleFilter::data() const
 		  (fRhs->resultType().colDataType == CalpontSystemCatalog::VARCHAR ||
 		   fRhs->resultType().colDataType == CalpontSystemCatalog::CHAR ||
            fRhs->resultType().colDataType == CalpontSystemCatalog::BLOB ||
+           fRhs->resultType().colDataType == CalpontSystemCatalog::TEXT ||
 		   fRhs->resultType().colDataType == CalpontSystemCatalog::VARBINARY ||
 		   fRhs->resultType().colDataType == CalpontSystemCatalog::DATE ||
 		   fRhs->resultType().colDataType == CalpontSystemCatalog::DATETIME))
@@ -187,6 +188,7 @@ const string SimpleFilter::data() const
 		  (fLhs->resultType().colDataType == CalpontSystemCatalog::VARCHAR ||
 		   fLhs->resultType().colDataType == CalpontSystemCatalog::CHAR ||
            fLhs->resultType().colDataType == CalpontSystemCatalog::BLOB ||
+           fLhs->resultType().colDataType == CalpontSystemCatalog::TEXT ||
 		   fLhs->resultType().colDataType == CalpontSystemCatalog::VARBINARY ||
 		   fLhs->resultType().colDataType == CalpontSystemCatalog::DATE ||
 		   fLhs->resultType().colDataType == CalpontSystemCatalog::DATETIME))

--- a/dbcon/execplan/treenode.h
+++ b/dbcon/execplan/treenode.h
@@ -395,6 +395,7 @@ inline bool TreeNode::getBoolVal()
 		//FIXME: Huh???
 		case CalpontSystemCatalog::VARBINARY:
         case CalpontSystemCatalog::BLOB:
+        case CalpontSystemCatalog::TEXT:
 			if (fResultType.colWidth <= 7)
 				return (atoi((char*)(&fResult.origIntVal)) != 0);
 			return (atoi(fResult.strVal.c_str()) != 0);
@@ -442,6 +443,7 @@ inline const std::string& TreeNode::getStrVal()
 		//FIXME: ???
 		case CalpontSystemCatalog::VARBINARY:
         case CalpontSystemCatalog::BLOB:
+        case CalpontSystemCatalog::TEXT:
 			if (fResultType.colWidth <= 7)
 				fResult.strVal = (char*)(&fResult.origIntVal);
 			break;
@@ -576,6 +578,7 @@ inline int64_t TreeNode::getIntVal()
 		//FIXME: ???
 		case CalpontSystemCatalog::VARBINARY:
         case CalpontSystemCatalog::BLOB:
+        case CalpontSystemCatalog::TEXT:
 			if (fResultType.colWidth <= 7)
 				return fResult.intVal;
 			return atoll(fResult.strVal.c_str());
@@ -660,6 +663,7 @@ inline float TreeNode::getFloatVal()
 		//FIXME: ???
 		case CalpontSystemCatalog::VARBINARY:
         case CalpontSystemCatalog::BLOB:
+        case CalpontSystemCatalog::TEXT:
 			if (fResultType.colWidth <= 7)
 				return atof((char*)(&fResult.origIntVal));
 			return atof(fResult.strVal.c_str());
@@ -708,6 +712,7 @@ inline double TreeNode::getDoubleVal()
 		//FIXME: ???
 		case CalpontSystemCatalog::VARBINARY:
         case CalpontSystemCatalog::BLOB:
+        case CalpontSystemCatalog::TEXT:
 			if (fResultType.colWidth <= 7)
 				return strtod((char*)(&fResult.origIntVal), NULL);
 			return strtod(fResult.strVal.c_str(), NULL);
@@ -749,6 +754,7 @@ inline IDB_Decimal TreeNode::getDecimalVal()
 	{
 		case CalpontSystemCatalog::CHAR:
 		case CalpontSystemCatalog::VARCHAR:
+        case CalpontSystemCatalog::TEXT:
 			throw logging::InvalidConversionExcept("TreeNode::getDecimalVal: non-support conversion from string");
 		case CalpontSystemCatalog::VARBINARY:
         case CalpontSystemCatalog::BLOB:

--- a/dbcon/joblist/crossenginestep.cpp
+++ b/dbcon/joblist/crossenginestep.cpp
@@ -243,7 +243,9 @@ void CrossEngineStep::setField(int i, const char* value, unsigned long length, R
 		else
 			row.setStringField("", i);
 	}
-	else if ((colType == CalpontSystemCatalog::BLOB) || (colType == CalpontSystemCatalog::VARBINARY))
+	else if ((colType == CalpontSystemCatalog::BLOB) ||
+            (colType == CalpontSystemCatalog::TEXT) ||
+            (colType == CalpontSystemCatalog::VARBINARY))
 	{
 		if (value != NULL)
 			row.setVarBinaryField((const uint8_t*)value, length, i);
@@ -369,6 +371,7 @@ int64_t CrossEngineStep::convertValueNum(
 		case CalpontSystemCatalog::VARCHAR:
 		case CalpontSystemCatalog::VARBINARY:
 		case CalpontSystemCatalog::BLOB:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::CLOB:
 			{
 				string i = boost::any_cast<string>(anyVal);

--- a/dbcon/joblist/expressionstep.cpp
+++ b/dbcon/joblist/expressionstep.cpp
@@ -325,8 +325,9 @@ void ExpressionStep::populateColumnInfo(ReturnedColumn* rc, JobInfo& jobInfo)
 {
 	// As of bug3695, make sure varbinary is not used in function expression.
 	if ((rc->resultType().colDataType == CalpontSystemCatalog::VARBINARY ||
-         rc->resultType().colDataType == CalpontSystemCatalog::BLOB) && !fVarBinOK)
-		throw runtime_error("VARBINARY in filter or function is not supported.");
+         rc->resultType().colDataType == CalpontSystemCatalog::BLOB ||
+         rc->resultType().colDataType == CalpontSystemCatalog::TEXT) && !fVarBinOK)
+		throw runtime_error("VARBINARY/BLOB in filter or function is not supported.");
 
 	SimpleColumn* sc = dynamic_cast<SimpleColumn*>(rc);
 	WindowFunctionColumn* wc = NULL;
@@ -346,8 +347,9 @@ void ExpressionStep::populateColumnInfo(SimpleColumn* sc, JobInfo& jobInfo)
 {
 	// As of bug3695, make sure varbinary is not used in function expression.
 	if ((sc->resultType().colDataType == CalpontSystemCatalog::VARBINARY ||
-         sc->resultType().colDataType == CalpontSystemCatalog::BLOB) && !fVarBinOK)
-		throw runtime_error ("VARBINARY in filter or function is not supported.");
+         sc->resultType().colDataType == CalpontSystemCatalog::BLOB ||
+         sc->resultType().colDataType == CalpontSystemCatalog::TEXT) && !fVarBinOK)
+		throw runtime_error ("VARBINARY/BLOB in filter or function is not supported.");
 
 	CalpontSystemCatalog::OID tblOid = joblist::tableOid(sc, jobInfo.csc);
 	string alias = extractTableAlias(sc);
@@ -412,8 +414,9 @@ void ExpressionStep::populateColumnInfo(WindowFunctionColumn* wc, JobInfo& jobIn
 {
 	// As of bug3695, make sure varbinary is not used in function expression.
 	if ((wc->resultType().colDataType == CalpontSystemCatalog::VARBINARY ||
-         wc->resultType().colDataType == CalpontSystemCatalog::BLOB) && !fVarBinOK)
-		throw runtime_error("VARBINARY in filter or function is not supported.");
+         wc->resultType().colDataType == CalpontSystemCatalog::BLOB ||
+         wc->resultType().colDataType == CalpontSystemCatalog::TEXT) && !fVarBinOK)
+		throw runtime_error("VARBINARY/BLOB in filter or function is not supported.");
 
 	// This is for window function in IN/EXISTS sub-query.
 	// In 4.0 implementation, the window function is cloned to where clause in a simple filter.
@@ -438,8 +441,9 @@ void ExpressionStep::populateColumnInfo(AggregateColumn* ac, JobInfo& jobInfo)
 {
 	// As of bug3695, make sure varbinary is not used in function expression.
 	if ((ac->resultType().colDataType == CalpontSystemCatalog::VARBINARY ||
-         ac->resultType().colDataType == CalpontSystemCatalog::BLOB) && !fVarBinOK)
-		throw runtime_error("VARBINARY in filter or function is not supported.");
+         ac->resultType().colDataType == CalpontSystemCatalog::BLOB ||
+         ac->resultType().colDataType == CalpontSystemCatalog::TEXT) && !fVarBinOK)
+		throw runtime_error("VARBINARY/BLOB in filter or function is not supported.");
 
 	// This is for aggregate function in IN/EXISTS sub-query.
 	TupleInfo ti(setExpTupleInfo(ac->resultType(), ac->expressionId(), ac->alias(), jobInfo));

--- a/dbcon/joblist/jlf_common.cpp
+++ b/dbcon/joblist/jlf_common.cpp
@@ -336,6 +336,7 @@ bool isCharCol(const CalpontSystemCatalog::ColType& colType)
 	case CalpontSystemCatalog::VARCHAR:
 	case CalpontSystemCatalog::CHAR:
 	case CalpontSystemCatalog::BLOB:
+	case CalpontSystemCatalog::TEXT:
 	case CalpontSystemCatalog::CLOB:
 		return true;
 		break;

--- a/dbcon/joblist/jlf_execplantojoblist.cpp
+++ b/dbcon/joblist/jlf_execplantojoblist.cpp
@@ -197,6 +197,7 @@ int64_t valueNullNum(const CalpontSystemCatalog::ColType& ct)
 	case CalpontSystemCatalog::VARCHAR:
 	case CalpontSystemCatalog::VARBINARY:
 	case CalpontSystemCatalog::BLOB:
+	case CalpontSystemCatalog::TEXT:
 	case CalpontSystemCatalog::CLOB:
 	case CalpontSystemCatalog::CHAR:
 
@@ -348,6 +349,7 @@ int64_t convertValueNum(const string& str, const CalpontSystemCatalog::ColType& 
 	case CalpontSystemCatalog::VARCHAR:
 	case CalpontSystemCatalog::VARBINARY:
 	case CalpontSystemCatalog::BLOB:
+	case CalpontSystemCatalog::TEXT:
 	case CalpontSystemCatalog::CLOB:
 		{
 			string i = boost::any_cast<string>(anyVal);

--- a/dbcon/joblist/pcolscan.cpp
+++ b/dbcon/joblist/pcolscan.cpp
@@ -172,7 +172,8 @@ pColScanStep::pColScanStep(
 
 	//If this is a dictionary column, fudge the numbers...
 	if ((fColType.colDataType == CalpontSystemCatalog::VARBINARY)
-        || (fColType.colDataType == CalpontSystemCatalog::BLOB))
+        || (fColType.colDataType == CalpontSystemCatalog::BLOB)
+        || (fColType.colDataType == CalpontSystemCatalog::TEXT))
 	{
 		fColType.colWidth = 8;
 		fIsDict = true;

--- a/dbcon/joblist/pcolstep.cpp
+++ b/dbcon/joblist/pcolstep.cpp
@@ -170,7 +170,8 @@ pColStep::pColStep(
 
 	//If this is a dictionary column, fudge the numbers...
 	if ((fColType.colDataType == CalpontSystemCatalog::VARBINARY)
-        || (fColType.colDataType == CalpontSystemCatalog::BLOB))
+        || (fColType.colDataType == CalpontSystemCatalog::BLOB)
+        || (fColType.colDataType == CalpontSystemCatalog::TEXT))
 	{
 		fColType.colWidth = 8;
 		fIsDict = true;

--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -137,6 +137,7 @@ inline string colTypeIdString(CalpontSystemCatalog::ColDataType type)
 		case CalpontSystemCatalog::VARCHAR:   return string("VARCHAR");
 		case CalpontSystemCatalog::CLOB:      return string("CLOB");
 		case CalpontSystemCatalog::BLOB:      return string("BLOB");
+		case CalpontSystemCatalog::TEXT:      return string("TEXT");
 		case CalpontSystemCatalog::UTINYINT:  return string("UTINYINT");
 		case CalpontSystemCatalog::USMALLINT: return string("USMALLINT");
 		case CalpontSystemCatalog::UDECIMAL:  return string("UDECIMAL");

--- a/dbcon/mysql/dumpcat_mysql.sql
+++ b/dbcon/mysql/dumpcat_mysql.sql
@@ -18,6 +18,7 @@ select
 	              when 12 then 'VARCHAR'
 	              when 13 then 'CLOB'
 	              when 14 then 'BLOB'
+	              when 15 then 'TEXT'
 	              end DATATYPE, 
 	SCALE, PREC, COLUMNLENGTH COLLEN, COLUMNPOSITION POS, COMPRESSIONTYPE CT
 from

--- a/dbcon/mysql/ha_calpont_ddl.cpp
+++ b/dbcon/mysql/ha_calpont_ddl.cpp
@@ -182,6 +182,10 @@ uint32_t convertDataType(int dataType)
 			calpontDataType = CalpontSystemCatalog::BLOB;
 			break;
 
+		case ddlpackage::DDL_TEXT:
+			calpontDataType = CalpontSystemCatalog::TEXT;
+			break;
+
 		case ddlpackage::DDL_UNSIGNED_TINYINT:
 			calpontDataType = CalpontSystemCatalog::UTINYINT;
 			break;

--- a/dbcon/mysql/ha_calpont_dml.cpp
+++ b/dbcon/mysql/ha_calpont_dml.cpp
@@ -1586,6 +1586,7 @@ int ha_calpont_impl_write_batch_row_(uchar *buf, TABLE* table, cal_impl_if::cal_
 				break;
 			}
             case CalpontSystemCatalog::BLOB:
+            case CalpontSystemCatalog::TEXT:
 			{
                 int dataLength = 0;
                 uintptr_t *dataptr;
@@ -1621,7 +1622,15 @@ int ha_calpont_impl_write_batch_row_(uchar *buf, TABLE* table, cal_impl_if::cal_
                 buf+= sizeof(uintptr_t);
                 for (int32_t i=0; i<dataLength; i++)
                 {
-                    fprintf(ci.filePtr, "%02x", *(uint8_t*)ucharptr); 
+                    if (ci.columnTypes[colpos].colDataType == CalpontSystemCatalog::BLOB)
+                    {
+                        fprintf(ci.filePtr, "%02x", *(uint8_t*)ucharptr); 
+                    }
+                    else
+                    {
+                        // TEXT Column
+                        fprintf(ci.filePtr, "%c%.*s%c%c", ci.enclosed_by, dataLength, ucharptr, ci.enclosed_by, ci.delimiter); 
+                    }
                     ucharptr++;
                 }
                 fprintf(ci.filePtr, "%c", ci.delimiter);

--- a/dbcon/mysql/ha_calpont_impl.cpp
+++ b/dbcon/mysql/ha_calpont_impl.cpp
@@ -624,6 +624,7 @@ int fetchNextRow(uchar *buf, cal_table_info& ti, cal_connection_info* ci)
 					break;
 				}
 				case CalpontSystemCatalog::BLOB:
+				case CalpontSystemCatalog::TEXT:
 				{
 					Field_blob *f2 = (Field_blob*)*f;
 					f2->set_ptr(row.getVarBinaryLength(s), (unsigned char*)row.getVarBinaryField(s));

--- a/dbcon/mysql/ha_calpont_partition.cpp
+++ b/dbcon/mysql/ha_calpont_partition.cpp
@@ -141,6 +141,8 @@ string name(CalpontSystemCatalog::ColType& ct)
 			return "VARBINARY";
 		case CalpontSystemCatalog::BLOB:
 			return "BLOB";
+		case CalpontSystemCatalog::TEXT:
+			return "TEXT";
 		case CalpontSystemCatalog::CLOB:
 			return "CLOB";
 		case CalpontSystemCatalog::UINT:
@@ -318,6 +320,7 @@ const int64_t IDB_format(char* str, CalpontSystemCatalog::ColType& ct, uint8_t& 
 	case CalpontSystemCatalog::VARCHAR:
 	case CalpontSystemCatalog::VARBINARY:
 	case CalpontSystemCatalog::BLOB:
+	case CalpontSystemCatalog::TEXT:
 	case CalpontSystemCatalog::CLOB:
 		{
 			string i = boost::any_cast<string>(anyVal);

--- a/dbcon/mysql/ha_window_function.cpp
+++ b/dbcon/mysql/ha_window_function.cpp
@@ -267,6 +267,7 @@ ReturnedColumn* buildWindowFunctionColumn(Item* item, gp_walk_info& gwi, bool& n
 							case CalpontSystemCatalog::VARCHAR:
 							case CalpontSystemCatalog::VARBINARY:
 							case CalpontSystemCatalog::BLOB:
+							case CalpontSystemCatalog::TEXT:
 							case CalpontSystemCatalog::CLOB:
 								boundTypeErr = true;
 								break;
@@ -309,6 +310,7 @@ ReturnedColumn* buildWindowFunctionColumn(Item* item, gp_walk_info& gwi, bool& n
 							case CalpontSystemCatalog::VARCHAR:
 							case CalpontSystemCatalog::VARBINARY:
 							case CalpontSystemCatalog::BLOB:
+							case CalpontSystemCatalog::TEXT:
 							case CalpontSystemCatalog::CLOB:
 								boundTypeErr = true;
 								break;
@@ -358,6 +360,7 @@ ReturnedColumn* buildWindowFunctionColumn(Item* item, gp_walk_info& gwi, bool& n
 							case CalpontSystemCatalog::VARCHAR:
 							case CalpontSystemCatalog::VARBINARY:
 							case CalpontSystemCatalog::BLOB:
+                            case CalpontSystemCatalog::TEXT:
 							case CalpontSystemCatalog::CLOB:
 								orderTypeErr = true;
 								break;

--- a/primitives/linux-port/column.cpp
+++ b/primitives/linux-port/column.cpp
@@ -250,6 +250,7 @@ inline bool isEmptyVal<8>(uint8_t type, const uint8_t* ival)
 	case CalpontSystemCatalog::DATETIME:
 	case CalpontSystemCatalog::VARBINARY:
     case CalpontSystemCatalog::BLOB:
+    case CalpontSystemCatalog::TEXT:
 		return (*val == joblist::CHAR8EMPTYROW);
 	case CalpontSystemCatalog::UBIGINT:
 		return (joblist::UBIGINTEMPTYROW == *val);
@@ -273,6 +274,7 @@ inline bool isEmptyVal<4>(uint8_t type, const uint8_t* ival)
 	case CalpontSystemCatalog::CHAR:
 	case CalpontSystemCatalog::VARCHAR:
     case CalpontSystemCatalog::BLOB:
+    case CalpontSystemCatalog::TEXT:
 	case CalpontSystemCatalog::DATE:
 	case CalpontSystemCatalog::DATETIME:
 		return (joblist::CHAR4EMPTYROW == *val);
@@ -295,6 +297,7 @@ inline bool isEmptyVal<2>(uint8_t type, const uint8_t* ival)
 	case CalpontSystemCatalog::CHAR:
 	case CalpontSystemCatalog::VARCHAR:
     case CalpontSystemCatalog::BLOB:
+    case CalpontSystemCatalog::TEXT:
 	case CalpontSystemCatalog::DATE:
 	case CalpontSystemCatalog::DATETIME:
 		return (joblist::CHAR2EMPTYROW == *val);
@@ -317,6 +320,7 @@ inline bool isEmptyVal<1>(uint8_t type, const uint8_t* ival)
 	case CalpontSystemCatalog::CHAR:
 	case CalpontSystemCatalog::VARCHAR:
     case CalpontSystemCatalog::BLOB:
+    case CalpontSystemCatalog::TEXT:
 	case CalpontSystemCatalog::DATE:
 	case CalpontSystemCatalog::DATETIME:
 		return (*val == joblist::CHAR1EMPTYROW);
@@ -348,6 +352,7 @@ inline bool isNullVal<8>(uint8_t type, const uint8_t* ival)
 	case CalpontSystemCatalog::DATETIME:
 	case CalpontSystemCatalog::VARBINARY:
     case CalpontSystemCatalog::BLOB:
+    case CalpontSystemCatalog::TEXT:
 		//@bug 339 might be a token here
 		//TODO: what's up with the second const here?
 		return (*val == joblist::CHAR8NULL || 0xFFFFFFFFFFFFFFFELL == *val);
@@ -373,6 +378,7 @@ inline bool isNullVal<4>(uint8_t type, const uint8_t* ival)
 	case CalpontSystemCatalog::CHAR:
 	case CalpontSystemCatalog::VARCHAR:
     case CalpontSystemCatalog::BLOB:
+    case CalpontSystemCatalog::TEXT:
 		return (joblist::CHAR4NULL == *val);
 	case CalpontSystemCatalog::DATE:
 	case CalpontSystemCatalog::DATETIME:
@@ -396,6 +402,7 @@ inline bool isNullVal<2>(uint8_t type, const uint8_t* ival)
 	case CalpontSystemCatalog::CHAR:
 	case CalpontSystemCatalog::VARCHAR:
     case CalpontSystemCatalog::BLOB:
+    case CalpontSystemCatalog::TEXT:
 	case CalpontSystemCatalog::DATE:
 	case CalpontSystemCatalog::DATETIME:
 		return (joblist::CHAR2NULL == *val);
@@ -418,6 +425,7 @@ inline bool isNullVal<1>(uint8_t type, const uint8_t* ival)
 	case CalpontSystemCatalog::CHAR:
 	case CalpontSystemCatalog::VARCHAR:
     case CalpontSystemCatalog::BLOB:
+    case CalpontSystemCatalog::TEXT:
 	case CalpontSystemCatalog::DATE:
 	case CalpontSystemCatalog::DATETIME:
 		return (*val == joblist::CHAR1NULL);
@@ -460,6 +468,7 @@ inline bool isMinMaxValid(const NewColRequestHeader *in) {
 			return (in->DataSize<9);
 		case CalpontSystemCatalog::VARCHAR:
         case CalpontSystemCatalog::BLOB:
+        case CalpontSystemCatalog::TEXT:
 			return (in->DataSize<8);
 		case CalpontSystemCatalog::TINYINT:
 		case CalpontSystemCatalog::SMALLINT:
@@ -514,7 +523,8 @@ inline bool colCompare(int64_t val1, int64_t val2, uint8_t COP, uint8_t rf, int 
 		return colCompare_(dVal1, dVal2, COP);
 	}
 
-	else if ( (type == CalpontSystemCatalog::CHAR || type == CalpontSystemCatalog::VARCHAR || type == CalpontSystemCatalog::BLOB) && !isNull )
+	else if ( (type == CalpontSystemCatalog::CHAR || type == CalpontSystemCatalog::VARCHAR ||
+            type == CalpontSystemCatalog::BLOB || type == CalpontSystemCatalog::TEXT) && !isNull )
 	{
 		if (!regex.used && !rf)
 			return colCompare_(order_swap(val1), order_swap(val2), COP);
@@ -1189,7 +1199,8 @@ inline void p_Col_ridArray(NewColRequestHeader *in,
 		if (out->ValidMinMax && !isNull && !isEmpty)
 		{
 
-			if ((in->DataType == CalpontSystemCatalog::CHAR || in->DataType == CalpontSystemCatalog::VARCHAR || in->DataType == CalpontSystemCatalog::BLOB ) && 1 < W)
+			if ((in->DataType == CalpontSystemCatalog::CHAR || in->DataType == CalpontSystemCatalog::VARCHAR ||
+                in->DataType == CalpontSystemCatalog::BLOB || in->DataType == CalpontSystemCatalog::TEXT ) && 1 < W)
 			{
 				if (colCompare(out->Min, val, COMPARE_GT, false, in->DataType, W, placeholderRegex))
 					out->Min = val;

--- a/primitives/primproc/columncommand.cpp
+++ b/primitives/primproc/columncommand.cpp
@@ -867,6 +867,7 @@ const uint64_t ColumnCommand::getEmptyRowValue( const execplan::CalpontSystemCat
 	case execplan::CalpontSystemCatalog::DATETIME :
 	case execplan::CalpontSystemCatalog::VARBINARY :
     case execplan::CalpontSystemCatalog::BLOB :
+    case execplan::CalpontSystemCatalog::TEXT :
 	default:
 		emptyVal = joblist::CHAR1EMPTYROW;
 		if ( width == (2 + offset) )

--- a/primitives/primproc/dictstep.cpp
+++ b/primitives/primproc/dictstep.cpp
@@ -510,7 +510,8 @@ void DictStep::_projectToRG(RowGroup &rg, uint32_t col)
 		// bug 4901 - move this inside the loop and call incrementally
 		// to save the unnecessary string copy
 		if ((rg.getColTypes()[col] != execplan::CalpontSystemCatalog::VARBINARY) &&
-            (rg.getColTypes()[col] != execplan::CalpontSystemCatalog::BLOB)) {
+            (rg.getColTypes()[col] != execplan::CalpontSystemCatalog::BLOB) &&
+            (rg.getColTypes()[col] != execplan::CalpontSystemCatalog::TEXT)) {
 			for (i = curResultCounter; i < tmpResultCounter; i++) {
 				rg.getRow(newRidList[i].pos, &r);
 				//cout << "serializing " << tmpStrings[i] << endl;

--- a/primitives/primproc/filtercommand.cpp
+++ b/primitives/primproc/filtercommand.cpp
@@ -95,7 +95,8 @@ Command* FilterCommand::makeFilterCommand(ByteStream& bs, vector<SCommand>& cmds
 		// due to endian issue
 		if (cmd0->getColType().colDataType == execplan::CalpontSystemCatalog::CHAR ||
 			cmd0->getColType().colDataType == execplan::CalpontSystemCatalog::VARCHAR ||
-            cmd0->getColType().colDataType == execplan::CalpontSystemCatalog::BLOB)
+            cmd0->getColType().colDataType == execplan::CalpontSystemCatalog::BLOB ||
+            cmd0->getColType().colDataType == execplan::CalpontSystemCatalog::TEXT)
 		{
 			StrFilterCmd* sc = new StrFilterCmd();
 			sc->setCompareFunc(CC);

--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -1122,6 +1122,7 @@ boost::any
 			break;
 
 			case CalpontSystemCatalog::BLOB:
+            case CalpontSystemCatalog::TEXT:
 			case CalpontSystemCatalog::CLOB:
 				value = data;
 			break;

--- a/utils/funcexp/func_hex.cpp
+++ b/utils/funcexp/func_hex.cpp
@@ -97,6 +97,7 @@ string Func_hex::getStrVal(rowgroup::Row& row,
 		}
 		case CalpontSystemCatalog::VARBINARY:
         case CalpontSystemCatalog::BLOB:
+        case CalpontSystemCatalog::TEXT:
 		{
 			const string& arg = parm[0]->data()->getStrVal(row, isNull);
 			uint64_t hexLen = arg.size() * 2;

--- a/utils/funcexp/func_length.cpp
+++ b/utils/funcexp/func_length.cpp
@@ -49,7 +49,8 @@ int64_t Func_length::getIntVal(rowgroup::Row& row,
 							CalpontSystemCatalog::ColType&)
 {
 	if ((fp[0]->data()->resultType().colDataType == CalpontSystemCatalog::VARBINARY) ||
-        (fp[0]->data()->resultType().colDataType == CalpontSystemCatalog::BLOB))
+        (fp[0]->data()->resultType().colDataType == CalpontSystemCatalog::BLOB) ||
+        (fp[0]->data()->resultType().colDataType == CalpontSystemCatalog::TEXT))
 		return fp[0]->data()->getStrVal(row, isNull).length();
 
 	return strlen(fp[0]->data()->getStrVal(row, isNull).c_str());

--- a/utils/funcexp/funcexp.cpp
+++ b/utils/funcexp/funcexp.cpp
@@ -268,6 +268,7 @@ void FuncExp::evaluate(rowgroup::Row& row, std::vector<execplan::SRCP>& expressi
 			case CalpontSystemCatalog::VARCHAR:
             // TODO: might not be right thing for BLOB
             case CalpontSystemCatalog::BLOB:
+            case CalpontSystemCatalog::TEXT:
 			{			
 				const std::string& val = expression[i]->getStrVal(row, isNull);
 				if (isNull)

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -359,6 +359,7 @@ string Row::toString() const
 					break;
 				case CalpontSystemCatalog::VARBINARY:
 				case CalpontSystemCatalog::BLOB:
+				case CalpontSystemCatalog::TEXT:
 				{
 					uint32_t len = getVarBinaryLength(i);
 					const uint8_t* val = getVarBinaryField(i);
@@ -409,6 +410,7 @@ string Row::toCSV() const
 					break;
 				case CalpontSystemCatalog::VARBINARY:
 				case CalpontSystemCatalog::BLOB:
+				case CalpontSystemCatalog::TEXT:
 				{
 					uint32_t len = getVarBinaryLength(i);
 					const uint8_t* val = getVarBinaryField(i);
@@ -512,8 +514,8 @@ void Row::initToNull()
 				memset(&data[offsets[i]], 0xFF, getColumnWidth(i));
 				break;
 			}
-			case CalpontSystemCatalog::BLOB: {
-				// TODO: no NULL value for long double yet, this is a nan.
+			case CalpontSystemCatalog::BLOB:
+            case CalpontSystemCatalog::TEXT: {
 				memset(&data[offsets[i]], 0xFF, getColumnWidth(i));
 				break;
 			}
@@ -589,6 +591,7 @@ bool Row::isNullValue(uint32_t colIndex) const
 			break;
 		}
 		case CalpontSystemCatalog::BLOB:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARBINARY: {
 			uint32_t pos = offsets[colIndex];
 			if (inStringTable(colIndex)) {
@@ -1081,7 +1084,9 @@ void applyMapping(const int *mapping, const Row &in, Row *out)
 	for (i = 0; i < in.getColumnCount(); i++)
 		if (mapping[i] != -1)
 		{
-            if (UNLIKELY(in.getColTypes()[i] == execplan::CalpontSystemCatalog::VARBINARY || in.getColTypes()[i] == execplan::CalpontSystemCatalog::BLOB))
+            if (UNLIKELY(in.getColTypes()[i] == execplan::CalpontSystemCatalog::VARBINARY ||
+                in.getColTypes()[i] == execplan::CalpontSystemCatalog::BLOB ||
+                in.getColTypes()[i] == execplan::CalpontSystemCatalog::TEXT))
 				out->setVarBinaryField(in.getVarBinaryField(i), in.getVarBinaryLength(i), mapping[i]);
             else if (UNLIKELY(in.isLongString(i)))
 				out->setStringField(in.getStringPointer(i), in.getStringLength(i), mapping[i]);

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -792,7 +792,8 @@ inline void Row::copyField(uint32_t destIndex, uint32_t srcIndex) const
 inline void Row::copyField(Row &out, uint32_t destIndex, uint32_t srcIndex) const
 {
 	if (UNLIKELY(types[srcIndex] == execplan::CalpontSystemCatalog::VARBINARY ||
-                 types[srcIndex] == execplan::CalpontSystemCatalog::BLOB))
+                 types[srcIndex] == execplan::CalpontSystemCatalog::BLOB ||
+                 types[srcIndex] == execplan::CalpontSystemCatalog::TEXT))
 		out.setVarBinaryField(getVarBinaryStringField(srcIndex), destIndex);
 	else if (UNLIKELY(isLongString(srcIndex)))
 		out.setStringField(getStringPointer(srcIndex), getStringLength(srcIndex), destIndex);
@@ -1264,7 +1265,8 @@ inline bool RowGroup::isLongString(uint32_t colIndex) const
 	return ((getColumnWidth(colIndex) > 7 && types[colIndex] == execplan::CalpontSystemCatalog::VARCHAR) ||
 		(getColumnWidth(colIndex) > 8 && types[colIndex] == execplan::CalpontSystemCatalog::CHAR) ||
 		types[colIndex] == execplan::CalpontSystemCatalog::VARBINARY ||
-        types[colIndex] == execplan::CalpontSystemCatalog::BLOB);
+        types[colIndex] == execplan::CalpontSystemCatalog::BLOB ||
+        types[colIndex] == execplan::CalpontSystemCatalog::TEXT);
 }
 
 inline bool RowGroup::usesStringTable() const
@@ -1417,7 +1419,9 @@ inline void copyRow(const Row &in, Row *out, uint32_t colCount)
 	}
 
 	for (uint32_t i = 0; i < colCount; i++) {
-		if (UNLIKELY(in.getColTypes()[i] == execplan::CalpontSystemCatalog::VARBINARY || in.getColTypes()[i] == execplan::CalpontSystemCatalog::BLOB))
+		if (UNLIKELY(in.getColTypes()[i] == execplan::CalpontSystemCatalog::VARBINARY ||
+            in.getColTypes()[i] == execplan::CalpontSystemCatalog::BLOB ||
+            in.getColTypes()[i] == execplan::CalpontSystemCatalog::TEXT))
 			out->setVarBinaryField(in.getVarBinaryStringField(i), i);
 		else if (UNLIKELY(in.isLongString(i)))
 			//out->setStringField(in.getStringField(i), i);

--- a/utils/windowfunction/windowfunctiontype.cpp
+++ b/utils/windowfunction/windowfunctiontype.cpp
@@ -89,6 +89,7 @@ map<int, string> colType2String = assign::map_list_of
 	(CalpontSystemCatalog::UDOUBLE, "UNSIGNED DOUBLE")
 	(CalpontSystemCatalog::LONGDOUBLE, "INTERNAL LONG DOUBLE")
 	(CalpontSystemCatalog::STRINT, "INTERNAL SHORT STRING")
+	(CalpontSystemCatalog::TEXT, "TEXT")
 ;
 
 

--- a/writeengine/server/we_ddlcommandproc.cpp
+++ b/writeengine/server/we_ddlcommandproc.cpp
@@ -451,7 +451,8 @@ uint8_t WE_DDLCommandProc::writeCreateSyscolumn(ByteStream& bs, std::string &err
 			if ( (dataType == CalpontSystemCatalog::CHAR && colDefPtr->fType->fLength > 8) ||
 				 (dataType == CalpontSystemCatalog::VARCHAR && colDefPtr->fType->fLength > 7) ||
 				 (dataType == CalpontSystemCatalog::VARBINARY && colDefPtr->fType->fLength > 7) ||
-                 (dataType == CalpontSystemCatalog::BLOB && colDefPtr->fType->fLength > 7) )
+                 (dataType == CalpontSystemCatalog::BLOB && colDefPtr->fType->fLength > 7) ||
+                 (dataType == CalpontSystemCatalog::TEXT && colDefPtr->fType->fLength > 7) )
 			{
 				hasDict = true;
 				dictOID.compressionType = colDefPtr->fType->fCompressiontype;
@@ -461,7 +462,8 @@ uint8_t WE_DDLCommandProc::writeCreateSyscolumn(ByteStream& bs, std::string &err
 
 				//@Bug 2534. Take away the limit of 255 and set the limit to 8000.
 				if ((colDefPtr->fType->fLength > 8000) &&
-                    (dataType != CalpontSystemCatalog::BLOB))
+                    (dataType != CalpontSystemCatalog::BLOB) &&
+                    (dataType != CalpontSystemCatalog::TEXT))
 				{
 					ostringstream os;
 					os << "char, varchar and varbinary length may not exceed 8000";
@@ -469,7 +471,8 @@ uint8_t WE_DDLCommandProc::writeCreateSyscolumn(ByteStream& bs, std::string &err
 				}
 			}
 			else if ((dataType == CalpontSystemCatalog::VARBINARY
-                    || dataType == CalpontSystemCatalog::BLOB)
+                    || dataType == CalpontSystemCatalog::BLOB
+                    || dataType == CalpontSystemCatalog::TEXT)
                     && colDefPtr->fType->fLength <= 7)
 			{
 				ostringstream os;
@@ -519,7 +522,8 @@ uint8_t WE_DDLCommandProc::writeCreateSyscolumn(ByteStream& bs, std::string &err
 					if (dataType == CalpontSystemCatalog::CHAR ||
 						dataType == CalpontSystemCatalog::VARCHAR ||
 						dataType == CalpontSystemCatalog::VARBINARY ||
-                        dataType == CalpontSystemCatalog::BLOB)
+                        dataType == CalpontSystemCatalog::BLOB ||
+                        dataType == CalpontSystemCatalog::TEXT)
 					{
 						if (colDefPtr->fType->fLength <= 0)
 						{
@@ -835,7 +839,8 @@ uint8_t WE_DDLCommandProc::writeSyscolumn(ByteStream& bs, std::string & err)
 
 			//@Bug 2534. Take away the limit of 255 and set the limit to 8000.
 			if ((colDefPtr->fType->fLength > 8000) &&
-                (dataType != CalpontSystemCatalog::BLOB))
+                (dataType != CalpontSystemCatalog::BLOB) &&
+                (dataType != CalpontSystemCatalog::TEXT))
 			{
 				ostringstream os;
 				os << "char, varchar and varbinary length may not exceed 8000";
@@ -843,7 +848,8 @@ uint8_t WE_DDLCommandProc::writeSyscolumn(ByteStream& bs, std::string & err)
 			}
 		}
 		else if ((dataType == CalpontSystemCatalog::VARBINARY
-                || dataType == CalpontSystemCatalog::BLOB)
+                || dataType == CalpontSystemCatalog::BLOB
+                || dataType == CalpontSystemCatalog::TEXT)
                 && colDefPtr->fType->fLength <= 7)
 		{
 			ostringstream os;
@@ -894,7 +900,8 @@ uint8_t WE_DDLCommandProc::writeSyscolumn(ByteStream& bs, std::string & err)
 					if (dataType == CalpontSystemCatalog::CHAR ||
 						dataType == CalpontSystemCatalog::VARCHAR ||
 						dataType == CalpontSystemCatalog::VARBINARY ||
-                        dataType == CalpontSystemCatalog::BLOB)
+                        dataType == CalpontSystemCatalog::BLOB ||
+                        dataType == CalpontSystemCatalog::TEXT)
 					{
 						if (colDefPtr->fType->fLength <= 0)
 						{
@@ -2253,6 +2260,8 @@ uint8_t WE_DDLCommandProc::updateSyscolumnTablename(ByteStream& bs, std::string 
 				&& column.colType.colWidth > 7)
 			|| (column.colType.colDataType == CalpontSystemCatalog::BLOB
 				&& column.colType.colWidth > 7)
+			|| (column.colType.colDataType == CalpontSystemCatalog::TEXT
+				&& column.colType.colWidth > 7)
 			|| (column.colType.colDataType == CalpontSystemCatalog::DECIMAL
 				&& column.colType.precision > 18)
 			|| (column.colType.colDataType == CalpontSystemCatalog::UDECIMAL
@@ -3010,6 +3019,8 @@ uint8_t WE_DDLCommandProc::updateSystablesTablename(ByteStream& bs, std::string 
 			|| (column.colType.colDataType == CalpontSystemCatalog::VARBINARY
 				&& column.colType.colWidth > 7)
 			|| (column.colType.colDataType == CalpontSystemCatalog::BLOB
+				&& column.colType.colWidth > 7)
+			|| (column.colType.colDataType == CalpontSystemCatalog::TEXT
 				&& column.colType.colWidth > 7)
 			|| (column.colType.colDataType == CalpontSystemCatalog::DECIMAL
 				&& column.colType.precision > 18)
@@ -3893,6 +3904,8 @@ uint8_t WE_DDLCommandProc::updateSyscolumnSetDefault(messageqcpp::ByteStream& bs
 			&& column.colType.colWidth > 7)
 		|| (column.colType.colDataType == CalpontSystemCatalog::BLOB
 			&& column.colType.colWidth > 7)
+		|| (column.colType.colDataType == CalpontSystemCatalog::TEXT
+			&& column.colType.colWidth > 7)
 		|| (column.colType.colDataType == CalpontSystemCatalog::DECIMAL
 			&& column.colType.precision > 18)
 		|| (column.colType.colDataType == CalpontSystemCatalog::UDECIMAL
@@ -4163,6 +4176,8 @@ uint8_t WE_DDLCommandProc::updateSyscolumnRenameColumn(messageqcpp::ByteStream& 
 			&& column1.colType.colWidth > 7)
 		|| (column1.colType.colDataType == CalpontSystemCatalog::BLOB
 			&& column1.colType.colWidth > 7)
+		|| (column1.colType.colDataType == CalpontSystemCatalog::TEXT
+			&& column1.colType.colWidth > 7)
 		|| (column1.colType.colDataType == CalpontSystemCatalog::DECIMAL
 			&& column1.colType.precision > 18)
 		|| (column1.colType.colDataType == CalpontSystemCatalog::UDECIMAL
@@ -4354,6 +4369,8 @@ uint8_t WE_DDLCommandProc::updateSyscolumnRenameColumn(messageqcpp::ByteStream& 
 		|| (column5.colType.colDataType == CalpontSystemCatalog::VARBINARY
 			&& column5.colType.colWidth > 7)
 		|| (column5.colType.colDataType == CalpontSystemCatalog::BLOB
+			&& column5.colType.colWidth > 7)
+		|| (column5.colType.colDataType == CalpontSystemCatalog::TEXT
 			&& column5.colType.colWidth > 7)
 		|| (column5.colType.colDataType == CalpontSystemCatalog::DECIMAL
 			&& column5.colType.precision > 18)

--- a/writeengine/server/we_ddlcommon.h
+++ b/writeengine/server/we_ddlcommon.h
@@ -317,6 +317,7 @@ inline boost::any getNullValueForType(const execplan::CalpontSystemCatalog::ColT
 			}
 			break;
         case execplan::CalpontSystemCatalog::BLOB:
+        case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::VARBINARY:
 			{
 				std::string charnull;
@@ -423,6 +424,10 @@ inline int convertDataType(int dataType)
 
 		case ddlpackage::DDL_BLOB:
 			calpontDataType = CalpontSystemCatalog::BLOB;
+			break;
+
+		case ddlpackage::DDL_TEXT:
+			calpontDataType = CalpontSystemCatalog::TEXT;
 			break;
 
         case ddlpackage::DDL_UNSIGNED_TINYINT:

--- a/writeengine/server/we_dmlcommandproc.cpp
+++ b/writeengine/server/we_dmlcommandproc.cpp
@@ -2072,6 +2072,7 @@ uint8_t WE_DMLCommandProc::processUpdate(messageqcpp::ByteStream& bs,
 							}
 							case CalpontSystemCatalog::VARBINARY:
 							case CalpontSystemCatalog::BLOB:
+                            case CalpontSystemCatalog::TEXT:
 							{
 								value = row.getVarBinaryStringField(fetchColPos);
 								break;
@@ -2358,6 +2359,7 @@ uint8_t WE_DMLCommandProc::processUpdate(messageqcpp::ByteStream& bs,
 								}
 								case CalpontSystemCatalog::VARBINARY:
 								case CalpontSystemCatalog::BLOB:
+                                case CalpontSystemCatalog::TEXT:
 								{
 									value = row.getVarBinaryStringField(fetchColPos);
 									break;

--- a/writeengine/server/we_dmlcommandproc.h
+++ b/writeengine/server/we_dmlcommandproc.h
@@ -111,7 +111,8 @@ class WE_DMLCommandProc
 				|| ((colType.colDataType == execplan::CalpontSystemCatalog::DECIMAL) && (colType.precision > 18))
 				|| ((colType.colDataType == execplan::CalpontSystemCatalog::UDECIMAL) && (colType.precision > 18))
 				|| (colType.colDataType == execplan::CalpontSystemCatalog::VARBINARY)
-                || (colType.colDataType == execplan::CalpontSystemCatalog::BLOB))
+                || (colType.colDataType == execplan::CalpontSystemCatalog::BLOB)
+                || (colType.colDataType == execplan::CalpontSystemCatalog::TEXT))
 			{
 				return true;
 			}

--- a/writeengine/shared/we_convertor.cpp
+++ b/writeengine/shared/we_convertor.cpp
@@ -414,6 +414,10 @@ void Convertor::convertColType(CalpontSystemCatalog::ColDataType dataType,
         case CalpontSystemCatalog::BLOB :
             internalType = WriteEngine::WR_BLOB; break;
 
+        // Map TEXT to WR_TEXT
+        case CalpontSystemCatalog::TEXT :
+            internalType = WriteEngine::WR_TEXT; break;
+
         // Map VARBINARY to WR_VARBINARY
         case CalpontSystemCatalog::VARBINARY:
             internalType = WriteEngine::WR_VARBINARY; break;
@@ -496,6 +500,10 @@ void Convertor::convertWEColType(ColType internalType,
         // Map BLOB to WR_BLOB
         case WriteEngine::WR_BLOB :
             dataType = CalpontSystemCatalog::BLOB; break;
+
+        // Map TEXT to WR_TEXT
+        case WriteEngine::WR_TEXT :
+            dataType = CalpontSystemCatalog::TEXT; break;
 
         // Map VARBINARY to WR_VARBINARY
         case WriteEngine::WR_VARBINARY:
@@ -597,6 +605,10 @@ void Convertor::convertColType(ColStruct* curStruct)
         // Map BLOB to WR_BLOB
         case CalpontSystemCatalog::BLOB :
             *internalType = WriteEngine::WR_BLOB; break;
+
+        // Map TEXT to WR_TEXT
+        case CalpontSystemCatalog::TEXT :
+            *internalType = WriteEngine::WR_TEXT; break;
 
         // Map VARBINARY to WR_VARBINARY
         case CalpontSystemCatalog::VARBINARY:

--- a/writeengine/shared/we_type.h
+++ b/writeengine/shared/we_type.h
@@ -104,6 +104,7 @@ namespace WriteEngine
         WR_USHORT           = 14,           /** @brief Unsigned Short */
         WR_UINT             = 15,           /** @brief Unsigned Int */
         WR_ULONGLONG        = 16,           /** @brief Unsigned Long long*/
+        WR_TEXT             = 17            /** @brief TEXT */
     };
 
     // Describes relation of field to column for a bulk load

--- a/writeengine/wrapper/we_colop.cpp
+++ b/writeengine/wrapper/we_colop.cpp
@@ -1455,6 +1455,7 @@ int ColumnOp::addExtent(
                 break;
             case WriteEngine::WR_VARBINARY :   // treat same as char for now
             case WriteEngine::WR_BLOB :
+            case WriteEngine::WR_TEXT :
             case WriteEngine::WR_CHAR :   
                 if (!bDelete)
                 {
@@ -1590,6 +1591,7 @@ int ColumnOp::addExtent(
                 break;
             case WriteEngine::WR_VARBINARY :   // treat same as char for now
             case WriteEngine::WR_BLOB :
+            case WriteEngine::WR_TEXT :
             case WriteEngine::WR_CHAR :   
                 if (!bDelete)
                 {
@@ -1720,6 +1722,7 @@ int ColumnOp::addExtent(
                 break;
             case WriteEngine::WR_VARBINARY :   // treat same as char for now
             case WriteEngine::WR_BLOB :
+            case WriteEngine::WR_TEXT :
             case WriteEngine::WR_CHAR :   
                 {
                     memcpy(charTmpBuf, (char*)valArray+i*8, 8);

--- a/writeengine/wrapper/writeengine.cpp
+++ b/writeengine/wrapper/writeengine.cpp
@@ -244,6 +244,7 @@ void WriteEngineWrapper::convertValue(const ColType colType, void* value, boost:
       case WriteEngine::WR_VARBINARY : // treat same as char for now
       case WriteEngine::WR_CHAR :
       case WriteEngine::WR_BLOB :
+      case WriteEngine::WR_TEXT :
                                     curStr = boost::any_cast<string>(data);
                                     if ((int) curStr.length() > MAX_COLUMN_BOUNDARY)
                                        curStr = curStr.substr(0, MAX_COLUMN_BOUNDARY);
@@ -363,7 +364,8 @@ void WriteEngineWrapper::convertValue(const ColType colType, void* valArray, con
                                        break;
          case WriteEngine::WR_VARBINARY : // treat same as char for now
          case WriteEngine::WR_CHAR :
-         case WriteEngine::WR_BLOB :   curStr = boost::any_cast<string>(data);
+         case WriteEngine::WR_BLOB :
+         case WriteEngine::WR_TEXT :   curStr = boost::any_cast<string>(data);
                                        if ((int) curStr.length() > MAX_COLUMN_BOUNDARY)
                                           curStr = curStr.substr(0, MAX_COLUMN_BOUNDARY);
                                        memcpy((char*)valArray + pos * MAX_COLUMN_BOUNDARY, curStr.c_str(), curStr.length());
@@ -413,7 +415,8 @@ void WriteEngineWrapper::convertValue(const ColType colType, void* valArray, con
                                        break;
          case WriteEngine::WR_VARBINARY : // treat same as char for now
          case WriteEngine::WR_CHAR :
-         case WriteEngine::WR_BLOB :   char tmp[10];
+         case WriteEngine::WR_BLOB :
+         case WriteEngine::WR_TEXT :   char tmp[10];
                                        memcpy(tmp, (char*)valArray + pos*8, 8);
                                        curStr = tmp;
                                        data = curStr;
@@ -687,6 +690,7 @@ int WriteEngineWrapper::deleteBadRows(const TxnID& txnid, ColStructList& colStru
 				case WriteEngine::WR_VARBINARY : // treat same as char for now
 				case WriteEngine::WR_CHAR:
 				case WriteEngine::WR_BLOB:
+                case WriteEngine::WR_TEXT:
 					valArray = (char*) calloc(sizeof(char), 1 * MAX_COLUMN_BOUNDARY);
 					break;
 				case WriteEngine::WR_FLOAT:
@@ -3314,6 +3318,7 @@ int WriteEngineWrapper::writeColumnRecords(const TxnID& txnid,
          case WriteEngine::WR_VARBINARY : // treat same as char for now
          case WriteEngine::WR_CHAR:
          case WriteEngine::WR_BLOB:
+         case WriteEngine::WR_TEXT:
             valArray = (char*) calloc(sizeof(char), totalRow * MAX_COLUMN_BOUNDARY);
             break;
          case WriteEngine::WR_FLOAT:
@@ -3519,6 +3524,7 @@ StopWatch timer;
                case WriteEngine::WR_VARBINARY : // treat same as char for now
                case WriteEngine::WR_CHAR:
                case WriteEngine::WR_BLOB:
+               case WriteEngine::WR_TEXT:
                   valArray = (char*) calloc(sizeof(char), totalRow1 * MAX_COLUMN_BOUNDARY);
                   break;
                case WriteEngine::WR_FLOAT:
@@ -3664,6 +3670,7 @@ timer.stop("writeRow ");
             case WriteEngine::WR_VARBINARY : // treat same as char for now
             case WriteEngine::WR_CHAR:
             case WriteEngine::WR_BLOB:
+            case WriteEngine::WR_TEXT:
                valArray = (char*) calloc(sizeof(char), totalRow2 * MAX_COLUMN_BOUNDARY);
                break;
             case WriteEngine::WR_FLOAT:
@@ -3806,6 +3813,7 @@ timer.stop("writeRow ");
             case WriteEngine::WR_VARBINARY : // treat same as char for now
             case WriteEngine::WR_CHAR:
             case WriteEngine::WR_BLOB:
+            case WriteEngine::WR_TEXT:
                valArray = (char*) calloc(sizeof(char), totalRow1 * MAX_COLUMN_BOUNDARY);
                break;
             case WriteEngine::WR_FLOAT:
@@ -4068,6 +4076,7 @@ StopWatch timer;
          case WriteEngine::WR_VARBINARY : // treat same as char for now
          case WriteEngine::WR_CHAR:
          case WriteEngine::WR_BLOB:
+         case WriteEngine::WR_TEXT:
             valArray = (char*) calloc(sizeof(char), 1 * MAX_COLUMN_BOUNDARY);
             break;
          case WriteEngine::WR_FLOAT:


### PR DESCRIPTION
* TEXT and BLOB now have separate identifiers internally
* TEXT columns are identified as such in system catalog
* cpimport only requires hex input for BLOB, not TEXT