### PR TITLE
MCOL-1182 Fix cross engine filters

### DIFF
--- a/dbcon/joblist/jlf_execplantojoblist.cpp
+++ b/dbcon/joblist/jlf_execplantojoblist.cpp
@@ -2236,12 +2236,11 @@ const JobStepVector doOuterJoinOnFilter(OuterJoinOnFilter* oj, JobInfo& jobInfo)
 							pp->right(p->left());
 						cpMap[p->left()] = pp;
 					}
-				}
-
-				p->left(nullTree);
-				p->right(nullTree);
-				delete p;
-				delete c;
+    				p->left(nullTree);
+    				p->right(nullTree);
+    				delete p;
+    				delete c;
+                }
 			}
 		}
 


### PR DESCRIPTION
Don't delete a join filter that hasn't actually been used yet. It
appears that tree pruning is happening in the wrong place.