### PR TITLE
MCOL-1403 Remove whitespace trimming on constants

### DIFF
--- a/dbcon/joblist/jlf_execplantojoblist.cpp
+++ b/dbcon/joblist/jlf_execplantojoblist.cpp
@@ -1500,10 +1500,7 @@ const JobStepVector doSimpleFilter(SimpleFilter* sf, JobInfo& jobInfo)
 			return doExpressionFilter(sf, jobInfo);
 		}
 
-		// trim trailing space char in the predicate
 		string constval(cc->constval());
-		size_t spos = constval.find_last_not_of(" ");
-		if (spos != string::npos) constval = constval.substr(0, spos+1);
 
 		CalpontSystemCatalog::OID dictOid = 0;
 		CalpontSystemCatalog::ColType ct = sc->colType();
@@ -2569,10 +2566,7 @@ const JobStepVector doConstantFilter(const ConstantFilter* cf, JobInfo& jobInfo)
 					if (ConstantColumn::NULLDATA == cc->type() && (opeq == *sop || opne == *sop))
 						cop = COMPARE_NIL;
 
-					// trim trailing space char
 					string value = cc->constval();
-					size_t spos = value.find_last_not_of(" ");
-					if (spos != string::npos) value = value.substr(0, spos+1);
 					pds->addFilter(cop, value);
 				}
 
@@ -2652,10 +2646,7 @@ const JobStepVector doConstantFilter(const ConstantFilter* cf, JobInfo& jobInfo)
 					if (ConstantColumn::NULLDATA == cc->type() && (opeq == *sop || opne == *sop))
 						cop = COMPARE_NIL;
 
-					// trim trailing space char
 					string value = cc->constval();
-					size_t spos = value.find_last_not_of(" ");
-					if (spos != string::npos) value = value.substr(0, spos+1);
 					pds->addFilter(cop, value);
 				}
 
@@ -2759,9 +2750,6 @@ const JobStepVector doConstantFilter(const ConstantFilter* cf, JobInfo& jobInfo)
 					int8_t cop = op2num(sop);
 					int64_t value = 0;
 					string constval = cc->constval();
-					// trim trailing space char
-					size_t spos = constval.find_last_not_of(" ");
-					if (spos != string::npos) constval = constval.substr(0, spos+1);
 
 					// @bug 1151 string longer than colwidth of char/varchar.
 					uint8_t rf = 0;

--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -4099,7 +4099,6 @@ void gp_walk(const Item *item, void *arg)
 			Item_string* isp = (Item_string*)item;
 			if (isp)
 			{
-				// @bug 3669. trim trailing spaces for the compare value
 				if (isp->result_type() == STRING_RESULT)
 				{
 					String val, *str = isp->val_str(&val);
@@ -4108,9 +4107,6 @@ void gp_walk(const Item *item, void *arg)
 					{
 						cval.assign(str->ptr(), str->length());
 					}
-					size_t spos = cval.find_last_not_of(" ");
-					if (spos != string::npos)
-						cval = cval.substr(0, spos+1);
 					gwip->rcWorkStack.push(new ConstantColumn(cval));
 					break;
 				}


### PR DESCRIPTION
This appears to be to fix equality matches in InfiniDB but at the same
time it breaks LIKE processing. Equality matching with trailing
whitespace was fixed in MCOL-1246 so the old InfiniDB patch can be
removed.