### PR TITLE
MCOL-2225 Make cross-engine step use backticks

### DIFF
--- a/dbcon/execplan/simplecolumn.cpp
+++ b/dbcon/execplan/simplecolumn.cpp
@@ -211,9 +211,9 @@ const string SimpleColumn::data() const
     if (!fData.empty())
         return fData;
     else if (!fTableAlias.empty())
-        return string(fSchemaName + '.' + fTableAlias + '.' + fColumnName);
+        return string("`" + fSchemaName + "`.`" + fTableAlias + "`.`" + fColumnName + "`");
 
-    return string(fSchemaName + '.' + fTableName + '.' + fColumnName);
+    return string("`" + fSchemaName + "`.`" + fTableName + "`.`" + fColumnName + "`");
 }
 
 SimpleColumn& SimpleColumn::operator=(const SimpleColumn& rhs)

--- a/dbcon/joblist/crossenginestep.cpp
+++ b/dbcon/joblist/crossenginestep.cpp
@@ -727,17 +727,17 @@ void CrossEngineStep::setProjectBPP(JobStep* jobStep1, JobStep*)
     else
         fSelectClause += "SELECT ";
 
-    fSelectClause += jobStep1->name();
+    fSelectClause += "`" + jobStep1->name() + "`";
 }
 
 
 string CrossEngineStep::makeQuery()
 {
     ostringstream oss;
-    oss << fSelectClause << " FROM " << fTable;
+    oss << fSelectClause << " FROM `" << fTable << "`";
 
     if (fTable.compare(fAlias) != 0)
-        oss << " " << fAlias;
+        oss << " `" << fAlias << "`";
 
     if (!fWhereClause.empty())
         oss << fWhereClause;


### PR DESCRIPTION
If an InnoDB table has spaces in the column names the cross engine step
would fail. This patch wraps quotes around the table and column names to
support this use case.