### PR TITLE
MCOL-835 Fix use-after-free crash in ExeMgr

### DIFF
--- a/dbcon/joblist/distributedenginecomm.cpp
+++ b/dbcon/joblist/distributedenginecomm.cpp
@@ -772,8 +772,10 @@ void DistributedEngineComm::write(messageqcpp::ByteStream &msg, uint32_t connect
 	lk.lock();
 	it = fSessionMessages.find(senderID);
 	if (it != fSessionMessages.end())
+    {
         mqe = it->second;
 		senderStats = &(mqe->stats);
+    }
 	lk.unlock();
 
 	newClients[connection]->write(msg, NULL, senderStats);

--- a/dbcon/joblist/distributedenginecomm.cpp
+++ b/dbcon/joblist/distributedenginecomm.cpp
@@ -765,12 +765,15 @@ void DistributedEngineComm::write(messageqcpp::ByteStream &msg, uint32_t connect
 
 	mutex::scoped_lock lk(fMlock, defer_lock_t());
 	MessageQueueMap::iterator it;
+    // This keeps mqe's stats from being freed until end of function
+    boost::shared_ptr<MQE> mqe;
 	Stats *senderStats = NULL;
 
 	lk.lock();
 	it = fSessionMessages.find(senderID);
 	if (it != fSessionMessages.end())
-		senderStats = &(it->second->stats);
+        mqe = it->second;
+		senderStats = &(mqe->stats);
 	lk.unlock();
 
 	newClients[connection]->write(msg, NULL, senderStats);
@@ -829,6 +832,8 @@ int DistributedEngineComm::writeToClient(size_t index, const ByteStream& bs, uin
 {
 	mutex::scoped_lock lk(fMlock, defer_lock_t());
 	MessageQueueMap::iterator it;
+    // Keep mqe's stats from being freed early
+    boost::shared_ptr<MQE> mqe;
 	Stats *senderStats = NULL;
 	uint32_t interleaver = 0;
 
@@ -839,7 +844,8 @@ int DistributedEngineComm::writeToClient(size_t index, const ByteStream& bs, uin
 		lk.lock();
 		it = fSessionMessages.find(sender);
 		if (it != fSessionMessages.end()) {
-			senderStats = &(it->second->stats);
+            mqe = it->second;
+			senderStats = &(mqe->stats);
 			if (doInterleaving)
 				interleaver = it->second->interleaver[index % it->second->pmCount]++;
 		}


### PR DESCRIPTION
It is possible that DistributedEngineComm can get the Stats object from
an MQE object and the MQE object freed before it's stats object is
passed to InetStreamSocket.

This patch makes sure that DistributedEngineComm gets a reference to MQE
instead of the pointer to the Stats object in another reference.
Therefore making sure that the Stats object still exists in
InetStreamSocket.