### PR TITLE
MCOL-1376 Fix compiler errors in Ubuntu 18.04

### DIFF
--- a/dbcon/joblist/tupleunion.cpp
+++ b/dbcon/joblist/tupleunion.cpp
@@ -48,7 +48,7 @@ using namespace dataconvert;
 namespace
 {
 //returns the value of 10 raised to the power x.
-inline double pow10(double x)
+inline double exp10(double x)
 {
     return exp(x * M_LN10);
 }
@@ -460,7 +460,7 @@ void TupleUnion::normalize(const Row& in, Row* out)
                         if (in.getScale(i))
                         {
                             double d = in.getIntField(i);
-                            d /= pow10(in.getScale(i));
+                            d /= exp10(in.getScale(i));
                             os.precision(15);
                             os << d;
                         }
@@ -570,7 +570,7 @@ dec1:
                         if (in.getScale(i))
                         {
                             double d = in.getUintField(i);
-                            d /= pow10(in.getScale(i));
+                            d /= exp10(in.getScale(i));
                             os.precision(15);
                             os << d;
                         }

--- a/utils/common/any.hpp
+++ b/utils/common/any.hpp
@@ -54,15 +54,25 @@ namespace anyimpl
 	template<typename T>
 	struct big_any_policy : typed_base_any_policy<T>
 	{
-		virtual void static_delete(void** x) { if (*x) 
-			delete(*reinterpret_cast<T**>(x)); *x = NULL; }
-		virtual void copy_from_value(void const* src, void** dest) { 
-		   *dest = new T(*reinterpret_cast<T const*>(src)); }
-		virtual void clone(void* const* src, void** dest) { 
-		   *dest = new T(**reinterpret_cast<T* const*>(src)); }
-		virtual void move(void* const* src, void** dest) { 
-		  (*reinterpret_cast<T**>(dest))->~T(); 
-		  **reinterpret_cast<T**>(dest) = **reinterpret_cast<T* const*>(src); }
+		virtual void static_delete(void** x)
+        {
+            if (*x)
+    			delete(*reinterpret_cast<T**>(x));
+            *x = NULL;
+        }
+		virtual void copy_from_value(void const* src, void** dest)
+        {
+		   *dest = new T(*reinterpret_cast<T const*>(src));
+        }
+		virtual void clone(void* const* src, void** dest)
+        {
+		   *dest = new T(**reinterpret_cast<T* const*>(src));
+        }
+		virtual void move(void* const* src, void** dest)
+        {
+		  (*reinterpret_cast<T**>(dest))->~T();
+		  **reinterpret_cast<T**>(dest) = **reinterpret_cast<T* const*>(src);
+        }
 		virtual void* get_value(void** src) { return *src; }
 	};
 

--- a/utils/common/cgroupconfigurator.cpp
+++ b/utils/common/cgroupconfigurator.cpp
@@ -19,6 +19,7 @@
 #include "configcpp.h"
 #include "logger.h"
 #include <fstream>
+#include <iostream>
 #include <boost/regex.hpp>
 #ifdef _MSC_VER
 #include "unistd.h"

--- a/utils/threadpool/threadpool.cpp
+++ b/utils/threadpool/threadpool.cpp
@@ -21,6 +21,7 @@
 *
 ***********************************************************************/
 #include <stdexcept>
+#include <iostream>
 using namespace std;
 
 #include "messageobj.h"


### PR DESCRIPTION
Ubuntu 18.04 uses GCC 7.3 which is a little stricter than before.

Fixes a few errors due to implicit includes that are no longer implicit
and a ton of warnings about the implied alignment of code in
utils/common/any.hpp