### PR TITLE
MCOL-2102 postConfigure -port now changes CrossEngineSupport Port

### DIFF
--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -801,6 +801,7 @@ int main(int argc, char* argv[])
         try
         {
             sysConfig->setConfig(InstallSection, "MySQLPort", mysqlPort);
+            sysConfig->setConfig("CrossEngineSupport", "Port", mysqlPort);
         }
         catch (...)
         {}


### PR DESCRIPTION
Set CrossEngineSupport Port number when setting MySQLPort via postConfigure -port