### PR TITLE
MCOL-1390 Fix SUBSTRING_INDEX for negative count

### DIFF
--- a/utils/funcexp/func_substring_index.cpp
+++ b/utils/funcexp/func_substring_index.cpp
@@ -71,6 +71,9 @@ std::string Func_substring_index::getStrVal(rowgroup::Row& row,
 	if ( count > (int64_t) end )
 		return str;
 
+    if (( count < 0 ) && ((count * -1) > end))
+        return str;
+
 	string value = str;
 
 	if ( count > 0 ) {


### PR DESCRIPTION
If negative count number is more than the number of characters in the
string then it should always return the string.

For example if a table contains SUBSTRING_INDEX('zzz', 'z', -5) should
return 'zzz'. Before this patch it would return NULL.