### PR TITLE
MCOL-1750 Stop threadpool memory leak

### DIFF
--- a/utils/threadpool/threadpool.cpp
+++ b/utils/threadpool/threadpool.cpp
@@ -94,7 +94,6 @@ void ThreadPool::stop()
     lock1.unlock();
 
     fNeedThread.notify_all();
-    fThreads.join_all();
 }
 
 
@@ -222,7 +221,8 @@ uint64_t ThreadPool::invoke(const Functor_T &threadfunc)
                 ++fThreadCount;
 
                 lock1.unlock();
-                fThreads.create_thread(beginThreadFunc(*this));
+                boost::thread* newThread = fThreads.create_thread(beginThreadFunc(*this));
+                newThread->detach();
 
                 if (bAdded)
                     break;


### PR DESCRIPTION
Threadpool could leak thread stack memory if the thread returns without
being joined. This is the case when the 10 minute cleanup timer is
triggered. We now detach threadpool threads so they clean themselves up.