### PR TITLE
MCOL-1579 Remove chmod of /dev/shm

### DIFF
--- a/oam/install_scripts/post-install
+++ b/oam/install_scripts/post-install
@@ -247,7 +247,6 @@ else
 	$SUDO chmod 777 /tmp
 	$installdir/bin/syslogSetup.sh --installdir=$installdir install > /tmp/syslog_install.log 2>&1
 	$SUDO chown $user:$user $installdir/etc/Columnstore.xml
-	$SUDO chmod -R 777 /dev/shm
 	$SUDO mkdir /var/lock/subsys > /dev/null 2>&1
 	$SUDO chmod 777 /var/lock/subsys > /dev/null 2>&1
 	$SUDO rm -f /var/lock/subsys/mysql-Columnstore

--- a/procmon/main.cpp
+++ b/procmon/main.cpp
@@ -131,13 +131,6 @@ int main(int argc, char **argv)
 	if (p && *p)
    		USER = p;
 
-	// change permissions on /dev/shm
-	if ( !rootUser)
-	{
-		string cmd = "sudo chmod 777 /dev/shm >/dev/null 2>&1";
-		system(cmd.c_str());
-	}
-
   	// get and set locale language    
 	string systemLang = "C";
 

--- a/procmon/processmonitor.cpp
+++ b/procmon/processmonitor.cpp
@@ -988,13 +988,6 @@ void ProcessMonitor::processMessage(messageqcpp::ByteStream msg, messageqcpp::IO
 					int requestStatus = oam::API_SUCCESS;
 					log.writeLog(__LINE__,  "MSG RECEIVED: Start All process request...");
 
-					// change permissions on /dev/shm
-					string cmd = "chmod 755 /dev/shm >/dev/null 2>&1";
-					if ( !rootUser)
-						cmd = "sudo chmod 777 /dev/shm >/dev/null 2>&1";
-				
-					system(cmd.c_str());
-
 					//start the mysqld daemon 
 					try {
 						oam.actionMysqlCalpont(MYSQL_START);


### PR DESCRIPTION
We appear to chmod /dev/shm as a workaround to a CentOS 7 bug that was
fixed last year which accidentally set it to 755. If a user has /dev/shm
locked down we should get them to fix it rather than modifying it
ourselves.

The code before this fixed changed a root install to 755 for /dev/shm
which instantly broke anything using mmap() with MAP_SHARED as an
unprivileged user.