### PR TITLE
Mcol 174

### DIFF
--- a/dbcon/execplan/predicateoperator.h
+++ b/dbcon/execplan/predicateoperator.h
@@ -35,6 +35,7 @@
 #include <alloca.h>
 #endif
 #include <cstring>
+#include <cmath>
 #include <boost/regex.hpp>
 
 #include "expressionparser.h"

--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -2899,7 +2899,7 @@ ReturnedColumn* buildReturnedColumn(Item* item, gp_walk_info& gwi, bool& nonSupp
             String val, *str = item->val_str(&val);
             string valStr;
             valStr.assign(str->ptr(), str->length());
-            rc = new ConstantColumn(valStr);
+            rc = new ConstantColumn(valStr, ConstantColumn::NUM);
             break;
         }
 

--- a/utils/funcexp/func_bitwise.cpp
+++ b/utils/funcexp/func_bitwise.cpp
@@ -93,10 +93,6 @@ bool getUIntValFromParm(
             {
                 isNull = true;
             }
-            else
-            {
-                value = 0;
-            }
         }
         break;
 

--- a/utils/funcexp/func_bitwise.cpp
+++ b/utils/funcexp/func_bitwise.cpp
@@ -106,9 +106,9 @@ bool getUIntValFromParm(
             {
                 d.value = 0;
             }
-
-            int64_t tmpval = d.value / helpers::power(d.scale);
-            int lefto = (d.value - tmpval * helpers::power(d.scale)) / helpers::power(d.scale - 1);
+            double dscale = d.scale;
+            int64_t tmpval = d.value / pow(10.0, dscale);
+            int lefto = (d.value - tmpval * pow(10.0, dscale)) / pow(10.0, dscale - 1);
 
             if ( tmpval >= 0 && lefto > 4 )
                 tmpval++;

--- a/utils/funcexp/func_cast.cpp
+++ b/utils/funcexp/func_cast.cpp
@@ -182,7 +182,7 @@ int64_t Func_cast_signed::getIntVal(Row& row,
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
             double dscale = d.scale;
             int64_t value = d.value / pow(10.0, dscale);
-            int lefto = (d.value - value * pow(10.0, dscale)) / pow(dscale - 1);
+            int lefto = (d.value - value * pow(10.0, dscale)) / pow(10.0, dscale - 1);
 
             if ( value >= 0 && lefto > 4 )
                 value++;
@@ -337,7 +337,7 @@ uint64_t Func_cast_unsigned::getUintVal(Row& row,
             }
 
             uint64_t value = d.value / pow(10.0, dscale);
-            int lefto = (d.value - value * pow(10.0, dscale)) / pow(dscale - 1);
+            int lefto = (d.value - value * pow(10.0, dscale)) / pow(10.0, dscale - 1);
 
             if ( value >= 0 && lefto > 4 )
                 value++;

--- a/utils/funcexp/func_cast.cpp
+++ b/utils/funcexp/func_cast.cpp
@@ -180,8 +180,9 @@ int64_t Func_cast_signed::getIntVal(Row& row,
         case execplan::CalpontSystemCatalog::UDECIMAL:
         {
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
-            int64_t value = d.value / helpers::power(d.scale);
-            int lefto = (d.value - value * helpers::power(d.scale)) / helpers::power(d.scale - 1);
+            double dscale = d.scale;
+            int64_t value = d.value / pow(10.0, dscale);
+            int lefto = (d.value - value * pow(10.0, dscale)) / pow(dscale - 1);
 
             if ( value >= 0 && lefto > 4 )
                 value++;
@@ -328,14 +329,15 @@ uint64_t Func_cast_unsigned::getUintVal(Row& row,
         case execplan::CalpontSystemCatalog::UDECIMAL:
         {
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
+            double dscale = d.scale;
 
             if (d.value < 0)
             {
                 return 0;
             }
 
-            uint64_t value = d.value / helpers::power(d.scale);
-            int lefto = (d.value - value * helpers::power(d.scale)) / helpers::power(d.scale - 1);
+            uint64_t value = d.value / pow(10.0, dscale);
+            int lefto = (d.value - value * pow(10.0, dscale)) / pow(dscale - 1);
 
             if ( value >= 0 && lefto > 4 )
                 value++;

--- a/utils/funcexp/func_char.cpp
+++ b/utils/funcexp/func_char.cpp
@@ -159,7 +159,7 @@ string Func_char::getStrVal(Row& row,
             double dscale = d.scale;
             // get decimal and round up
             int value = d.value / pow(10.0, dscale);
-            int lefto = (d.value - value * pow(10.0, dscale)) / pow(dscale - 1);
+            int lefto = (d.value - value * pow(10.0, dscale)) / pow(10.0, dscale - 1);
 
             if ( lefto > 4 )
                 value++;

--- a/utils/funcexp/func_char.cpp
+++ b/utils/funcexp/func_char.cpp
@@ -156,9 +156,10 @@ string Func_char::getStrVal(Row& row,
         case execplan::CalpontSystemCatalog::UDECIMAL:
         {
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
+            double dscale = d.scale;
             // get decimal and round up
-            int value = d.value / helpers::power(d.scale);
-            int lefto = (d.value - value * helpers::power(d.scale)) / helpers::power(d.scale - 1);
+            int value = d.value / pow(10.0, dscale);
+            int lefto = (d.value - value * pow(10.0, dscale)) / pow(dscale - 1);
 
             if ( lefto > 4 )
                 value++;

--- a/utils/funcexp/func_elt.cpp
+++ b/utils/funcexp/func_elt.cpp
@@ -71,8 +71,9 @@ string Func_elt::getStrVal(rowgroup::Row& row,
         case CalpontSystemCatalog::DECIMAL:
         {
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
-            number = d.value / helpers::power(d.scale);
-            int lefto = (d.value - number * helpers::power(d.scale)) / helpers::power(d.scale - 1);
+            double dscale = d.scale;
+            number = d.value / pow(10.0, dscale);
+            int lefto = (d.value - number * pow(10.0, dscale)) / pow(dscale - 1);
 
             if ( number >= 0 && lefto > 4 )
                 number++;

--- a/utils/funcexp/func_elt.cpp
+++ b/utils/funcexp/func_elt.cpp
@@ -73,7 +73,7 @@ string Func_elt::getStrVal(rowgroup::Row& row,
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
             double dscale = d.scale;
             number = d.value / pow(10.0, dscale);
-            int lefto = (d.value - number * pow(10.0, dscale)) / pow(dscale - 1);
+            int lefto = (d.value - number * pow(10.0, dscale)) / pow(10.0, dscale - 1);
 
             if ( number >= 0 && lefto > 4 )
                 number++;

--- a/utils/funcexp/func_makedate.cpp
+++ b/utils/funcexp/func_makedate.cpp
@@ -68,8 +68,9 @@ uint64_t makedate(rowgroup::Row& row,
         case CalpontSystemCatalog::DECIMAL:
         {
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
-            year = d.value / helpers::power(d.scale);
-            int lefto = (d.value - year * helpers::power(d.scale)) / helpers::power(d.scale - 1);
+            double dscale = d.scale;
+            year = d.value / pow(10.0, dscale);
+            int lefto = (d.value - year * pow(10.0, dscale)) / pow(dscale - 1);
 
             if ( year >= 0 && lefto > 4 )
                 year++;
@@ -127,8 +128,9 @@ uint64_t makedate(rowgroup::Row& row,
         case CalpontSystemCatalog::DECIMAL:
         {
             IDB_Decimal d = parm[1]->data()->getDecimalVal(row, isNull);
-            int64_t tmp = d.value / helpers::power(d.scale);
-            int lefto = (d.value - tmp * helpers::power(d.scale)) / helpers::power(d.scale - 1);
+            double dscale = d.scale;
+            int64_t tmp = d.value / pow(10.0, dscale);
+            int lefto = (d.value - tmp * pow(10.0, dscale)) / pow(dscale - 1);
 
             if ( tmp >= 0 && lefto > 4 )
                 tmp++;

--- a/utils/funcexp/func_makedate.cpp
+++ b/utils/funcexp/func_makedate.cpp
@@ -70,7 +70,7 @@ uint64_t makedate(rowgroup::Row& row,
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
             double dscale = d.scale;
             year = d.value / pow(10.0, dscale);
-            int lefto = (d.value - year * pow(10.0, dscale)) / pow(dscale - 1);
+            int lefto = (d.value - year * pow(10.0, dscale)) / pow(10.0, dscale - 1);
 
             if ( year >= 0 && lefto > 4 )
                 year++;
@@ -130,7 +130,7 @@ uint64_t makedate(rowgroup::Row& row,
             IDB_Decimal d = parm[1]->data()->getDecimalVal(row, isNull);
             double dscale = d.scale;
             int64_t tmp = d.value / pow(10.0, dscale);
-            int lefto = (d.value - tmp * pow(10.0, dscale)) / pow(dscale - 1);
+            int lefto = (d.value - tmp * pow(10.0, dscale)) / pow(10.0, dscale - 1);
 
             if ( tmp >= 0 && lefto > 4 )
                 tmp++;

--- a/utils/funcexp/func_maketime.cpp
+++ b/utils/funcexp/func_maketime.cpp
@@ -76,7 +76,7 @@ string Func_maketime::getStrVal(rowgroup::Row& row,
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
             double dscale = d.scale;
             hour = d.value / pow(10.0, dscale);
-            int lefto = (d.value - hour * pow(10.0, dscale)) / pow(dscale - 1);
+            int lefto = (d.value - hour * pow(10.0, dscale)) / pow(10.0, dscale - 1);
 
             if ( hour >= 0 && lefto > 4 )
                 hour++;
@@ -116,7 +116,7 @@ string Func_maketime::getStrVal(rowgroup::Row& row,
             IDB_Decimal d = parm[1]->data()->getDecimalVal(row, isNull);
             double dscale = d.scale;
             min = d.value / pow(10.0, dscale);
-            int lefto = (d.value - min * pow(10.0, dscale)) / pow(dscale - 1);
+            int lefto = (d.value - min * pow(10.0, dscale)) / pow(10.0, dscale - 1);
 
             if ( min >= 0 && lefto > 4 )
                 min++;
@@ -162,7 +162,7 @@ string Func_maketime::getStrVal(rowgroup::Row& row,
             IDB_Decimal d = parm[2]->data()->getDecimalVal(row, isNull);
             double dscale = d.scale;
             sec = d.value / pow(10.0, dscale);
-            int lefto = (d.value - sec * pow(10.0, dscale)) / pow(dscale - 1);
+            int lefto = (d.value - sec * pow(10.0, dscale)) / pow(10.0, dscale - 1);
 
             if ( sec >= 0 && lefto > 4 )
                 sec++;

--- a/utils/funcexp/func_maketime.cpp
+++ b/utils/funcexp/func_maketime.cpp
@@ -74,8 +74,9 @@ string Func_maketime::getStrVal(rowgroup::Row& row,
         case CalpontSystemCatalog::DECIMAL:
         {
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
-            hour = d.value / helpers::power(d.scale);
-            int lefto = (d.value - hour * helpers::power(d.scale)) / helpers::power(d.scale - 1);
+            double dscale = d.scale;
+            hour = d.value / pow(10.0, dscale);
+            int lefto = (d.value - hour * pow(10.0, dscale)) / pow(dscale - 1);
 
             if ( hour >= 0 && lefto > 4 )
                 hour++;
@@ -113,8 +114,9 @@ string Func_maketime::getStrVal(rowgroup::Row& row,
         case CalpontSystemCatalog::DECIMAL:
         {
             IDB_Decimal d = parm[1]->data()->getDecimalVal(row, isNull);
-            min = d.value / helpers::power(d.scale);
-            int lefto = (d.value - min * helpers::power(d.scale)) / helpers::power(d.scale - 1);
+            double dscale = d.scale;
+            min = d.value / pow(10.0, dscale);
+            int lefto = (d.value - min * pow(10.0, dscale)) / pow(dscale - 1);
 
             if ( min >= 0 && lefto > 4 )
                 min++;
@@ -158,8 +160,9 @@ string Func_maketime::getStrVal(rowgroup::Row& row,
         case CalpontSystemCatalog::DECIMAL:
         {
             IDB_Decimal d = parm[2]->data()->getDecimalVal(row, isNull);
-            sec = d.value / helpers::power(d.scale);
-            int lefto = (d.value - sec * helpers::power(d.scale)) / helpers::power(d.scale - 1);
+            double dscale = d.scale;
+            sec = d.value / pow(10.0, dscale);
+            int lefto = (d.value - sec * pow(10.0, dscale)) / pow(dscale - 1);
 
             if ( sec >= 0 && lefto > 4 )
                 sec++;

--- a/utils/funcexp/func_mod.cpp
+++ b/utils/funcexp/func_mod.cpp
@@ -75,7 +75,7 @@ IDB_Decimal Func_mod::getDecimalVal(Row& row,
 
     IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
     int64_t value = d.value / pow(10.0, d.scale);
-    int lefto = d.value % pow(10.0, d.scale);
+    int lefto = d.value % (int)pow(10.0, d.scale);
 
     int64_t mod = (value % div) * pow(10.0, d.scale) + lefto;
 

--- a/utils/funcexp/func_mod.cpp
+++ b/utils/funcexp/func_mod.cpp
@@ -74,10 +74,10 @@ IDB_Decimal Func_mod::getDecimalVal(Row& row,
     }
 
     IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
-    int64_t value = d.value / helpers::power(d.scale);
-    int lefto = d.value % helpers::power(d.scale);
+    int64_t value = d.value / pow(10.0, d.scale);
+    int lefto = d.value % pow(10.0, d.scale);
 
-    int64_t mod = (value % div) * helpers::power(d.scale) + lefto;
+    int64_t mod = (value % div) * pow(10.0, d.scale) + lefto;
 
     retValue.value = mod;
     retValue.scale = d.scale;
@@ -164,7 +164,7 @@ double Func_mod::getDoubleVal(Row& row,
         case execplan::CalpontSystemCatalog::UDECIMAL:
         {
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
-            int64_t value = d.value / helpers::power(d.scale);
+            int64_t value = d.value / pow(10.0, d.scale);
 
             mod = value % div;
         }
@@ -268,7 +268,7 @@ long double Func_mod::getLongDoubleVal(Row& row,
         case execplan::CalpontSystemCatalog::UDECIMAL:
         {
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
-            int64_t value = d.value / helpers::power(d.scale);
+            int64_t value = d.value / pow(10.0, d.scale);
 
             mod = value % div;
         }
@@ -375,7 +375,7 @@ int64_t Func_mod::getIntVal(Row& row,
         case execplan::CalpontSystemCatalog::UDECIMAL:
         {
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
-            int64_t value = d.value / helpers::power(d.scale);
+            int64_t value = d.value / pow(10.0, d.scale);
 
             mod = value % div;
         }
@@ -473,7 +473,7 @@ uint64_t Func_mod::getUIntVal(Row& row,
         case execplan::CalpontSystemCatalog::UDECIMAL:
         {
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
-            int64_t value = d.value / helpers::power(d.scale);
+            int64_t value = d.value / pow(10.0, d.scale);
 
             mod = value % div;
         }

--- a/utils/funcexp/func_period_diff.cpp
+++ b/utils/funcexp/func_period_diff.cpp
@@ -85,7 +85,7 @@ int64_t Func_period_diff::getIntVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::UDECIMAL:
         {
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
-            period1 = d.value / helpers::power(d.scale);
+            period1 = d.value / pow(10.0, d.scale);
             break;
         }
 
@@ -133,7 +133,7 @@ int64_t Func_period_diff::getIntVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::UDECIMAL:
         {
             IDB_Decimal d = parm[1]->data()->getDecimalVal(row, isNull);
-            period2 = d.value / helpers::power(d.scale);
+            period2 = d.value / pow(10.0, d.scale);
             break;
         }
 


### PR DESCRIPTION
Allows numerical functions on strings, so long as the string can be interpreted as a number. Ex: '255' or '0x0b1123df'
Also replaced custom power function with standard to allow for more than nine decimal places.