### PR TITLE
MCOL-2061 Add upgrade path to rebuild FRM files

### DIFF
--- a/dbcon/ddlpackageproc/altertableprocessor.cpp
+++ b/dbcon/ddlpackageproc/altertableprocessor.cpp
@@ -2064,7 +2064,8 @@ void AlterTableProcessor::tableComment(uint32_t sessionID, execplan::CalpontSyst
     }
     else
     {
-        throw std::runtime_error("Invalid table comment");
+        // Generic table comment, we don't need to do anything
+        return;
     }
 
     // Get the OID for autoinc (if exists)


### PR DESCRIPTION
A major upgrade (1.1 -> 1.2 for example) may have issues due to stale
FRM table IDs. This commit adds a stored procedure that changes the
table comment to empty on every ColumnStore table to repair the IDs.

The user should run this as part of the upgrade procedure between major
versions.