### PR TITLE
Found other places in the BRM code that were using fstreams vs IDB*.

### DIFF
--- a/versioning/BRM/blockresolutionmanager.cpp
+++ b/versioning/BRM/blockresolutionmanager.cpp
@@ -109,7 +109,7 @@ int BlockResolutionManager::saveState(string filename) throw()
         // truncate teh file if already exists since no truncate in HDFS.
         const char* filename = journalFilename.c_str();
 
-        if (IDBPolicy::useHdfs())
+        if (true || IDBPolicy::useHdfs())
         {
             IDBDataFile* journal = IDBDataFile::open(
                                        IDBPolicy::getType(filename, IDBPolicy::WRITEENG), filename, "wb", 0);

--- a/versioning/BRM/sessionmanagerserver.cpp
+++ b/versioning/BRM/sessionmanagerserver.cpp
@@ -119,7 +119,7 @@ SessionManagerServer::SessionManagerServer() : unique32(0), unique64(0), txnidfd
 
     txnidFilename = conf->getConfig("SessionManager", "TxnIDFile");
 
-    if (!IDBPolicy::useHdfs())
+    if (false && !IDBPolicy::useHdfs())
     {
         txnidfd = open(txnidFilename.c_str(), O_RDWR | O_CREAT | O_BINARY, 0664);
 
@@ -178,7 +178,7 @@ again:
     // If we fail to read a full four bytes for any value, then the
     // value isn't in the file, and we start with the default.
 
-    if (!IDBPolicy::useHdfs())
+    if (false && !IDBPolicy::useHdfs())
     {
         // Last transaction id
         lseek(txnidfd, 0, SEEK_SET);
@@ -297,7 +297,7 @@ again:
 */
 void SessionManagerServer::saveSystemState()
 {
-    if (!IDBPolicy::useHdfs())
+    if (false && !IDBPolicy::useHdfs())
     {
         int err = 0;
         uint32_t lSystemState = systemState;
@@ -377,7 +377,7 @@ const TxnID SessionManagerServer::newTxnID(const SID session, bool block, bool i
     if (isDDL)
         ++_sysCatVerID;
 
-    if (!IDBPolicy::useHdfs())
+    if (false && !IDBPolicy::useHdfs())
     {
         int filedata[2];
         filedata[0] = _verID;

--- a/versioning/BRM/slavecomm.cpp
+++ b/versioning/BRM/slavecomm.cpp
@@ -138,19 +138,16 @@ SlaveComm::SlaveComm(string hostname, SlaveDBRMNode* s) :
         firstSlave = true;
         journalName = savefile + "_journal";
         const char* filename = journalName.c_str();
-        uint32_t utmp = ::umask(0);
 
-        if (IDBPolicy::useHdfs())
+        if (true || IDBPolicy::useHdfs())
         {
             journalh = IDBDataFile::open(
-                           IDBPolicy::getType(filename, IDBPolicy::WRITEENG), filename, "r+b", 0);
+                           IDBPolicy::getType(filename, IDBPolicy::WRITEENG), filename, "w+b", 0);
         }
         else
         {
             journal.open(filename, ios_base::binary | ios_base::out | ios_base::app);
         }
-
-        ::umask(utmp);
 
         if ((journal.is_open() == false) && (journalh == NULL))
             throw runtime_error("Could not open the BRM journal for writing!");
@@ -2009,11 +2006,11 @@ void SlaveComm::do_confirm()
     {
         const char* filename = tmp.c_str();
 
-        if (!IDBPolicy::useHdfs() && currentSaveFD < 0)
+        if ((false && !IDBPolicy::useHdfs()) && currentSaveFD < 0)
         {
             currentSaveFD = open(filename, O_WRONLY | O_CREAT, 0664);
         }
-        else if (IDBPolicy::useHdfs() && !currentSaveFile)
+        else if ((true || IDBPolicy::useHdfs()) && !currentSaveFile)
         {
             currentSaveFile = IDBDataFile::open(
                                   IDBPolicy::getType(filename, IDBPolicy::WRITEENG), filename, "wb", 0);
@@ -2027,10 +2024,7 @@ void SlaveComm::do_confirm()
             log(os.str());
             throw runtime_error(os.str());
         }
-
-#ifndef _MSC_VER
-        chmod(filename, 0664);
-#endif
+        
         tmp = savefile + (saveFileToggle ? 'A' : 'B');
         slave->saveState(tmp);
 #ifndef _MSC_VER
@@ -2062,11 +2056,9 @@ void SlaveComm::do_confirm()
             saveFileToggle = !saveFileToggle;
 
             const char* filename = journalName.c_str();
-            uint32_t utmp = ::umask(0);
             delete journalh;
             journalh = IDBDataFile::open(
                            IDBPolicy::getType(filename, IDBPolicy::WRITEENG), filename, "w+b", 0);
-            ::umask(utmp);
 
             if (!journalh)
                 throw runtime_error("Could not open the BRM journal for writing!");
@@ -2258,7 +2250,7 @@ int SlaveComm::replayJournal(string prefix)
 
     const char* filename = journalName.c_str();
 
-    if (IDBPolicy::useHdfs())
+    if (true || IDBPolicy::useHdfs())
     {
         IDBDataFile* journalf = IDBDataFile::open(
                                     IDBPolicy::getType(filename, IDBPolicy::WRITEENG), filename, "rb", 0);
@@ -2368,7 +2360,7 @@ void SlaveComm::saveDelta()
     {
         uint32_t len = delta.length();
 
-        if (IDBPolicy::useHdfs())
+        if (true || IDBPolicy::useHdfs())
         {
             journalh->write((const char*) &len, sizeof(len));
             journalh->write((const char*) delta.buf(), delta.length());

--- a/versioning/BRM/tablelockserver.cpp
+++ b/versioning/BRM/tablelockserver.cpp
@@ -63,7 +63,7 @@ void TableLockServer::save()
 
     const char* filename_p = filename.c_str();
 
-    if (IDBPolicy::useHdfs())
+    if (true || IDBPolicy::useHdfs())
     {
         scoped_ptr<IDBDataFile> out(IDBDataFile::open(
                                         IDBPolicy::getType(filename_p, IDBPolicy::WRITEENG),
@@ -109,7 +109,7 @@ void TableLockServer::load()
     TableLockInfo tli;
 
     /* Need to standardize the file error handling */
-    if (IDBPolicy::useHdfs())
+    if (true || IDBPolicy::useHdfs())
     {
         const char* filename_p = filename.c_str();
         scoped_ptr<IDBDataFile>  in(IDBDataFile::open(


### PR DESCRIPTION
Came across add'l places where the BRM code is using fstreams rather than the IDBDataFile stuff.  Forced the IDBDataFile paths.  Also fixed a bug in journal file usage where it would open it with read access instead of write access down the IDB* path.

Will remove the fstream code after a couple weeks.