### PR TITLE
MCOL-1138 - fix issue where no HOT_STANDBY procmgr existed after pm1 …

### DIFF
--- a/procmgr/main.cpp
+++ b/procmgr/main.cpp
@@ -1828,9 +1828,18 @@ void pingDeviceThread()
 								break;
 	
 							// if disabled and not amazon, skip
-							if (opState == oam::AUTO_DISABLED && !amazon)
+							if ( (opState == oam::AUTO_DISABLED) && !amazon)
 								break;
 	
+							// if disabled, amazon,and NOT terminated skip
+							if ( (opState == oam::AUTO_DISABLED) && amazon)
+							{
+							      // return values = 'ip address' for running or rebooting, stopped or terminated
+							      string currentIPAddr = oam.getEC2InstanceIpAddress(hostName);
+							      if ( currentIPAddr != "terminated")
+									break;
+							}
+							
 							log.writeLog(__LINE__, "module failed to respond to pings: " + moduleName, LOG_TYPE_WARNING);
 	
 							//bump module ping failure counter

--- a/procmgr/processmanager.cpp
+++ b/procmgr/processmanager.cpp
@@ -9455,7 +9455,7 @@ int ProcessManager::OAMParentModuleChange()
 
 	//restart/reinit processes to force their release of the controller node port
 	if ( ( config.ServerInstallType() == oam::INSTALL_COMBINE_DM_UM_PM)  &&
-		( moduleNameList.size() <= 1 && config.moduleType() == "pm") )
+		( moduleNameList.size() <= 0 && config.moduleType() == "pm") )
 	{
 		status = 0;
 	}
@@ -9710,7 +9710,8 @@ std::string ProcessManager::getStandbyModule()
 				//already have a hot-standby
 				return "";
 
-			if ( backupStandbyModule != "NONE" )
+			if ( ( backupStandbyModule != "NONE" ) ||
+			      ( newStandbyModule != "NONE" ) )
 				continue;
 
 			if ( systemprocessstatus.processstatus[i].ProcessName == "ProcessManager" &&


### PR DESCRIPTION
fixed 2 issues

1.  fix issue where no HOT_STANDBY procmgr existed after pm1  outage
2. on a Parent pm outage, it was going  through recovery code in the parent outage code and in module outage code.  Changed to have it only process the outage in the parent outage code