### PR TITLE
Mcol 1847 - absolute cache size option

### DIFF
--- a/oam/etc/Columnstore.xml
+++ b/oam/etc/Columnstore.xml
@@ -427,12 +427,9 @@
 	</DBRM_Worker10>
 	<DBBC>
 		<!-- The percentage of RAM to use for the disk block cache. Defaults to 70% -->
+        <!-- Alternatively, this can be specified in absolute terms using
+             the suffixes 'm' or 'g' to denote size in megabytes or gigabytes.-->
 		<!-- <NumBlocksPct>70</NumBlocksPct> -->
-
-        <!-- If preferred, the user can specify cache size in terms of megabytes.
-             If both Pct and MB are specified, PrimProc will use Pct. -->
-        <!-- <NumBlocksInMB>2048</NumBlocksInMB> -->
-
 		<!-- <NumThreads>16</NumThreads> --> <!-- 1-256.  Default is 16. -->
 		<NumCaches>1</NumCaches><!-- # of parallel caches to instantiate -->
 		<IOMTracing>0</IOMTracing>

--- a/oam/etc/Columnstore.xml.singleserver
+++ b/oam/etc/Columnstore.xml.singleserver
@@ -419,12 +419,9 @@
 	</DBRM_Worker10>
 	<DBBC>
 		<!-- The percentage of RAM to use for the disk block cache. Defaults to 70% -->
+        <!-- Alternatively, this can be specified in absolute terms using
+             the suffixes 'm' or 'g' to denote size in megabytes or gigabytes.-->
 		<NumBlocksPct>50</NumBlocksPct>
-
-        <!-- If preferred, the user can specify cache size in terms of megabytes.
-             If both Pct and MB are specified, PrimProc will use Pct. -->
-        <!-- <NumBlocksInMB>2048</NumBlocksInMB> -->
-
 		<!-- <NumThreads>16</NumThreads> --> <!-- 1-256.  Default is 16. -->
 		<NumCaches>1</NumCaches><!-- # of parallel caches to instantiate -->
 		<IOMTracing>0</IOMTracing>

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -526,16 +526,20 @@ int main(int argc, char* argv[])
     }
 
 #else
-    if (temp > 0)
+    bool cacheInMB = false;
+    if (temp > 0) {
         BRPBlocksPct = temp;
-    /* MCOL-1847.  Did the user specify this in MB or GB? */
-    int len = strBlockPct.length();
-    if (strBlockPct[len-1] == 'g' || strBlockPct[len-1] == 'm')
-    {
-        if (strBlockPct[len-1] == 'g')
-            BRPBlocksPct *= 1024;
-        BRPBlocks = BRPBlocksPct * 128;   // 128 blocks per MB
+        /* MCOL-1847.  Did the user specify this in MB or GB? */
+        int len = strBlockPct.length();
+        if (strBlockPct[len-1] == 'g' || strBlockPct[len-1] == 'm')
+        {
+            if (strBlockPct[len-1] == 'g')
+                BRPBlocksPct *= 1024;
+            cacheInMB = true;
+        }
     }
+    if (cacheInMB)
+        BRPBlocks = BRPBlocksPct * 128;   // 128 blocks per MB
     else
         BRPBlocks = ((BRPBlocksPct / 100.0) * (double) cg.getTotalMemory()) / 8192;
 #endif

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -391,7 +391,7 @@ int main(int argc, char* argv[])
     int serverQueueSize = 10;
     int processorWeight = 8 * 1024;
     int processorQueueSize = 10 * 1024;
-    int BRPBlocksPct = 70;
+    int64_t BRPBlocksPct = 70;
     uint32_t BRPBlocks = 1887437;
     int BRPThreads = 16;
     int cacheCount = 1;
@@ -526,20 +526,19 @@ int main(int argc, char* argv[])
     }
 
 #else
-    bool cacheInMB = false;
+    bool absCache = false;
     if (temp > 0) {
         BRPBlocksPct = temp;
-        /* MCOL-1847.  Did the user specify this in MB or GB? */
+        /* MCOL-1847.  Did the user specify this as an absolute? */
         int len = strBlockPct.length();
-        if (strBlockPct[len-1] == 'g' || strBlockPct[len-1] == 'm')
-        {
-            if (strBlockPct[len-1] == 'g')
-                BRPBlocksPct *= 1024;
-            cacheInMB = true;
+        if ((strBlockPct[len-1] >= 'a' && strBlockPct[len-1] <= 'z') ||
+          (strBlockPct[len-1] >= 'A' && strBlockPct[len-1] <= 'Z')) {
+            absCache = true;
+            BRPBlocksPct = Config::fromText(strBlockPct);
         }
     }
-    if (cacheInMB)
-        BRPBlocks = BRPBlocksPct * 128;   // 128 blocks per MB
+    if (absCache)
+        BRPBlocks = BRPBlocksPct / 8192;
     else
         BRPBlocks = ((BRPBlocksPct / 100.0) * (double) cg.getTotalMemory()) / 8192;
 #endif


### PR DESCRIPTION
Daniel suggested we re-use the NumBlocksPct config param to avoid headaches in support.  So now if the user specifies a 'm' or a 'g' suffix, it will be interpreted as mega/giga bytes.  Anything else (or nothing) will be interpreted as %age.

https://jira.mariadb.org/browse/MCOL-1847
