### PR TITLE
MCOL-655 Enable debug symbols on releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,8 @@ endif()
 
 
 FOREACH(BUILD_TYPE RELEASE RELWITHDEBINFO MINSIZEREL)
-    SET(CMAKE_CXX_FLAGS_${BUILD_TYPE} "-g0 -O3 -fno-strict-aliasing -Wall -fno-tree-vectorize -DDBUG_OFF -DHAVE_CONFIG_H")
-    SET(CMAKE_C_FLAGS_${BUILD_TYPE} "-g0 -O3 -fno-strict-aliasing -Wall -fno-tree-vectorize -DDBUG_OFF -DHAVE_CONFIG_H")
+    SET(CMAKE_CXX_FLAGS_${BUILD_TYPE} "-g -O3 -fno-strict-aliasing -Wall -fno-tree-vectorize -DDBUG_OFF -DHAVE_CONFIG_H")
+    SET(CMAKE_C_FLAGS_${BUILD_TYPE} "-g -O3 -fno-strict-aliasing -Wall -fno-tree-vectorize -DDBUG_OFF -DHAVE_CONFIG_H")
 ENDFOREACH()
 
 SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ggdb3 -fno-tree-vectorize -DSAFE_MUTEX -DSAFEMALLOC -DENABLED_DEBUG_SYNC -O0 -Wall -D_DEBUG -DHAVE_CONFIG_H")


### PR DESCRIPTION
Makes it easier to debug user core files