### PR TITLE
MCOL-1228 Allow alter table for TEXT/BLOB

### DIFF
--- a/dbcon/ddlpackageproc/altertableprocessor.cpp
+++ b/dbcon/ddlpackageproc/altertableprocessor.cpp
@@ -174,7 +174,10 @@ bool typesAreSame(const CalpontSystemCatalog::ColType& colType, const ColumnType
 	case (CalpontSystemCatalog::CLOB):
 		break;
 	case (CalpontSystemCatalog::BLOB):
+        if (newType.fType == DDL_BLOB && colType.colWidth == newType.fLength) return true;
+        break;
 	case (CalpontSystemCatalog::TEXT):
+        if (newType.fType == DDL_TEXT && colType.colWidth == newType.fLength) return true;
 		break;
 	default:
 		break;


### PR DESCRIPTION
CHANGE COLUMN was blocked for TEXT and BLOB types. This fix applies to
things like TINYTEXT as well as the only difference internally is the
column width.