### PR TITLE
MCOL-3389 DML operations created two fCatalogMap entries per session.

### DIFF
--- a/writeengine/server/we_dmlcommandproc.cpp
+++ b/writeengine/server/we_dmlcommandproc.cpp
@@ -664,6 +664,10 @@ uint8_t WE_DMLCommandProc::processSingleInsert(messageqcpp::ByteStream& bs, std:
         }
 	}
 
+    // MCOL-1495 Remove fCatalogMap entries CS won't use anymore.
+    CalpontSystemCatalog::removeCalpontSystemCatalog(sessionId);
+    CalpontSystemCatalog::removeCalpontSystemCatalog(sessionId | 0x80000000);
+
 	return rc;
 }
 
@@ -1255,7 +1259,9 @@ End-Disable use of MetaFile for bulk rollback support
 			BulkRollbackMgr::deleteMetaFile( tblOid );
         }
 	}
-	//cout << "Batch insert return code " << rc << endl;
+    // MCOL-1495 Remove fCatalogMap entries CS won't use anymore.
+    CalpontSystemCatalog::removeCalpontSystemCatalog(sessionId);
+    CalpontSystemCatalog::removeCalpontSystemCatalog(sessionId | 0x80000000);
 	return rc;
 }
 
@@ -1906,17 +1912,10 @@ uint8_t WE_DMLCommandProc::processBatchInsertBinary(messageqcpp::ByteStream& bs,
 		args.add(cols);
 		err = IDBErrorInfo::instance()->errorMsg(WARN_DATA_TRUNC,args);
 
-		// Strict mode enabled, so rollback on warning
-		// NOTE: This doesn't seem to be a possible code path yet
-		/*if (insertPkg.get_isWarnToError())
-		{
-				string applName ("BatchInsert");
-				fWEWrapper.bulkRollback(tblOid,txnid.id,tableName.toString(),
-					applName, false, err);
-				BulkRollbackMgr::deleteMetaFile( tblOid );
-		}*/
-	}
-	//cout << "Batch insert return code " << rc << endl;
+   }
+    // MCOL-1495 Remove fCatalogMap entries CS won't use anymore.
+    CalpontSystemCatalog::removeCalpontSystemCatalog(sessionId);
+    CalpontSystemCatalog::removeCalpontSystemCatalog(sessionId | 0x80000000);
 	return rc;
 }
 
@@ -2046,6 +2045,9 @@ uint8_t WE_DMLCommandProc::commitBatchAutoOn(messageqcpp::ByteStream& bs, std::s
         cacheutils::flushPrimProcAllverBlocks(dictFlushBlks);
         fWEWrapper.getDictMap().erase(txnID);
     }
+    // MCOL-1495 Remove fCatalogMap entries CS won't use anymore.
+    CalpontSystemCatalog::removeCalpontSystemCatalog(sessionId);
+    CalpontSystemCatalog::removeCalpontSystemCatalog(sessionId | 0x80000000);
 	return rc;
 }
 
@@ -3426,7 +3428,6 @@ uint8_t WE_DMLCommandProc::processUpdate(messageqcpp::ByteStream& bs,
 		args.add(cols);
 		err = IDBErrorInfo::instance()->errorMsg(WARN_DATA_TRUNC,args);
 	}
-	//cout << "finished update" << endl;
 	return rc;
 }
 
@@ -3591,6 +3592,10 @@ uint8_t WE_DMLCommandProc::processFlushFiles(messageqcpp::ByteStream& bs, std::s
 	//if (idbdatafile::IDBPolicy::useHdfs())
 	//		cacheutils::dropPrimProcFdCache();
 	TableMetaData::removeTableMetaData(tableOid);
+
+    // MCOL-1495 Remove fCatalogMap entries CS won't use anymore.
+    CalpontSystemCatalog::removeCalpontSystemCatalog(txnId);
+    CalpontSystemCatalog::removeCalpontSystemCatalog(txnId | 0x80000000);
 	return rc;
 }
 
@@ -3759,7 +3764,6 @@ uint8_t WE_DMLCommandProc::processDelete(messageqcpp::ByteStream& bs,
 				err = IDBErrorInfo::instance()->errorMsg(ERR_VERSIONBUFFER_OVERFLOW);
 			}
 	}
-	//cout << "WES return rc " << (int)rc << " with msg " << err << endl;
 	return rc;
 }
 


### PR DESCRIPTION
    These entries were never deleted so WE leaks about 7MB per 100 DML
    sessions. I add purge operations in the very end of four functions
    involved in DML.