### PR TITLE
MCOL-830 Allow cross engine to work with UTF8

### DIFF
--- a/dbcon/joblist/crossenginestep.cpp
+++ b/dbcon/joblist/crossenginestep.cpp
@@ -96,6 +96,10 @@ int LibMySQL::init(const char* h, unsigned int p, const char* u, const char* w, 
 			fErrStr = "fatal error in mysql_real_connect()";
             ret = mysql_errno(fCon);
 		}
+        else
+        {
+            mysql_set_character_set(fCon, "utf8");
+        }
 	}
 	else
 	{


### PR DESCRIPTION
UTF8 characters just showed as question marks. This patch makes them
retrieve correctly.