### PR TITLE
MCOL-3317 Moved fill-next-block from writeRow() into allocRowId.

### DIFF
--- a/dbcon/ddlpackageproc/droptableprocessor.cpp
+++ b/dbcon/ddlpackageproc/droptableprocessor.cpp
@@ -289,9 +289,9 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackage(ddlpackage::Dro
 
         //get a unique number
         VERBOSE_INFO("Removing the SYSTABLE meta data");
-//#ifdef IDB_DDL_DEBUG
+#ifdef IDB_DDL_DEBUG
         cout << fTxnid.id << " Removing the SYSTABLEs meta data" << endl;
-//#endif
+#endif
         bytestream << (ByteStream::byte)WE_SVR_DELETE_SYSTABLE;
         bytestream << uniqueId;
         bytestream << (uint32_t) dropTableStmt.fSessionID;
@@ -324,9 +324,9 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackage(ddlpackage::Dro
 
         try
         {
-// #ifdef IDB_DDL_DEBUG
+#ifdef IDB_DDL_DEBUG
             cout << fTxnid.id << " Drop table sending WE_SVR_DELETE_SYSTABLES to pm " << pmNum << endl;
-//#endif
+#endif
             //cout << "deleting systable entries with txnid " << txnID.id << endl;
             fWEClient->write(bytestream, (uint32_t)pmNum);
 
@@ -356,18 +356,18 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackage(ddlpackage::Dro
         }
         catch (runtime_error& ex) //write error
         {
-// #ifdef IDB_DDL_DEBUG
+#ifdef IDB_DDL_DEBUG
             cout << fTxnid.id << " Drop table got exception" << endl;
-// #endif
+#endif
             rc = NETWORK_ERROR;
             errorMsg = ex.what();
         }
         catch (...)
         {
             rc = NETWORK_ERROR;
-//#ifdef IDB_DDL_DEBUG
+#ifdef IDB_DDL_DEBUG
             cout << fTxnid.id << " Drop table got unknown exception" << endl;
-//#endif
+#endif
         }
 
         if (rc != 0)
@@ -417,9 +417,9 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackage(ddlpackage::Dro
 
         try
         {
-//#ifdef IDB_DDL_DEBUG
+#ifdef IDB_DDL_DEBUG
             cout << fTxnid.id << " Drop table sending WE_SVR_DELETE_SYSCOLUMN to pm " << pmNum << endl;
-//#endif
+#endif
             fWEClient->write(bytestream, (unsigned)pmNum);
 
             while (1)
@@ -448,18 +448,18 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackage(ddlpackage::Dro
         }
         catch (runtime_error& ex) //write error
         {
-//#ifdef IDB_DDL_DEBUG
+#ifdef IDB_DDL_DEBUG
             cout << fTxnid.id << " Drop table got exception" << endl;
-//#endif
+#endif
             rc = NETWORK_ERROR;
             errorMsg = ex.what();
         }
         catch (...)
         {
             rc = NETWORK_ERROR;
-// #ifdef IDB_DDL_DEBUG
+#ifdef IDB_DDL_DEBUG
             cout << fTxnid.id << " Drop table got unknown exception" << endl;
-//#endif
+#endif
         }
 
         if (rc != 0)
@@ -612,9 +612,9 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackage(ddlpackage::Dro
         bytestream << (uint32_t) oidList[i];
     }
 
-//#ifdef IDB_DDL_DEBUG
+#ifdef IDB_DDL_DEBUG
     cout << fTxnid.id << " Drop table removing column files" << endl;
-//#endif
+#endif
     uint32_t msgRecived = 0;
 
     try
@@ -686,9 +686,9 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackage(ddlpackage::Dro
     //Flush primProc cache
     rc = cacheutils::flushOIDsFromCache( oidList );
     //Delete extents from extent map
-//#ifdef IDB_DDL_DEBUG
+#ifdef IDB_DDL_DEBUG
     cout << fTxnid.id << " Drop table deleteOIDs" << endl;
-//#endif
+#endif
     rc = fDbrm->deleteOIDs(oidList);
 
     if (rc != 0)

--- a/dbcon/mysql/ha_calpont_ddl.cpp
+++ b/dbcon/mysql/ha_calpont_ddl.cpp
@@ -2150,7 +2150,7 @@ int ProcessDDLStatement(string& ddlStatement, string& schema, const string& tabl
         if (b == ddlpackageprocessor::DDLPackageProcessor::WARNING)
         {
             rc = 0;
-            string errmsg ("Error occured during file deletion. Restart DMLProc or use command tool ddlcleanup to clean up. " );
+            string errmsg ("Error occured during file deletion. Restart DDLProc or use command tool ddlcleanup to clean up. " );
             push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 9999, errmsg.c_str());
         }
 

--- a/writeengine/shared/we_define.h
+++ b/writeengine/shared/we_define.h
@@ -152,6 +152,7 @@ const int   ERR_FILE_STAT           = ERR_FILEBASE + 16;// Error getting stats o
 const int   ERR_VB_FILE_NOT_EXIST   = ERR_FILEBASE + 17;// Version buffer file not exists
 const int   ERR_FILE_FLUSH          = ERR_FILEBASE + 18;// Error flushing file
 const int   ERR_FILE_GLOBBING       = ERR_FILEBASE + 19;// Error globbing a file name
+const int   ERR_FILE_EOF            = ERR_FILEBASE + 20;// EOF
 
 //--------------------------------------------------------------------------
 // XML level error

--- a/writeengine/shared/we_fileop.cpp
+++ b/writeengine/shared/we_fileop.cpp
@@ -2603,8 +2603,16 @@ int FileOp::readFile( IDBDataFile* pFile, unsigned char* readBuf,
 {
     if ( pFile != NULL )
     {
-        if ( pFile->read( readBuf, readSize ) != readSize )
+        int bc = pFile->read( readBuf, readSize );
+        if (bc != readSize) 
+        {
+            // MCOL-498 EOF if a next block is empty
+            if (bc == 0)
+            {
+                return ERR_FILE_EOF;
+            }
             return ERR_FILE_READ;
+        }
     }
     else
         return ERR_FILE_NULL;


### PR DESCRIPTION
    Intro* INSERT statements could face a non-existant block when MCOL-498 feature
    is enabled. writeRow() guard blocks was supposed to proactively create empty
    blocks. The pre-patch logic failed when first value in the block has been
    removed by DELETE and this overwrites the whole valid block with empty magics.
    This patch moves proactive creation logic into allocRowId().