### PR TITLE
Fix compilation problems with gcc 8.2.1:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ SET (PACKAGE_STRING columnstore-${PACKAGE_VERSION})
 
 
 SET (ENGINE_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-SET (INSTALL_ENGINE "/usr/local/mariadb/columnstore")
+SET (INSTALL_ENGINE "/usr/local/mariadb/columnstore" CACHE PATH "Location of installed engine")
 
 # use, i.e. don't skip the full RPATH for the build tree
 SET(CMAKE_SKIP_BUILD_RPATH  FALSE)

--- a/dbcon/joblist/expressionstep.cpp
+++ b/dbcon/joblist/expressionstep.cpp
@@ -508,7 +508,7 @@ void ExpressionStep::updateInputIndex(map<uint32_t, uint32_t>& indexMap, const J
             CalpontSystemCatalog::OID oid = sc->oid();
             CalpontSystemCatalog::OID dictOid = 0;
             CalpontSystemCatalog::ColType ct;
-            uint32_t key = fColumnKeys[distance(fColumns.begin(), it)];
+            uint32_t key = fColumnKeys[std::distance(fColumns.begin(), it)];
 
             if (sc->schemaName().empty())
             {

--- a/dbcon/joblist/groupconcat.cpp
+++ b/dbcon/joblist/groupconcat.cpp
@@ -261,7 +261,7 @@ void GroupConcatInfo::mapColumns(const RowGroup& projRG)
             }
             else
             {
-                idx = distance(keys.begin(), i3);
+                idx = std::distance(keys.begin(), i3);
             }
 
             (*k)->fOrderCond.push_back(make_pair(idx, i2->second));

--- a/dbcon/joblist/jlf_tuplejoblist.cpp
+++ b/dbcon/joblist/jlf_tuplejoblist.cpp
@@ -999,12 +999,12 @@ bool combineJobStepsByTable(TableInfoMap::iterator& mit, JobInfo& jobInfo)
             unsigned itInc = 1;               // iterator increase number
             unsigned numOfStepsAddToBps = 0;  // # steps to be added into TBPS
 
-            if ((distance(it, end) > 2 &&
+            if ((std::distance(it, end) > 2 &&
                     dynamic_cast<pDictionaryScan*>(it->get()) != NULL &&
                     (dynamic_cast<pColScanStep*>((it + 1)->get()) != NULL ||
                      dynamic_cast<pColStep*>((it + 1)->get()) != NULL) &&
                     dynamic_cast<TupleHashJoinStep*>((it + 2)->get()) != NULL) ||
-                    (distance(it, end) > 1 &&
+                    (std::distance(it, end) > 1 &&
                      dynamic_cast<pDictionaryScan*>(it->get()) != NULL &&
                      dynamic_cast<TupleHashJoinStep*>((it + 1)->get()) != NULL))
             {
@@ -1045,7 +1045,7 @@ bool combineJobStepsByTable(TableInfoMap::iterator& mit, JobInfo& jobInfo)
                 itInc = 1;
                 numOfStepsAddToBps = 0;
             }
-            else if (distance(begin, it) > 1 &&
+            else if (std::distance(begin, it) > 1 &&
                      (dynamic_cast<pDictionaryScan*>((it - 1)->get()) != NULL ||
                       dynamic_cast<pDictionaryScan*>((it - 2)->get()) != NULL) &&
                      dynamic_cast<TupleHashJoinStep*>(it->get()) != NULL)
@@ -1054,14 +1054,14 @@ bool combineJobStepsByTable(TableInfoMap::iterator& mit, JobInfo& jobInfo)
                 itInc = 1;
                 numOfStepsAddToBps = 0;
             }
-            else if (distance(it, end) > 2 &&
+            else if (std::distance(it, end) > 2 &&
                      dynamic_cast<pColStep*>((it + 1)->get()) != NULL &&
                      dynamic_cast<FilterStep*>((it + 2)->get()) != NULL)
             {
                 itInc = 3;
                 numOfStepsAddToBps = 3;
             }
-            else if (distance(it, end) > 3 &&
+            else if (std::distance(it, end) > 3 &&
                      dynamic_cast<pColStep*>((it + 1)->get()) != NULL &&
                      dynamic_cast<pDictionaryStep*>((it + 2)->get()) != NULL &&
                      dynamic_cast<FilterStep*>((it + 3)->get()) != NULL)
@@ -1069,7 +1069,7 @@ bool combineJobStepsByTable(TableInfoMap::iterator& mit, JobInfo& jobInfo)
                 itInc = 4;
                 numOfStepsAddToBps = 4;
             }
-            else if (distance(it, end) > 3 &&
+            else if (std::distance(it, end) > 3 &&
                      dynamic_cast<pDictionaryStep*>((it + 1)->get()) != NULL &&
                      dynamic_cast<pColStep*>((it + 2)->get()) != NULL &&
                      dynamic_cast<FilterStep*>((it + 3)->get()) != NULL)
@@ -1077,7 +1077,7 @@ bool combineJobStepsByTable(TableInfoMap::iterator& mit, JobInfo& jobInfo)
                 itInc = 4;
                 numOfStepsAddToBps = 4;
             }
-            else if (distance(it, end) > 4 &&
+            else if (std::distance(it, end) > 4 &&
                      dynamic_cast<pDictionaryStep*>((it + 1)->get()) != NULL &&
                      dynamic_cast<pColStep*>((it + 2)->get()) != NULL &&
                      dynamic_cast<pDictionaryStep*>((it + 3)->get()) != NULL &&
@@ -1086,7 +1086,7 @@ bool combineJobStepsByTable(TableInfoMap::iterator& mit, JobInfo& jobInfo)
                 itInc = 5;
                 numOfStepsAddToBps = 5;
             }
-            else if (distance(it, end) > 1 &&
+            else if (std::distance(it, end) > 1 &&
                      (dynamic_cast<pColStep*>(it->get()) != NULL ||
                       dynamic_cast<pColScanStep*>(it->get()) != NULL) &&
                      dynamic_cast<pDictionaryStep*>((it + 1)->get()) != NULL)
@@ -2049,7 +2049,7 @@ uint32_t getKeyIndex(uint32_t key, const RowGroup& rg)
     if (i == rg.getKeys().end())
         throw runtime_error("No key found.");
 
-    return distance(rg.getKeys().begin(), i);
+    return std::distance(rg.getKeys().begin(), i);
 }
 
 

--- a/dbcon/joblist/joblistfactory.cpp
+++ b/dbcon/joblist/joblistfactory.cpp
@@ -1181,11 +1181,11 @@ const JobStepVector doAggProject(const CalpontSelectExecutionPlan* csep, JobInfo
                         else
                             it = pcv.insert(pcv.end(), srcp);
 
-                        projectKeys.insert(projectKeys.begin() + distance(pcv.begin(), it), tupleKey);
+                        projectKeys.insert(projectKeys.begin() + std::distance(pcv.begin(), it), tupleKey);
                     }
                     else if (doDistinct) // @bug4250, move forward distinct column if necessary.
                     {
-                        uint32_t pos = distance(projectKeys.begin(), keyIt);
+                        uint32_t pos = std::distance(projectKeys.begin(), keyIt);
 
                         if (pos >= lastGroupByPos)
                         {
@@ -1332,11 +1332,11 @@ const JobStepVector doAggProject(const CalpontSelectExecutionPlan* csep, JobInfo
                 else
                     it = pcv.insert(pcv.end(), srcp);
 
-                projectKeys.insert(projectKeys.begin() + distance(pcv.begin(), it), tupleKey);
+                projectKeys.insert(projectKeys.begin() + std::distance(pcv.begin(), it), tupleKey);
             }
             else if (doDistinct) // @bug4250, move forward distinct column if necessary.
             {
-                uint32_t pos = distance(projectKeys.begin(), keyIt);
+                uint32_t pos = std::distance(projectKeys.begin(), keyIt);
 
                 if (pos >= lastGroupByPos)
                 {
@@ -1464,7 +1464,7 @@ void changePcolStepToPcolScan(JobStepVector::iterator& it, JobStepVector::iterat
     {
         //If we have a pDictionaryScan-pColStep duo, then change the pColStep
         if (typeid(*(it->get())) == typeid(pDictionaryScan) &&
-                distance(it, end) > 1 &&
+                std::distance(it, end) > 1 &&
                 typeid(*((it + 1)->get())) == typeid(pColStep))
         {
             ++it;

--- a/dbcon/joblist/windowfunctionstep.cpp
+++ b/dbcon/joblist/windowfunctionstep.cpp
@@ -1571,8 +1571,8 @@ void WindowFunctionStep::sort(std::vector<RowPosition>::iterator v, uint64_t n)
         }
     }
 
-    sort(v, distance(v, h) + 1);
-    sort(l, distance(l, v) + n);
+    sort(v, std::distance(v, h) + 1);
+    sort(l, std::distance(l, v) + n);
 }
 
 

--- a/exemgr/main.cpp
+++ b/exemgr/main.cpp
@@ -227,7 +227,7 @@ const string prettyPrintMiniInfo(const string& in)
     {
         vector<string>::iterator iter2 = iter1->begin();
         vector<string>::iterator end2 = iter1->end();
-        assert(distance(iter2, end2) == header_parts);
+        assert(std::distance(iter2, end2) == header_parts);
         int i = 0;
 
         while (iter2 != end2)

--- a/procmgr/processmanager.cpp
+++ b/procmgr/processmanager.cpp
@@ -23,6 +23,7 @@
 
 //#define NDEBUG
 #include <cassert>
+#include <boost/tokenizer.hpp>
 
 #include "columnstoreversion.h"
 #include "processmanager.h"

--- a/procmon/main.cpp
+++ b/procmon/main.cpp
@@ -19,6 +19,7 @@
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 #include <boost/version.hpp>
+#include <boost/tokenizer.hpp>
 namespace bi = boost::interprocess;
 
 #include "processmonitor.h"

--- a/utils/rwlock/rwlock.h
+++ b/utils/rwlock/rwlock.h
@@ -33,7 +33,6 @@
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 #include <boost/interprocess/sync/interprocess_semaphore.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #if defined(_MSC_VER) && defined(xxxRWLOCK_DLLEXPORT)
 #define EXPORT __declspec(dllexport)

--- a/versioning/BRM/autoincrementmanager.cpp
+++ b/versioning/BRM/autoincrementmanager.cpp
@@ -34,6 +34,8 @@ using namespace boost::posix_time;
 namespace BRM
 {
 
+const uint32_t AutoincrementManager::lockTime = 30;
+
 AutoincrementManager::AutoincrementManager()
 {
 }

--- a/versioning/BRM/autoincrementmanager.h
+++ b/versioning/BRM/autoincrementmanager.h
@@ -54,7 +54,7 @@ public:
     EXPORT void deleteSequence(uint32_t OID);
 
 private:
-    static const uint32_t lockTime = 30;   // 30 seconds
+    static const uint32_t lockTime;   // 30 seconds
     struct sequence
     {
         sequence() : value(0), overflow(0) { }


### PR DESCRIPTION
  -  /version/BRM/autoincrementmanager.cpp/.h fixes missing symbol during
     link

Fix installation with cmake --build . --target install where the server
isn't installed in the default location.  To use, pass -DINSTALL_ENGINE
to cmake:
  -  /CMakeLists.txt allow parameterized server install path

Fix compilation problems with gcc 8.2.1 and boost 1.69.0:
  -  Fully qualify std::distance to avoid identifier clash since boost
     now seems to declare a global distance as well.
  -  Fix odd preprocessor clash of __builtin_expect by removing the
     inclusion of boost/date_time/posix_time/posix_time.hpp from
     /utils/rwlock/rwlock.h which seems to be a relic. Subsequent to
     this arose missing definitions from boost::tokenizer requiring
     inclusion in the remaining files.