### PR TITLE
MCOL-716 Support UTF-8 for table and column names.

### DIFF
--- a/dbcon/mysql/ha_calpont_ddl.cpp
+++ b/dbcon/mysql/ha_calpont_ddl.cpp
@@ -2206,8 +2206,8 @@ int ha_calpont_impl_rename_table_(const char* from, const char* to, cal_connecti
         return -1;
     }
 
-    // This explicitely shields both db objects with quotes that the lexer strips down later.
-    stmt = "alter table `" + fromPair.second + "` rename to `" + toPair.second + "`;";
+    stmt = thd->query();
+    stmt += ';';
     string db;
 
     if ( thd->db )
@@ -2220,7 +2220,7 @@ int ha_calpont_impl_rename_table_(const char* from, const char* to, cal_connecti
     int rc = ProcessDDLStatement(stmt, db, "", tid2sid(thd->thread_id), emsg);
 
     if (rc != 0)
-        push_warning(thd, Sql_condition::WARN_LEVEL_ERROR, 9999, emsg.c_str());
+        push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 9999, emsg.c_str());
 
     return rc;
 }
@@ -2262,7 +2262,7 @@ extern "C"
         int rc = ProcessDDLStatement(stmt, db, "", tid2sid(thd->thread_id), emsg, compressiontype);
 
         if (rc != 0)
-            push_warning(thd, Sql_condition::WARN_LEVEL_ERROR, 9999, emsg.c_str());
+            push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 9999, emsg.c_str());
 
         return rc;
     }


### PR DESCRIPTION
It occures, that major DDL/DML functions support a subset of UTF-8(according with [this](https://mariadb.com/kb/en/library/identifier-names/)) for table/column identifiers and only 'ALTER TABLE RENAME' doesn't support it because the mariadb plugin function ha_calpont_impl_rename_table_() replaces the initial query. I changed this and also replace push_warning() arguments according with recomendations given in server_code/sql/sql_error.cc to avoid possible sigabort.
Kindly take a look at the tiny [functional tests results](https://hastebin.com/bojufapave.vbs).