### PR TITLE
MCOL-1037 Fix race condition in FIFO buffer

### DIFF
--- a/dbcon/joblist/fifo.h
+++ b/dbcon/joblist/fifo.h
@@ -345,17 +345,27 @@ void FIFO<element_t>::signalPs()
 template<typename element_t>
 inline bool FIFO<element_t>::next(uint64_t id, element_t *out)
 {
+    base::mutex.lock();
 	fConsumptionStarted = true;
  	if (cpos[id] >= fMaxElements)
+    {
+        base::mutex.unlock();
 		if (!waitForSwap(id))
 			return false;
+        base::mutex.lock();
+    }
 
 	*out = cBuffer[cpos[id]++];
 
 #ifndef ONE_CS
  	if (cpos[id] == fMaxElements)
+    {
+        base::mutex.unlock();
 		signalPs();
+        return true;
+    }
 #endif
+    base::mutex.unlock();
 	return true;
 }
 

--- a/primitives/linux-port/column.cpp
+++ b/primitives/linux-port/column.cpp
@@ -65,8 +65,6 @@ inline uint64_t order_swap(uint64_t x)
 template <int W>
 inline string fixChar(int64_t intval);
 
-idb_regex_t placeholderRegex;
-
 template <class T>
 inline int  compareBlock(  const void * a, const void * b )
 {
@@ -954,6 +952,7 @@ inline void p_Col_ridArray(NewColRequestHeader *in,
 	uint16_t *ridArray=0;
 	uint8_t *in8 = reinterpret_cast<uint8_t *>(in);
 	const uint8_t filterSize = sizeof(uint8_t) + sizeof(uint8_t) + W;
+    idb_regex_t placeholderRegex;
 
 	placeholderRegex.used = false;
 


### PR DESCRIPTION
The FIFO buffer could get data in next() whilst a data swap is happening
due to a rare race condition. This patch adds mutexes around the parts
that could race.

The observed effect of this race was during a complex aggregate query
the results would occasionally be incorrect.

In addition this fixes a race condition in PrimProc's regex processor.