### PR TITLE
MCOL-537 Regression test doesn't tolerate 'failed' in stderr, stdout.

### DIFF
--- a/tools/dbloadxml/colxml.cpp
+++ b/tools/dbloadxml/colxml.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv)
     // set effective ID to root
     if( setuid( 0 ) < 0 )
     {
-        std::cerr << " colxml: setuid failed " << std::endl;
+        std::cerr << " colxml: couldn't set uid " << std::endl;
     }
     setlocale(LC_ALL, "");
     WriteEngine::Config::initConfigCache(); // load Columnstore.xml config settings

--- a/utils/dataconvert/dataconvert.h
+++ b/utils/dataconvert/dataconvert.h
@@ -675,7 +675,7 @@ inline void DataConvert::timeToString1( long long timevalue, char* buf, unsigned
     }
     // this snprintf call causes a compiler warning b/c buffer size is less
     // then maximum string size.
-#if defined(__GNUC__) && __GNUC__ >= 6
+#if defined(__GNUC__) && __GNUC__ >= 8
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation="
     snprintf( buf, buflen, "%02d%02d%02d",

--- a/utils/threadpool/threadpool.h
+++ b/utils/threadpool/threadpool.h
@@ -77,7 +77,7 @@ public:
     boost::thread* create_thread(F threadfunc)
     {
         boost::lock_guard<boost::shared_mutex> guard(m);
-#if defined(__GNUC__) && __GNUC__ >= 7
+#if defined(__GNUC__) && __GNUC__ >= 6
         std::unique_ptr<boost::thread> new_thread(new boost::thread(threadfunc));
 #else
         std::auto_ptr<boost::thread> new_thread(new boost::thread(threadfunc));

--- a/writeengine/bulk/cpimport.cpp
+++ b/writeengine/bulk/cpimport.cpp
@@ -1025,7 +1025,7 @@ int main(int argc, char** argv)
     // set effective ID to root
     if( setuid( 0 ) < 0 )
     {
-        std::cerr << " cpimport: setuid failed " << std::endl;
+        std::cerr << " cpimport: couldn't set uid " << std::endl;
     } 
 #endif
     setupSignalHandlers();

--- a/writeengine/splitter/we_splitterapp.cpp
+++ b/writeengine/splitter/we_splitterapp.cpp
@@ -609,7 +609,7 @@ int main(int argc, char** argv)
     // @BUG4343
     if( setuid( 0 ) < 0 )
     {
-        std::cerr << " we_splitterapp: setuid failed " << std::endl;
+        std::cerr << " we_splitterapp: couldn't set uid " << std::endl;
     }
 
     std::cin.sync_with_stdio(false);


### PR DESCRIPTION
    I reformulate the messages.

    Changed version in preprocessor conditions to avoid compilation
    warnings in Debian 9.