### PR TITLE
MCOL-1662 Use version buffer for UPDATEs

### DIFF
--- a/writeengine/server/we_dmlcommandproc.cpp
+++ b/writeengine/server/we_dmlcommandproc.cpp
@@ -2515,6 +2515,7 @@ uint8_t WE_DMLCommandProc::processUpdate(messageqcpp::ByteStream& bs,
 	boost::scoped_array<int> preBlkNums(new int[columnsUpdated.size()]);
 	boost::scoped_array<OID> oids(new OID[columnsUpdated.size()]);
 
+    BRMWrapper::setUseVb(true);
 	for (unsigned int j = 0; j < columnsUpdated.size(); j++)
 	{
 		//timer.start("lookupsyscat");


### PR DESCRIPTION
For some reason version buffer is not turned up for update queries which
means that the version number for dictionary blocks is not changed.
This can lead to dirty cache reads resulting in _CpNoTf_ in the results.

This patch turns on version buffer for updates.