### PR TITLE
mcol-1009 and mcol-1014

### DIFF
--- a/dbcon/mysql/my.cnf
+++ b/dbcon/mysql/my.cnf
@@ -53,7 +53,7 @@ infinidb_compression_type=2
 infinidb_stringtable_threshold=20
 
 # infinidb local query flag
-# infinidb_local_query=1
+infinidb_local_query=0
 
 infinidb_diskjoin_smallsidelimit=0
 infinidb_diskjoin_largesidelimit=0

--- a/dbcon/mysql/mysql-Columnstore
+++ b/dbcon/mysql/mysql-Columnstore
@@ -61,7 +61,7 @@ datadir=$basedir/db
 # Value here is overriden by value in my.cnf. 
 # 0 means don't wait at all
 # Negative numbers mean to wait indefinitely
-service_startup_timeout=30
+service_startup_timeout=60
 
 # Lock directory for RedHat / SuSE.
 lockdir='/var/lock/subsys'
@@ -262,6 +262,8 @@ wait_for_gone () {
   done
 
   log_failure_msg
+  kill_by_pid
+
   return 1
 }
 
@@ -310,7 +312,7 @@ fi
 kill_by_pid() {
   # let's see if we can kill the 2 mysql procs by hand
   # get the our mysql from ps
-  eval $(ps -ef | grep "$COLUMNSTORE_INSTALL_DIR/mysql//bin/mysqld" | grep -v grep | head -1 | awk '{printf "pid=%d\n", $2}')
+  eval $(ps -ef | grep "$COLUMNSTORE_INSTALL_DIR/mysql/bin/mysqld" | grep -v grep | head -1 | awk '{printf "pid=%d\n", $2}')
 
   if [ -n "$pid" ]; then
 	ppid=$(ps -o ppid= -p $pid)
@@ -369,6 +371,7 @@ case "$mode" in
         wait_for_gone $mysqld_pid "$mysqld_pid_file_path"; return_value=$?
       else
         log_failure_msg "MySQL server process #$mysqld_pid is not running!"
+        kill_by_pid
         rm "$mysqld_pid_file_path"
       fi
 

--- a/oam/etc/Columnstore.xml
+++ b/oam/etc/Columnstore.xml
@@ -226,7 +226,7 @@
 	<SystemConfig>
 		<SystemLang>C</SystemLang>
 		<SystemName>columnstore-1</SystemName>
-		<ParentOAMModuleName>unassigned</ParentOAMModuleName>
+		<ParentOAMModuleName>pm1</ParentOAMModuleName>
 		<StandbyOAMModuleName>unassigned</StandbyOAMModuleName>
 		<PrimaryUMModuleName>unassigned</PrimaryUMModuleName>
 		<ModuleHeartbeatPeriod>1</ModuleHeartbeatPeriod>

--- a/oam/install_scripts/CMakeLists.txt
+++ b/oam/install_scripts/CMakeLists.txt
@@ -33,6 +33,7 @@ install(PROGRAMS post-install
                 myCnf-include-args.text 
                 myCnf-exclude-args.text
                 columnstore.service
+                mariadb-command-line.sh 
                 DESTINATION ${ENGINE_BINDIR} COMPONENT platform)               
                 
 install(FILES  module DESTINATION ${ENGINE_LOCALDIR} COMPONENT platform)

--- a/oam/install_scripts/mariadb-command-line.sh
+++ b/oam/install_scripts/mariadb-command-line.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# $Id$
+#
+# generic MariaDB Columnstore Command Line script.
+#
+# Notes: This script gets run by ProcMon during installs and upgrades:
+
+# check log for error
+checkForError() {
+	grep ERROR /tmp/mariadb-command-line.log > /tmp/error.check
+	if [ `cat /tmp/error.check | wc -c` -ne 0 ]; then
+		echo "ERROR: check log file: /tmp/mariadb-command-line.log"
+		rm -f /tmp/error.check
+		exit 1
+	fi
+	rm -f /tmp/error.check
+}
+
+prefix=/usr/local
+installdir=$prefix/mariadb/columnstore
+pwprompt=
+for arg in "$@"; do
+	if [ `expr -- "$arg" : '--command='` -eq 10 ]; then
+		command1="`echo $arg | awk -F= '{print $2}'`"
+		command2="`echo $arg | awk -F= '{print $3}'`"
+		command=$command1"="$command2
+	elif [ `expr -- "$arg" : '--installdir='` -eq 13 ]; then
+		installdir="`echo $arg | awk -F= '{print $2}'`"
+		prefix=`dirname $installdir`
+	elif [ `expr -- "$arg" : '--port='` -eq 7 ]; then
+		port="`echo $arg | awk -F= '{print $2}'`"
+	fi
+done
+
+test -f $installdir/post/functions && . $installdir/post/functions
+
+
+>/tmp/mariadb-command-line.log
+
+#
+# Run command
+#
+echo "Run command" >>/tmp/mariadb-command-line.log
+cat >/tmp/mariadb-command-line.sql <<EOD
+$command;
+EOD
+
+cat /tmp/mariadb-command-line.sql >> /tmp/mariadb-command-line.log
+$installdir/mysql/bin/mysql \
+	--defaults-extra-file=$installdir/mysql/my.cnf \
+	--user=root \
+	calpontsys < /tmp/mariadb-command-line.sql >> /tmp/mariadb-command-line.log 2>&1
+
+checkForError
+
+#alls good, 'OK' for success
+echo "OK"
+exit 0

--- a/oam/install_scripts/master-rep-columnstore.sh
+++ b/oam/install_scripts/master-rep-columnstore.sh
@@ -24,9 +24,6 @@ for arg in "$@"; do
 	if [ `expr -- "$arg" : '--prefix='` -eq 9 ]; then
 		prefix="`echo $arg | awk -F= '{print $2}'`"
 		installdir=$prefix/mariadb/columnstore
-	elif [ `expr -- "$arg" : '--password='` -eq 11 ]; then
-		password="`echo $arg | awk -F= '{print $2}'`"
-		pwprompt="--password=$password"
 	elif [ `expr -- "$arg" : '--installdir='` -eq 13 ]; then
 		installdir="`echo $arg | awk -F= '{print $2}'`"
 		prefix=`dirname $installdir`
@@ -54,7 +51,7 @@ EOD
 cat /tmp/idb_master-rep.sql >>/tmp/master-rep-status-$hostipaddr.log
 $installdir/mysql/bin/mysql \
 	--defaults-extra-file=$installdir/mysql/my.cnf \
-	--user=root $pwprompt \
+	--user=root \
 	calpontsys </tmp/idb_master-rep.sql >>/tmp/master-rep-status-$hostipaddr.log 2>&1
 
 checkForError
@@ -72,7 +69,7 @@ EOD
 cat /tmp/idb_master-rep.sql >>/tmp/master-rep-status-$hostipaddr.log
 $installdir/mysql/bin/mysql \
 	--defaults-extra-file=$installdir/mysql/my.cnf \
-	--user=root $pwprompt \
+	--user=root \
 	calpontsys </tmp/idb_master-rep.sql >>/tmp/master-rep-status-$hostipaddr.log 2>&1
 
 checkForError
@@ -88,7 +85,7 @@ EOD
 cat /tmp/idb_master-rep.sql >>/tmp/master-rep-status-$hostipaddr.log
 $installdir/mysql/bin/mysql \
 	--defaults-extra-file=$installdir/mysql/my.cnf \
-	--user=root $pwprompt \
+	--user=root \
 	calpontsys </tmp/idb_master-rep.sql >>/tmp/master-rep-status-$hostipaddr.log 2>&1
 
 checkForError
@@ -101,7 +98,7 @@ EOD
 cat /tmp/idb_master-rep.sql >/tmp/show-master-status.log
 $installdir/mysql/bin/mysql \
 	--defaults-extra-file=$installdir/mysql/my.cnf \
-	--user=root $pwprompt \
+	--user=root \
 	calpontsys </tmp/idb_master-rep.sql >>/tmp/show-master-status.log
 
 

--- a/oam/install_scripts/slave-rep-columnstore.sh
+++ b/oam/install_scripts/slave-rep-columnstore.sh
@@ -24,9 +24,6 @@ for arg in "$@"; do
 	if [ `expr -- "$arg" : '--prefix='` -eq 9 ]; then
 		prefix="`echo $arg | awk -F= '{print $2}'`"
 		installdir=$prefix/mariadb/columnstore
-	elif [ `expr -- "$arg" : '--password='` -eq 11 ]; then
-		password="`echo $arg | awk -F= '{print $2}'`"
-		pwprompt="--password=$password"
 	elif [ `expr -- "$arg" : '--installdir='` -eq 13 ]; then
 		installdir="`echo $arg | awk -F= '{print $2}'`"
 		prefix=`dirname $installdir`
@@ -59,7 +56,7 @@ EOD
 cat /tmp/idb_slave-rep.sql >>/tmp/slave-rep-status.log
 $installdir/mysql/bin/mysql \
 	--defaults-extra-file=$installdir/mysql/my.cnf \
-	--user=root $pwprompt \
+	--user=root \
 	calpontsys </tmp/idb_slave-rep.sql >>/tmp/slave-rep-status.log 2>&1
 
 checkForError
@@ -82,7 +79,7 @@ EOD
 cat /tmp/idb_slave-rep.sql >>/tmp/slave-rep-status.log
 $installdir/mysql/bin/mysql \
 	--defaults-extra-file=$installdir/mysql/my.cnf \
-	--user=root $pwprompt \
+	--user=root \
 	calpontsys </tmp/idb_slave-rep.sql >>/tmp/slave-rep-status.log 2>&1
 
 checkForError
@@ -98,7 +95,7 @@ EOD
 cat /tmp/idb_slave-rep.sql >>/tmp/slave-rep-status.log
 $installdir/mysql/bin/mysql \
 	--defaults-extra-file=$installdir/mysql/my.cnf \
-	--user=root $pwprompt \
+	--user=root \
 	calpontsys </tmp/idb_slave-rep.sql >>/tmp/slave-rep-status.log 2>&1
 
 checkForError
@@ -114,7 +111,7 @@ EOD
 cat /tmp/idb_slave-rep.sql >>/tmp/slave-rep-status.log
 $installdir/mysql/bin/mysql \
 	--defaults-extra-file=$installdir/mysql/my.cnf \
-	--user=root $pwprompt \
+	--user=root \
 	calpontsys </tmp/idb_slave-rep.sql >>/tmp/slave-rep-status.log 2>&1
 
 checkForError

--- a/oamapps/postConfigure/helpers.cpp
+++ b/oamapps/postConfigure/helpers.cpp
@@ -368,7 +368,7 @@ int sendUpgradeRequest(int IserverTypeInstall, bool pmwithum)
 *
 *
 ******************************************************************************************/
-int sendReplicationRequest(int IserverTypeInstall, std::string password, std::string port, bool pmwithum)
+int sendReplicationRequest(int IserverTypeInstall, std::string password, bool pmwithum)
 {
 	Oam oam;
 
@@ -459,7 +459,7 @@ int sendReplicationRequest(int IserverTypeInstall, std::string password, std::st
 						{ // set for slave repl request
 							// don't do PMs unless PMwithUM flag is set
 							string moduleType = (*pt).DeviceName.substr(0,MAX_MODULE_TYPE_SIZE);
-
+							
 							if ( ( moduleType == "pm" && !pmwithum ) &&
 							     ( IserverTypeInstall != oam::INSTALL_COMBINE_DM_UM_PM ) ) {
 								pt++;
@@ -476,7 +476,6 @@ int sendReplicationRequest(int IserverTypeInstall, std::string password, std::st
 	
 							msg << masterLogFile;
 							msg << masterLogPos;
-							msg << port;
 
 							returnStatus = sendMsgProcMon( (*pt).DeviceName, msg, requestID, 30 );
 			

--- a/oamapps/postConfigure/helpers.h
+++ b/oamapps/postConfigure/helpers.h
@@ -39,7 +39,7 @@ extern void dbrmDirCheck();
 extern void mysqlSetup();
 extern int sendMsgProcMon( std::string module, ByteStream msg, int requestID, int timeout );
 extern int sendUpgradeRequest(int IserverTypeInstall, bool pmwithum);
-extern int sendReplicationRequest(int IserverTypeInstall, std::string password, std::string mysqlPort, bool pmwithum);
+extern int sendReplicationRequest(int IserverTypeInstall, std::string password, bool pmwithum);
 extern void checkFilesPerPartion(int DBRootCount, Config* sysConfig);
 extern void checkMysqlPort( string& mysqlPort, Config* sysConfig);
 extern bool writeConfig(Config* sysConfig);

--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -3497,7 +3497,7 @@ int main(int argc, char *argv[])
 			cout.flush();
 
 			//send message to procmon's to run mysql replication script
-			int status = sendReplicationRequest(IserverTypeInstall, password, mysqlPort, pmwithum);
+			int status = sendReplicationRequest(IserverTypeInstall, password, pmwithum);
 
 			if ( status != 0 ) {
 				cout << endl << " MariaDB ColumnStore Install Failed" << endl << endl;

--- a/procmgr/processmanager.cpp
+++ b/procmgr/processmanager.cpp
@@ -10328,18 +10328,6 @@ int ProcessManager::setMySQLReplication(oam::DeviceNetworkList devicenetworklist
 */
 	log.writeLog(__LINE__, "Setup MySQL Replication", LOG_TYPE_DEBUG);
 
-	// mysql port number
-	string MySQLPort;
-	try {
-		oam.getSystemConfig("MySQLPort", MySQLPort);
-	}
-	catch(...) {
-		MySQLPort = "3306";
-	}
-
-	if ( MySQLPort.empty() )
-		MySQLPort = "3306";
-
 	//get master info
 	if ( masterModule == oam::UnassignedName)
 	{
@@ -10390,6 +10378,13 @@ int ProcessManager::setMySQLReplication(oam::DeviceNetworkList devicenetworklist
 				if ( remoteModuleName == masterModule )
 					continue;
 
+				// don't do PMs unless PMwithUM flag is set
+				if ( config.ServerInstallType() != oam::INSTALL_COMBINE_DM_UM_PM ) {
+					string moduleType = remoteModuleName.substr(0,MAX_MODULE_TYPE_SIZE);
+					if ( moduleType == "pm" && PMwithUM == "n" )
+						continue;
+				}
+		
 				ByteStream msg;
 				ByteStream::byte requestID = oam::MASTERDIST;
 				msg << requestID;
@@ -10485,7 +10480,6 @@ int ProcessManager::setMySQLReplication(oam::DeviceNetworkList devicenetworklist
 				
 					msg1 << masterLogFile;
 					msg1 << masterLogPos;
-					msg1 << MySQLPort;
 				}
 
 				returnStatus = sendMsgProcMon( remoteModuleName, msg1, requestID, 60 );
@@ -10534,7 +10528,6 @@ int ProcessManager::setMySQLReplication(oam::DeviceNetworkList devicenetworklist
 			
 				msg1 << masterLogFile;
 				msg1 << masterLogPos;
-				msg1 << MySQLPort;
 			}
 		
 			returnStatus = sendMsgProcMon( remoteModuleName, msg1, requestID, 60 );

--- a/procmon/processmonitor.h
+++ b/procmon/processmonitor.h
@@ -492,12 +492,18 @@ public:
     /**
      *@brief run upgrade script
      */
-	int runUpgrade(std::string mysqlpw);
+//	int runUpgrade(std::string mysqlpw);
 
     /**
      *@brief change my.cnf
      */
 	int changeMyCnf(std::string type);
+
+
+    /**
+     *@brief run MariaDB Command Line script
+     */
+        int runMariaDBCommandLine(std::string command);
 
     /**
      *@brief run Master Replication script
@@ -512,7 +518,7 @@ public:
     /**
      *@brief run Slave Replication script
      */
-	int runSlaveRep(std::string& masterLogFile, std::string& masterLogPos, std::string& port);
+	int runSlaveRep(std::string& masterLogFile, std::string& masterLogPos);
 
     /**
      *@brief run Disable Replication script


### PR DESCRIPTION
change in ProcessMonitor.cpp to fix 1009, added new code to do the my.cnf changes via the mysql console and remove restarting of mysqld.
changes in ProcessMonitor.cpp for mcol-1014 - in the master-dist, master-rep, slave-dist, add checks to not send to PMs when to needed
change my.cnf, local query entty change to uncomment and assign as 0
change mysql-Columnstore - increase the start timeout for the stop waiting and also add where it will be the kill_by_pid when it fails to stops after waiting for the timeout period
Columnstore.xml changed ParentOam from unassigned to pm1