### PR TITLE
MCOL-1844.  Preserve user-added args in 'myCnf-include-args.text' across upgrades

### DIFF
--- a/oam/install_scripts/pre-uninstall
+++ b/oam/install_scripts/pre-uninstall
@@ -138,6 +138,7 @@ if [ $quiet != 1 ]; then
 	#make copy of Columnstore.xml
 	/bin/cp -f $installdir/etc/Columnstore.xml $installdir/etc/Columnstore.xml.rpmsave > /dev/null 2>&1
 	/bin/cp -f $installdir/mysql/my.cnf $installdir/mysql/my.cnf.rpmsave > /dev/null 2>&1
+	cp $installdir/bin/myCnf-include-args.text $installdir/bin/myCnf-include-args.text.rpmsave >& /dev/null
 	rm -f $installdir/etc/AlarmConfig.xml.installSave
 fi
 

--- a/oamapps/postConfigure/mycnfUpgrade.cpp
+++ b/oamapps/postConfigure/mycnfUpgrade.cpp
@@ -54,6 +54,59 @@
 using namespace std;
 using namespace oam;
 
+
+/* MCOL-1844.  On an upgrade, the user may have customized options in their old 
+ * myCnf-include-args.text file.  Merge it with the packaged version, and then process as we
+ * have before.
+ */
+string rtrim(const string &in) {
+	string::const_reverse_iterator rbegin = in.rbegin();
+	while (rbegin != in.rend() && isspace(*rbegin))
+		++rbegin;
+	return string(in.begin(), rbegin.base());
+}
+
+void mergeMycnfIncludeArgs() 
+{
+	string userArgsFilename = startup::StartUp::installDir() + "/bin/myCnf-include-args.text.rpmsave";
+	string packagedArgsFilename = startup::StartUp::installDir() + "/bin/myCnf-include-args.text";
+	ifstream userArgs(userArgsFilename.c_str());
+	fstream packagedArgs(packagedArgsFilename.c_str(), ios::in);
+
+	if (!userArgs || !packagedArgs)
+		return;
+
+	// de-dup the args and comments in both files
+	set<string> argMerger;
+	set<string> comments;
+	string line;
+	while (getline(packagedArgs, line)) {
+		line = rtrim(line);
+		if (line[0] == '#')
+			comments.insert(line);
+		else if (line.size() > 0)
+			argMerger.insert(line);
+	}
+    while (getline(userArgs, line)) {
+        line = rtrim(line);
+        if (line[0] == '#')
+            comments.insert(line);
+        else if (line.size() > 0)
+            argMerger.insert(line);
+    }
+	userArgs.close();	
+	packagedArgs.close();
+
+	// write the merged version, comments first.  They'll get ordered 
+	// alphabetically but, meh.
+	packagedArgs.open(packagedArgsFilename.c_str(), ios::out | ios::trunc);
+	for (set<string>::iterator it = comments.begin(); it != comments.end(); it++)
+		packagedArgs << *it << endl;
+	for (set<string>::iterator it = argMerger.begin(); it != argMerger.end(); it++)
+		packagedArgs << *it << endl;
+	packagedArgs.close();
+}
+
 int main(int argc, char *argv[])
 {
 	Oam oam;
@@ -83,6 +136,10 @@ int main(int argc, char *argv[])
 		cerr << "mycnfUpgrade - my.cnf.rpmsave file not found: " << mycnfsaveFile << endl;
 		exit (1);
 	}
+
+	// MCOL-1844.  The user may have added options to their myCnf-include-args file.  Merge 
+	// myCnf-include-args.text with myCnf-include-args.text.rpmsave, save in myCnf-include-args.text
+	mergeMycnfIncludeArgs();
 
 	//include arguments file
 	string includeFile = startup::StartUp::installDir() + "/bin/myCnf-include-args.text";
@@ -144,7 +201,7 @@ int main(int argc, char *argv[])
 					ofstream newFile (mycnfFile.c_str());	
 					
 					//create new file
-					int fd = open(mycnfFile.c_str(), O_RDWR|O_CREAT, 0666);
+					int fd = open(mycnfFile.c_str(), O_RDWR|O_CREAT, 0644);
 					
 					copy(lines.begin(), lines.end(), ostream_iterator<string>(newFile, "\n"));
 					newFile.close();


### PR DESCRIPTION
The 1.1 version of the mcol-1844 PR in develop.