### PR TITLE
MCOL-1021 Fix dictionary de-duplication cache

### DIFF
--- a/writeengine/dictionary/we_dctnry.cpp
+++ b/writeengine/dictionary/we_dctnry.cpp
@@ -628,6 +628,8 @@ int Dctnry::insertDctnry2(Signature& sig)
     int rc = 0;
     int write_size;
     bool lbid_in_token = false;
+    size_t origSigSize = sig.size;
+    unsigned char* origSig = sig.signature;
 
     sig.token.bc = 0;
 
@@ -718,6 +720,8 @@ int Dctnry::insertDctnry2(Signature& sig)
      
         }
     }
+    sig.size = origSigSize;
+    sig.signature = origSig;
     return NO_ERROR;
 }
 
@@ -825,8 +829,7 @@ int Dctnry::insertDctnry(const char* buf,
 
         //...Search for the string in our string cache
         //if it fits into one block (< 8KB)
-        if ((m_arraySize < MAX_STRING_CACHE_SIZE) &&
-            (curSig.size <= MAX_SIGNATURE_SIZE))
+        if (curSig.size <= MAX_SIGNATURE_SIZE)
         {
             //Stats::startParseEvent("getTokenFromArray");
             found = getTokenFromArray(curSig);
@@ -1375,8 +1378,7 @@ int  Dctnry::updateDctnry(unsigned char* sigValue, int& sigSize,
 
     // Look for string in cache
     // As long as the string <= 8000 bytes
-    if ((m_arraySize < MAX_STRING_CACHE_SIZE) &&
-        (sigSize <= MAX_SIGNATURE_SIZE))
+    if (sigSize <= MAX_SIGNATURE_SIZE)
     {
         bool found = false;
         found = getTokenFromArray(sig);


### PR DESCRIPTION
The signatures were getting destroyed whilst processing before being
used in the dictionary de-duplication cache making the cache full of
empty strings. This fix resets the signature after insertion for the
cache.

This fix also lets the signature cache be read when there is 1000
entries in it.