### PR TITLE
MCOL-895 Sort system catalog ridList

### DIFF
--- a/dbcon/execplan/calpontsystemcatalog.h
+++ b/dbcon/execplan/calpontsystemcatalog.h
@@ -1215,6 +1215,8 @@ std::ostream& operator<<(std::ostream& os, const CalpontSystemCatalog::ColType& 
 
 const std::string colDataTypeToString(CalpontSystemCatalog::ColDataType cdt);
 
+bool ctListSort(const CalpontSystemCatalog::ColType& a, const CalpontSystemCatalog::ColType& b);
+
 } //namespace execplan
 
 #endif											//EXECPLAN_CALPONTSYSTEMCATALOG_H


### PR DESCRIPTION
It is possible to have the columns for a table in a different order
within the system catalog. This causes problems for things like
WriteEngine so this patch sorts the columns based on position for the
system catalog cache.