### PR TITLE
MCOL-664 Add function support for TEXT

### DIFF
--- a/dbcon/joblist/expressionstep.cpp
+++ b/dbcon/joblist/expressionstep.cpp
@@ -325,8 +325,7 @@ void ExpressionStep::populateColumnInfo(ReturnedColumn* rc, JobInfo& jobInfo)
 {
 	// As of bug3695, make sure varbinary is not used in function expression.
 	if ((rc->resultType().colDataType == CalpontSystemCatalog::VARBINARY ||
-         rc->resultType().colDataType == CalpontSystemCatalog::BLOB ||
-         rc->resultType().colDataType == CalpontSystemCatalog::TEXT) && !fVarBinOK)
+         rc->resultType().colDataType == CalpontSystemCatalog::BLOB) && !fVarBinOK)
 		throw runtime_error("VARBINARY/BLOB in filter or function is not supported.");
 
 	SimpleColumn* sc = dynamic_cast<SimpleColumn*>(rc);
@@ -347,8 +346,7 @@ void ExpressionStep::populateColumnInfo(SimpleColumn* sc, JobInfo& jobInfo)
 {
 	// As of bug3695, make sure varbinary is not used in function expression.
 	if ((sc->resultType().colDataType == CalpontSystemCatalog::VARBINARY ||
-         sc->resultType().colDataType == CalpontSystemCatalog::BLOB ||
-         sc->resultType().colDataType == CalpontSystemCatalog::TEXT) && !fVarBinOK)
+         sc->resultType().colDataType == CalpontSystemCatalog::BLOB) && !fVarBinOK)
 		throw runtime_error ("VARBINARY/BLOB in filter or function is not supported.");
 
 	CalpontSystemCatalog::OID tblOid = joblist::tableOid(sc, jobInfo.csc);
@@ -414,8 +412,7 @@ void ExpressionStep::populateColumnInfo(WindowFunctionColumn* wc, JobInfo& jobIn
 {
 	// As of bug3695, make sure varbinary is not used in function expression.
 	if ((wc->resultType().colDataType == CalpontSystemCatalog::VARBINARY ||
-         wc->resultType().colDataType == CalpontSystemCatalog::BLOB ||
-         wc->resultType().colDataType == CalpontSystemCatalog::TEXT) && !fVarBinOK)
+         wc->resultType().colDataType == CalpontSystemCatalog::BLOB) && !fVarBinOK)
 		throw runtime_error("VARBINARY/BLOB in filter or function is not supported.");
 
 	// This is for window function in IN/EXISTS sub-query.
@@ -441,8 +438,7 @@ void ExpressionStep::populateColumnInfo(AggregateColumn* ac, JobInfo& jobInfo)
 {
 	// As of bug3695, make sure varbinary is not used in function expression.
 	if ((ac->resultType().colDataType == CalpontSystemCatalog::VARBINARY ||
-         ac->resultType().colDataType == CalpontSystemCatalog::BLOB ||
-         ac->resultType().colDataType == CalpontSystemCatalog::TEXT) && !fVarBinOK)
+         ac->resultType().colDataType == CalpontSystemCatalog::BLOB) && !fVarBinOK)
 		throw runtime_error("VARBINARY/BLOB in filter or function is not supported.");
 
 	// This is for aggregate function in IN/EXISTS sub-query.

--- a/utils/funcexp/func_between.cpp
+++ b/utils/funcexp/func_between.cpp
@@ -174,6 +174,7 @@ namespace
 			}
 			case execplan::CalpontSystemCatalog::VARCHAR: // including CHAR'
 			case execplan::CalpontSystemCatalog::CHAR:
