### PR TITLE
MCOL-3395 Always clear dctnry cache on close

### DIFF
--- a/writeengine/dictionary/we_dctnry.cpp
+++ b/writeengine/dictionary/we_dctnry.cpp
@@ -419,8 +419,7 @@ int Dctnry::closeDctnry(bool realClose)
         return rc;
 
     //cout <<"Init called! m_dctnryOID ="  << m_dctnryOID << endl;
-    if (realClose)
-        freeStringCache( );
+    freeStringCache( );
 
     return NO_ERROR;
 }


### PR DESCRIPTION
The dictionary cache needs to be cleared every time it is closed so that
on bulk insert we don't mix the cache between columns.