### PR TITLE
MCOL-1829 Subquery with limited order by could potentially return unordered set.

### DIFF
--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -5554,6 +5554,8 @@ void TupleAggregateStep::threadedAggregateRowGroups(uint32_t threadID)
                                     rowIn.copyField(distRow[j], k, multiDist->subAggregators()[j]->getGroupByCols()[k].get()->fInputColumnIndex);
                                 }
 
+                                // TBD This approach could potentiall
+                                // put all values in on bucket.
                                 bucketID = distRow[j].hash(hashLens[j] - 1) % fNumOfBuckets;
                                 rowBucketVecs[bucketID][j].push_back(rowIn.getPointer());
                                 rowIn.nextRow();
@@ -5572,6 +5574,8 @@ void TupleAggregateStep::threadedAggregateRowGroups(uint32_t threadID)
                         for (uint64_t i = 0; i < fRowGroupIns[threadID].getRowCount(); ++i)
                         {
                             // The key is the groupby columns, which are the leading columns.
+                            // TBD This approach could potentiall
+                            // put all values in on bucket.
                             int bucketID = rowIn.hash(hashLens[0] - 1) % fNumOfBuckets;
                             rowBucketVecs[bucketID][0].push_back(rowIn.getPointer());
                             rowIn.nextRow();

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -1183,6 +1183,7 @@ inline bool Row::equals(const Row& r2, const std::vector<uint32_t>& keyCols) con
 
 inline bool Row::equals(const Row& r2, uint32_t lastCol) const
 {
+    // This check fires with empty r2 only.
     if (lastCol >= columnCount)
         return true;
 

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -461,7 +461,8 @@ uint64_t IdbOrderBy::Hasher::operator()(const Row::Pointer& p) const
 {
     Row& row = ts->row1;
     row.setPointer(p);
-    uint64_t ret = row.hash(colCount);
+    // MCOL-1829 Row::h uses colcount as an array idx down a callstack.
+    uint64_t ret = row.hash();//(colCount - 1);
     //cout << "hash(): returning " << ret << " for row: " << row.toString() << endl;
     return ret;
 }
@@ -471,7 +472,9 @@ bool IdbOrderBy::Eq::operator()(const Row::Pointer& d1, const Row::Pointer& d2) 
     Row& r1 = ts->row1, &r2 = ts->row2;
     r1.setPointer(d1);
     r2.setPointer(d2);
-    bool ret = r1.equals(r2, colCount);
+    // MCOL-1829 Row::equals uses 2nd argument as container size boundary
+    // so it must be column count - 1.
+    bool ret = r1.equals(r2, colCount - 1);
     //cout << "equals(): returning " << (int) ret << " for r1: " << r1.toString() << " r2: " << r2.toString()
     //	<< endl;
 


### PR DESCRIPTION
MCOL-1829 Subquery with limited order by could potentially return unordered set.
	There were two code mistakes: Eq::operator() always returned true for
	any pair and Hasher::operator() always returned 0 as a key.