### PR TITLE
MCOL-838 Enforce copy of string in StringStore

### DIFF
--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -144,7 +144,7 @@ uint32_t StringStore::deserialize(ByteStream &bs)
 	for (i = 0; i < count; i++) {
 		//cout << "deserializing " << size << " bytes\n";
         bs >> buf;
-        shared_ptr<std::string> newString(new std::string(buf));
+        shared_ptr<std::string> newString(new std::string(buf.c_str()));
 		mem.push_back(newString);
 		//bs.advance(size);
 		ret += (size + 4);


### PR DESCRIPTION
Since we aren't using C++11 the deserialize was doing using reference
counts for string copy which occasionally caused a use after free.