### PR TITLE
MCOL-1029 Skip cached conditions

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -4317,6 +4317,14 @@ void gp_walk(const Item *item, void *arg)
 			bool isOr = (ftype == Item_func::COND_OR_FUNC);
             bool isXor = (ftype == Item_func::XOR_FUNC);
 
+            // MCOL-1029 A cached COND_ITEM is something like:
+            // AND (TRUE OR FALSE)
+            // We can skip it
+            if (isCached)
+            {
+                break;
+            }
+
 			List<Item> *argumentList;
 			List<Item> xorArgumentList;
 			if (isXor)
@@ -4369,7 +4377,7 @@ void gp_walk(const Item *item, void *arg)
 						}
 					}
 				}
-			
+
 				// @bug1603. MySQL's filter tree is a multi-tree grouped by operator. So more than
 				// two filters saved on the stack so far might belong to this operator.
 				uint32_t leftInStack = gwip->ptWorkStack.size() - argumentList->elements + 1;


### PR DESCRIPTION
Cached conditions are things like (TRUE OR FALSE). They don't actually
add any value to the query and were breaking our working stack trying to
process them.