### PR TITLE
MCOL-1660/1659 Table/column identifiers support spaces in DDL.

### DIFF
--- a/dbcon/ddlpackage/ddl.l
+++ b/dbcon/ddlpackage/ddl.l
@@ -72,9 +72,9 @@ ident_start [A-Za-z\200-\377_]
 ident_cont [A-Za-z\200-\377_0-9\$]
 identifier {ident_start}{ident_cont}*
 /* fully qualified names regexes */
-fq_identifier {identifier}\.{identifier}
-identifier_quoted {grave_accent}{identifier}{grave_accent}
-identifier_double_quoted {double_quote}{identifier}{double_quote}
+ident_w_spaces {identifier}\x20*
+identifier_quoted {grave_accent}{ident_w_spaces}+{grave_accent}
+identifier_double_quoted {double_quote}{ident_w_spaces}+{double_quote}
 
 integer			[-+]?{digit}+
 decimal			([-+]?({digit}*\.{digit}+)|({digit}+\.{digit}*))

--- a/dbcon/ddlpackage/ddl.y
+++ b/dbcon/ddlpackage/ddl.y
@@ -604,7 +604,7 @@ table_name:
 	;
 
 qualified_name:
-	| ident {
+	ident {
 				if (x->fDBSchema.size())
 					$$ = new QualifiedName((char*)x->fDBSchema.c_str(), $1);
 				else


### PR DESCRIPTION
MCOL-1660/1659 Table/column identifiers support spaces in DDL.