### PR TITLE
MCOL-3239 CS pushes relevant filter predicates into derived tables.

### DIFF
--- a/dbcon/execplan/functioncolumn.cpp
+++ b/dbcon/execplan/functioncolumn.cpp
@@ -420,6 +420,16 @@ void FunctionColumn::setDerivedTable()
                 break;
             }
         }
+        // MCOL-3239 Block for func column with both
+        // derived table column and normal table column.
+        else if (derivedTableAlias == "")
+        {
+            if (sc->tableAlias().length())
+            {
+                derivedTableAlias = "";
+                break;
+            }
+        }
     }
 
     fDerivedTable = derivedTableAlias;


### PR DESCRIPTION
    This change disables predicate push for function column that
    contains both derived table column and non-derived table column.