### PR TITLE
MCOL-674 Fix subquery in UPDATE

### DIFF
--- a/dbcon/mysql/ha_calpont_impl.cpp
+++ b/dbcon/mysql/ha_calpont_impl.cpp
@@ -1038,8 +1038,8 @@ uint32_t doUpdateDelete(THD *thd)
             }
             else if ( value->type() == Item::SUBSELECT_ITEM )
             {
-//                isFromCol = true;
-//                columnAssignmentPtr->fFromCol = true;
+                isFromCol = true;
+                columnAssignmentPtr->fFromCol = true;
 //                Item_field* setIt = reinterpret_cast<Item_field*> (value);
 //                string sectableName = string(setIt->table_name);
 //                string secschemaName = string(setIt->db_name);


### PR DESCRIPTION
When some subquery changes were made over a year ago the flag to state
that an UPDATE subquery was not constant data was accidentally commented
out. This brings it back in again.