### PR TITLE
MCOL-2051: CS uses 'NULL' literal as NULL when UPDATEs varchar field

### DIFF
--- a/dbcon/dmlpackage/dml.y
+++ b/dbcon/dmlpackage/dml.y
@@ -566,17 +566,11 @@ assignment_commalist:
 assignment:
 		column COMPARISON scalar_exp
 		{
-		   $$ = new ColumnAssignment();
-		   $$->fColumn = $1; 
-		   $$->fOperator = $2;
-		   $$->fScalarExpression = $3;
+		   $$ = new ColumnAssignment($1, $2, $3);
 		}
 	|	column COMPARISON NULLX
 		{
-		   $$ = new ColumnAssignment();
-		   $$->fColumn = $1;
-		   $$->fOperator = $2;
-		   $$->fScalarExpression = $3;
+		   $$ = new ColumnAssignment($1, $2, $3);
 		}
 	;
 

--- a/dbcon/dmlpackage/dmlcolumn.cpp
+++ b/dbcon/dmlpackage/dmlcolumn.cpp
@@ -40,10 +40,6 @@ DMLColumn::DMLColumn(std::string name, std::string value, bool isFromCol, uint32
 {
     fName = name;
     fData = value;
-    if (( strcasecmp(value.c_str(), "NULL") == 0) || (value.length() == 0) )
-    {
-          isNULL = true;
-    } 
     fisNULL = isNULL;
 	fIsFromCol = isFromCol;
 	fFuncScale = funcScale;

--- a/dbcon/dmlpackage/dmlpkg.h
+++ b/dbcon/dmlpackage/dmlpkg.h
@@ -409,8 +409,9 @@ public:
     std::string fColumn;
     std::string fOperator;
     std::string fScalarExpression;
-	bool fFromCol;
-	uint32_t fFuncScale;
+    bool fFromCol;
+    uint32_t fFuncScale;
+    bool fIsNull = false;
 };
 
 /** @brief Stores a value list or a query specification

--- a/dbcon/dmlpackage/dmlpkg.h
+++ b/dbcon/dmlpackage/dmlpkg.h
@@ -397,6 +397,14 @@ public:
 class ColumnAssignment
 {
 public:
+    explicit ColumnAssignment(
+        std::string const& column,
+        std::string const& op = "=",
+        std::string const& expr = "") :
+        fColumn(column), fOperator(op), fScalarExpression(expr),
+        fFromCol(false), fFuncScale(0), fIsNull(false)
+        {};
+
     /** @brief dump to stdout
      */
     std::ostream& put(std::ostream &os) const;
@@ -411,7 +419,7 @@ public:
     std::string fScalarExpression;
     bool fFromCol;
     uint32_t fFuncScale;
-    bool fIsNull = false;
+    bool fIsNull;
 };
 
 /** @brief Stores a value list or a query specification

--- a/dbcon/dmlpackage/updatedmlpackage.cpp
+++ b/dbcon/dmlpackage/updatedmlpackage.cpp
@@ -245,7 +245,8 @@ void UpdateDMLPackage::buildUpdateFromMysqlBuffer(UpdateSqlStatement&  updateStm
     while (iter != updateStmt.fColAssignmentListPtr->end())
     {
         ColumnAssignment* colaPtr  = *iter;
-        DMLColumn* colPtr = new DMLColumn(colaPtr->fColumn, colaPtr->fScalarExpression, colaPtr->fFromCol, colaPtr->fFuncScale);
+        DMLColumn* colPtr = new DMLColumn(colaPtr->fColumn, colaPtr->fScalarExpression, colaPtr->fFromCol, colaPtr->fFuncScale,
+            colaPtr->fIsNull);
         rowPtr->get_ColumnList().push_back(colPtr);
 
         ++iter;

--- a/dbcon/mysql/ha_calpont_impl.cpp
+++ b/dbcon/mysql/ha_calpont_impl.cpp
@@ -928,10 +928,7 @@ uint32_t doUpdateDelete(THD *thd)
             else
                 schemaName = string(item->db_name);
 
-            columnAssignmentPtr = new ColumnAssignment();
-            columnAssignmentPtr->fColumn = string(item->name);
-            columnAssignmentPtr->fOperator = "=";
-            columnAssignmentPtr->fFuncScale = 0;
+            columnAssignmentPtr = new ColumnAssignment(item->name, "=", "");
             Item *value= value_it++;
             if (value->type() ==  Item::STRING_ITEM)
             {

--- a/dbcon/mysql/ha_calpont_impl.cpp
+++ b/dbcon/mysql/ha_calpont_impl.cpp
@@ -1044,8 +1044,9 @@ uint32_t doUpdateDelete(THD *thd)
             else if ( value->type() ==  Item::NULL_ITEM )
             {
 //                dmlStmt += "NULL";
-                columnAssignmentPtr->fScalarExpression = "NULL";
+                columnAssignmentPtr->fScalarExpression = "";
                 columnAssignmentPtr->fFromCol = false;
+                columnAssignmentPtr->fIsNull = true;
             }
             else if ( value->type() == Item::SUBSELECT_ITEM )
             {


### PR DESCRIPTION
Added proxying of NULL values.
Note: empty strings are still considered NULLs later on.