### PR TITLE
MCOL-1607.  Let postconfigure store hostnames in the configuration.

### DIFF
--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -662,9 +662,14 @@ int main(int argc, char* argv[])
         if (moduleconfig.hostConfigList.size() > 0 )
         {
             HostConfigList::iterator pt1 = moduleconfig.hostConfigList.begin();
-            string PM1ipAdd = (*pt1).IPAddr;
+            
+            // MCOL-1607.  The 'am I pm1?' check below requires an ipaddr.
+            string PM1ipAdd = oam.getIPAddress((*pt1).IPAddr.c_str());
+            if (PM1ipAdd.empty())
+                PM1ipAdd = (*pt1).IPAddr;    // this is what it was doing before              
+                
             //cout << PM1ipAdd << endl;
-
+            
             if ( PM1ipAdd != "127.0.0.1" )
             {
                 if ( PM1ipAdd != "0.0.0.0")
@@ -2601,6 +2606,13 @@ int main(int argc, char* argv[])
                                     if (strlen(pcommand) > 0) newModuleIPAddr = pcommand;
 
                                     callFree(pcommand);
+                                }
+                                
+                                if (!doNotResolveHostNames)
+                                {
+                                    string ugh = oam.getIPAddress(newModuleIPAddr);
+                                    if (ugh.length() > 0)
+                                        newModuleIPAddr = ugh;
                                 }
 
                                 if (newModuleIPAddr == "127.0.0.1" || newModuleIPAddr == "0.0.0.0" || newModuleIPAddr == "128.0.0.1")
@@ -6580,7 +6592,7 @@ bool glusterSetup(string password, bool doNotResolveHostNames)
             //prompt for IP address
             while (true)
             {
-                prompt = "Enter PM #" + oam.itoa(DataRedundancyConfigs[pm].pmID) + " IP Address of " + moduleHostName + " (" + moduleIPAddr + ") > ";
+                prompt = "Enter PM #" + oam.itoa(DataRedundancyConfigs[pm].pmID) + " IP Address or hostname of " + moduleHostName + " (" + moduleIPAddr + ") > ";
                 pcommand = callReadline(prompt.c_str());
 
                 if (pcommand)
@@ -6588,6 +6600,13 @@ bool glusterSetup(string password, bool doNotResolveHostNames)
                     if (strlen(pcommand) > 0) moduleIPAddr = pcommand;
 
                     callFree(pcommand);
+                }
+                
+                if (!doNotResolveHostNames)
+                {
+                    string ugh = oam.getIPAddress(moduleIPAddr);
+                    if (ugh.length() > 0)
+                        moduleIPAddr = ugh;
                 }
 
                 if (moduleIPAddr == "127.0.0.1" || moduleIPAddr == "0.0.0.0" || moduleIPAddr == "128.0.0.1")


### PR DESCRIPTION
Daniel found a couple problems in 1.2.3rc on centos 7
1) if you use postconfig without -x, it doesn't take hostnames at all.
2) if you do use -x, it stores the hostname, but when you run postconfig again, it doesn't think it's on PM1 anymore.

For #1, it looks like that was a pre-existing inconsistency in the path Daniel went down. Fixed that, and another one of those I found.  Also fixed a prompt that asked for IP addresses only, when it also would take hostnames.

For #2, the existing 'am I PM 1?' check looks at ip addresses, I made postconfig resolve hostname -> IP before that.