### PR TITLE
MCOL-895 Sort system catalog ridList

### DIFF
--- a/dbcon/execplan/calpontsystemcatalog.cpp
+++ b/dbcon/execplan/calpontsystemcatalog.cpp
@@ -3093,18 +3093,35 @@ const CalpontSystemCatalog::RIDList CalpontSystemCatalog::columnRIDs(const Table
                 ctList[i].nextvalue = ((*it)->GetData(i));
         }
     }
-    
+    // MCOL-895 sort ctList, we can't specify an ORDER BY to do this yet
+    std::sort(ctList, ctList + ti.numOfCols, ctListSort);
+
     // populate colinfo cache
     lk3.lock();
     for (int i = 0; i < ti.numOfCols; i++)
         fColinfomap[ctList[i].columnOID] = ctList[i];
     lk3.unlock();
-    
+
+    // Re-sort the output based on the sorted ctList
+    // Don't need to do this for the cached list as this will be already sorted
+    RIDList rlOut;
+    for (int i = 0; i < ti.numOfCols; i++)
+    {
+        OID objid = ctList[i].columnOID;
+        for (size_t j = 0; j < rl.size(); j++)
+        {
+            if (rl[j].objnum == objid)
+            {
+                rlOut.push_back(rl[j]);
+            }
+        }
+    }
+
     delete [] ctList;
    // delete col[9];    
-    if (rl.size() != 0)
+    if (rlOut.size() != 0)
     {
-        return rl;
+        return rlOut;
     }
 		
 		Message::Args args;
@@ -5786,6 +5803,11 @@ vector<CalpontSystemCatalog::OID> getAllSysCatOIDs()
 	for (oid = SYSCOLUMN_DICT_BASE + 1; oid < SYSCOLUMN_DICT_MAX; oid++)
 		ret.push_back(oid);
 	return ret;
+}
+
+bool ctListSort(const CalpontSystemCatalog::ColType& a, const CalpontSystemCatalog::ColType& b)
+{
+    return a.colPosition < b.colPosition;
 }
 
 } // namespace execplan

--- a/dbcon/execplan/calpontsystemcatalog.h
+++ b/dbcon/execplan/calpontsystemcatalog.h
@@ -1247,6 +1247,8 @@ std::ostream& operator<<(std::ostream& os, const CalpontSystemCatalog::ColType& 
 
 const std::string colDataTypeToString(CalpontSystemCatalog::ColDataType cdt);
 
+bool ctListSort(const CalpontSystemCatalog::ColType& a, const CalpontSystemCatalog::ColType& b);
+
 } //namespace execplan
 
 #endif											//EXECPLAN_CALPONTSYSTEMCATALOG_H


### PR DESCRIPTION
It is possible to have the columns for a table in a different order
within the system catalog. This causes problems for things like
WriteEngine so this patch sorts the columns based on position for the
system catalog cache.