### PR TITLE
MCOL-978 Disable QCache for ColumnStore

### DIFF
--- a/dbcon/mysql/ha_calpont.h
+++ b/dbcon/mysql/ha_calpont.h
@@ -239,6 +239,8 @@ public:
     THR_LOCK_DATA** store_lock(THD* thd, THR_LOCK_DATA** to,
                                enum thr_lock_type lock_type);     ///< required
     const COND* cond_push(const COND* cond);
+    uint8 table_cache_type() { return HA_CACHE_TBL_NOCACHE; }
+
 };
 #endif //HA_CALPONT_H__
 


### PR DESCRIPTION
ColumnStore tables can have data modifications away from a specific
MariaDB server. This means it is possible for QCache to not be
invalidated properly in vtable mode 0. This patch makes sure it is
disabled for ColumnStore.