### PR TITLE
MCOL-858 Preserve NULs in StringStore deserialize

### DIFF
--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -136,7 +136,10 @@ void StringStore::deserialize(ByteStream &bs)
 	for (i = 0; i < count; i++) {
 		//cout << "deserializing " << size << " bytes\n";
         bs >> buf;
-        shared_ptr<std::string> newString(new std::string(buf.c_str()));
+        // We do this to avoid pre-C++11 zero copy hell but need to
+        // preserve all data including NULs so using c_str() is out.
+        shared_ptr<std::string> newString(new std::string());
+        newString->append(buf);
 		mem.push_back(newString);
 	}
 	return;


### PR DESCRIPTION
The fix for MCOL-838 broke VARBINARY as it truncated on the first NUL on
StringStore deserialize. This fix uses append() to force a copy instead
whilst preserving length.

This fixes test012