### PR TITLE
change signature array in a std::set ! lookup performance is now log(…

### DIFF
--- a/writeengine/bulk/we_colbufmgr.cpp
+++ b/writeengine/bulk/we_colbufmgr.cpp
@@ -45,7 +45,7 @@ namespace
 {
 // Minimum time to wait for a condition, so as to periodically wake up and
 // check the global job status, to see if the job needs to terminate.
-const int COND_WAIT_SECONDS = 3;
+const int COND_WAIT_SECONDS = 1;
 }
 
 namespace WriteEngine

--- a/writeengine/dictionary/we_dctnry.h
+++ b/writeengine/dictionary/we_dctnry.h
@@ -56,6 +56,17 @@ typedef struct Signature
     Token token;
 } Signature;
 
+struct sig_compare {
+	bool operator() (const Signature& a, const Signature& b) const {
+		if (a.size == b.size){
+			return memcmp(a.signature,b.signature,a.size)<0;}
+		else if (a.size<b.size){
+			return true;
+		}else{ return false;}
+	}
+}; 
+
+
 /**
  * @brief Class to interface with dictionary store files.
  */
@@ -285,7 +296,7 @@ protected:
     virtual void  closeDctnryFile(bool doFlush, std::map<FID, FID>& oids);
     virtual int   numOfBlocksInFile();
 
-    Signature    m_sigArray[MAX_STRING_CACHE_SIZE]; // string cache
+    std::set<Signature,sig_compare> m_sigArray;
     int          m_arraySize;                       // num strings in m_sigArray
 
     // m_dctnryHeader  used for hdr when readSubBlockEntry is used to read a blk

--- a/writeengine/dictionary/we_dctnrystore.cpp
+++ b/writeengine/dictionary/we_dctnrystore.cpp
@@ -133,7 +133,7 @@ const int  DctnryStore::updateDctnryStore(unsigned char* sigValue,
         sig.signature = new unsigned char[sigSize];
         memcpy (sig.signature, sigValue, sigSize);
         sig.token = token;
-        m_dctnry.m_sigArray[m_dctnry.m_arraySize] = sig;
+        m_dctnry.m_sigArray.insert(sig) = sig;
         m_dctnry.m_arraySize++;
     }
 


### PR DESCRIPTION
…N). About 10x performance can be expected on cpimport containing varchars.

Signed-off-by: Patrice Linel <plinel@localhost>