### PR TITLE
MCOL-1799 Fix length() with BLOB

### DIFF
--- a/dbcon/joblist/expressionstep.cpp
+++ b/dbcon/joblist/expressionstep.cpp
@@ -286,6 +286,7 @@ void ExpressionStep::addColumn(ReturnedColumn* rc, JobInfo& jobInfo)
         scs = &(fc->simpleColumnList());
         wcs = &(fc->windowfunctionColumnList());
         fVarBinOK = ((strcmp(fc->functionName().c_str(), "hex") == 0) ||
+                     (strcmp(fc->functionName().c_str(), "octet_length") == 0) ||
                      (strcmp(fc->functionName().c_str(), "length") == 0));
     }
 


### PR DESCRIPTION
In 10.3 it gets renamed to octet_length()