### PR TITLE
MCOL-1985 Server set decimal count for UDF based on both parameters. …

### DIFF
--- a/utils/regr/corr.h
+++ b/utils/regr/corr.h
@@ -25,8 +25,7 @@
  * Columnstore interface for for the corr function
  *
  *
- *    CREATE AGGREGATE FUNCTION corr returns REAL
- *    soname 'libregr_mysql.so';
+ *    CREATE AGGREGATE FUNCTION corr returns REAL soname 'libregr_mysql.so';
  *
  */
 #ifndef HEADER_corr

--- a/utils/regr/covar_pop.h
+++ b/utils/regr/covar_pop.h
@@ -25,8 +25,7 @@
  * Columnstore interface for for the covar_pop function
  *
  *
- *    CREATE AGGREGATE FUNCTION covar_pop returns REAL
- *    soname 'libregr_mysql.so';
+ *    CREATE AGGREGATE FUNCTION covar_pop returns REAL soname 'libregr_mysql.so';
  *
  */
 #ifndef HEADER_covar_pop

--- a/utils/regr/covar_samp.h
+++ b/utils/regr/covar_samp.h
@@ -25,8 +25,7 @@
  * Columnstore interface for for the covar_samp function
  *
  *
- *    CREATE AGGREGATE FUNCTION covar_samp returns REAL
- *    soname 'libregr_mysql.so';
+ *    CREATE AGGREGATE FUNCTION covar_samp returns REAL soname 'libregr_mysql.so';
  *
  */
 #ifndef HEADER_covar_samp

--- a/utils/regr/regr_avgx.cpp
+++ b/utils/regr/regr_avgx.cpp
@@ -63,13 +63,6 @@ mcsv1_UDAF::ReturnCode regr_avgx::init(mcsv1Context* context,
         context->setErrorMessage("regr_avgx() with a non-numeric x argument");
         return mcsv1_UDAF::ERROR;
     }
-    if (!(isNumeric(colTypes[1].dataType)))
-    {
-        // The error message will be prepended with
-        // "The storage engine for the table doesn't support "
-        context->setErrorMessage("regr_avgx() with a non-numeric independant (second) argument");
-        return mcsv1_UDAF::ERROR;
-    }
 
     context->setUserDataSize(sizeof(regr_avgx_data));
     context->setResultType(CalpontSystemCatalog::DOUBLE);

--- a/utils/regr/regr_avgx.h
+++ b/utils/regr/regr_avgx.h
@@ -25,8 +25,7 @@
  * Columnstore interface for for the regr_avgx function
  *
  *
- *    CREATE AGGREGATE FUNCTION regr_avgx returns REAL soname
- *    'libregr_mysql.so';
+ *    CREATE AGGREGATE FUNCTION regr_avgx returns REAL soname 'libregr_mysql.so';
  *
  */
 #ifndef HEADER_regr_avgx

