### PR TITLE
Repairs develop build mode w OAM disabled. 

### DIFF
--- a/cmake/configureEngine.cmake
+++ b/cmake/configureEngine.cmake
@@ -717,7 +717,7 @@ SET (inline "")
 ENDIF()
 
 IF($ENV{SKIP_OAM_INIT})
-    SET(SKIP_OAM_INIT 1)
+    set(SKIP_OAM_INIT 1 CACHE BOOL "Skip OAM initialization" FORCE)
 ENDIF()
 
 EXECUTE_PROCESS(

--- a/exemgr/main.cpp
+++ b/exemgr/main.cpp
@@ -73,6 +73,7 @@
 #include "liboamcpp.h"
 #include "crashtrace.h"
 #include "utils_utf8.h"
+#include "config.h"
 
 #if defined(SKIP_OAM_INIT)
 #include "dbrm.h"


### PR DESCRIPTION
Now one can use -DSKIP_OAM_INIT=1 instead of using environmental variable.