### PR TITLE
Tentative fix for the getsystemnetworkconfig cmd re mcol-1607.

### DIFF
--- a/oamapps/mcsadmin/mcsadmin.cpp
+++ b/oamapps/mcsadmin/mcsadmin.cpp
@@ -5404,7 +5404,14 @@ int processCommand(string* arguments)
 
                             for ( ; pt1 != (*pt).hostConfigList.end() ; pt1++)
                             {
-                                string ipAddr = (*pt1).IPAddr;
+                                /* MCOL-1607.  IPAddr may be a host name here b/c it is read straight
+                                from the config file. */
+                                string tmphost = oam.getIPAddress(pt1->IPAddr);
+                                string ipAddr;
+                                if (tmphost.empty())
+                                    ipAddr = pt1->IPAddr;
+                                else
+                                    ipAddr = tmphost;
                                 string hostname = (*pt1).HostName;
                                 string nicID = oam.itoa((*pt1).NicID);
 


### PR DESCRIPTION
The getsystemnetworkconfig cmd in mcsadmin used to print whatever was the config file as the ip address.  With the mcol-1607 mod, that could be a hostname.  This patch makes it resolve whatever is in the config file before printing.  If an ip addr is in the config file, that's what gets printed.  If a hostname, it prints the ip addr.