### PR TITLE
MCOL-2146 MCOL-2159  Fix for group_concat(distinct ... ) to use all unique values in a row

### DIFF
--- a/dbcon/joblist/groupconcat.cpp
+++ b/dbcon/joblist/groupconcat.cpp
@@ -760,7 +760,7 @@ void GroupConcatOrderBy::initialize(const rowgroup::SP_GroupConcat& gcc)
 uint64_t GroupConcatOrderBy::getKeyLength() const
 {
     // only distinct the concatenated columns
-    return fConcatColumns.size() - 1; // cols 0 to fConcatColumns will be conpared
+    return fConcatColumns.size(); // cols 0 to fConcatColumns.size() - 1 will be compared
 }
 
 

--- a/dbcon/joblist/limitedorderby.cpp
+++ b/dbcon/joblist/limitedorderby.cpp
@@ -91,7 +91,7 @@ void LimitedOrderBy::initialize(const RowGroup& rg, const JobInfo& jobInfo)
 // not just a column count.
 uint64_t LimitedOrderBy::getKeyLength() const
 {
-    return fOrderByCond.size();
+    return fRow0.getColumnCount();
 }
 
 

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -506,8 +506,8 @@ uint64_t IdbOrderBy::Hasher::operator()(const Row::Pointer& p) const
 {
     Row& row = ts->row1;
     row.setPointer(p);
-    // MCOL-1829 Row::h uses colcount as an array idx down a callstack.
-    uint64_t ret = row.hash();
+    // MCOL-1829 Row::hash uses colcount - 1 as an array idx down a callstack.
+    uint64_t ret = row.hash(colCount - 1);
     return ret;
 }
 
@@ -517,7 +517,7 @@ bool IdbOrderBy::Eq::operator()(const Row::Pointer& d1, const Row::Pointer& d2) 
     r1.setPointer(d1);
     r2.setPointer(d2);
     // MCOL-1829 Row::equals uses 2nd argument as key columns container size boundary
-    bool ret = r1.equals(r2, colCount);
+    bool ret = r1.equals(r2, colCount - 1);
 
     return ret;
 }


### PR DESCRIPTION
The actual issue with group_concat(distinct ... ) not returning all unique values in a row was due to GroupConcatOrderBy::getKeyLength() returning the array bound index (which is one less) instead of the actual number of columns in group_concat. This when combined with Row::equals(colCount - 1) would cause Row::equals() to skip the last column in group_concat to determine the row equality. This PR fixes this. 