### PR TITLE
MCOL-697 Remove 64KB VARCHAR response limit

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -2239,8 +2239,6 @@ CalpontSystemCatalog::ColType colType_MysqlToIDB (const Item* item)
 			{
 				if (ct.colWidth < 20)
 					ct.colWidth = 20; // for infinidb date length
-				if (ct.colWidth > 65535)
-					ct.colWidth = 65535;
 			}
 			// @bug5083. MySQL gives string type for date/datetime column.
 			// need to adjust here.


### PR DESCRIPTION
This was a hard coded limit due to StringStore not being able to handle
more than this. It restricts hex() unnecessarily and is now redundant.