### PR TITLE
MCOL-1070 Fix exists in view subquery

### DIFF
--- a/dbcon/joblist/subquerytransformer.cpp
+++ b/dbcon/joblist/subquerytransformer.cpp
@@ -399,6 +399,7 @@ void SubQueryTransformer::updateCorrelateInfo()
 						sc->schemaName("");
 						sc->tableName(fVtable.name());
 						sc->tableAlias(fVtable.alias());
+                        sc->viewName(fVtable.view());
 						sc->oid(fVtable.columnOid(k->second));
 						sc->columnName(fVtable.columns()[k->second]->columnName());
 						const CalpontSystemCatalog::ColType& ct = fVtable.columnType(k->second);

--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -1810,6 +1810,11 @@ SimpleColumn* buildSimpleColFromDerivedTable(gp_walk_info& gwi, Item_field* ifp)
 							{
 								sc->derivedTable(derivedName);
 								sc->derivedRefCol(cols[j].get());
+                                if (tblList->belong_to_view)
+                                {
+                                    sc->viewName(lower(tblList->belong_to_view->alias));
+                                }
+
 							}
 							break;
 						}


### PR DESCRIPTION
When ExeMgr processes a correlated exists filter for a subquery inside a
view the de-duplication check doesn't work. We sometimes check unique
with the view name, sometimes not. We don't need the view name here so
remove it if we don't have it.

Also push the view name in the subquery.