+            case execplan::CalpontSystemCatalog::TEXT:
 			{
 				const string& val = pm[0]->data()->getStrVal(row, isNull);
 				if (notBetween)
@@ -215,6 +216,7 @@ CalpontSystemCatalog::ColType Func_between::operationType( FunctionParm& fp, Cal
 		ct = op.operationType();
 
 		if ((fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::CHAR &&
+			fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::TEXT && 
 			fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::VARCHAR) || 
 			ct.colDataType == CalpontSystemCatalog::DATE ||
 			ct.colDataType == CalpontSystemCatalog::DATETIME)

--- a/utils/funcexp/func_bitand.cpp
+++ b/utils/funcexp/func_bitand.cpp
@@ -85,6 +85,7 @@ int64_t Func_bitand::getIntVal(Row& row,
 	
 			case execplan::CalpontSystemCatalog::VARCHAR:
 			case execplan::CalpontSystemCatalog::CHAR:
+			case execplan::CalpontSystemCatalog::TEXT:
 			{
 				int64_t value = parm[i]->data()->getIntVal(row, isNull);
 				if (isNull)

--- a/utils/funcexp/func_bitwise.cpp
+++ b/utils/funcexp/func_bitwise.cpp
@@ -85,6 +85,7 @@ bool getUIntValFromParm(
 
         case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			value = parm->data()->getIntVal(row, isNull);
 			if (isNull)

--- a/utils/funcexp/func_case.cpp
+++ b/utils/funcexp/func_case.cpp
@@ -101,6 +101,7 @@ inline uint64_t simple_case_cmp(Row& row,
         }
 
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		{
    			const string& ev = parm[n]->data()->getStrVal(row, isNull);
@@ -252,6 +253,7 @@ CalpontSystemCatalog::ColType caseOperationType(FunctionParm& fp,
 			{
 				// the case expression
 				if (fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::CHAR &&
+					fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::TEXT &&
 					fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::VARCHAR)
 				{
 					PredicateOperator op;
@@ -267,6 +269,7 @@ CalpontSystemCatalog::ColType caseOperationType(FunctionParm& fp,
 		}
 
 		if (fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::CHAR &&
+            fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::TEXT &&
 			fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::VARCHAR)
 		{
 			// this is not a string column
@@ -280,6 +283,7 @@ CalpontSystemCatalog::ColType caseOperationType(FunctionParm& fp,
 
 			// If any parm is of string type, the result type should be string. (same as if)
 			else if (rct.colDataType != CalpontSystemCatalog::CHAR &&
+                        rct.colDataType != CalpontSystemCatalog::TEXT &&
 						rct.colDataType != CalpontSystemCatalog::VARCHAR)
 			{
 				op.setOpType(rct, fp[i]->data()->resultType());

--- a/utils/funcexp/func_cast.cpp
+++ b/utils/funcexp/func_cast.cpp
@@ -134,6 +134,7 @@ int64_t Func_cast_signed::getIntVal(Row& row,
 
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			const string& value = parm[0]->data()->getStrVal(row, isNull);
 			if (isNull)
@@ -243,6 +244,7 @@ uint64_t Func_cast_unsigned::getUintVal(Row& row,
 
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			const string& value = parm[0]->data()->getStrVal(row, isNull);
 			if (isNull)
@@ -358,6 +360,7 @@ string Func_cast_char::getStrVal(Row& row,
 
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			const string& value = parm[0]->data()->getStrVal(row, isNull);
 			if (isNull)
@@ -519,6 +522,7 @@ int32_t Func_cast_date::getDateIntVal(rowgroup::Row& row,
 		}
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+        case execplan::CalpontSystemCatalog::TEXT:
 		{
 			val = dataconvert::DataConvert::stringToDate(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)
@@ -588,6 +592,7 @@ int64_t Func_cast_date::getDatetimeIntVal(rowgroup::Row& row,
 		}
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+        case execplan::CalpontSystemCatalog::TEXT:
 		{
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)
@@ -716,6 +721,7 @@ int64_t Func_cast_datetime::getDatetimeIntVal(rowgroup::Row& row,
 		}
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)
@@ -893,6 +899,7 @@ IDB_Decimal Func_cast_decimal::getDecimalVal(Row& row,
 
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
         {
             const string& strValue = parm[0]->data()->getStrVal(row, isNull);
             const char* str = strValue.c_str();

--- a/utils/funcexp/func_ceil.cpp
+++ b/utils/funcexp/func_ceil.cpp
@@ -122,6 +122,7 @@ int64_t Func_ceil::getIntVal(Row& row,
 
 		case CalpontSystemCatalog::VARCHAR:
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		{
 			const string& str = parm[0]->data()->getStrVal(row, isNull);
 			if (!isNull)
@@ -197,6 +198,7 @@ uint64_t Func_ceil::getUintVal(Row& row,
 
 		case CalpontSystemCatalog::VARCHAR:
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		{
 			const string& str = parm[0]->data()->getStrVal(row, isNull);
 			if (!isNull)
@@ -247,7 +249,8 @@ double Func_ceil::getDoubleVal(Row& row,
 		ret = ceil(parm[0]->data()->getDoubleVal(row, isNull));
 	}
 	else if (op_ct.colDataType == CalpontSystemCatalog::VARCHAR ||
-			 op_ct.colDataType == CalpontSystemCatalog::CHAR)
+			 op_ct.colDataType == CalpontSystemCatalog::CHAR ||
+			 op_ct.colDataType == CalpontSystemCatalog::TEXT)
 	{
 		const string& str = parm[0]->data()->getStrVal(row, isNull);
 		if (!isNull)
@@ -280,7 +283,8 @@ string Func_ceil::getStrVal(Row& row,
 		op_ct.colDataType == CalpontSystemCatalog::FLOAT ||
         op_ct.colDataType == CalpontSystemCatalog::UFLOAT ||
 		op_ct.colDataType == CalpontSystemCatalog::VARCHAR ||
-		op_ct.colDataType == CalpontSystemCatalog::CHAR)
+		op_ct.colDataType == CalpontSystemCatalog::CHAR ||
+		op_ct.colDataType == CalpontSystemCatalog::TEXT)
 	{
 		snprintf(tmp, 511, "%f", getDoubleVal(row, parm, isNull, op_ct));
 

--- a/utils/funcexp/func_char.cpp
+++ b/utils/funcexp/func_char.cpp
@@ -121,6 +121,7 @@ string Func_char::getStrVal(Row& row,
 
         case execplan::CalpontSystemCatalog::VARCHAR: // including CHAR'
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::DOUBLE:
         case execplan::CalpontSystemCatalog::UDOUBLE:
 		{

--- a/utils/funcexp/func_char_length.cpp
+++ b/utils/funcexp/func_char_length.cpp
@@ -73,6 +73,7 @@ int64_t Func_char_length::getIntVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR: // including CHAR
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
 		{

--- a/utils/funcexp/func_date.cpp
+++ b/utils/funcexp/func_date.cpp
@@ -88,6 +88,7 @@ int64_t Func_date::getIntVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
 		{

--- a/utils/funcexp/func_date_add.cpp
+++ b/utils/funcexp/func_date_add.cpp
@@ -661,6 +661,7 @@ int64_t Func_date_add::getIntVal(rowgroup::Row& row,
 		}
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			break;
@@ -693,6 +694,7 @@ int64_t Func_date_add::getIntVal(rowgroup::Row& row,
 	ConstantColumn* constCol = dynamic_cast<ConstantColumn*>(parm[3]->data());
 	execplan::CalpontSystemCatalog::ColType ct3 = parm[3]->data()->resultType();
 	if ((ct3.colDataType == execplan::CalpontSystemCatalog::CHAR ||
+         ct3.colDataType == execplan::CalpontSystemCatalog::TEXT ||
 	     ct3.colDataType == execplan::CalpontSystemCatalog::VARCHAR) &&
 	    constCol != NULL && constCol->constval().compare("SUB") == 0)
 		funcType = OP_SUB;

--- a/utils/funcexp/func_date_format.cpp
+++ b/utils/funcexp/func_date_format.cpp
@@ -238,6 +238,7 @@ string Func_date_format::getStrVal(rowgroup::Row& row,
 			break;
 		case CalpontSystemCatalog::CHAR:
 		case CalpontSystemCatalog::VARCHAR:
+		case CalpontSystemCatalog::TEXT:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)
 			{

--- a/utils/funcexp/func_day.cpp
+++ b/utils/funcexp/func_day.cpp
@@ -58,6 +58,7 @@ int64_t Func_day::getIntVal(rowgroup::Row& row,
 			val = parm[0]->data()->getIntVal(row, isNull);
 			return (uint32_t)((val >> 38) & 0x3f);
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_dayname.cpp
+++ b/utils/funcexp/func_dayname.cpp
@@ -68,6 +68,7 @@ int64_t Func_dayname::getIntVal(rowgroup::Row& row,
 			day = (uint32_t)((val >> 38) & 0x3f);
 			break;
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_dayofweek.cpp
+++ b/utils/funcexp/func_dayofweek.cpp
@@ -67,6 +67,7 @@ int64_t Func_dayofweek::getIntVal(rowgroup::Row& row,
 			day = (uint32_t)((val >> 38) & 0x3f);
 			break;
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_dayofyear.cpp
+++ b/utils/funcexp/func_dayofyear.cpp
@@ -67,6 +67,7 @@ int64_t Func_dayofyear::getIntVal(rowgroup::Row& row,
 			day = (uint32_t)((val >> 38) & 0x3f);
 			break;
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_elt.cpp
+++ b/utils/funcexp/func_elt.cpp
@@ -60,6 +60,7 @@ string Func_elt::getStrVal(rowgroup::Row& row,
 		case CalpontSystemCatalog::DOUBLE:
 		case CalpontSystemCatalog::FLOAT:
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 		{
 			double value = parm[0]->data()->getDoubleVal(row, isNull);

--- a/utils/funcexp/func_extract.cpp
+++ b/utils/funcexp/func_extract.cpp
@@ -118,6 +118,7 @@ int64_t Func_extract::getIntVal(rowgroup::Row& row,
 		break;
 	case CalpontSystemCatalog::VARCHAR:
 	case CalpontSystemCatalog::CHAR:
+	case CalpontSystemCatalog::TEXT:
 	{
 		const string& val = parm[0]->data()->getStrVal(row, isNull);
 		time = dataconvert::DataConvert::stringToDatetime(val);

--- a/utils/funcexp/func_floor.cpp
+++ b/utils/funcexp/func_floor.cpp
@@ -118,6 +118,7 @@ int64_t Func_floor::getIntVal(Row& row,
 
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			const string& str = parm[0]->data()->getStrVal(row, isNull);
 			if (!isNull)
@@ -200,6 +201,7 @@ uint64_t Func_floor::getUintVal(Row& row,
 
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			const string& str = parm[0]->data()->getStrVal(row, isNull);
 			if (!isNull)
@@ -252,7 +254,8 @@ double Func_floor::getDoubleVal(Row& row,
 		ret = floor(parm[0]->data()->getDoubleVal(row, isNull));
 	}
 	else if (op_ct.colDataType == CalpontSystemCatalog::VARCHAR ||
-			 op_ct.colDataType == CalpontSystemCatalog::CHAR)
+			 op_ct.colDataType == CalpontSystemCatalog::CHAR ||
+			 op_ct.colDataType == CalpontSystemCatalog::TEXT)
 	{
 		const string& str = parm[0]->data()->getStrVal(row, isNull);
 		if (!isNull)
@@ -278,7 +281,8 @@ string Func_floor::getStrVal(Row& row,
 		op_ct.colDataType == CalpontSystemCatalog::FLOAT ||
 		op_ct.colDataType == CalpontSystemCatalog::UFLOAT ||
 		op_ct.colDataType == CalpontSystemCatalog::VARCHAR ||
-		op_ct.colDataType == CalpontSystemCatalog::CHAR)
+		op_ct.colDataType == CalpontSystemCatalog::CHAR ||
+		op_ct.colDataType == CalpontSystemCatalog::TEXT)
 	{
 		snprintf(tmp, 511, "%f", getDoubleVal(row, parm, isNull, op_ct));
 

--- a/utils/funcexp/func_hex.cpp
+++ b/utils/funcexp/func_hex.cpp
@@ -72,6 +72,7 @@ string Func_hex::getStrVal(rowgroup::Row& row,
 	switch (parm[0]->data()->resultType().colDataType)
 	{
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 		case CalpontSystemCatalog::DATETIME:
 		case CalpontSystemCatalog::DATE:
@@ -97,7 +98,6 @@ string Func_hex::getStrVal(rowgroup::Row& row,
 		}
 		case CalpontSystemCatalog::VARBINARY:
         case CalpontSystemCatalog::BLOB:
-        case CalpontSystemCatalog::TEXT:
 		{
 			const string& arg = parm[0]->data()->getStrVal(row, isNull);
 			uint64_t hexLen = arg.size() * 2;

--- a/utils/funcexp/func_hour.cpp
+++ b/utils/funcexp/func_hour.cpp
@@ -78,6 +78,7 @@ int64_t Func_hour::getIntVal(rowgroup::Row& row,
 		}
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_if.cpp
+++ b/utils/funcexp/func_if.cpp
@@ -47,6 +47,7 @@ bool boolVal(SPTP& parm, Row& row, bool& isNull)
 		switch (parm->data()->resultType().colDataType)
 		{
 			case CalpontSystemCatalog::CHAR:
+			case CalpontSystemCatalog::TEXT:
 			case CalpontSystemCatalog::VARCHAR:
 				ret = (atoi((char*)(parm->data()->getStrVal().c_str())) != 0);
             case CalpontSystemCatalog::FLOAT:
@@ -95,7 +96,9 @@ CalpontSystemCatalog::ColType Func_if::operationType(FunctionParm& fp, CalpontSy
 	// If any parm is of string type, the result type should be string.
 	if (fp[1]->data()->resultType().colDataType == CalpontSystemCatalog::CHAR ||
 		  fp[1]->data()->resultType().colDataType == CalpontSystemCatalog::VARCHAR ||
+		  fp[1]->data()->resultType().colDataType == CalpontSystemCatalog::TEXT ||
 		  fp[2]->data()->resultType().colDataType == CalpontSystemCatalog::CHAR ||
+		  fp[2]->data()->resultType().colDataType == CalpontSystemCatalog::TEXT ||
 		  fp[2]->data()->resultType().colDataType == CalpontSystemCatalog::VARCHAR)
 	{
 		CalpontSystemCatalog::ColType ct;

--- a/utils/funcexp/func_in.cpp
+++ b/utils/funcexp/func_in.cpp
@@ -169,6 +169,7 @@ namespace
 			}
 			case execplan::CalpontSystemCatalog::VARCHAR: // including CHAR'
 			case execplan::CalpontSystemCatalog::CHAR:
+			case execplan::CalpontSystemCatalog::TEXT:
 			{
 				const string& val = pm[0]->data()->getStrVal(row, isNull);
 				if (isNull)
@@ -211,7 +212,8 @@ CalpontSystemCatalog::ColType Func_in::operationType( FunctionParm& fp, CalpontS
 	{
 		//op.setOpType(op.operationType(), fp[i]->data()->resultType());
 		if (fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::CHAR &&
-			fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::VARCHAR)
+			fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::VARCHAR &&
+            fp[i]->data()->resultType().colDataType != CalpontSystemCatalog::TEXT)
 		{
 			allString = false;
 			op.setOpType(ct, fp[i]->data()->resultType());
@@ -222,6 +224,8 @@ CalpontSystemCatalog::ColType Func_in::operationType( FunctionParm& fp, CalpontS
 			if ((fp[i]->data()->resultType().colDataType == CalpontSystemCatalog::CHAR && 
 				  fp[i]->data()->resultType().colWidth > 8) || 
 				  (fp[i]->data()->resultType().colDataType == CalpontSystemCatalog::VARCHAR &&
+				  fp[i]->data()->resultType().colWidth >= 8) || 
+				  (fp[i]->data()->resultType().colDataType == CalpontSystemCatalog::TEXT &&
 				  fp[i]->data()->resultType().colWidth >= 8))
 				  allNonToken = false;
 		}

--- a/utils/funcexp/func_isnull.cpp
+++ b/utils/funcexp/func_isnull.cpp
@@ -68,6 +68,7 @@ bool Func_isnull::getBoolVal(Row& row,
 			parm[0]->data()->getDecimalVal(row, isNull);
 			break;
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			parm[0]->data()->getStrVal(row, isNull);
 			break;

--- a/utils/funcexp/func_last_day.cpp
+++ b/utils/funcexp/func_last_day.cpp
@@ -69,6 +69,7 @@ int64_t Func_last_day::getIntVal(rowgroup::Row& row,
 			day = (uint32_t)((val >> 38) & 0x3f);
 			break;
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_length.cpp
+++ b/utils/funcexp/func_length.cpp
@@ -49,8 +49,7 @@ int64_t Func_length::getIntVal(rowgroup::Row& row,
 							CalpontSystemCatalog::ColType&)
 {
 	if ((fp[0]->data()->resultType().colDataType == CalpontSystemCatalog::VARBINARY) ||
-        (fp[0]->data()->resultType().colDataType == CalpontSystemCatalog::BLOB) ||
-        (fp[0]->data()->resultType().colDataType == CalpontSystemCatalog::TEXT))
+        (fp[0]->data()->resultType().colDataType == CalpontSystemCatalog::BLOB))
 		return fp[0]->data()->getStrVal(row, isNull).length();
 
 	return strlen(fp[0]->data()->getStrVal(row, isNull).c_str());

--- a/utils/funcexp/func_makedate.cpp
+++ b/utils/funcexp/func_makedate.cpp
@@ -57,6 +57,7 @@ uint64_t makedate(rowgroup::Row& row,
 		case CalpontSystemCatalog::DOUBLE:
 		case CalpontSystemCatalog::FLOAT:
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 		{
 			double value = parm[0]->data()->getDoubleVal(row, isNull);
@@ -102,6 +103,7 @@ uint64_t makedate(rowgroup::Row& row,
 		case CalpontSystemCatalog::DOUBLE:
 		case CalpontSystemCatalog::FLOAT:
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 		{
 			dayofyear = parm[1]->data()->getStrVal(row, isNull);

--- a/utils/funcexp/func_maketime.cpp
+++ b/utils/funcexp/func_maketime.cpp
@@ -63,6 +63,7 @@ string Func_maketime::getStrVal(rowgroup::Row& row,
 		case CalpontSystemCatalog::DOUBLE:
 		case CalpontSystemCatalog::FLOAT:
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 		{
 			double value = parm[0]->data()->getDoubleVal(row, isNull);
@@ -96,6 +97,7 @@ string Func_maketime::getStrVal(rowgroup::Row& row,
 		case CalpontSystemCatalog::DOUBLE:
 		case CalpontSystemCatalog::FLOAT:
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 		{
 			double value = parm[1]->data()->getDoubleVal(row, isNull);
@@ -135,6 +137,7 @@ string Func_maketime::getStrVal(rowgroup::Row& row,
 		case CalpontSystemCatalog::DOUBLE:
 		case CalpontSystemCatalog::FLOAT:
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 		{
 			double value = parm[2]->data()->getDoubleVal(row, isNull);

--- a/utils/funcexp/func_math.cpp
+++ b/utils/funcexp/func_math.cpp
@@ -104,6 +104,7 @@ double Func_acos::getDoubleVal(Row& row,
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
         case execplan::CalpontSystemCatalog::UBIGINT:
@@ -189,6 +190,7 @@ double Func_asin::getDoubleVal(Row& row,
 		case execplan::CalpontSystemCatalog::FLOAT:
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::CHAR:
 		case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
@@ -275,6 +277,7 @@ double Func_atan::getDoubleVal(Row& row,
         case execplan::CalpontSystemCatalog::FLOAT:
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::CHAR:
 		case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
@@ -396,6 +399,7 @@ double Func_cos::getDoubleVal(Row& row,
         case execplan::CalpontSystemCatalog::FLOAT:
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::CHAR:
 		case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
@@ -481,6 +485,7 @@ double Func_cot::getDoubleVal(Row& row,
         case execplan::CalpontSystemCatalog::FLOAT:
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::CHAR:
 		case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
@@ -674,6 +679,7 @@ double Func_log::getDoubleVal(Row& row,
 
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			isNull = true;
 			return doubleNullVal();
@@ -763,6 +769,7 @@ double Func_log2::getDoubleVal(Row& row,
 
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			isNull = true;
 			return doubleNullVal();
@@ -852,6 +859,7 @@ double Func_log10::getDoubleVal(Row& row,
 
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			isNull = true;
 			return doubleNullVal();
@@ -895,6 +903,7 @@ double Func_sin::getDoubleVal(Row& row,
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
         case execplan::CalpontSystemCatalog::UBIGINT:
@@ -980,6 +989,7 @@ double Func_sqrt::getDoubleVal(Row& row,
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
         case execplan::CalpontSystemCatalog::UBIGINT:
@@ -1065,6 +1075,7 @@ double Func_tan::getDoubleVal(Row& row,
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
         case execplan::CalpontSystemCatalog::UBIGINT:
@@ -1166,6 +1177,7 @@ string Func_format::getStrVal(Row& row,
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			double rawValue = parm[0]->data()->getDoubleVal(row, isNull);
 
@@ -1355,6 +1367,7 @@ double Func_radians::getDoubleVal(Row& row,
         case execplan::CalpontSystemCatalog::FLOAT:
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::CHAR:
 		case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
@@ -1440,6 +1453,7 @@ double Func_degrees::getDoubleVal(Row& row,
         case execplan::CalpontSystemCatalog::FLOAT:
         case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::CHAR:
 		case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:

--- a/utils/funcexp/func_microsecond.cpp
+++ b/utils/funcexp/func_microsecond.cpp
@@ -62,6 +62,7 @@ int64_t Func_microsecond::getIntVal(rowgroup::Row& row,
 			microSecond = (uint32_t)((val & 0xfffff));
 			break;
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_minute.cpp
+++ b/utils/funcexp/func_minute.cpp
@@ -78,6 +78,7 @@ int64_t Func_minute::getIntVal(rowgroup::Row& row,
 		}
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_mod.cpp
+++ b/utils/funcexp/func_mod.cpp
@@ -159,6 +159,7 @@ double Func_mod::getDoubleVal(Row& row,
 		
 		case execplan::CalpontSystemCatalog::CHAR:
 		case execplan::CalpontSystemCatalog::VARCHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			double value = parm[0]->data()->getDoubleVal(row, isNull);
 			mod = fmod(value,div);
@@ -203,6 +204,7 @@ int64_t Func_mod::getIntVal(Row& row,
 		case execplan::CalpontSystemCatalog::TINYINT:
 		case execplan::CalpontSystemCatalog::SMALLINT:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		{
 			int64_t value = parm[0]->data()->getIntVal(row, isNull);
@@ -290,6 +292,7 @@ uint64_t Func_mod::getUIntVal(Row& row,
 		case execplan::CalpontSystemCatalog::TINYINT:
 		case execplan::CalpontSystemCatalog::SMALLINT:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		{
 			int64_t value = parm[0]->data()->getIntVal(row, isNull);

--- a/utils/funcexp/func_month.cpp
+++ b/utils/funcexp/func_month.cpp
@@ -58,6 +58,7 @@ int64_t Func_month::getIntVal(rowgroup::Row& row,
 			val = parm[0]->data()->getIntVal(row, isNull);
 			return (unsigned)((val >> 44) & 0xf);
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_monthname.cpp
+++ b/utils/funcexp/func_monthname.cpp
@@ -85,6 +85,7 @@ int64_t Func_monthname::getIntVal(rowgroup::Row& row,
 			val = parm[0]->data()->getIntVal(row, isNull);
 			return (unsigned)((val >> 44) & 0xf);
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_nullif.cpp
+++ b/utils/funcexp/func_nullif.cpp
@@ -74,6 +74,7 @@ int64_t Func_nullif::getIntVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::UDECIMAL:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			exp2 = parm[1]->data()->getIntVal(row, isNull);
 			if (isNull) {
@@ -177,6 +178,7 @@ uint64_t Func_nullif::getUintVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::UDECIMAL:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			int64_t iexp2 = parm[1]->data()->getIntVal(row, isNull);
 			if (isNull || iexp2 < 0) {
@@ -290,6 +292,7 @@ int32_t Func_nullif::getDateIntVal(rowgroup::Row& row,
 		case execplan::CalpontSystemCatalog::DECIMAL:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			exp2 = parm[1]->data()->getIntVal(row, isNull);
 			if (isNull) {
@@ -352,6 +355,7 @@ int64_t Func_nullif::getDatetimeIntVal(rowgroup::Row& row,
 		case execplan::CalpontSystemCatalog::DECIMAL:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			exp2 = parm[1]->data()->getIntVal(row, isNull);
 			if (isNull) {
@@ -415,6 +419,7 @@ double Func_nullif::getDoubleVal(rowgroup::Row& row,
 		case execplan::CalpontSystemCatalog::DECIMAL:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			exp2 = parm[1]->data()->getDoubleVal(row, isNull);
 			if (isNull) {
@@ -491,6 +496,7 @@ execplan::IDB_Decimal Func_nullif::getDecimalVal(rowgroup::Row& row,
 	
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			int64_t value = parm[1]->data()->getIntVal(row, isNull);
 			if (isNull) {

--- a/utils/funcexp/func_period_diff.cpp
+++ b/utils/funcexp/func_period_diff.cpp
@@ -86,6 +86,7 @@ int64_t Func_period_diff::getIntVal(rowgroup::Row& row,
 		}
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			period1 = atoi(parm[0]->data()->getStrVal(row, isNull).c_str());
 			break;
@@ -129,6 +130,7 @@ int64_t Func_period_diff::getIntVal(rowgroup::Row& row,
 		}
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			period2 = atoi(parm[1]->data()->getStrVal(row, isNull).c_str());
 			break;

--- a/utils/funcexp/func_quarter.cpp
+++ b/utils/funcexp/func_quarter.cpp
@@ -61,6 +61,7 @@ int64_t Func_quarter::getIntVal(rowgroup::Row& row,
 			month = (val >> 44) & 0xf;
 			break;
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:			
 		{
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));

--- a/utils/funcexp/func_regexp.cpp
+++ b/utils/funcexp/func_regexp.cpp
@@ -70,6 +70,7 @@ namespace
 			case execplan::CalpontSystemCatalog::USMALLINT:
 			case execplan::CalpontSystemCatalog::VARCHAR: // including CHAR'
 			case execplan::CalpontSystemCatalog::CHAR:
+			case execplan::CalpontSystemCatalog::TEXT:
 			case execplan::CalpontSystemCatalog::DOUBLE:
             case execplan::CalpontSystemCatalog::UDOUBLE:
 			case execplan::CalpontSystemCatalog::FLOAT:
@@ -129,6 +130,7 @@ namespace
 			case execplan::CalpontSystemCatalog::FLOAT:
             case execplan::CalpontSystemCatalog::UFLOAT:
 			case execplan::CalpontSystemCatalog::CHAR:
+			case execplan::CalpontSystemCatalog::TEXT:
 			{
 				pattern = pm[1]->data()->getStrVal(row, isNull);
 				break;

--- a/utils/funcexp/func_round.cpp
+++ b/utils/funcexp/func_round.cpp
@@ -283,6 +283,7 @@ IDB_Decimal Func_round::getDecimalVal(Row& row,
 		case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			int64_t s = 0;
 			double  p = 1;

--- a/utils/funcexp/func_sec_to_time.cpp
+++ b/utils/funcexp/func_sec_to_time.cpp
@@ -138,6 +138,7 @@ string Func_sec_to_time::getStrVal(rowgroup::Row& row,
 		
 		case execplan::CalpontSystemCatalog::CHAR:
 		case execplan::CalpontSystemCatalog::VARCHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			val = parm[0]->data()->getIntVal(row, isNull);
 	        

--- a/utils/funcexp/func_second.cpp
+++ b/utils/funcexp/func_second.cpp
@@ -78,6 +78,7 @@ int64_t Func_second::getIntVal(rowgroup::Row& row,
 		}
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_str_to_date.cpp
+++ b/utils/funcexp/func_str_to_date.cpp
@@ -86,6 +86,7 @@ dataconvert::DateTime getDateTime (rowgroup::Row& row,
 			break;
 		}
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 		{
 			const string& valref = parm[0]->data()->getStrVal(row, isNull);

--- a/utils/funcexp/func_time.cpp
+++ b/utils/funcexp/func_time.cpp
@@ -85,6 +85,7 @@ string Func_time::getStrVal(rowgroup::Row& row,
 		}
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_time_format.cpp
+++ b/utils/funcexp/func_time_format.cpp
@@ -72,6 +72,7 @@ string Func_time_format::getStrVal(rowgroup::Row& row,
 			break;
 		case CalpontSystemCatalog::CHAR:
 		case CalpontSystemCatalog::VARCHAR:
+		case CalpontSystemCatalog::TEXT:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)
 			{

--- a/utils/funcexp/func_time_to_sec.cpp
+++ b/utils/funcexp/func_time_to_sec.cpp
@@ -68,6 +68,7 @@ int64_t Func_time_to_sec::getIntVal(rowgroup::Row& row,
 			sec = (uint32_t)((val >> 20) & 0x3f);
 			break;
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
         case CalpontSystemCatalog::VARCHAR:
             {
                 std::string strVal = parm[0]->data()->getStrVal(row, isNull);

--- a/utils/funcexp/func_timediff.cpp
+++ b/utils/funcexp/func_timediff.cpp
@@ -116,6 +116,7 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
 			break;
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 			val1 = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull), &isDate1);
 			break;
 		case execplan::CalpontSystemCatalog::BIGINT:
@@ -151,6 +152,7 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
 			break;
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 			val2 = dataconvert::DataConvert::stringToDatetime(parm[1]->data()->getStrVal(row, isNull), &isDate2);
 			break;
 		case execplan::CalpontSystemCatalog::BIGINT:

--- a/utils/funcexp/func_to_days.cpp
+++ b/utils/funcexp/func_to_days.cpp
@@ -84,6 +84,7 @@ int64_t Func_to_days::getIntVal(rowgroup::Row& row,
 
 		case execplan::CalpontSystemCatalog::VARCHAR: // including CHAR'
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			const string& value = parm[0]->data()->getStrVal(row, isNull);
 			int64_t val = 0;

--- a/utils/funcexp/func_truncate.cpp
+++ b/utils/funcexp/func_truncate.cpp
@@ -264,6 +264,7 @@ IDB_Decimal Func_truncate::getDecimalVal(Row& row,
 		case execplan::CalpontSystemCatalog::UFLOAT:
 		case execplan::CalpontSystemCatalog::VARCHAR:
 		case execplan::CalpontSystemCatalog::CHAR:
+		case execplan::CalpontSystemCatalog::TEXT:
 		{
 			int64_t s = 0;
 			double  p = 1;

--- a/utils/funcexp/func_unix_timestamp.cpp
+++ b/utils/funcexp/func_unix_timestamp.cpp
@@ -82,6 +82,7 @@ int64_t Func_unix_timestamp::getIntVal(rowgroup::Row& row,
 			break;
 		case CalpontSystemCatalog::CHAR:
 		case CalpontSystemCatalog::VARCHAR:
+		case CalpontSystemCatalog::TEXT:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)
 			{

--- a/utils/funcexp/func_week.cpp
+++ b/utils/funcexp/func_week.cpp
@@ -72,6 +72,7 @@ int64_t Func_week::getIntVal(rowgroup::Row& row,
 			day = (uint32_t)((val >> 38) & 0x3f);
 			break;
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_weekday.cpp
+++ b/utils/funcexp/func_weekday.cpp
@@ -67,6 +67,7 @@ int64_t Func_weekday::getIntVal(rowgroup::Row& row,
 			day = (uint32_t)((val >> 38) & 0x3f);
 			break;
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_year.cpp
+++ b/utils/funcexp/func_year.cpp
@@ -58,6 +58,7 @@ int64_t Func_year::getIntVal(rowgroup::Row& row,
 			val = parm[0]->data()->getIntVal(row, isNull);
 			return (unsigned)((val >> 48) & 0xffff);
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)

--- a/utils/funcexp/func_yearweek.cpp
+++ b/utils/funcexp/func_yearweek.cpp
@@ -75,6 +75,7 @@ int64_t Func_yearweek::getIntVal(rowgroup::Row& row,
 			day = (uint32_t)((val >> 38) & 0x3f);
 			break;
 		case CalpontSystemCatalog::CHAR:
+		case CalpontSystemCatalog::TEXT:
 		case CalpontSystemCatalog::VARCHAR:
 			val = dataconvert::DataConvert::stringToDatetime(parm[0]->data()->getStrVal(row, isNull));
 			if (val == -1)


### PR DESCRIPTION
For the initial BLOB/TEXT pull request we put them in the same bucket as
VARBINARY, forcing many functions to be disabled. This patch enables the
same TEXT function support as VARCHAR.