### PR TITLE
MCOL-901 group_concat() uses only a subset of unique values

### DIFF
--- a/dbcon/joblist/limitedorderby.cpp
+++ b/dbcon/joblist/limitedorderby.cpp
@@ -77,8 +77,6 @@ void LimitedOrderBy::initialize(const RowGroup& rg, const JobInfo& jobInfo)
         map<uint32_t, uint32_t>::iterator j = keyToIndexMap.find(i->first);
         idbassert(j != keyToIndexMap.end());
 
-        // TODO Ordering direction in CSEP differs from
-        // internal direction representation. This behavior should be fixed
         fOrderByCond.push_back(IdbSortSpec(j->second, i->second));
     }
 
@@ -86,16 +84,14 @@ void LimitedOrderBy::initialize(const RowGroup& rg, const JobInfo& jobInfo)
     fStart = jobInfo.limitStart;
     fCount = jobInfo.limitCount;
 
-//	fMemSize = (fStart + fCount) * rg.getRowSize();
-
     IdbOrderBy::initialize(rg);
 }
 
-
+// This must return a proper number of key columns and
+// not just a column count.
 uint64_t LimitedOrderBy::getKeyLength() const
 {
-    //return (fRow0.getSize() - 2);
-    return fRow0.getColumnCount();
+    return fOrderByCond.size();
 }
 
 

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -1,4 +1,5 @@
 /* Copyright (C) 2014 InfiniDB, Inc.
+   Copyright (C) 2019 MariaDB Corporation
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License
@@ -19,7 +20,6 @@
 
 
 #include <iostream>
-//#define NDEBUG
 #include <cassert>
 #include <string>
 #include <stack>
@@ -463,7 +463,6 @@ uint64_t IdbOrderBy::Hasher::operator()(const Row::Pointer& p) const
     row.setPointer(p);
     // MCOL-1829 Row::h uses colcount as an array idx down a callstack.
     uint64_t ret = row.hash();
-    //cout << "hash(): returning " << ret << " for row: " << row.toString() << endl;
     return ret;
 }
 
@@ -472,11 +471,8 @@ bool IdbOrderBy::Eq::operator()(const Row::Pointer& d1, const Row::Pointer& d2) 
     Row& r1 = ts->row1, &r2 = ts->row2;
     r1.setPointer(d1);
     r2.setPointer(d2);
-    // MCOL-1829 Row::equals uses 2nd argument as container size boundary
-    // so it must be column count - 1.
-    bool ret = r1.equals(r2, colCount - 1);
-    //cout << "equals(): returning " << (int) ret << " for r1: " << r1.toString() << " r2: " << r2.toString()
-    //	<< endl;
+    // MCOL-1829 Row::equals uses 2nd argument as key columns container size boundary
+    bool ret = r1.equals(r2, colCount);
 
     return ret;
 }


### PR DESCRIPTION
group_concat() uses only a subset of unique values        
        b/c an incorrect number of key columns was used whilst
        initializing Eq() struct. The regression caused by
        changes made for MCOL-1829 so I revised the changes
        made. Now LimitedOrderBy::getKeyLength() returns an
        actual key columns count.