### PR TITLE
MCOL-662 Fix multiple filters in CrossEngine

### DIFF
--- a/dbcon/joblist/crossenginestep.h
+++ b/dbcon/joblist/crossenginestep.h
@@ -201,7 +201,7 @@ protected:
 	std::string fSelectClause;
 
 	// Function & Expression columns
-	boost::shared_ptr<execplan::ParseTree> fFeFilters;
+    std::vector<boost::shared_ptr<execplan::ParseTree> > fFeFilters;
 	std::vector<boost::shared_ptr<execplan::ReturnedColumn> > fFeSelects;
 	std::vector<boost::shared_ptr<execplan::ReturnedColumn> > fFeFcnJoin;
 	std::map<uint32_t, uint32_t> fColumnMap;   // projected key position (k->p)


### PR DESCRIPTION
If a CrossEngine step has multiple filters the filters were overwriting
each other. This fix stores the filters as a vector and processes them
in a loop.