### PR TITLE
MCOL-1197 Make -c work in cpimport

### DIFF
--- a/writeengine/splitter/we_cmdargs.h
+++ b/writeengine/splitter/we_cmdargs.h
@@ -77,6 +77,7 @@ class WECmdArgs
 		char getDelimChar() { return fColDelim; }
 		ImportDataMode getImportDataMode() const { return fImportDataMode; }
 		bool getConsoleLog() { return fConsoleLog; }
+        int getReadBufSize() { return fReadBufSize; }
 
 		bool isCpimportInvokeMode(){return (fBlockMode3)? false : fCpiInvoke;}
 		bool isQuiteMode() const {	return fQuiteMode;	}

--- a/writeengine/splitter/we_filereadthread.cpp
+++ b/writeengine/splitter/we_filereadthread.cpp
@@ -87,6 +87,15 @@ WEFileReadThread::WEFileReadThread(WESDHandler& aSdh):fSdh(aSdh),
 {
 	//TODO batch qty to get from config
 	fBatchQty = 10000;
+    if (fSdh.getReadBufSize() < DEFAULTBUFFSIZE)
+    {
+        fBuffSize = DEFAULTBUFFSIZE;
+    }
+    else
+    {
+        fBuffSize = fSdh.getReadBufSize();
+    }
+    fBuff = new char [fBuffSize];
 
 }
 
@@ -106,6 +115,7 @@ WEFileReadThread::~WEFileReadThread()
 		delete fpThread;
 	}
 	fpThread=0;
+    delete []fBuff;
 	//cout << "WEFileReadThread destructor called" << endl;
 }
 
@@ -330,16 +340,16 @@ unsigned int WEFileReadThread::readDataFile(messageqcpp::SBS& Sbs)
 			if(fEnclEsc)
 			{
 				//pStart = aBuff;
-				aLen = getNextRow(fInFile, fBuff, sizeof(fBuff)-1);
+				aLen = getNextRow(fInFile, fBuff, fBuffSize-1);
 			}
 			else
 			{
-				fInFile.getline(fBuff, sizeof(fBuff)-1);
+				fInFile.getline(fBuff, fBuffSize-1);
 				aLen=fInFile.gcount();
 			}
 			////aLen chars incl \n, Therefore aLen-1; '<<' oper won't go past it
 			//cout << "Data Length " << aLen <<endl;
-			if((aLen < (sizeof(fBuff)-2)) && (aLen>0))
+			if((aLen < (fBuffSize-2)) && (aLen>0))
 			{
 				fBuff[aLen-1] = '\n';
 				fBuff[aLen]=0;
@@ -348,7 +358,7 @@ unsigned int WEFileReadThread::readDataFile(messageqcpp::SBS& Sbs)
 				aIdx++;
 				if(fSdh.getDebugLvl()>2) cout << "File data line = " << aIdx <<endl;
 			}
-			else if(aLen>=sizeof(fBuff)-2)	//Didn't hit delim; BIG ROW
+			else if(aLen>=fBuffSize-2)	//Didn't hit delim; BIG ROW
 			{
 				cout <<"Bad Row data " << endl;
 				cout << fBuff << endl;

--- a/writeengine/splitter/we_filereadthread.h
+++ b/writeengine/splitter/we_filereadthread.h
@@ -98,7 +98,7 @@ public:
     void add2InputDataFileList(std::string& FileName);
 
 private:
-    enum { MAXBUFFSIZE=1024*1024 };
+    enum { DEFAULTBUFFSIZE=1024*1024 };
 
     // don't allow anyone else to set
     void setTgtPmId(unsigned int fTgtPmId) { this->fTgtPmId = fTgtPmId; }
@@ -120,7 +120,8 @@ private:
     char fEncl;							// Encl char
     char fEsc;							// Esc char
     char fDelim;						// Column Delimit char
-    char fBuff[MAXBUFFSIZE];			// main data buffer
+    char* fBuff;			// main data buffer
+    int fBuffSize;
 };
 
 } /* namespace WriteEngine */

--- a/writeengine/splitter/we_sdhandler.cpp
+++ b/writeengine/splitter/we_sdhandler.cpp
@@ -2301,6 +2301,13 @@ char WESDHandler::getEscChar()
 
 //------------------------------------------------------------------------------
 
+int WESDHandler::getReadBufSize()
+{
+    return fRef.fCmdArgs.getReadBufSize();
+}
+
+//------------------------------------------------------------------------------
+
 char WESDHandler::getDelimChar()
 {
 	return fRef.fCmdArgs.getDelimChar();

--- a/writeengine/splitter/we_sdhandler.h
+++ b/writeengine/splitter/we_sdhandler.h
@@ -149,6 +149,7 @@ public:
     char getEscChar();
     char getDelimChar();
 	bool getConsoleLog();
+    int getReadBufSize();
     ImportDataMode getImportDataMode() const;
     void sysLog(const logging::Message::Args& msgArgs,
     		logging::LOG_TYPE logType, logging::Message::MessageID msgId);


### PR DESCRIPTION
It turns out -c wasn't actually connected to anything and now with have
BLOB/TEXT it is pretty useful. If -c is set to < 1MB then 1MB is used,
otherwise it will use the selected buffer size.