### PR TITLE
MCOL-1016 Fix I_S calculations

### DIFF
--- a/dbcon/mysql/columnstore_info.sql
+++ b/dbcon/mysql/columnstore_info.sql
@@ -82,9 +82,7 @@ DROP PROCEDURE IF EXISTS `compression_ratio` //
 
 CREATE PROCEDURE compression_ratio()
 BEGIN
-SELECT CONCAT(((sum(compressed_data_size) / sum(data_size)) * 100), '%') COMPRESSION_RATIO FROM INFORMATION_SCHEMA.COLUMNSTORE_EXTENTS ce
-JOIN INFORMATION_SCHEMA.COLUMNSTORE_FILES cf ON ce.object_id = cf.object_id
-WHERE compressed_data_size IS NOT NULL;
+SELECT CONCAT((SELECT SUM(file_size) FROM information_schema.columnstore_files WHERE compressed_data_size IS NOT NULL) / (SELECT SUM(data_size) FROM information_schema.columnstore_extents) * 100, '%') COMPRESSION_RATIO;
 END //
 
 DELIMITER ;

--- a/dbcon/mysql/is_columnstore_extents.cpp
+++ b/dbcon/mysql/is_columnstore_extents.cpp
@@ -152,14 +152,18 @@ static int is_columnstore_extents_fill(THD *thd, TABLE_LIST *tables, COND *cond)
                 default:
                     table->field[14]->store("Unknown", strlen("Unknown"), cs);
             }
-            // MCOL-454: special case, sometimes blockOffset can be > 0 and HWM can be 0
+            // MCOL-1016: on multiple segments HWM is set to 0 on the lower
+            // segments, we don't want these to show as 8KB. The down side is
+            // if the column has less than 1 block it will show as 0 bytes.
+            // We have no lookahead without it getting messy so this is the
+            // best compromise.
             if (iter->HWM == 0)
             {
-                table->field[15]->store(8192);
+                table->field[15]->store(0);
             }
             else
             {
-                table->field[15]->store((iter->HWM - iter->blockOffset + 1) * 8192);
+                table->field[15]->store((iter->HWM + 1) * 8192);
             }
 
             if (schema_table_store_record(thd, table))


### PR DESCRIPTION
* COLUMNSTORE_EXTENTS data_size now shows the total size on the highest
segment of an extent file. It also shows 0 bytes if HWM is zero so that
if there is more than one segment it doesn't show 8192 bytes for the
lower segments.
* COMPRESSION_RATIO was missing some data and using compressed data size
instead of file size (which is probably more realistic).