### PR TITLE
MCOL-2018 Fix array bounds issue

### DIFF
--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -1617,7 +1617,7 @@ inline bool StringStore::isNullValue(uint64_t off) const
         return true;
     if (mc->data[offset+4] == 0)    // "" = NULL string for some reason...
         return true;
-    return (*((uint64_t *) &mc->data[offset]+4) == *((uint64_t *) joblist::CPNULLSTRMARK.c_str()));
+    return (memcmp(&mc->data[offset+4], joblist::CPNULLSTRMARK.c_str(), 8) == 0);
 }
 
 inline bool StringStore::equals(const std::string &str, uint64_t off) const


### PR DESCRIPTION
StringStore NULL check includes a check for _CpNuLl_ in the
StringStore. This is a case should never happen but we keep it just in
case.

Unfortunately this check was skipping 4*8 bytes instead of just 4 bytes.
This is definitely bad behaviour but it could cause an out-of-bounds read
based crash.