### PR TITLE
MCOL-1624 mcssystemready() does more testing

### DIFF
--- a/dbcon/mysql/ha_calpont_impl.cpp
+++ b/dbcon/mysql/ha_calpont_impl.cpp
@@ -2015,6 +2015,7 @@ extern "C"
         Oam oam;
         DBRM dbrm(true);
         SystemStatus systemstatus;
+        WriteEngine::FileOp fileOp;
 
         try
         {
@@ -2022,8 +2023,15 @@ extern "C"
 
             if (systemstatus.SystemOpState == ACTIVE
                     && dbrm.getSystemReady()
-                    && dbrm.getSystemQueryReady())
+                    && dbrm.getSystemQueryReady()
+                    && fileOp.existsOIDDir(1001))
             {
+                // Test getting system catalogue data from ExeMgr
+                boost::shared_ptr<execplan::CalpontSystemCatalog> systemCatalogPtr =
+                    execplan::CalpontSystemCatalog::makeCalpontSystemCatalog(0);
+                systemCatalogPtr->identity(execplan::CalpontSystemCatalog::FE);
+                systemCatalogPtr->getTableCount();
+
                 return 1;
             }
         }


### PR DESCRIPTION
Now checks if system catalog exists and if we can query the system
catalogue in FE mode (and therefore tests ExeMgr and PrimProc).