### PR TITLE
MCOL-1330 Make debug flag let valgrind work

### DIFF
--- a/exemgr/main.cpp
+++ b/exemgr/main.cpp
@@ -1354,7 +1354,9 @@ int main(int argc, char* argv[])
 		setenv("CALPONT_CSC_IDENT", "um", 1);
 #endif
 	setupSignalHandlers();
-    int err = setupResources();
+    int err = 0;
+    if (!gDebug)
+        err = setupResources();
     string errMsg;
     switch (err)
     {

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -299,6 +299,22 @@ int main(int argc, char* argv[])
     // This is unset due to the way we start it
     program_invocation_short_name = const_cast<char*>("PrimProc");
 
+    int gDebug = 0;
+    int c;
+
+    while ((c = getopt(argc, argv, "d")) != EOF)
+    {
+        switch(c)
+        {
+            case 'd':
+                gDebug++;
+                break;
+            case '?':
+            default:
+                break;
+        }
+    }
+
 	Config* cf = Config::makeConfig();
 
 	setupSignalHandlers();
@@ -307,7 +323,9 @@ int main(int argc, char* argv[])
 
 	mlp = new primitiveprocessor::Logger();
 
-    int err = setupResources();
+    int err = 0;
+    if (!gDebug)
+        err = setupResources();
     string errMsg;
     switch (err)
     {

--- a/writeengine/server/we_server.cpp
+++ b/writeengine/server/we_server.cpp
@@ -103,6 +103,21 @@ int main(int argc, char** argv)
 
     printf ("Locale is : %s\n", systemLang.c_str() );
 
+    int gDebug = 0;
+    int c;
+    while ((c = getopt(argc, argv, "d")) != EOF)
+    {
+        switch (c)
+        {
+            case 'd':
+                gDebug++;
+                break;
+            case '?':
+            default:
+                break;
+        }
+    }
+
 	//set BUSY_INIT state
 	{
 		// Is there a reason to have a seperate Oam instance for this?
@@ -196,7 +211,9 @@ int main(int argc, char** argv)
 		}
 	}
 
-    int err = setupResources();
+    int err = 0;
+    if (!gDebug)
+        err = setupResources();
     string errMsg;
     switch (err)
     {


### PR DESCRIPTION
Add a '-d' flag to WriteEngine, ExeMgr and PrimProc to let valgrind work
with them.