### PR TITLE
MCOL-1229 - IS.columnstore_columns crashes when DDL is simultaneously…

### DIFF
--- a/dbcon/mysql/is_columnstore_columns.cpp
+++ b/dbcon/mysql/is_columnstore_columns.cpp
@@ -84,7 +84,7 @@ static int is_columnstore_columns_fill(THD *thd, TABLE_LIST *tables, COND *cond)
                 continue;
             }
             else {
-                throw;
+                return 1;
             }
         }
 


### PR DESCRIPTION
… executing.

The crash was due to an attempt to iterate over the columns of a recently dropped table.
Such a table will now be ignored.