### PR TITLE
MCOL-857 Fix thread leak on ByteStream exception

### DIFF
--- a/primitives/primproc/primitiveserver.cpp
+++ b/primitives/primproc/primitiveserver.cpp
@@ -1223,8 +1223,17 @@ struct BPPHandler
 		uint32_t key;
 		BPPMap::iterator it;
 
-		bs.advance(sizeof(ISMPacketHeader));
-		bs >> key;
+        try
+        {
+		    bs.advance(sizeof(ISMPacketHeader));
+    		bs >> key;
+        }
+        catch(...)
+        {
+            // MCOL-857 We don't have the full packet yet
+            bs.rewind();
+            return -1;
+        }
         mutex::scoped_lock scoped(bppLock);
         bppKeysIt = std::find(bppKeys.begin(), bppKeys.end(), key);
         if (bppKeysIt != bppKeys.end()) {
@@ -1425,10 +1434,20 @@ struct BPPHandler
 		uint32_t uniqueID, sessionID, stepID;
 		BPPMap::iterator it;
 
-		bs.advance(sizeof(ISMPacketHeader));
-		bs >> sessionID;
-		bs >> stepID;
-		bs >> uniqueID;
+        try
+        {
+
+    		bs.advance(sizeof(ISMPacketHeader));
+	    	bs >> sessionID;
+		    bs >> stepID;
+    		bs >> uniqueID;
+        }
+        catch(...)
+        {
+            // MCOL-857 We don't appear to have the full packet yet!
+            bs.rewind();
+            return -1;
+        }
 
 		mutex::scoped_lock lk(djLock);
 		mutex::scoped_lock scoped(bppLock);


### PR DESCRIPTION
ByteStream::advance can throw an exception if there isn't enough data in
the buffer yet. PrimProc's BPP processor would not catch this causing a
thread to be leaked every time. This was happening on BPP destroy and
abort.