### PR TITLE
MCOL-859 DDL System catalog mutex deadlock

### DIFF
--- a/dbcon/execplan/calpontsystemcatalog.cpp
+++ b/dbcon/execplan/calpontsystemcatalog.cpp
@@ -1190,7 +1190,7 @@ const CalpontSystemCatalog::ColType CalpontSystemCatalog::colTypeDct(const OID& 
 	}
 
     // check map first cached column type
-    boost::mutex::scoped_lock lk3(fDctTokenMapLock);
+    boost::recursive_mutex::scoped_lock lk3(fDctTokenMapLock);
 	DctTokenMap::const_iterator iter = fDctTokenMap.find(dictOid);
 	if (iter != fDctTokenMap.end())
 		return colType(iter->second);
@@ -5320,7 +5320,7 @@ void CalpontSystemCatalog::flushCache()
 	buildSysTablemap();
 	lk3.unlock();
 
-	boost::mutex::scoped_lock lk4(fDctTokenMapLock);
+	boost::recursive_mutex::scoped_lock lk4(fDctTokenMapLock);
 	fDctTokenMap.clear();
 	buildSysDctmap();
 	lk4.unlock();

--- a/dbcon/execplan/calpontsystemcatalog.h
+++ b/dbcon/execplan/calpontsystemcatalog.h
@@ -871,7 +871,8 @@ private:
 
 	typedef std::map<OID, OID> DctTokenMap;
 	DctTokenMap fDctTokenMap;
-	boost::mutex fDctTokenMapLock;
+	// MCOL-859: this can lock when already locked in the same thread
+	boost::recursive_mutex fDctTokenMapLock;
 
 		typedef std::map<OID, TableName> TableNameMap;
 		TableNameMap fTableNameMap;


### PR DESCRIPTION
A race between a DDL change and a system catalog version cache update
can cause a deadlock in DDLProc. This makes the mutex recursive.