### PR TITLE
MCOL-2009 MCOL-1702 : join() inside of joblist::abort caused threads …

### DIFF
--- a/dbcon/joblist/joblist.cpp
+++ b/dbcon/joblist/joblist.cpp
@@ -1067,10 +1067,6 @@ void JobList::abort()
 			fQuery[i]->abort();
 		for (i = 0; i < fProject.size(); i++)
 			fProject[i]->abort();
-		for (i = 0; i < fQuery.size(); i++)
-			fQuery[i]->join();
-		for (i = 0; i < fProject.size(); i++)
-			fProject[i]->join();
 	}
 }
 


### PR DESCRIPTION
…to be blocked on an abort