### PR TITLE
MCOL-3424 Fix handler API breakage for write_row()

### DIFF
--- a/dbcon/mysql/ha_calpont.cpp
+++ b/dbcon/mysql/ha_calpont.cpp
@@ -305,7 +305,7 @@ int ha_calpont::close(void)
   sql_insert.cc, sql_select.cc, sql_table.cc, sql_udf.cc and sql_update.cc
 */
 
-int ha_calpont::write_row(uchar* buf)
+int ha_calpont::write_row(const uchar* buf)
 {
     DBUG_ENTER("ha_calpont::write_row");
     int rc = ha_calpont_impl_write_row(buf, table);

--- a/dbcon/mysql/ha_calpont.h
+++ b/dbcon/mysql/ha_calpont.h
@@ -136,7 +136,7 @@ public:
       We implement this in ha_example.cc. It's not an obligatory method;
       skip it and and MySQL will treat it as not implemented.
     */
-    int write_row(uchar* buf);
+    int write_row(const uchar* buf);
 
     /** @brief
       We implement this in ha_example.cc. It's not an obligatory method;

--- a/dbcon/mysql/ha_calpont_dml.cpp
+++ b/dbcon/mysql/ha_calpont_dml.cpp
@@ -653,7 +653,7 @@ int ha_calpont_impl_write_last_batch(TABLE* table, cal_connection_info& ci, bool
 
 }
 
-int ha_calpont_impl_write_row_(uchar* buf, TABLE* table, cal_connection_info& ci, ha_rows& rowsInserted)
+int ha_calpont_impl_write_row_(const uchar* buf, TABLE* table, cal_connection_info& ci, ha_rows& rowsInserted)
 {
     int rc = 0;
     //timer.start( "buildValueList");
@@ -743,13 +743,13 @@ int ha_calpont_impl_write_row_(uchar* buf, TABLE* table, cal_connection_info& ci
     }
 }
 
-int ha_calpont_impl_write_batch_row_(uchar* buf, TABLE* table, cal_impl_if::cal_connection_info& ci)
+int ha_calpont_impl_write_batch_row_(const uchar* buf, TABLE* table, cal_impl_if::cal_connection_info& ci)
 {
     ByteStream rowData;
     int rc = 0;
     //std::ostringstream  data;
     bool nullVal = false;
-    uchar* bufHdr = buf;	// bit flag indicating a field is null. Only those fields that are nullable are represented.
+    const uchar* bufHdr = buf;	// bit flag indicating a field is null. Only those fields that are nullable are represented.
     int32_t headerByte = 0; // Current byte in the bufHdr
     int32_t headerBit = 0;  // current bit in the bufHdr current byte.
     uint16_t colpos = 0;
@@ -815,7 +815,7 @@ int ha_calpont_impl_write_batch_row_(uchar* buf, TABLE* table, cal_impl_if::cal_
                     }
                     else
                     {
-                        uchar* tmp1 = buf;
+                        const uchar* tmp1 = buf;
                         uint32_t tmp = (tmp1[2] << 16) + (tmp1[1] << 8) + tmp1[0];
 
                         int day = tmp & 0x0000001fl;
@@ -1491,11 +1491,12 @@ int ha_calpont_impl_write_batch_row_(uchar* buf, TABLE* table, cal_impl_if::cal_
 
                         if (ci.columnTypes[colpos].scale == 0)
                         {
-                            uchar* tmpBuf = buf;
+                            const uchar* tmpBuf = buf;
                             //test flag bit for sign
                             bool posNum  = tmpBuf[0] & (0x80);
-                            tmpBuf[0] ^= 0x80; //flip the bit
-                            int32_t tmp1 = tmpBuf[0];
+                            uchar tmpChr = tmpBuf[0];
+                            tmpChr ^= 0x80; //flip the bit
+                            int32_t tmp1 = tmpChr;
 
                             if (totalBytes > 4)
                             {
@@ -1589,11 +1590,12 @@ int ha_calpont_impl_write_batch_row_(uchar* buf, TABLE* table, cal_impl_if::cal_
                         }
                         else
                         {
-                            uchar* tmpBuf = buf;
+                            const uchar* tmpBuf = buf;
                             //test flag bit for sign
                             bool posNum  = tmpBuf[0] & (0x80);
-                            tmpBuf[0] ^= 0x80; //flip the bit
-                            int32_t tmp1 = tmpBuf[0];
+                            uchar tmpChr = tmpBuf[0];
+                            tmpChr ^= 0x80; //flip the bit
+                            int32_t tmp1 = tmpChr;
 
                             //fetch the digits before decimal point
                             if (bytesBefore == 0)
@@ -1805,7 +1807,7 @@ int ha_calpont_impl_write_batch_row_(uchar* buf, TABLE* table, cal_impl_if::cal_
                                 buf = buf + 2 ;
                             }
 
-                            uchar* tmpBuf = buf;
+                            const uchar* tmpBuf = buf;
 
                             for (int32_t i = 0; i < dataLength; i++)
                             {
@@ -1831,7 +1833,7 @@ int ha_calpont_impl_write_batch_row_(uchar* buf, TABLE* table, cal_impl_if::cal_
                             if ( dataLength > ci.columnTypes[colpos].colWidth)
                                 dataLength = ci.columnTypes[colpos].colWidth;
 
-                            uchar* tmpBuf = buf;
+                            const uchar* tmpBuf = buf;
 
                             for (int32_t i = 0; i < dataLength; i++)
                             {

--- a/dbcon/mysql/ha_calpont_impl.cpp
+++ b/dbcon/mysql/ha_calpont_impl.cpp
@@ -2937,7 +2937,7 @@ int ha_calpont_impl_delete_table(const char* name)
     int rc = ha_calpont_impl_delete_table_(dbName, name, *ci);
     return rc;
 }
-int ha_calpont_impl_write_row(uchar* buf, TABLE* table)
+int ha_calpont_impl_write_row(const uchar* buf, TABLE* table)
 {
     THD* thd = current_thd;
     //sleep(100);

--- a/dbcon/mysql/ha_calpont_impl.h
+++ b/dbcon/mysql/ha_calpont_impl.h
@@ -31,7 +31,7 @@ extern int ha_calpont_impl_close(void);
 extern int ha_calpont_impl_rnd_init(TABLE* table);
 extern int ha_calpont_impl_rnd_next(uchar* buf, TABLE* table);
 extern int ha_calpont_impl_rnd_end(TABLE* table, bool is_derived_hand = false);
-extern int ha_calpont_impl_write_row(uchar* buf, TABLE* table);
+extern int ha_calpont_impl_write_row(const uchar* buf, TABLE* table);
 extern void ha_calpont_impl_start_bulk_insert(ha_rows rows, TABLE* table);
 extern int ha_calpont_impl_end_bulk_insert(bool abort, TABLE* table);
 extern int ha_calpont_impl_rename_table(const char* from, const char* to);
@@ -56,8 +56,8 @@ extern int ha_cs_impl_pushdown_init(mcs_handler_info* handler_info , TABLE* tabl
 #include "ha_calpont.h"
 #include "ha_mcs_pushdown.h"
 extern int ha_calpont_impl_rename_table_(const char* from, const char* to, cal_impl_if::cal_connection_info& ci);
-extern int ha_calpont_impl_write_row_(uchar* buf, TABLE* table, cal_impl_if::cal_connection_info& ci, ha_rows& rowsInserted);
-extern int ha_calpont_impl_write_batch_row_(uchar* buf, TABLE* table, cal_impl_if::cal_connection_info& ci);
+extern int ha_calpont_impl_write_row_(const uchar* buf, TABLE* table, cal_impl_if::cal_connection_info& ci, ha_rows& rowsInserted);
+extern int ha_calpont_impl_write_batch_row_(const uchar* buf, TABLE* table, cal_impl_if::cal_connection_info& ci);
 extern int ha_calpont_impl_write_last_batch(TABLE* table, cal_impl_if::cal_connection_info& ci, bool abort);
 extern int ha_calpont_impl_commit_ (handlerton* hton, THD* thd, bool all, cal_impl_if::cal_connection_info& ci);
 extern int ha_calpont_impl_rollback_ (handlerton* hton, THD* thd, bool all, cal_impl_if::cal_connection_info& ci);


### PR DESCRIPTION
The MariaDB handler API changed for write_row(). The 'buf' parameter is
now a 'const'. This meant that our implementation didn't match the
virtual call so ours was no longer called. This implemented the 'const'.