### PR TITLE
MCOL-656 Fix LIKE on non-dict CHAR/VARCHAR

### DIFF
--- a/dbcon/joblist/jlf_execplantojoblist.cpp
+++ b/dbcon/joblist/jlf_execplantojoblist.cpp
@@ -1663,10 +1663,7 @@ const JobStepVector doSimpleFilter(SimpleFilter* sf, JobInfo& jobInfo)
 				jsv.push_back(sjstep);
 			}
 		}
-		else if ( CalpontSystemCatalog::CHAR != ct.colDataType &&
-				 CalpontSystemCatalog::VARCHAR != ct.colDataType &&
-				 CalpontSystemCatalog::VARBINARY != ct.colDataType &&
-				 ConstantColumn::NULLDATA != cc->type() &&
+		else if ( ConstantColumn::NULLDATA != cc->type() &&
 				 (cop & COMPARE_LIKE) ) // both like and not like
 		{
 			return doExpressionFilter(sf, jobInfo);


### PR DESCRIPTION
The LIKE part of the query for non-dict CHAR/VARCHAR was converted to an
INT based on the length of the column. So on a 2 byte CHAR a LIKE of
'%05%' was truncated to '%0' which is a very different query. We should
not cast this to INT because we could use a LIKE of > 8 bytes on a
non-dict column. This patch turns LIKE into an expressionStep which
cater for longer strings rather than a simpleFilter.