### PR TITLE
Mcol 1558.  make the path stored in BRM_saves_current a relative path instead of an abs one.

### DIFF
--- a/oam/install_scripts/pre-uninstall
+++ b/oam/install_scripts/pre-uninstall
@@ -132,6 +132,7 @@ if [ $quiet != 1 ]; then
 	#make copy of Columnstore.xml
 	/bin/cp -f $installdir/etc/Columnstore.xml $installdir/etc/Columnstore.xml.rpmsave > /dev/null 2>&1
 	/bin/cp -f $installdir/mysql/my.cnf $installdir/mysql/my.cnf.rpmsave > /dev/null 2>&1
+	cp $installdir/bin/myCnf-include-args.text $installdir/bin/myCnf-include-args.text.rpmsave >& /dev/null
 	rm -f $installdir/etc/AlarmConfig.xml.installSave
 fi
 

--- a/oamapps/postConfigure/mycnfUpgrade.cpp
+++ b/oamapps/postConfigure/mycnfUpgrade.cpp
@@ -54,6 +54,58 @@
 using namespace std;
 using namespace oam;
 
+/* MCOL-1844.  On an upgrade, the user may have customized options in their old
+ * myCnf-include-args.text file.  Merge it with the packaged version, and then process as we
+ * have before.
+ */
+string rtrim(const string &in) {
+    string::const_reverse_iterator rbegin = in.rbegin();
+    while (rbegin != in.rend() && isspace(*rbegin))
+        ++rbegin;
+    return string(in.begin(), rbegin.base());
+}
+
+void mergeMycnfIncludeArgs()
+{
+    string userArgsFilename = startup::StartUp::installDir() + "/bin/myCnf-include-args.text.rpmsave";
+    string packagedArgsFilename = startup::StartUp::installDir() + "/bin/myCnf-include-args.text";
+    ifstream userArgs(userArgsFilename.c_str());
+    fstream packagedArgs(packagedArgsFilename.c_str(), ios::in);
+
+    if (!userArgs || !packagedArgs)
+        return;
+
+    // de-dup the args and comments in both files
+    set<string> argMerger;
+    set<string> comments;
+    string line;
+    while (getline(packagedArgs, line)) {
+        line = rtrim(line);
+        if (line[0] == '#')
+            comments.insert(line);
+        else if (line.size() > 0)
+            argMerger.insert(line);
+    }
+    while (getline(userArgs, line)) {
+        line = rtrim(line);
+        if (line[0] == '#')
+            comments.insert(line);
+        else if (line.size() > 0)
+            argMerger.insert(line);
+    }
+    userArgs.close();
+    packagedArgs.close();
+
+    // write the merged version, comments first.  They'll get ordered
+    // alphabetically but, meh.
+    packagedArgs.open(packagedArgsFilename.c_str(), ios::out | ios::trunc);
+    for (set<string>::iterator it = comments.begin(); it != comments.end(); it++)
+        packagedArgs << *it << endl;
+    for (set<string>::iterator it = argMerger.begin(); it != argMerger.end(); it++)
+        packagedArgs << *it << endl;
+    packagedArgs.close();
+}
+
 int main(int argc, char* argv[])
 {
     Oam oam;
@@ -89,6 +141,10 @@ int main(int argc, char* argv[])
         cerr << "mycnfUpgrade - my.cnf.rpmsave file not found: " << mycnfsaveFile << endl;
         exit (1);
     }
+
+    // MCOL-1844.  The user may have added options to their myCnf-include-args file.  Merge
+    // myCnf-include-args.text with myCnf-include-args.text.rpmsave, save in myCnf-include-args.text
+    mergeMycnfIncludeArgs();
 
     //include arguments file
     string includeFile = startup::StartUp::installDir() + "/bin/myCnf-include-args.text";

