### PR TITLE
MCOL-2233 substring_index() now returns correct value when index value is negative.

### DIFF
--- a/utils/funcexp/func_substring_index.cpp
+++ b/utils/funcexp/func_substring_index.cpp
@@ -62,7 +62,7 @@ std::string Func_substring_index::getStrVal(rowgroup::Row& row,
     if (isNull)
         return "";
 
-    size_t count = fp[2]->data()->getIntVal(row, isNull);
+    int64_t count = fp[2]->data()->getIntVal(row, isNull);
 
     if (isNull)
         return "";
@@ -70,7 +70,8 @@ std::string Func_substring_index::getStrVal(rowgroup::Row& row,
     if ( count == 0 )
         return "";
 
-    size_t end = strlen(str.c_str());
+    // To avoid comparison b/w int64_t and size_t
+    int64_t end = strlen(str.c_str()) & 0x7fffffffffffffff;
 
     if ( count >  end )
         return str;
@@ -84,7 +85,7 @@ std::string Func_substring_index::getStrVal(rowgroup::Row& row,
     {
         int pointer = 0;
 
-        for ( size_t i = 0 ; i < count ; i ++ )
+        for ( int64_t i = 0 ; i < count ; i ++ )
         {
             string::size_type pos = str.find(delim, pointer);
 
@@ -103,7 +104,7 @@ std::string Func_substring_index::getStrVal(rowgroup::Row& row,
         int pointer = end;
         int start = 0;
 
-        for ( size_t i = 0 ; i < count ; i ++ )
+        for ( int64_t i = 0 ; i < count ; i ++ )
         {
             string::size_type pos = str.rfind(delim, pointer);
 


### PR DESCRIPTION
MCOL-2233 substring_index() now returns correct value when index value is negative.
The problem caused by unsigned type used to store negative index value.