### PR TITLE
MCOL-3391 Fix columnstore_upgrade unicode support

### DIFF
--- a/dbcon/mysql/columnstore_info.sql
+++ b/dbcon/mysql/columnstore_info.sql
@@ -101,7 +101,7 @@ END //
 create procedure columnstore_upgrade()
 `columnstore_upgrade`: BEGIN
     DECLARE done INTEGER DEFAULT 0;
-    DECLARE schema_table VARCHAR(100) DEFAULT "";
+    DECLARE schema_table VARCHAR(100) CHARACTER SET utf8 DEFAULT "";
     DECLARE table_list CURSOR FOR select concat('`', table_schema,'`.`',table_name,'`') from information_schema.tables where engine='columnstore';
     DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = 1;
     OPEN table_list;
@@ -115,6 +115,5 @@ create procedure columnstore_upgrade()
         DEALLOCATE PREPARE stmt;
     END LOOP;
 END //
-delimiter ;
 
 DELIMITER ;


### PR DESCRIPTION
The columnstore_upgrade() procedure would break on utf8 table names.
This patch fixes that.