### PR TITLE
MCOL-669 TEXT cpimport fixes

### DIFF
--- a/dbcon/execplan/calpontsystemcatalog.h
+++ b/dbcon/execplan/calpontsystemcatalog.h
@@ -153,11 +153,11 @@ public:
 			UFLOAT,			/*!< Unsigned FLOAT type */
 			UBIGINT,		/*!< Unsigned BIGINT type */
 			UDOUBLE,		/*!< Unsigned DOUBLE type */
-			NUM_OF_COL_DATA_TYPE,
+            TEXT,           /*!< TEXT type */
+			NUM_OF_COL_DATA_TYPE, /* NEW TYPES ABOVE HERE */
 			LONGDOUBLE,		/* @bug3241, dev and variance calculation only */
-			STRINT,			/* @bug3532, string as int for fast comparison */
-            TEXT            /*!< TEXT type */
-	};
+			STRINT			/* @bug3532, string as int for fast comparison */
+   	};
 
 	/** the set of column constraint types
 	 *

--- a/writeengine/shared/we_type.h
+++ b/writeengine/shared/we_type.h
@@ -152,7 +152,8 @@ namespace WriteEngine
                 "unsigned-int",
                 "unsigned-float",
                 "unsigned-bigint",
-                "unsigned-double"
+                "unsigned-double",
+                "text"
          };
 
     enum FuncType { FUNC_WRITE_ENGINE, FUNC_INDEX, FUNC_DICTIONARY };


### PR DESCRIPTION
* 64KB TEXT column had off-by-one length pointer counting
* TEXT I_S/LDI was looping where it shouldn't causing pointer issues
* TEXT data type wasn't fully understood by cpimport