### PR TITLE
MCOL-707 Fix memory accounting for ORDER BY

### DIFF
--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -339,13 +339,13 @@ void IdbOrderBy::initialize(const RowGroup& rg)
 	IdbCompare::initialize(rg);
 
 	uint64_t newSize = fRowsPerRG * rg.getRowSize();
-	if (!fRm->getMemory(newSize, fSessionMemLimit))
+	fMemSize += newSize;
+    if (!fRm->getMemory(newSize, fSessionMemLimit))
 	{
 		cerr << IDBErrorInfo::instance()->errorMsg(fErrorCode)
 			 << " @" << __FILE__ << ":" << __LINE__;
 		throw IDBExcept(fErrorCode);
 	}
-	fMemSize += newSize;
 	fData.reinit(fRowGroup, fRowsPerRG);
 	fRowGroup.setData(&fData);
 	fRowGroup.resetRowGroup(0);


### PR DESCRIPTION
Missed off window function order by memory accounting in my first commit
for MCOL-707. Fixed in the same way