### PR TITLE
MCOL-1116 Fix I_S.CS_FILES for missing dbroot

### DIFF
--- a/dbcon/mysql/is_columnstore_files.cpp
+++ b/dbcon/mysql/is_columnstore_files.cpp
@@ -124,6 +124,17 @@ static int is_columnstore_files_fill(THD *thd, TABLE_LIST *tables, COND *cond)
                 iter++;
                 continue;
             }
+
+            try
+            {
+                oam_instance.getDbrootPmConfig(iter->dbRoot, pmId);
+            }
+            catch (std::runtime_error)
+            {
+                // MCOL-1116: If we are here a DBRoot is offline/missing
+                iter++;
+                continue;
+            }
             table->field[0]->store(oid);
             table->field[1]->store(iter->segmentNum);
             table->field[2]->store(iter->partitionNum);
@@ -134,7 +145,7 @@ static int is_columnstore_files_fill(THD *thd, TABLE_LIST *tables, COND *cond)
             std::string DbRootPath = config->getConfig("SystemConfig", DbRootName.str());
             fileSize = compressedFileSize = 0;
             snprintf(fullFileName, WriteEngine::FILE_NAME_SIZE, "%s/%s", DbRootPath.c_str(), oidDirName);
-            oam_instance.getDbrootPmConfig(iter->dbRoot, pmId);
+
             std::ostringstream oss;
             oss << "pm" << pmId << "_WriteEngineServer";
             std::string client = oss.str();


### PR DESCRIPTION
If a dbroot is missing/offline mysqld would crash on
information_schema.columnstore_files due to not catching an exception.
This patch now catches the exception.