### PR TITLE
MCOL-973 Fix DOUBLE typecast crash

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -2655,7 +2655,7 @@ ArithmeticColumn* buildArithmeticColumn(Item_func* item, gp_walk_info& gwi, bool
 			}
 		}
 
-		if (!lhs->data() || !rhs->data() || nonSupport)
+		if (nonSupport || !lhs->data() || !rhs->data())
 		{
 			gwi.fatalParseError = true;
 			if (gwi.parseErrorText.empty())
@@ -2688,7 +2688,7 @@ ArithmeticColumn* buildArithmeticColumn(Item_func* item, gp_walk_info& gwi, bool
 				gwi.rcWorkStack.pop();
 			}
 		}
-		if (!rhs->data() || nonSupport)
+		if (nonSupport || !rhs->data())
 		{
 			gwi.fatalParseError = true;
 			if (gwi.parseErrorText.empty())

--- a/utils/funcexp/funcexp.cpp
+++ b/utils/funcexp/funcexp.cpp
@@ -86,6 +86,7 @@ FuncExp::FuncExp()
 	fFuncMap["cast_as_date"] = new Func_cast_date();	//dlh
 	fFuncMap["cast_as_datetime"] = new Func_cast_datetime();	//dlh
 	fFuncMap["decimal_typecast"] = new Func_cast_decimal();	//dlh
+    fFuncMap["double_typecast"] = new Func_cast_double();
 	fFuncMap["ceil"] = new Func_ceil();	//dlh
 	fFuncMap["ceiling"] = new Func_ceil();	//dlh
 	fFuncMap["char"] = new Func_char();	//dlh

--- a/utils/funcexp/functor_real.h
+++ b/utils/funcexp/functor_real.h
@@ -303,6 +303,31 @@ public:
 						execplan::CalpontSystemCatalog::ColType& op_ct);
 };
 
+/** @brief Func_cast_double class
+  */
+class Func_cast_double : public Func_Real
+{
+public:
+	Func_cast_double() : Func_Real("cast_double") {}
+	virtual ~Func_cast_double() {}
+
+	execplan::CalpontSystemCatalog::ColType operationType(FunctionParm& fp, execplan::CalpontSystemCatalog::ColType& resultType);
+
+	int64_t getIntVal(rowgroup::Row& row,
+						FunctionParm& fp,
+						bool& isNull,
+						execplan::CalpontSystemCatalog::ColType& op_ct);
+
+	double getDoubleVal(rowgroup::Row& row,
+						FunctionParm& fp,
+						bool& isNull,
+						execplan::CalpontSystemCatalog::ColType& op_ct);
+
+	std::string getStrVal(rowgroup::Row& row,
+						FunctionParm& fp,
+						bool& isNull,
+						execplan::CalpontSystemCatalog::ColType& op_ct);
+};
 
 /** @brief Func_mod class
   */


### PR DESCRIPTION
DOUBLE typecast was not supported and the failure detection caused a
crash.

This patch adds support for DOUBLE typecast and fixes the crash caused
when a non-supported function is detected as part of an arithmatic.