### PR TITLE
MCOL-1008 Fix bad length on bulk DML insert

### DIFF
--- a/dbcon/mysql/ha_calpont_dml.cpp
+++ b/dbcon/mysql/ha_calpont_dml.cpp
@@ -893,12 +893,12 @@ int ha_calpont_impl_write_batch_row_(uchar *buf, TABLE* table, cal_impl_if::cal_
 						{
 							if (ci.columnTypes[colpos].colWidth < 256)
 							{
-								dataLength = *(int8_t*) buf;
+								dataLength = *(uint8_t*) buf;
 								buf++;
 							}
 							else
 							{
-								dataLength = *(int16_t*) buf;
+								dataLength = *(uint16_t*) buf;
 								buf = buf + 2 ;
 							}
                             escape.assign((char*)buf, dataLength);
@@ -909,7 +909,7 @@ int ha_calpont_impl_write_batch_row_(uchar *buf, TABLE* table, cal_impl_if::cal_
 						{
 							if (ci.columnTypes[colpos].colWidth < 86)
 							{
-								dataLength = *(int8_t*) buf;
+								dataLength = *(uint8_t*) buf;
 								buf++;
 							}
 							else


### PR DESCRIPTION
If a VARCHAR was defined as less than 255 characters and a data via LDI
or INSERT...SELECT was > 127 characters the length field would contain a
negative number.

In 1.0.11 and 1.1.0 this was not a problem because we cast the negative
back again. With MCOL-877 we stoped doing the double-cast. This patch
casts properly the first time.