### PR TITLE
MCOL-1726 Make cleartablelock remove txn from BRM

### DIFF
--- a/tools/cleartablelock/cleartablelock.cpp
+++ b/tools/cleartablelock/cleartablelock.cpp
@@ -620,6 +620,12 @@ int main(int argc, char** argv)
 
 		rc = execBulkRollbackReq( msgQueClts, pmList,
 			&brm, tInfo, tblName.toString(), rollbackOnly, errMsg );
+
+        BRM::TxnID txn;
+        txn.id = tInfo.ownerTxnID;
+        txn.valid = true;
+        brm.rolledback(txn);
+
 		if (rc != 0)
 		{
 			logFinalStatus( tblName.toString(), lockID, errMsg );


### PR DESCRIPTION
With an API txn (and likely other scenarios) cleartablelock will roll
back the txn and lock but leave a stale txn pointer in the BRM. This
causes restart/shutdown to warn that transactions are still open.

This patch makes sure BRM removes the txn from the list.