--- a/procmon/processmonitor.cpp
+++ b/procmon/processmonitor.cpp
@@ -2586,7 +2586,7 @@ pid_t ProcessMonitor::startProcess(string processModuleType, string processName,
                 if (line[0] == '/')    // handle absolute paths (saved by an old version)
                     dbrmFile = line;
                 else
-                    dbrmFile = DBRMroot + line;
+                    dbrmFile = DBRMroot.substr(0, DBRMroot.find_last_of('/') + 1) + line;
 
 //				if ( !gOAMParentModuleFlag ) {
 

--- a/procmon/processmonitor.cpp
+++ b/procmon/processmonitor.cpp
@@ -2582,7 +2582,11 @@ pid_t ProcessMonitor::startProcess(string processModuleType, string processName,
                 oldFile->pread(line, 0, fileSize - 1);  // skip the \n
                 line[fileSize] = '\0';  // not necessary, but be sure.
                 // MCOL-1558 - the _current file is now relative to DBRMRoot
-                string dbrmFile = DBRMroot + line;
+                string dbrmFile;
+                if (line[0] == '/')    // handle absolute paths (saved by an old version)
+                    dbrmFile = line;
+                else
+                    dbrmFile = DBRMroot + line;
 
 //				if ( !gOAMParentModuleFlag ) {
 

--- a/procmon/processmonitor.cpp
+++ b/procmon/processmonitor.cpp
@@ -1736,7 +1736,7 @@ void ProcessMonitor::processMessage(messageqcpp::ByteStream msg, messageqcpp::IO
 
 			break;
 		}
-        
+
         case PROCUNMOUNT:
         {
             string dbrootID;
@@ -2581,7 +2581,8 @@ pid_t ProcessMonitor::startProcess(string processModuleType, string processName,
                 char line[200] = {0};
                 oldFile->pread(line, 0, fileSize - 1);  // skip the \n
                 line[fileSize] = '\0';  // not necessary, but be sure.
-                string dbrmFile = line;
+                // MCOL-1558 - the _current file is now relative to DBRMRoot
+                string dbrmFile = DBRMroot + line;
 
 //				if ( !gOAMParentModuleFlag ) {
 

--- a/versioning/BRM/save_brm.cpp
+++ b/versioning/BRM/save_brm.cpp
@@ -101,7 +101,7 @@ int main (int argc, char** argv)
         prefix += '\n';
 #endif
         // for MCOL-1558.  Make the _current file relative to DBRMRoot
-        string relative = prefix.substr(prefix.find_last_of('/'));
+        string relative = prefix.substr(prefix.find_last_of('/') + 1);
         currentFile->write(relative.c_str(), relative.length());
     }
     catch (exception& e)

--- a/versioning/BRM/save_brm.cpp
+++ b/versioning/BRM/save_brm.cpp
@@ -100,7 +100,9 @@ int main (int argc, char** argv)
 #ifndef _MSC_VER
         prefix += '\n';
 #endif
-        currentFile->write(prefix.c_str(), prefix.length());
+        // for MCOL-1558.  Make the _current file relative to DBRMRoot
+        string relative = prefix.substr(prefix.find_last_of('/'));
+        currentFile->write(relative.c_str(), relative.length());
     }
     catch (exception& e)
     {

--- a/versioning/BRM/slavecomm.cpp
+++ b/versioning/BRM/slavecomm.cpp
@@ -100,7 +100,7 @@ SlaveComm::SlaveComm(string hostname, SlaveDBRMNode* s) :
             }
         }
     }
-    
+
     string tmpDir = startup::StartUp::tmpDir();
 
     /* NOTE: this string has to match whatever is designated as the first slave */
@@ -2038,9 +2038,11 @@ void SlaveComm::do_confirm()
 
         if (currentSaveFile)
         {
-            err = currentSaveFile->write(tmp.c_str(), tmp.length());
+            // MCOL-1558.  Make the _current file relative to DBRMRoot.
+            string relative = tmp.substr(tmp.find_last_of('/') + 1);
+            err = currentSaveFile->write(relative.c_str(), relative.length());
 
-            if (err < (int) tmp.length())
+            if (err < (int) relative.length())
             {
                 ostringstream os;
                 os  << "WorkerComm: currentfile write() returned " << err
@@ -2070,9 +2072,11 @@ void SlaveComm::do_confirm()
         else
         {
             lseek(currentSaveFD, 0, SEEK_SET);
-            err = write(currentSaveFD, tmp.c_str(), tmp.length());
+            // MCOL-1558.  Make the _current file relative to DBRMRoot.
+            string relative = tmp.substr(tmp.find_last_of('/') + 1);
+            err = write(currentSaveFD, relative.c_str(), relative.length());
 
-            if (err < (int) tmp.length())
+            if (err < (int) relative.length())
             {
                 ostringstream os;
                 os  << "WorkerComm: currentfile write() returned " << err
@@ -2089,7 +2093,7 @@ void SlaveComm::do_confirm()
             _chsize_s(currentSaveFD, tmp.length());
             _commit(currentSaveFD);
 #else
-            err = ftruncate(currentSaveFD, tmp.length());
+            err = ftruncate(currentSaveFD, relative.length());
             fsync(currentSaveFD);
 #endif
             saveFileToggle = !saveFileToggle;


### PR DESCRIPTION
https://jira.mariadb.org/browse/MCOL-1558

I see commit 65779c7 in this list right now.  That's part of another pull request & should be safe to ignore.  My fault, I forgot to put that change in its own feature branch.  I would suggest waiting for that PR to be merged before merging this one.
