### PR TITLE
MCOL-2151, added jemalloc dependency check in columnstoreClusterTester

### DIFF
--- a/utils/clusterTester/columnstoreClusterTester.sh
+++ b/utils/clusterTester/columnstoreClusterTester.sh
@@ -721,7 +721,7 @@ checkPackages()
   echo "** Run MariaDB ColumnStore Dependent Package Check"
   echo ""
 
-  declare -a CENTOS_PKG=("expect" "perl" "perl-DBI" "openssl" "zlib" "file" "sudo" "libaio" "rsync" "snappy" "net-tools" "perl-DBD-MySQL")
+  declare -a CENTOS_PKG=("expect" "perl" "perl-DBI" "openssl" "zlib" "file" "sudo" "libaio" "rsync" "jemalloc" "snappy" "net-tools" "perl-DBD-MySQL")
 
   if [ "$OS" == "centos6" ] || [ "$OS" == "centos7" ]; then
     if [ ! `which yum 2>/dev/null` ] ; then
@@ -796,7 +796,7 @@ checkPackages()
     fi
   fi
 
-  declare -a SUSE_PKG=("boost-devel" "expect" "perl" "perl-DBI" "openssl" "file" "sudo" "libaio1" "rsync" "libsnappy1" "net-tools" "perl-DBD-mysql")
+  declare -a SUSE_PKG=("boost-devel" "expect" "perl" "perl-DBI" "openssl" "file" "sudo" "libaio1" "rsync" "jemalloc" "libsnappy1" "net-tools" "perl-DBD-mysql")
 
   if [ "$OS" == "suse12" ]; then
     if [ ! `which rpm 2>/dev/null` ] ; then
@@ -848,7 +848,7 @@ checkPackages()
     fi
   fi  
 
-  declare -a UBUNTU_PKG=("libboost-all-dev" "expect" "libdbi-perl" "perl" "openssl" "file" "sudo" "libreadline-dev" "rsync" "libsnappy1V5" "net-tools" "libdbd-mysql-perl")
+  declare -a UBUNTU_PKG=("libboost-all-dev" "expect" "libdbi-perl" "perl" "openssl" "file" "sudo" "libreadline-dev" "rsync" "jemalloc" "libsnappy1V5" "net-tools" "libdbd-mysql-perl")
 
   if [ "$OS" == "ubuntu16" ] ; then
     if [ ! `which dpkg 2>/dev/null` ] ; then
@@ -913,7 +913,7 @@ checkPackages()
    fi
   fi
 
-  declare -a DEBIAN_PKG=("libboost-all-dev" "expect" "libdbi-perl" "perl" "openssl" "file" "sudo" "libreadline-dev" "rsync" "libsnappy1" "net-tools" "libdbd-mysql-perl")
+  declare -a DEBIAN_PKG=("libboost-all-dev" "expect" "libdbi-perl" "perl" "openssl" "file" "sudo" "libreadline-dev" "rsync" "jemalloc" "libsnappy1" "net-tools" "libdbd-mysql-perl")
 
   if [ "$OS" == "debian8" ]; then
     if [ ! `which dpkg 2>/dev/null` ] ; then
@@ -978,7 +978,7 @@ checkPackages()
     fi
   fi
   
-  declare -a DEBIAN9_PKG=("libboost-all-dev" "expect" "libdbi-perl" "perl" "openssl" "file" "sudo" "libreadline5" "rsync" "libsnappy1V5" "net-tools" "libaio1")
+  declare -a DEBIAN9_PKG=("libboost-all-dev" "expect" "libdbi-perl" "perl" "openssl" "file" "sudo" "libreadline5" "rsync" "jemalloc" "libsnappy1V5" "net-tools" "libaio1")
 
   if [ "$OS" == "debian9" ]; then
     if [ ! `which dpkg 2>/dev/null` ] ; then


### PR DESCRIPTION
MCOL-2151, added jemalloc dependency check in ColumnStore Dependent Package Check module of columnstoreClusterTester 


#  /usr/local/mariadb/columnstore/bin/columnstoreClusterTester.sh --ipaddr=172.20.2.208

*** This is the MariaDB Columnstore Cluster System test tool ***

** Validate local OS is supported

Local Node OS System Name : CentOS Linux 7 (Core)

** Run Ping access Test to remote nodes

172.20.2.208  Node Passed ping test

** Run SSH Login access Test to remote nodes

172.20.2.208  Node Passed SSH login test using ssh-keys

** Run OS check - OS version needs to be the same on all nodes

Local Node OS Version : CentOS Linux 7 (Core)

172.20.2.208 Node OS Version : CentOS Linux 7 (Core)

** Run Locale check - Locale needs to be the same on all nodes

Local Node Locale : LANG=en_US.UTF-8
172.20.2.208 Node Locale : LANG=en_US.UTF-8

** Run SELINUX check - Setting should to be disabled on all nodes

Local Node SELINUX setting is Not Enabled
172.20.2.208 Node SELINUX setting is Not Enabled

** Run Firewall Services check - Firewall Services should to be Inactive on all nodes

Local Node iptables service is Not Active
Local Node ufw service is Not Active
Local Node firewalld service is Not Active
Local Node firewall service is Not Active

172.20.2.208 Node iptables service is Not Enabled
172.20.2.208 Node ufw service is Not Enabled
172.20.2.208 Node firewalld service is Not Enabled
172.20.2.208 Node firewall service is Not Enabled


** Run MariaDB ColumnStore Port (8600-8620) availibility test

172.20.2.208  Node Passed port test

** Run Date/Time check - Date/Time should be within 10 seconds on all nodes

Passed: 172.20.2.208 Node date/time is within 10 seconds of local node

** Run MariaDB ColumnStore Dependent Package Check

Local Node - Passed, all dependency packages are installed

Failed, 172.20.2.208 Node package jemalloc is not installed, please install

Failure occurred, do you want to continue? (y,n) >