### PR TITLE
regr_agvx creation fix

### DIFF
--- a/dbcon/mysql/install_calpont_mysql.sh
+++ b/dbcon/mysql/install_calpont_mysql.sh
@@ -84,7 +84,7 @@ CREATE FUNCTION idbpartition RETURNS STRING soname 'libcalmysql.so';
 CREATE FUNCTION idblocalpm RETURNS INTEGER soname 'libcalmysql.so';
 CREATE FUNCTION mcssystemready RETURNS INTEGER soname 'libcalmysql.so';
 CREATE FUNCTION mcssystemreadonly RETURNS INTEGER soname 'libcalmysql.so';
-CREATE AGGREGATE FUNCTION regr_avgx RETURNS REAL soname 'libcalmysql.dll';
+CREATE AGGREGATE FUNCTION regr_avgx RETURNS REAL soname 'libudf_mysql.so';
 
 CREATE DATABASE IF NOT EXISTS infinidb_vtable;
 CREATE DATABASE IF NOT EXISTS infinidb_querystats;


### PR DESCRIPTION
The UDAF regr_avgx wasn't created because of an incorrect .so name used in the CREATE AGGREGATE FUNCTION statement.