### PR TITLE
MCOL-1885 Fix libmysql error handling

### DIFF
--- a/utils/libmysql_client/libmysql_client.cpp
+++ b/utils/libmysql_client/libmysql_client.cpp
@@ -104,6 +104,7 @@ int LibMySQL::run(const char* query)
     {
         fErrStr = "fatal error runing mysql_real_query() in libmysql_client lib";
         ret = -1;
+        return ret;
     }
 
     fRes = mysql_use_result(fCon);
@@ -117,7 +118,7 @@ int LibMySQL::run(const char* query)
     return ret;
 }
 
-void LibMySQL::handleMySqlError(const char* errStr, unsigned int errCode)
+void LibMySQL::handleMySqlError(const char* errStr, int errCode)
 {
     ostringstream oss;
 

--- a/utils/libmysql_client/libmysql_client.h
+++ b/utils/libmysql_client/libmysql_client.h
@@ -38,7 +38,7 @@ public:
     // run the query
     int run(const char* q);
 
-    void handleMySqlError(const char*, unsigned int);
+    void handleMySqlError(const char*, int);
 
     MYSQL* getMySqlCon()
     {


### PR DESCRIPTION
If an error occurs in mysql_real_query() it fell through and tried to
get a result set anyway. This caused the MariaDB error message to be
forgotten and a generic one returned instead.

This fix returns the query error message and also uses the int error
code for generic errors instead of casting it to an unsigned int.