### PR TITLE
MCOL-1829 Subquery with SELECT DISTINCT..ORDER BY returns only one record.

### DIFF
--- a/dbcon/joblist/limitedorderby.cpp
+++ b/dbcon/joblist/limitedorderby.cpp
@@ -108,14 +108,12 @@ void LimitedOrderBy::processRow(const rowgroup::Row& row)
 	if (fOrderByQueue.size() < fStart+fCount)
 	{
 		copyRow(row, &fRow0);
-		//memcpy(fRow0.getData(), row.getData(), row.getSize());
 		OrderByRow newRow(fRow0, fRule);
 		fOrderByQueue.push(newRow);
 
 		// add to the distinct map
 		if (fDistinct)
 			fDistinctMap->insert(fRow0.getPointer());
-			//fDistinctMap->insert(make_pair((fRow0.getData()+2), fRow0.getData()));
 
 		fRowGroup.incRowCount();
 		fRow0.nextRow();
@@ -142,21 +140,15 @@ void LimitedOrderBy::processRow(const rowgroup::Row& row)
 	{
 		OrderByRow swapRow = fOrderByQueue.top();
 		row1.setData(swapRow.fData);
-		fOrderByQueue.pop();
-		if (!fDistinct)
+        copyRow(row, &row1);
+
+        if (fDistinct)
 		{
-			copyRow(row, &row1);
-			//memcpy(swapRow.fData, row.getData(), row.getSize());
-		}
-		else
-		{
-			fDistinctMap->erase(row.getPointer());
-			copyRow(row, &row1);
+			fDistinctMap->erase(fOrderByQueue.top().fData);
 			fDistinctMap->insert(row1.getPointer());
-			//fDistinctMap->erase(fDistinctMap->find(row.getData() + 2));
-			//memcpy(swapRow.fData, row.getData(), row.getSize());
-			//fDistinctMap->insert(make_pair((swapRow.fData+2), swapRow.fData));
 		}
+
+        fOrderByQueue.pop();
 		fOrderByQueue.push(swapRow);
 	}
 }

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -443,7 +443,8 @@ uint64_t IdbOrderBy::Hasher::operator()(const Row::Pointer &p) const
 {
 	Row &row = ts->row1;
 	row.setPointer(p);
-	uint64_t ret = row.hash(colCount);
+    // MCOL-1829 Row::h uses colcount as an array idx down a callstack.
+    uint64_t ret = row.hash();
 	//cout << "hash(): returning " << ret << " for row: " << row.toString() << endl;
 	return ret;
 }
@@ -453,7 +454,9 @@ bool IdbOrderBy::Eq::operator()(const Row::Pointer &d1, const Row::Pointer &d2) 
 	Row &r1 = ts->row1, &r2 = ts->row2;
 	r1.setPointer(d1);
 	r2.setPointer(d2);
-	bool ret = r1.equals(r2, colCount);
+    // MCOL-1829 Row::equals uses 2nd argument as container size boundary
+    // so it must be column count - 1.
+    bool ret = r1.equals(r2, colCount - 1);
 	//cout << "equals(): returning " << (int) ret << " for r1: " << r1.toString() << " r2: " << r2.toString()
 	//	<< endl;
 


### PR DESCRIPTION
    Partially backported the change from develop-1.2.
    There were two code mistakes: Eq::operator() always returned true for
    any pair and Hasher::operator() always returned 0 as a key.