--- a/utils/regr/regr_avgy.cpp
+++ b/utils/regr/regr_avgy.cpp
@@ -60,14 +60,7 @@ mcsv1_UDAF::ReturnCode regr_avgy::init(mcsv1Context* context,
     {
         // The error message will be prepended with
         // "The storage engine for the table doesn't support "
-        context->setErrorMessage("regr_avgy() with a non-numeric x argument");
-        return mcsv1_UDAF::ERROR;
-    }
-    if (!(isNumeric(colTypes[0].dataType)))
-    {
-        // The error message will be prepended with
-        // "The storage engine for the table doesn't support "
-        context->setErrorMessage("regr_avgy() with a non-numeric dependant (first) argument");
+        context->setErrorMessage("regr_avgy() with a non-numeric y argument");
         return mcsv1_UDAF::ERROR;
     }
 

--- a/utils/regr/regr_avgy.h
+++ b/utils/regr/regr_avgy.h
@@ -25,8 +25,7 @@
  * Columnstore interface for for the regr_avgy function
  *
  *
- *    CREATE AGGREGATE FUNCTION regr_avgy returns REAL soname
- *    'libregr_mysql.so';
+ *    CREATE AGGREGATE FUNCTION regr_avgy returns REAL soname 'libregr_mysql.so';
  *
  */
 #ifndef HEADER_regr_avgy

--- a/utils/regr/regr_count.h
+++ b/utils/regr/regr_count.h
@@ -25,8 +25,7 @@
  * Columnstore interface for for the regr_count function
  *
  *
- *    CREATE AGGREGATE FUNCTION regr_count returns INTEGER
- *    soname 'libregr_mysql.so';
+ *    CREATE AGGREGATE FUNCTION regr_count returns INTEGER soname 'libregr_mysql.so';
  *
  */
 #ifndef HEADER_regr_count

--- a/utils/regr/regr_intercept.h
+++ b/utils/regr/regr_intercept.h
@@ -25,8 +25,7 @@
  * Columnstore interface for for the regr_intercept function
  *
  *
- *    CREATE AGGREGATE FUNCTION regr_intercept returns REAL
- *    soname 'libregr_mysql.so';
+ *    CREATE AGGREGATE FUNCTION regr_intercept returns REAL soname 'libregr_mysql.so';
  *
  */
 #ifndef HEADER_regr_intercept

--- a/utils/regr/regr_r2.h
+++ b/utils/regr/regr_r2.h
@@ -25,8 +25,7 @@
  * Columnstore interface for for the regr_r2 function
  *
  *
- *    CREATE AGGREGATE FUNCTION regr_r2 returns REAL
- *    soname 'libregr_mysql.so';
+ *    CREATE AGGREGATE FUNCTION regr_r2 returns REAL soname 'libregr_mysql.so';
  *
  */
 #ifndef HEADER_regr_r2

--- a/utils/regr/regr_slope.h
+++ b/utils/regr/regr_slope.h
@@ -25,8 +25,7 @@
  * Columnstore interface for for the regr_slope function
  *
  *
- *    CREATE AGGREGATE FUNCTION regr_slope returns REAL
- *    soname 'libregr_mysql.so';
+ *    CREATE AGGREGATE FUNCTION regr_slope returns REAL soname 'libregr_mysql.so';
  *
  */
 #ifndef HEADER_regr_slope

--- a/utils/regr/regr_sxx.h
+++ b/utils/regr/regr_sxx.h
@@ -25,8 +25,7 @@
  * Columnstore interface for for the regr_sxx function
  *
  *
- *    CREATE AGGREGATE FUNCTION regr_sxx returns REAL
- *    soname 'libregr_mysql.so';
+ *    CREATE AGGREGATE FUNCTION regr_sxx returns REAL soname 'libregr_mysql.so';
  *
  */
 #ifndef HEADER_regr_sxx

--- a/utils/regr/regr_sxy.h
+++ b/utils/regr/regr_sxy.h
@@ -25,8 +25,7 @@
  * Columnstore interface for for the regr_sxy function
  *
  *
- *    CREATE AGGREGATE FUNCTION regr_sxy returns REAL
- *    soname 'libregr_mysql.so';
+ *    CREATE AGGREGATE FUNCTION regr_sxy returns REAL soname 'libregr_mysql.so';
  *
  */
 #ifndef HEADER_regr_sxy

--- a/utils/regr/regr_syy.h
+++ b/utils/regr/regr_syy.h
@@ -25,8 +25,7 @@
  * Columnstore interface for for the regr_syy function
  *
  *
- *    CREATE AGGREGATE FUNCTION regr_syy returns REAL
- *    soname 'libregr_mysql.so';
+ *    CREATE AGGREGATE FUNCTION regr_syy returns REAL soname 'libregr_mysql.so';
  *
  */
 #ifndef HEADER_regr_syy

--- a/utils/regr/regrmysql.cpp
+++ b/utils/regr/regrmysql.cpp
@@ -167,10 +167,13 @@ extern "C"
             strcpy(message,"regr_avgx() with a non-numeric independant (second) argument");
             return 1;
         }
-    
-        if (initid->decimals != DECIMAL_NOT_SPECIFIED)
+        if (args->arg_type[1] == DECIMAL_RESULT && initid->decimals != DECIMAL_NOT_SPECIFIED)
         {
-            initid->decimals +=4;
+            initid->decimals += 4;
+        }
+        else
+        {
+            initid->decimals = DECIMAL_NOT_SPECIFIED;
         }
         
         if (!(data = (struct regr_avgx_data*) malloc(sizeof(struct regr_avgx_data))))
@@ -272,9 +275,13 @@ extern "C"
             return 1;
         }
 
-        if (initid->decimals != DECIMAL_NOT_SPECIFIED)
+        if (args->arg_type[0] == DECIMAL_RESULT && initid->decimals != DECIMAL_NOT_SPECIFIED)
         {
-            initid->decimals +=4;
+            initid->decimals += 4;
+        }
+        else
+        {
+            initid->decimals = DECIMAL_NOT_SPECIFIED;
         }
                         
         if (!(data = (struct regr_avgy_data*) malloc(sizeof(struct regr_avgy_data))))


### PR DESCRIPTION
…This doesn't work for regr_avgx and regr_avgy, which only care about one of them. Do our best to handle it reasonably. Still gives unlimited decimals for InnoDB when the unused parameter is not numeric.