### PR TITLE
MCOL-2230 Fix TIMEDIFF() handling

### DIFF
--- a/utils/funcexp/func_timediff.cpp
+++ b/utils/funcexp/func_timediff.cpp
@@ -118,7 +118,10 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
 
         case execplan::CalpontSystemCatalog::TIME:
         case execplan::CalpontSystemCatalog::DATETIME:
-            if (type1 != type2)
+            // Diff between time and datetime returns NULL in MariaDB
+            if ((type2 == execplan::CalpontSystemCatalog::TIME ||
+                 type2 == execplan::CalpontSystemCatalog::DATETIME) &&
+                 type1 != type2)
             {
                 isNull = true;
                 break;


### PR DESCRIPTION
TIMEDIFF would not compare datetime with string correctly, causing a
NULL saturation.