### PR TITLE
MCOL-1694 & MCOL-1505 Improved exception handling

### DIFF
--- a/ddlproc/ddlproc.cpp
+++ b/ddlproc/ddlproc.cpp
@@ -135,8 +135,30 @@ int main(int argc, char* argv[])
         {
             oam.processInitComplete("DDLProc", ACTIVE);
         }
+        catch (std::exception& ex)
+        {
+            cerr << ex.what() << endl;
+            LoggingID logid(23, 0, 0);
+            logging::Message::Args args1;
+            logging::Message msg(1);
+            args1.add("DDLProc init caught exception: ");
+            args1.add(ex.what());
+            msg.format( args1 );
+            logging::Logger logger(logid.fSubsysID);
+            logger.logMessage(LOG_TYPE_CRITICAL, msg, logid);
+            return 1;
+        }
         catch (...)
         {
+            cerr << "Caught unknown exception in init!" << endl;
+            LoggingID logid(23, 0, 0);
+            logging::Message::Args args1;
+            logging::Message msg(1);
+            args1.add("DDLProc init caught unknown exception");
+            msg.format( args1 );
+            logging::Logger logger(logid.fSubsysID);
+            logger.logMessage(LOG_TYPE_CRITICAL, msg, logid);
+            return 1;
         }
     }
 
@@ -147,21 +169,28 @@ int main(int argc, char* argv[])
     catch (std::exception& ex)
     {
         cerr << ex.what() << endl;
+        LoggingID logid(23, 0, 0);
         Message::Args args;
         Message message(8);
         args.add("DDLProc failed on: ");
         args.add(ex.what());
         message.format( args );
-
+        logging::Logger logger(logid.fSubsysID);
+        logger.logMessage(LOG_TYPE_CRITICAL, message, logid);
+        return 1;
     }
     catch (...)
     {
         cerr << "Caught unknown exception!" << endl;
+        LoggingID logid(23, 0, 0);
         Message::Args args;
         Message message(8);
         args.add("DDLProc failed on: ");
-        args.add("receiving DDLPackage");
+        args.add("receiving DDLPackage (unknown exception)");
         message.format( args );
+        logging::Logger logger(logid.fSubsysID);
+        logger.logMessage(LOG_TYPE_CRITICAL, message, logid);
+        return 1;
     }
     return 0;
 }

--- a/dmlproc/dmlproc.cpp
+++ b/dmlproc/dmlproc.cpp
@@ -494,8 +494,30 @@ int main(int argc, char* argv[])
 		// At first we set to BUSY_INIT
 		oam.processInitComplete("DMLProc", oam::BUSY_INIT);
     }
+    catch (std::exception& ex)
+    {
+        cerr << ex.what() << endl;
+        LoggingID logid(21, 0, 0);
+        logging::Message::Args args1;
+        logging::Message msg(1);
+        args1.add("DMLProc init caught exception: ");
+        args1.add(ex.what());
+        msg.format( args1 );
+        logging::Logger logger(logid.fSubsysID);
+        logger.logMessage(LOG_TYPE_CRITICAL, msg, logid);
+        return 1;
+    }
     catch (...)
     {
+        cerr << "Caught unknown exception in init!" << endl;
+        LoggingID logid(21, 0, 0);
+        logging::Message::Args args1;
+        logging::Message msg(1);
+        args1.add("DMLProc init caught unknown exception");
+        msg.format( args1 );
+        logging::Logger logger(logid.fSubsysID);
+        logger.logMessage(LOG_TYPE_CRITICAL, msg, logid);
+        return 1;
     }
 	
 	//@Bug 1627
@@ -584,8 +606,30 @@ int main(int argc, char* argv[])
     {
         oam.processInitComplete("DMLProc", ACTIVE);
     }
+    catch (std::exception& ex)
+    {
+        cerr << ex.what() << endl;
+        LoggingID logid(21, 0, 0);
+        logging::Message::Args args1;
+        logging::Message msg(1);
+        args1.add("DMLProc init caught exception: ");
+        args1.add(ex.what());
+        msg.format( args1 );
+        logging::Logger logger(logid.fSubsysID);
+        logger.logMessage(LOG_TYPE_CRITICAL, msg, logid);
+        return 1;
+    }
     catch (...)
     {
+        cerr << "Caught unknown exception in init!" << endl;
+        LoggingID logid(21, 0, 0);
+        logging::Message::Args args1;
+        logging::Message msg(1);
+        args1.add("DMLProc init caught unknown exception");
+        msg.format( args1 );
+        logging::Logger logger(logid.fSubsysID);
+        logger.logMessage(LOG_TYPE_CRITICAL, msg, logid);
+        return 1;
     }
 	Dec = DistributedEngineComm::instance(rm);
 

--- a/dmlproc/dmlprocessor.cpp
+++ b/dmlproc/dmlprocessor.cpp
@@ -1155,8 +1155,28 @@ void DMLServer::start()
 		}
 		cancelThread.join();
 	}
+    catch (std::exception& ex)
+    {
+        cerr << ex.what() << endl;
+        logging::LoggingID lid(21);
+        Message::Args args;
+        Message message(8);
+        args.add("DMLProc init caught exception: ");
+        args.add(ex.what());
+        message.format(args);
+        logging::Logger logger(lid.fSubsysID);
+        logger.logMessage(logging::LOG_TYPE_CRITICAL, message, lid);
+    }
 	catch (...)
 	{
+        cerr << "Caught unknown exception!" << endl;
+        logging::LoggingID lid(21);
+        Message::Args args;
+        Message message(8);
+        args.add("DMLProc init caught unknown exception");
+        message.format(args);
+        logging::Logger logger(lid.fSubsysID);
+        logger.logMessage(logging::LOG_TYPE_CRITICAL, message, lid);
 	}
 }
 

--- a/exemgr/main.cpp
+++ b/exemgr/main.cpp
@@ -1300,8 +1300,34 @@ void cleanTempDir()
 	assert(tmpPrefix != "/");
 
 	/* This is quite scary as ExeMgr usually runs as root */
-	boost::filesystem::remove_all(tmpPrefix);
-	boost::filesystem::create_directories(tmpPrefix);
+    try
+    {
+    	boost::filesystem::remove_all(tmpPrefix);
+    	boost::filesystem::create_directories(tmpPrefix);
+    }
+    catch (std::exception& ex)
+    {
+        cerr << ex.what() << endl;
+        LoggingID logid(16, 0, 0);
+        Message::Args args;
+        Message message(8);
+        args.add("Execption whilst cleaning tmpdir: ");
+        args.add(ex.what());
+        message.format( args );
+        logging::Logger logger(logid.fSubsysID);
+        logger.logMessage(LOG_TYPE_WARNING, message, logid);
+    }
+    catch (...)
+    {
+        cerr << "Caught unknown exception during tmpdir cleanup" << endl;
+        LoggingID logid(16, 0, 0);
+        Message::Args args;
+        Message message(8);
+        args.add("Unknown execption whilst cleaning tmpdir");
+        message.format( args );
+        logging::Logger logger(logid.fSubsysID);
+        logger.logMessage(LOG_TYPE_WARNING, message, logid);
+    }
 }
 
 


### PR DESCRIPTION
This patch catches exceptions in DDLProc, DMLProc and ExeMgr which could
potentially happen during startup. Logging them instead of silently
ignoring them (or crashing in ExeMgr).