### PR TITLE
MCOL-515 Fix cross engine for FE2/3 modes

### DIFF
--- a/dbcon/joblist/crossenginestep.cpp
+++ b/dbcon/joblist/crossenginestep.cpp
@@ -225,7 +225,7 @@ void CrossEngineStep::setFcnExpGroup3(const vector<execplan::SRCP>& fe)
 
 void CrossEngineStep::setFE23Output(const rowgroup::RowGroup& rg)
 {
-	fRowGroupFe3 = fRowGroupDelivered = rg;
+	fRowGroupFe3 = fRowGroupDelivered = fRowGroupAdded = rg;
 }
 
 


### PR DESCRIPTION
When subqueries and group by are used in CrossEngine the first row group
is either corrupted or ignored. This is related to MCOL-430 which fixed
the case for FE1 mode.