### PR TITLE
MCOL-573. Reserverd words as table and column names.

### DIFF
--- a/dbcon/ddlpackage/CMakeLists.txt
+++ b/dbcon/ddlpackage/CMakeLists.txt
@@ -9,6 +9,10 @@ ADD_CUSTOM_COMMAND(
     DEPENDS ddl.y ddl.l
 )
 
+# Parser puts extra info to stderr.
+INCLUDE(../../check_compiler_flag.cmake)
+MY_CHECK_AND_SET_COMPILER_FLAG("-DYYDEBUG" DEBUG)
+
 ########### next target ###############
 
 set(ddlpackage_LIB_SRCS

--- a/dbcon/ddlpackage/ddl.l
+++ b/dbcon/ddlpackage/ddl.l
@@ -31,10 +31,11 @@
 #endif
 
 using namespace ddlpackage;
+typedef enum { NOOP, STRIP_QUOTES } copy_action_t;
 int lineno = 1;
 void ddlerror(struct pass_to_bison* x, char const *s);
 
-static char* scanner_copy(char *str, yyscan_t yyscanner);
+static char* scanner_copy(char *str, yyscan_t yyscanner, copy_action_t action = NOOP );
 
 %}
 
@@ -54,6 +55,10 @@ horiz_space [ \t\f]
 newline [\n\r]
 non_newline [^\n\r]
 
+quote '
+double_quote \"
+grave_accent `
+
 comment ("--"{non_newline}*)
 self			[,()\[\].;\:\+\-\*\/\%\^\<\>\=]
 whitespace ({space}+|{comment})
@@ -62,6 +67,10 @@ digit [0-9]
 ident_start [A-Za-z\200-\377_]
 ident_cont [A-Za-z\200-\377_0-9\$]
 identifier {ident_start}{ident_cont}*
+/* fully qualified names regexes */
+fq_identifier {identifier}\.{identifier}
+identifer_quoted {grave_accent}{identifier}{grave_accent}
+identifer_double_quoted {double_quote}{identifier}{double_quote}
 
 integer			[-+]?{digit}+
 decimal			([-+]?({digit}*\.{digit}+)|({digit}+\.{digit}*))
@@ -69,10 +78,13 @@ real			({integer}|{decimal})[Ee][-+]?{digit}+
 realfail1		({integer}|{decimal})[Ee]
 realfail2		({integer}|{decimal})[Ee][-+]
 
-quote '
-grave_accent `
 
 %%
+
+
+{identifer_quoted} { ddlget_lval(yyscanner)->str = scanner_copy( ddlget_text(yyscanner), yyscanner, STRIP_QUOTES ); return IDENT; }
+{identifer_double_quoted} { ddlget_lval(yyscanner)->str = scanner_copy( ddlget_text(yyscanner), yyscanner, STRIP_QUOTES ); return IDENT; }
+{fq_identifier} { ddlget_lval(yyscanner)->str = scanner_copy(ddlget_text(yyscanner), yyscanner); return FQ_IDENT; }
 
 ACTION {return ACTION;}
 ADD {return ADD;}
@@ -198,6 +210,11 @@ using namespace ddlpackage;
  */
 void scanner_init(const char* str, yyscan_t yyscanner)
 {
+#ifdef YYDEBUG
+    extern int ddldebug;
+    ddldebug = 1;
+#endif
+
 	size_t slen = strlen(str);
    scan_data* pScanData = (scan_data*)ddlget_extra(yyscanner);
 
@@ -246,10 +263,21 @@ void scanner_finish(yyscan_t yyscanner)
    pScanData->valbuf.clear();
 }
 
-char* scanner_copy (char *str, yyscan_t yyscanner)
+char* scanner_copy (char *str, yyscan_t yyscanner, copy_action_t action)
 {
-   char* nv = strdup(str);
-   if(nv)
-      ((scan_data*)ddlget_extra(yyscanner))->valbuf.push_back(nv);
-   return nv;
+    char* result;
+    char* nv = strdup(str);
+    result = nv;
+
+    // free strduped memory later to prevent possible memory leak
+    if(nv)
+        ((scan_data*)ddlget_extra(yyscanner))->valbuf.push_back(nv);
+
+    if(action == STRIP_QUOTES)
+    {
+        nv[strlen(str) - 1] = '\0';
+        result = nv + 1;
+    }
+
+    return result;
 }

--- a/dbcon/ddlpackage/ddl.y
+++ b/dbcon/ddlpackage/ddl.y
@@ -48,6 +48,7 @@
    */
 
 %{
+#include "string.h"
 #include "sqlparser.h"
 
 #ifdef _MSC_VER
@@ -121,7 +122,7 @@ REFERENCES RENAME RESTRICT SET SMALLINT TABLE TEXT TIME TINYBLOB TINYTEXT
 TINYINT TO UNIQUE UNSIGNED UPDATE USER SESSION_USER SYSTEM_USER VARCHAR VARBINARY
 VARYING WITH ZONE DOUBLE IDB_FLOAT REAL CHARSET IDB_IF EXISTS CHANGE TRUNCATE
 
-%token <str> IDENT FCONST SCONST CP_SEARCH_CONDITION_TEXT ICONST DATE
+%token <str> FQ_IDENT IDENT FCONST SCONST CP_SEARCH_CONDITION_TEXT ICONST DATE
 
 /* Notes:
  * 1. "ata" stands for alter_table_action
@@ -611,7 +612,19 @@ table_name:
 	;
 
 qualified_name:
-	IDENT '.' IDENT {$$ = new QualifiedName($1, $3);}
+	FQ_IDENT {
+                char* delimeterPosition = strchr(const_cast<char*>($1), '.');
+                if( delimeterPosition )
+                {
+                    *delimeterPosition = '\0';
+                    char* schemaName = const_cast<char*>($1);
+                    char* tableName = delimeterPosition + 1;
+                    $$ = new QualifiedName(schemaName, tableName);
+                    *delimeterPosition = '.';
+                }
+                else
+                    $$ = new QualifiedName($1);
+             }
 	| IDENT {
 				if (x->fDBSchema.size())
 					$$ = new QualifiedName((char*)x->fDBSchema.c_str(), $1);

--- a/dbcon/mysql/ha_calpont_ddl.cpp
+++ b/dbcon/mysql/ha_calpont_ddl.cpp
@@ -2179,7 +2179,6 @@ int ha_calpont_impl_rename_table_(const char* from, const char* to, cal_connecti
     THD* thd = current_thd;
     string emsg;
 
-    ostringstream stmt1;
     pair<string, string> fromPair;
     pair<string, string> toPair;
     string stmt;
@@ -2207,9 +2206,8 @@ int ha_calpont_impl_rename_table_(const char* from, const char* to, cal_connecti
         return -1;
     }
 
-    stmt1 << "alter table " << fromPair.second << " rename to " << toPair.second << ";";
-
-    stmt = stmt1.str();
+    // This explicitely shields both db objects with quotes that the lexer strips down later.
+    stmt = "alter table `" + fromPair.second + "` rename to `" + toPair.second + "`;";
     string db;
 
     if ( thd->db )


### PR DESCRIPTION
Both quotation types: grave accent ` and double quote " are supported. Bison parser outputs extra information if built in debug mode.