### PR TITLE
MCOL-697 Limit the return length for LONGBLOB

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -2233,7 +2233,15 @@ CalpontSystemCatalog::ColType colType_MysqlToIDB (const Item* item)
 			break;
 		case STRING_RESULT:
 			ct.colDataType = CalpontSystemCatalog::VARCHAR;
-			ct.colWidth = item->max_length;
+            // MCOL-697 the longest TEXT we deal with is 2100000000 so
+            // limit to that. Otherwise for LONGBLOB ct.colWidth ends
+            // up being -1 and demons eat your data and first born
+            // (or you just get truncated to 20 bytes with the 'if'
+            // below)
+            if (item->max_length < 2100000000)
+                ct.colWidth = item->max_length;
+            else
+                ct.colWidth = 2100000000;
 			// force token
 			if (item->type() == Item::FUNC_ITEM)
 			{


### PR DESCRIPTION
For LONGBLOB the string return length was 4GB for functions which got
converted to -1 and then to 20. This patch sets it to just under 2GB
which we use for LONGBLOB everywhere else.