### PR TITLE
MCOL-1219: Object and column identifiers can start with a digit now.

### DIFF
--- a/dbcon/ddlpackage/ddl.l
+++ b/dbcon/ddlpackage/ddl.l
@@ -64,7 +64,7 @@ self			[,()\[\].;\:\+\-\*\/\%\^\<\>\=]
 whitespace ({space}+|{comment})
 
 digit [0-9]
-ident_start [A-Za-z\200-\377_]
+ident_start [A-Za-z\200-\377_0-9]
 ident_cont [A-Za-z\200-\377_0-9\$]
 identifier {ident_start}{ident_cont}*
 /* fully qualified names regexes */


### PR DESCRIPTION
Object and column identifiers can start with a digit now.