### PR TITLE
MCOL-944 Fix aggregate type switch

### DIFF
--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -1173,7 +1173,14 @@ void TupleAggregateStep::prep1PhaseAggregate(
 				scaleAgg.push_back(0);
 				// work around count() in select subquery
 				precisionAgg.push_back(9999);
-				typeAgg.push_back(CalpontSystemCatalog::BIGINT);
+                if (isUnsigned(typeProj[colProj]))
+                {
+                    typeAgg.push_back(CalpontSystemCatalog::UBIGINT);
+                }
+                else
+                {
+                    typeAgg.push_back(CalpontSystemCatalog::BIGINT);
+                }
 				widthAgg.push_back(bigIntWidth);
 			}
 			break;
@@ -1211,7 +1218,14 @@ void TupleAggregateStep::prep1PhaseAggregate(
 				keysAgg.push_back(key);
 				scaleAgg.push_back(0);
 				precisionAgg.push_back(-16);  // for connector to skip null check
-				typeAgg.push_back(CalpontSystemCatalog::BIGINT);
+                if (isUnsigned(typeProj[colProj]))
+                {
+                    typeAgg.push_back(CalpontSystemCatalog::UBIGINT);
+                }
+                else
+                {
+                    typeAgg.push_back(CalpontSystemCatalog::BIGINT);
+                }
 				widthAgg.push_back(bigIntWidth);
 			}
 			break;
