### PR TITLE
Brm save improvement

### DIFF
--- a/utils/idbdatafile/IDBPolicy.cpp
+++ b/utils/idbdatafile/IDBPolicy.cpp
@@ -83,8 +83,15 @@ void IDBPolicy::init( bool bEnableLogging, bool bUseRdwrMemBuffer, const string&
         else
         {
 			cout << tmpfilepath << endl;
-
-            if (!boost::filesystem::create_directory(tmpfilepath))
+            bool itWorked = false;
+            
+            try 
+            {
+                itWorked = boost::filesystem::create_directories(tmpfilepath);
+            }
+            catch (...)
+            { }
+            if (!itWorked)
             {
                 // We failed to create the scratch directory
                 ostringstream oss;

--- a/versioning/BRM/extentmap.cpp
+++ b/versioning/BRM/extentmap.cpp
@@ -1493,7 +1493,7 @@ void ExtentMap::save(const string& filename)
         }
 
         allocdSize = fEMShminfo->allocdSize / sizeof(EMEntry);
-        const int emEntrySize = sizeof(EMEntry);
+        //const int emEntrySize = sizeof(EMEntry);
 
         int first = -1, last = -1, err;
         size_t progress, writeSize;
@@ -1504,7 +1504,7 @@ void ExtentMap::save(const string& filename)
             else if (fExtentMap[i].range.size <= 0 && first != -1)
             {
                 last = i;
-                writeSize = (last - first) * emEntrySize;
+                writeSize = (last - first) * sizeof(EMEntry);
                 progress = 0;
                 char *writePos = (char *) &fExtentMap[first];
                 while (progress < writeSize)
@@ -1523,7 +1523,7 @@ void ExtentMap::save(const string& filename)
         }
         if (first != -1)
         {
-            writeSize = (allocdSize - first) * emEntrySize;
+            writeSize = (allocdSize - first) * sizeof(EMEntry);
             progress = 0;
             char *writePos = (char *) &fExtentMap[first];
             while (progress < writeSize)
@@ -1539,14 +1539,15 @@ void ExtentMap::save(const string& filename)
             }
         }
 
-        allocdSize = fFLShminfo->allocdSize / sizeof(InlineLBIDRange);
+        //allocdSize = fFLShminfo->allocdSize / sizeof(InlineLBIDRange);
         //const int inlineLbidRangeSize = sizeof(InlineLBIDRange);
 
         progress = 0;
+        writeSize = fFLShminfo->allocdSize;
         char *writePos = (char *) fFreeList;
-        while (progress < (size_t) allocdSize)
+        while (progress < writeSize)
         {
-            err = out->write(writePos + progress, allocdSize - progress);
+            err = out->write(writePos + progress, writeSize - progress);
             if (err < 0)
             {
                 releaseFreeList(READ);
@@ -1556,7 +1557,7 @@ void ExtentMap::save(const string& filename)
             progress += err;
         }
     }
-    else    // this is the fstream version to be expired
+    else   // this is the fstream version to be expired
     {
         ofstream out;
 

--- a/versioning/BRM/extentmap.cpp
+++ b/versioning/BRM/extentmap.cpp
@@ -1253,14 +1253,22 @@ void ExtentMap::loadVersion4(IDBDataFile* in)
         growEMShmseg(nrows);
     }
 
-    for (int i = 0; i < emNumElements; i++)
+    size_t progress = 0, writeSize = emNumElements * sizeof(EMEntry);
+    int err;
+    char *writePos = (char *) fExtentMap;
+    while (progress < writeSize)
     {
-        if (in->read((char*) &fExtentMap[i], sizeof(EMEntry)) != sizeof(EMEntry))
+        err = in->read(writePos + progress, writeSize - progress);
+        if (err <= 0)
         {
             log_errno("ExtentMap::loadVersion4(): read ");
             throw runtime_error("ExtentMap::loadVersion4(): read failed. Check the error log.");
         }
-
+        progress += (uint) err;
+    }
+    
+    for (int i = 0; i < emNumElements; i++)
+    {
         reserveLBIDRange(fExtentMap[i].range.start, fExtentMap[i].range.size);
 
         //@bug 1911 - verify status value is valid
@@ -1268,6 +1276,7 @@ void ExtentMap::loadVersion4(IDBDataFile* in)
                 fExtentMap[i].status > EXTENTSTATUSMAX)
             fExtentMap[i].status = EXTENTAVAILABLE;
     }
