### PR TITLE
MCOL-2273 Improve disk usage reporting

### DIFF
--- a/oamapps/serverMonitor/diskMonitor.cpp
+++ b/oamapps/serverMonitor/diskMonitor.cpp
@@ -240,7 +240,7 @@ void diskMonitor()
 	
 					blksize = buf.f_bsize; 
 					blocks = buf.f_blocks; 
-					freeblks = buf.f_bfree; 
+					freeblks = buf.f_bavail; 
 	
 					totalBlocks = blocks * blksize;
 					free = freeblks * blksize; 
@@ -359,7 +359,7 @@ void diskMonitor()
 			
 							blksize = buf.f_bsize; 
 							blocks = buf.f_blocks; 
-							freeblks = buf.f_bfree; 
+							freeblks = buf.f_bavail; 
 			
 							totalBlocks = blocks * blksize;
 							free = freeblks * blksize; 


### PR DESCRIPTION
Use the amount of available space rather than the amount of free space.
The two numbers are usually different because the free blocks may be
unusable at the time.