### PR TITLE
MCOL-1654.  Querystats table creation broken.

### DIFF
--- a/dbcon/mysql/install_calpont_mysql.sh
+++ b/dbcon/mysql/install_calpont_mysql.sh
@@ -99,7 +99,7 @@ CREATE TABLE IF NOT EXISTS infinidb_querystats.querystats
   query varchar(8000),
   startTime timestamp NOT NULL,
   endTime timestamp NOT NULL,
-  rows bigint,
+  \`rows\` bigint,
   errno int,
   phyIO bigint,
   cacheIO bigint,


### PR DESCRIPTION
Escaped the ` chars to make the shell happy.

Conflicts:
	dbcon/mysql/install_calpont_mysql.sh