### PR TITLE
MCOL-1989 Fix view in view subquery outer join

### DIFF
--- a/dbcon/execplan/calpontselectexecutionplan.h
+++ b/dbcon/execplan/calpontselectexecutionplan.h
@@ -354,6 +354,10 @@ public:
 	void derivedTbAlias(const std::string derivedTbAlias) { fDerivedTbAlias = derivedTbAlias; }
 	const std::string derivedTbAlias() const { return fDerivedTbAlias; }
 
+    void derivedTbView(const std::string derivedTbView) { fDerivedTbView = derivedTbView; }
+    const std::string derivedTbView() const { return fDerivedTbView; }
+
+
 	void limitStart(const uint64_t limitStart) { fLimitStart = limitStart; }
 	const uint64_t limitStart() const { return fLimitStart; }
 
@@ -565,6 +569,7 @@ private:
 	// for subselect
 	uint64_t fSubType;
 	std::string fDerivedTbAlias;
+    std::string fDerivedTbView;
 
 	// for limit
 	uint64_t fLimitStart;

--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -1833,7 +1833,14 @@ SimpleColumn* buildSimpleColFromDerivedTable(gp_walk_info& gwi, Item_field* ifp)
 					sc->colPosition(j);
 					string tableAlias(csep->derivedTbAlias());
 					sc->tableAlias(lower(tableAlias));
-					sc->viewName(lower(viewName));
+                    if (!viewName.empty())
+                    {
+                            sc->viewName(viewName);
+                    }
+                    else
+                    {
+                            sc->viewName(csep->derivedTbView());
+                    }
 					sc->resultType(cols[j]->resultType());
 					sc->hasAggregate(cols[j]->hasAggregate());
 					if (col)

--- a/dbcon/mysql/ha_from_sub.cpp
+++ b/dbcon/mysql/ha_from_sub.cpp
@@ -317,6 +317,7 @@ SCSEP FromSubQuery::transform()
 	gwi.subQuery = this;
 	gwi.viewName = fGwip.viewName;
 	csep->derivedTbAlias(fAlias); // always lower case
+    csep->derivedTbView(fGwip.viewName.alias);
 
 	if (getSelectPlan(gwi, *fFromSub, csep) != 0)
 	{


### PR DESCRIPTION
A view calling a view as part of a subquery outer join was not getting
the view name for the derived table columns. Which caused ColumnStore to
think it was joining outside of the view and triggered a missing column
error.

This fix adds the view name from the subquery if one cannot be obtained
from the field object.