+    
 
     fEMShminfo->currentSize = emNumElements * sizeof(EMEntry);
 
@@ -1328,7 +1337,8 @@ void ExtentMap::load(const string& filename, bool fixFL)
         throw;
     }
 
-    if (IDBPolicy::useHdfs())
+    // XXXPAT: Forcing the IDB path.  Remove the fstream path once we see this works.
+    if (true || IDBPolicy::useHdfs())
     {
         const char* filename_p = filename.c_str();
         scoped_ptr<IDBDataFile>  in(IDBDataFile::open(
@@ -1363,7 +1373,7 @@ void ExtentMap::load(const string& filename, bool fixFL)
             throw;
         }
     }
-    else
+    else   // fstream path to be remove
     {
         ifstream in;
         in.open(filename.c_str(), ios_base::in | ios_base::binary);
@@ -1443,14 +1453,15 @@ void ExtentMap::save(const string& filename)
         throw runtime_error("ExtentMap::save(): got request to save an empty BRM");
     }
 
-    if (IDBPolicy::useHdfs())
+    // XXXPAT: I don't know why there are two options here.  It can just use the IDBDataFile stuff.
+    // Forcing the IDB option to execute for now.  Leaving the old fstream version there in case we find there's 
+    // a case the IDB option doesn't work.
+    if (true || IDBPolicy::useHdfs())
     {
-        utmp = ::umask(0);
         const char* filename_p = filename.c_str();
         scoped_ptr<IDBDataFile> out(IDBDataFile::open(
                                         IDBPolicy::getType(filename_p, IDBPolicy::WRITEENG),
                                         filename_p, "wb", IDBDataFile::USE_VBUF));
-        ::umask(utmp);
 
         if (!out)
         {
@@ -1484,50 +1495,68 @@ void ExtentMap::save(const string& filename)
         allocdSize = fEMShminfo->allocdSize / sizeof(EMEntry);
         const int emEntrySize = sizeof(EMEntry);
 
+        int first = -1, last = -1, err;
+        size_t progress, writeSize;
         for (i = 0; i < allocdSize; i++)
         {
-            if (fExtentMap[i].range.size > 0)
+            if (fExtentMap[i].range.size > 0 && first == -1)
+                first = i;
+            else if (fExtentMap[i].range.size <= 0 && first != -1)
             {
-                try
+                last = i;
+                writeSize = (last - first) * emEntrySize;
+                progress = 0;
+                char *writePos = (char *) &fExtentMap[first];
+                while (progress < writeSize)
                 {
-                    bytes = out->write((char*) &fExtentMap[i], emEntrySize);
-
-                    if (bytes != emEntrySize)
+                    err = out->write(writePos + progress, writeSize - progress);
+                    if (err < 0)
+                    {
+                        releaseFreeList(READ);
+                        releaseEMEntryTable(READ);
                         throw ios_base::failure("ExtentMap::save(): write failed. Check the error log.");
+                    }
+                    progress += err;
                 }
-                catch (...)
+                first = -1;
+            }
+        }
+        if (first != -1)
+        {
+            writeSize = (allocdSize - first) * emEntrySize;
+            progress = 0;
+            char *writePos = (char *) &fExtentMap[first];
+            while (progress < writeSize)
+            {
+                err = out->write(writePos + progress, writeSize - progress);
+                if (err < 0)
                 {
                     releaseFreeList(READ);
                     releaseEMEntryTable(READ);
-                    throw;
+                    throw ios_base::failure("ExtentMap::save(): write failed. Check the error log.");
                 }
+                progress += err;
             }
         }
 
         allocdSize = fFLShminfo->allocdSize / sizeof(InlineLBIDRange);
-        const int inlineLbidRangeSize = sizeof(InlineLBIDRange);
+        //const int inlineLbidRangeSize = sizeof(InlineLBIDRange);
 
-        for (i = 0; i < allocdSize; i++)
+        progress = 0;
+        char *writePos = (char *) fFreeList;
+        while (progress < (size_t) allocdSize)
         {
-//			if (fFreeList[i].size > 0) {
-            try
-            {
-                int bytes = out->write((char*) &fFreeList[i], inlineLbidRangeSize);
-
-                if (bytes != inlineLbidRangeSize)
-                    throw ios_base::failure("ExtentMap::save(): write failed. Check the error log.");
-            }
-            catch (...)
+            err = out->write(writePos + progress, allocdSize - progress);
+            if (err < 0)
             {
                 releaseFreeList(READ);
                 releaseEMEntryTable(READ);
-                throw;
+                throw ios_base::failure("ExtentMap::save(): write failed. Check the error log.");
             }
-
-//			}
+            progress += err;
         }
     }
-    else
+    else    // this is the fstream version to be expired
     {
         ofstream out;
 

--- a/versioning/BRM/oidserver.cpp
+++ b/versioning/BRM/oidserver.cpp
@@ -349,12 +349,17 @@ void OIDServer::initializeBitmap() const
     writeData(buf, 0, HeaderSize);
 
     // reset buf to all 0's and write the bitmap
-    for (i = 0; i < HeaderSize; i++)
-        buf[i] = 0;
+    //for (i = 0; i < HeaderSize; i++)
+    //    buf[i] = 0;
 
-    for (i = 0; i < bitmapSize; i += HeaderSize)
-        writeData(buf, HeaderSize + i, (bitmapSize - i > HeaderSize ? HeaderSize : bitmapSize - i));
+    //for (i = 0; i < bitmapSize; i += HeaderSize)
+    //    writeData(buf, HeaderSize + i, (bitmapSize - i > HeaderSize ? HeaderSize : bitmapSize - i));
 
+    uint8_t *bitmapbuf = new uint8_t[bitmapSize];
+    memset(bitmapbuf, 0, bitmapSize);
+    writeData(bitmapbuf, HeaderSize, bitmapSize);
+    delete bitmapbuf;
+    
     flipOIDBlock(0, firstOID, 0);
 
     /* append a 16-bit 0 to indicate 0 entries in the vboid->dbroot mapping */

--- a/versioning/BRM/oidserver.cpp
+++ b/versioning/BRM/oidserver.cpp
@@ -153,7 +153,8 @@ void OIDServer::writeData(uint8_t* buf, off_t offset, int size) const
     if (size == 0)
         return;
 
-    if (IDBPolicy::useHdfs())
+    // XXXPAT: Forcing the IDB* path.  Get rid of the fstream path when appropriate.
+    if (true || IDBPolicy::useHdfs())
     {
         for (errCount = 0; errCount < MaxRetries && seekerr != offset; errCount++)
         {
@@ -231,7 +232,8 @@ void OIDServer::readData(uint8_t* buf, off_t offset, int size) const
     if (size == 0)
         return;
 
-    if (IDBPolicy::useHdfs())
+    // XXXPAT: Forcing the IDB* path.  Get rid of the fstream path when appropriate.
+    if (true || IDBPolicy::useHdfs())
     {
         for (errCount = 0; errCount < MaxRetries && seekerr != offset; errCount++)
         {
@@ -354,14 +356,16 @@ void OIDServer::initializeBitmap() const
 
     //for (i = 0; i < bitmapSize; i += HeaderSize)
     //    writeData(buf, HeaderSize + i, (bitmapSize - i > HeaderSize ? HeaderSize : bitmapSize - i));
-
+    
     uint8_t *bitmapbuf = new uint8_t[bitmapSize];
     memset(bitmapbuf, 0, bitmapSize);
     writeData(bitmapbuf, HeaderSize, bitmapSize);
-    delete bitmapbuf;
+    delete[] bitmapbuf;
     
     flipOIDBlock(0, firstOID, 0);
 
+    buf[0] = 0;
+    buf[1] = 0;
     /* append a 16-bit 0 to indicate 0 entries in the vboid->dbroot mapping */
     writeData(buf, StartOfVBOidSection, 2);
 }
@@ -384,7 +388,8 @@ OIDServer::OIDServer() : fFp(NULL), fFd(-1)
         throw runtime_error(os.str());
     }
 
-    if (IDBPolicy::useHdfs())
+    // XXXPAT: Forcing the IDB* path.
+    if (true || IDBPolicy::useHdfs())
     {
         if (!IDBPolicy::exists(fFilename.c_str()))   //no bitmap file
         {
@@ -616,7 +621,7 @@ retry:
     {
         writeData(buf, offset, byteSize);
 
-        if (IDBPolicy::useHdfs())
+        if (true || IDBPolicy::useHdfs())
             fFp->flush();
 
         delete [] buf;
@@ -663,7 +668,7 @@ retry:
     {
         writeData(buf, offset, byteSize);
 
-        if (IDBPolicy::useHdfs())
+        if (true || IDBPolicy::useHdfs())
             fFp->flush();
 
         delete [] buf;
@@ -785,7 +790,7 @@ void OIDServer::patchFreelist(struct FEntry* freelist, int start, int num) const
     {
         writeData(reinterpret_cast<uint8_t*>(freelist), 0, HeaderSize);
 
-        if (IDBPolicy::useHdfs())
+        if (true || IDBPolicy::useHdfs())
             fFp->flush();
     }
 }
@@ -813,7 +818,7 @@ int OIDServer::allocVBOID(uint16_t dbroot)
         throw;
     }
 
-    if (IDBPolicy::useHdfs())
+    if (true || IDBPolicy::useHdfs())
         fFp->flush();
 
     return ret;
@@ -887,7 +892,7 @@ int OIDServer::allocOIDs(int num)
     writeData(reinterpret_cast<uint8_t*>(freelist), 0, HeaderSize);
     flipOIDBlock(bestMatchBegin, num, 0);
 
-    if (IDBPolicy::useHdfs())
+    if (true || IDBPolicy::useHdfs())
         fFp->flush();
 
     return bestMatchBegin;

--- a/versioning/BRM/slavecomm.cpp
+++ b/versioning/BRM/slavecomm.cpp
@@ -1891,7 +1891,7 @@ void SlaveComm::do_vbRollback1(ByteStream& msg)
     if (!standalone)
         master.write(reply);
 
-    takeSnapshot = true;
+    doSaveDelta = true;
 }
 
 void SlaveComm::do_vbRollback2(ByteStream& msg)
@@ -1930,7 +1930,7 @@ void SlaveComm::do_vbRollback2(ByteStream& msg)
     if (!standalone)
         master.write(reply);
 
-    takeSnapshot = true;
+    doSaveDelta = true;
 }
 
 void SlaveComm::do_vbCommit(ByteStream& msg)
@@ -1962,7 +1962,7 @@ void SlaveComm::do_vbCommit(ByteStream& msg)
     if (!standalone)
         master.write(reply);
 
-    takeSnapshot = true;
+    doSaveDelta = true;
 }
 
 void SlaveComm::do_undo()


### PR DESCRIPTION
This is for MCOL-3242.  Want to get this in before I go on vacation.

This replaces the element-by-element writing pattern of the BRM structures with a clustered writing pattern of like-types.  Ex, the EM/VBBM/VSS only write allocated entries.  The new version scans for groups of allocated/unallocated entries, and writes a group of consecutive allocated entries in one write() op.  This greatly reduces the # of write() calls.  On the read() side, I have it read the whole thing in one read(), and do whatever per-element processing needs to be done on it afterward.

I modded the OID server code the same way, because I saw the same access pattern when it would init the oid bitmap.

I don't know who did the IDB* conversion (was originally fstream) for these classes, but what they did is copy the original code and flip between them depending on whether HDFS was being used.  So, the IO code all looks like:
  if (HDFS)
 { 
   original code using IDBDataFiles
 }
 else
 {
  original code using fstreams
  }

There's no need for that.  Or at least there should be no need.  Hard to say whether the hacker had a reason for that or not.  What I've done for this patch is force the decision to go down the IDBDataFile version, which is the path with the optimization.  After an appropriate period where we see things are working, 2 weeks after merging maybe, I will follow up and delete the fstream version.

To verify correctness, I hacked my local copy to go down both the IDBDatafile path that I've modified, and the original fstream version, which produced 2 files for each BRM struct.  I ran many tests to populate them, saved at random points, and used a script to verify the 2 files were identical.  I could have written code to automatically check after every execution but figured this was good enough b/c the changes aren't that complicated.  That said, the reviewer should go over it with a fine-tooth comb.