### PR TITLE
MCOL-2052 IS.columnstore_files now prints correct number of records for any relation out.

### DIFF
--- a/dbcon/mysql/is_columnstore_files.cpp
+++ b/dbcon/mysql/is_columnstore_files.cpp
@@ -110,7 +110,7 @@ static int generate_result(BRM::OID_t oid, BRM::DBRM *emp, TABLE *table, THD *th
         if (iter->blockOffset > 0)
         {
             iter++;
-            return 0;
+            continue;
         }
 
         try


### PR DESCRIPTION
    Return statement called in generate_result() returns too early.