### PR TITLE
MCOL-593 Add optional MariaDB replication support

### DIFF
--- a/dbcon/mysql/ha_calpont_ddl.cpp
+++ b/dbcon/mysql/ha_calpont_ddl.cpp
@@ -2078,8 +2078,7 @@ int ha_calpont_impl_create_(const char* name, TABLE* table_arg, HA_CREATE_INFO* 
     if ( schemaSyncOnly && isCreate)
         return rc;
 
-    //this is replcated DDL, treat it just like SSO
-    if (thd->slave_thread)
+    if (thd->slave_thread && !ci.replicationEnabled)
         return rc;
 
     //@bug 5660. Error out REAL DDL/DML on slave node.
@@ -2277,8 +2276,7 @@ int ha_calpont_impl_delete_table_(const char* db, const char* name, cal_connecti
         return 0;
     }
 
-    //this is replcated DDL, treat it just like SSO
-    if (thd->slave_thread)
+    if (thd->slave_thread && !ci.replicationEnabled)
         return 0;
 
     //@bug 5660. Error out REAL DDL/DML on slave node.
@@ -2417,8 +2415,7 @@ int ha_calpont_impl_rename_table_(const char* from, const char* to, cal_connecti
     pair<string, string> toPair;
     string stmt;
 
-    //this is replicated DDL, treat it just like SSO
-    if (thd->slave_thread)
+    if (thd->slave_thread && !ci.replicationEnabled)
         return 0;
 
     //@bug 5660. Error out REAL DDL/DML on slave node.

--- a/dbcon/mysql/ha_calpont_dml.cpp
+++ b/dbcon/mysql/ha_calpont_dml.cpp
@@ -2078,7 +2078,8 @@ int ha_calpont_impl_commit_ (handlerton* hton, THD* thd, bool all, cal_connectio
             thd->infinidb_vtable.vtable_state == THD::INFINIDB_SELECT_VTABLE )
         return rc;
 
-    if (thd->slave_thread) return 0;
+    if (thd->slave_thread && !ci.replicationEnabled)
+        return 0;
 
     std::string command("COMMIT");
 #ifdef INFINIDB_DEBUG

--- a/dbcon/mysql/ha_calpont_impl_if.h
+++ b/dbcon/mysql/ha_calpont_impl_if.h
@@ -251,10 +251,18 @@ struct cal_connection_info
         useXbit(false),
         utf8(false),
         useCpimport(1),
-        delimiter('\7')
+        delimiter('\7'),
+        replicationEnabled(false)
     {
         // check if this is a slave mysql daemon
         isSlaveNode = checkSlave();
+
+        std::string option = config::Config::makeConfig()->getConfig("SystemConfig", "ReplicationEnabled");
+
+        if (!option.compare("Y"))
+        {
+            replicationEnabled = true;
+        }
     }
 
     static bool checkSlave()
@@ -319,6 +327,7 @@ struct cal_connection_info
     char delimiter;
     char enclosed_by;
     std::vector <execplan::CalpontSystemCatalog::ColType> columnTypes;
+    bool replicationEnabled;
 };
 
 typedef std::tr1::unordered_map<int, cal_connection_info> CalConnMap;


### PR DESCRIPTION
This patch will allow MariaDB replication into UM1 when enabling the
following is added to the SystemConfig section of Columnstore.xml:

<ReplicationEnabled>Y</ReplicationEnabled>

The intended use case is to replication from an InnoDB MariaDB server
into ColumnStore. You would need to create the tables on the ColumnStore
slave as "ColumnStore" and the same tables in the master as InnoDB.

At the moment the use case is narrow and could be prone to problems so
this will use the hidden flag until we can improve it.