@@ -1561,13 +1575,21 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(
 					if (typeProj[colProj] != CalpontSystemCatalog::DOUBLE &&
 						typeProj[colProj] != CalpontSystemCatalog::FLOAT)
 					{
-						typeAgg.push_back(CalpontSystemCatalog::BIGINT);
-						uint32_t scale = scaleProj[colProj];
+                        if (isUnsigned(typeProj[colProj]))
+                        {
+                            typeAgg.push_back(CalpontSystemCatalog::UBIGINT);
+                            precisionAgg.push_back(20);
+                        }
+                        else
+                        {
+                            typeAgg.push_back(CalpontSystemCatalog::BIGINT);
+                            precisionAgg.push_back(19);
+                        }
+                        uint32_t scale = scaleProj[colProj];
 						// for int average, FE expects a decimal
 						if (aggOp == ROWAGG_AVG)
 							scale = jobInfo.scaleOfAvg[aggKey]; // scale += 4;
 						scaleAgg.push_back(scale);
-						precisionAgg.push_back(19);
 						widthAgg.push_back(bigIntWidth);
 					}
 					else
@@ -1594,7 +1616,14 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(
 					scaleAgg.push_back(0);
 					// work around count() in select subquery
 					precisionAgg.push_back(9999);
-					typeAgg.push_back(CalpontSystemCatalog::BIGINT);
+                    if (isUnsigned(typeProj[colProj]))
+                    {
+                        typeAgg.push_back(CalpontSystemCatalog::UBIGINT);
+                    }
+                    else
+                    {
+                        typeAgg.push_back(CalpontSystemCatalog::BIGINT);
+                    }
 					widthAgg.push_back(bigIntWidth);
 					colAgg++;
 				}
@@ -1654,7 +1683,15 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(
 					scaleAgg.push_back(0);
 					precisionAgg.push_back(-16);  // for connector to skip null check
 					typeAgg.push_back(CalpontSystemCatalog::BIGINT);
-					widthAgg.push_back(bigIntWidth);
+                    if (isUnsigned(typeProj[colProj]))
+                    {
+                        typeAgg.push_back(CalpontSystemCatalog::UBIGINT);
+                    }
+                    else
+                    {
+                        typeAgg.push_back(CalpontSystemCatalog::BIGINT);
+                    }
+                    widthAgg.push_back(bigIntWidth);
 					colAgg++;
 				}
 				break;
@@ -1758,13 +1795,21 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(
 					if (typeAgg[colAgg] != CalpontSystemCatalog::DOUBLE &&
 						typeAgg[colAgg] != CalpontSystemCatalog::FLOAT)
 					{
-						typeAggDist.push_back(CalpontSystemCatalog::BIGINT);
+                        if (isUnsigned(typeAgg[colAgg]))
+                        {
+                            typeAggDist.push_back(CalpontSystemCatalog::UBIGINT);
+                            precisionAggDist.push_back(20);
+                        }
+                        else
+                        {
+                            typeAggDist.push_back(CalpontSystemCatalog::BIGINT);
+                            precisionAggDist.push_back(19);
+                        }
 						uint32_t scale = scaleProj[colAgg];
 						// for int average, FE expects a decimal
 						if (aggOp == ROWAGG_DISTINCT_AVG)
 							scale = jobInfo.scaleOfAvg[retKey]; // scale += 4;
 						scaleAggDist.push_back(scale);
-						precisionAggDist.push_back(19);
 						widthAggDist.push_back(bigIntWidth);
 					}
 					else
@@ -1784,7 +1829,14 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(
 					scaleAggDist.push_back(0);
 					// work around count() in select subquery
 					precisionAggDist.push_back(9999);
-					typeAggDist.push_back(CalpontSystemCatalog::BIGINT);
+                    if (isUnsigned(typeAgg[colAgg]))
+                    {
+                        typeAggDist.push_back(CalpontSystemCatalog::UBIGINT);
+                    }
+                    else
+                    {
+                        typeAggDist.push_back(CalpontSystemCatalog::BIGINT);
+                    }
 					widthAggDist.push_back(bigIntWidth);
 				}
 				break;
@@ -1853,8 +1905,16 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(
 									oidsAggDist.push_back(oidsAgg[colAgg]);
 									keysAggDist.push_back(retKey);
 									scaleAggDist.push_back(0);
-									precisionAggDist.push_back(19);
-									typeAggDist.push_back(CalpontSystemCatalog::BIGINT);
+                                    if (isUnsigned(typeAgg[colAgg]))
+                                    {
+                                        typeAggDist.push_back(CalpontSystemCatalog::UBIGINT);
+                                        precisionAggDist.push_back(20);
+                                    }
+                                    else
+                                    {
+                                        typeAggDist.push_back(CalpontSystemCatalog::BIGINT);
+                                        precisionAggDist.push_back(19);
+                                    }
 									widthAggDist.push_back(bigIntWidth);
 								}
 							}
@@ -2585,7 +2645,14 @@ void TupleAggregateStep::prep2PhasesAggregate(
 					scaleAggPm.push_back(0);
 					// work around count() in select subquery
 					precisionAggPm.push_back(9999);
-					typeAggPm.push_back(CalpontSystemCatalog::BIGINT);
+                    if (isUnsigned(typeProj[colProj]))
+                    {
+                        typeAggPm.push_back(CalpontSystemCatalog::UBIGINT);
+                    }
+                    else
+                    {
+                        typeAggPm.push_back(CalpontSystemCatalog::BIGINT);
+                    }
 					widthAggPm.push_back(bigIntWidth);
 					colAggPm++;
 				}
@@ -2644,8 +2711,15 @@ void TupleAggregateStep::prep2PhasesAggregate(
 					keysAggPm.push_back(aggKey);
 					scaleAggPm.push_back(0);
 					precisionAggPm.push_back(-16);  // for connector to skip null check
-					typeAggPm.push_back(CalpontSystemCatalog::BIGINT);
-					widthAggPm.push_back(bigIntWidth);
+                    if (isUnsigned(typeProj[colProj]))
+                    {
+                        typeAggPm.push_back(CalpontSystemCatalog::UBIGINT);
+                    }
+                    else
+                    {
+                        typeAggPm.push_back(CalpontSystemCatalog::BIGINT);
+                    }
+                    widthAggPm.push_back(bigIntWidth);
 					colAggPm++;
 				}
 				break;
@@ -3235,7 +3309,14 @@ void TupleAggregateStep::prep2PhasesDistinctAggregate(
 					scaleAggPm.push_back(0);
 					// work around count() in select subquery
 					precisionAggPm.push_back(9999);
-					typeAggPm.push_back(CalpontSystemCatalog::BIGINT);
+                    if (isUnsigned(typeProj[colProj]))
+                    {
+                        typeAggPm.push_back(CalpontSystemCatalog::UBIGINT);
+                    }
+                    else
+                    {
+                        typeAggPm.push_back(CalpontSystemCatalog::BIGINT);
+                    }
 					widthAggPm.push_back(bigIntWidth);
 					colAggPm++;
 				}
@@ -3294,7 +3375,14 @@ void TupleAggregateStep::prep2PhasesDistinctAggregate(
 					keysAggPm.push_back(aggKey);
 					scaleAggPm.push_back(0);
 					precisionAggPm.push_back(-16);  // for connector to skip null check
-					typeAggPm.push_back(CalpontSystemCatalog::BIGINT);
+                    if (isUnsigned(typeProj[colProj]))
+                    {
+                        typeAggPm.push_back(CalpontSystemCatalog::UBIGINT);
+                    }
+                    else
+                    {
+                        typeAggPm.push_back(CalpontSystemCatalog::BIGINT);
+                    }
 					widthAggPm.push_back(bigIntWidth);
 					colAggPm++;
 				}
@@ -3416,13 +3504,21 @@ void TupleAggregateStep::prep2PhasesDistinctAggregate(
 					if (typeAggUm[colUm] != CalpontSystemCatalog::DOUBLE &&
 						typeAggUm[colUm] != CalpontSystemCatalog::FLOAT)
 					{
-						typeAggDist.push_back(CalpontSystemCatalog::BIGINT);
+                        if (isUnsigned(typeAggUm[colUm]))
+                        {
+                            typeAggDist.push_back(CalpontSystemCatalog::UBIGINT);
+                            precisionAggDist.push_back(20);
+                        }
+                        else
+                        {
+                            typeAggDist.push_back(CalpontSystemCatalog::BIGINT);
+                            precisionAggDist.push_back(19);
+                        }
 						uint32_t scale = scaleAggUm[colUm];
 						// for int average, FE expects a decimal
 						if (aggOp == ROWAGG_DISTINCT_AVG)
 							scale = jobInfo.scaleOfAvg[retKey]; // scale += 4;
 						scaleAggDist.push_back(scale);
-						precisionAggDist.push_back(19);
 						widthAggDist.push_back(bigIntWidth);
 					}
 					else
@@ -3445,7 +3541,14 @@ void TupleAggregateStep::prep2PhasesDistinctAggregate(
 					scaleAggDist.push_back(0);
 					// work around count() in select subquery
 					precisionAggDist.push_back(9999);
-					typeAggDist.push_back(CalpontSystemCatalog::BIGINT);
+                    if (isUnsigned(typeAggUm[colUm]))
+                    {
+                        typeAggDist.push_back(CalpontSystemCatalog::UBIGINT);
+                    }
+                    else
+                    {
+                        typeAggDist.push_back(CalpontSystemCatalog::BIGINT);
+                    }
 					widthAggDist.push_back(bigIntWidth);
 				}
 				break;

--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -3194,13 +3194,21 @@ void TupleAggregateStep::prep2PhasesDistinctAggregate(
 					if (typeProj[colProj] != CalpontSystemCatalog::DOUBLE &&
 						typeProj[colProj] != CalpontSystemCatalog::FLOAT)
 					{
-						typeAggPm.push_back(CalpontSystemCatalog::BIGINT);
+                        if (isUnsigned(typeProj[colProj]))
+                        {
+                            typeAggPm.push_back(CalpontSystemCatalog::UBIGINT);
+                            precisionAggPm.push_back(20);
+                        }
+                        else
+                        {
+						    typeAggPm.push_back(CalpontSystemCatalog::BIGINT);
+                            precisionAggPm.push_back(19);
+                        }
 						uint32_t scale = scaleProj[colProj];
 						// for int average, FE expects a decimal
 						if (aggOp == ROWAGG_AVG)
 							scale = jobInfo.scaleOfAvg[aggKey]; // scale += 4;
 						scaleAggPm.push_back(scale);
-						precisionAggPm.push_back(19);
 						widthAggPm.push_back(bigIntWidth);
 					}
 					else


### PR DESCRIPTION
Aggregates could switch from unsigned to signed prior to execution. This
causes issues with NULL values since signed and unsigned NULLs are
different.