### PR TITLE
SM toolkit fix (mcol-3402)

### DIFF
--- a/storage-manager/CMakeLists.txt
+++ b/storage-manager/CMakeLists.txt
@@ -146,17 +146,37 @@ add_dependencies(unit_tests test_files)
 target_link_libraries(unit_tests storagemanager)
 set_property(TARGET unit_tests PROPERTY CXX_STANDARD 11)
 
+# The includes and lib linkages required to link against cloudio ... 
+# pretty crazy.  When lib dependencies are eventually config'd right,
+# change this to only include and link against cloudio.
+include_directories(${CMAKE_SOURCE_DIR}/utils/cloudio ${ENGINE_COMMON_INCLUDES})
 add_executable(smcat src/smcat.cpp)
-target_link_libraries(smcat storagemanager)
+target_link_libraries(smcat storagemanager cloudio
+    ${ENGINE_LDFLAGS}
+    ${ENGINE_EXEC_LIBS}
+    ${MARIADB_CLIENT_LIBS}
+)
 
 add_executable(smput src/smput.cpp)
-target_link_libraries(smput storagemanager)
+target_link_libraries(smput storagemanager cloudio
+    ${ENGINE_LDFLAGS}
+    ${ENGINE_EXEC_LIBS}
+    ${MARIADB_CLIENT_LIBS}
+)
 
 add_executable(smls src/smls.cpp)
-target_link_libraries(smls storagemanager)
+target_link_libraries(smls storagemanager cloudio
+    ${ENGINE_LDFLAGS}
+    ${ENGINE_EXEC_LIBS}
+    ${MARIADB_CLIENT_LIBS}
+)
 
 add_executable(smrm src/smrm.cpp)
-target_link_libraries(smrm storagemanager)
+target_link_libraries(smrm storagemanager cloudio
+    ${ENGINE_LDFLAGS}
+    ${ENGINE_EXEC_LIBS}
+    ${MARIADB_CLIENT_LIBS}
+)
 
 install(TARGETS StorageManager smcat smput smls smrm storagemanager
     RUNTIME DESTINATION ${INSTALL_ENGINE}/bin

--- a/storage-manager/src/IOCoordinator.cpp
+++ b/storage-manager/src/IOCoordinator.cpp
@@ -531,7 +531,7 @@ ssize_t IOCoordinator::append(const char *_filename, const uint8_t *data, size_t
             metadata.updateEntryLength(i->offset, (err + i->length));
             cache->newJournalEntry(firstDir, err+JOURNAL_ENTRY_HEADER_SIZE);
             synchronizer->newJournalEntry(firstDir, i->key, err+JOURNAL_ENTRY_HEADER_SIZE);
-            if (err < writeLength)
+            if (err < (int64_t) writeLength)
             {
                 //logger->log(LOG_ERR,"IOCoordinator::append(): journal failed to complete write, %u of %u bytes written.",count,length);
                 goto out;
@@ -583,7 +583,7 @@ ssize_t IOCoordinator::append(const char *_filename, const uint8_t *data, size_t
         cache->newObject(firstDir, newObject.key,err);
         newObjectKeys.push_back(newObject.key);
 
-        if (err < writeLength)
+        if (err < (int64_t) writeLength)
         {
             //logger->log(LOG_ERR,"IOCoordinator::append(): newObject failed to complete write, %u of %u bytes written.",count,length);
             // make the object reflect length actually written
@@ -608,7 +608,7 @@ int IOCoordinator::open(const char *_filename, int openmode, struct stat *out)
     bf::path filename = ownership.get(_filename);
     boost::scoped_ptr<ScopedFileLock> s;
     
-    if (openmode & O_CREAT || openmode | O_TRUNC)
+    if (openmode & O_CREAT || openmode & O_TRUNC)
         s.reset(new ScopedWriteLock(this, filename.string()));
     else
         s.reset(new ScopedReadLock(this, filename.string()));
@@ -658,7 +658,7 @@ int IOCoordinator::stat(const char *_path, struct stat *out)
 {
     bf::path filename = ownership.get(_path);
     
-    if (bf::is_directory(metaPath/filename))
+    if (bf::exists(metaPath/filename))
         return ::stat((metaPath/filename).string().c_str(), out);
 
     ScopedReadLock s(this, filename.string());

--- a/storage-manager/src/IOCoordinator.cpp
+++ b/storage-manager/src/IOCoordinator.cpp
@@ -658,7 +658,7 @@ int IOCoordinator::stat(const char *_path, struct stat *out)
 {
     bf::path filename = ownership.get(_path);
     
-    if (bf::exists(metaPath/filename))
+    if (bf::is_directory(metaPath/filename))
         return ::stat((metaPath/filename).string().c_str(), out);
 
     ScopedReadLock s(this, filename.string());

--- a/storage-manager/src/Ownership.cpp
+++ b/storage-manager/src/Ownership.cpp
@@ -99,7 +99,7 @@ bf::path Ownership::get(const bf::path &p)
         ret = normalizedPath;
         prefix = *(normalizedPath.begin());
     }
-         
+    
     mutex.lock();
     if (ownedPrefixes.find(prefix) == ownedPrefixes.end())
     {
@@ -192,7 +192,7 @@ void Ownership::releaseOwnership(const bf::path &p, bool isDtor)
 void Ownership::_takeOwnership(const bf::path &p)
 {
     logger->log(LOG_DEBUG, "Ownership: taking ownership of %s", p.string().c_str());
-    bf::create_directories(metadataPrefix/p);
+    //bf::create_directories(metadataPrefix/p);
     DELETE(p, "FLUSHING");
     DELETE(p, "REQUEST_TRANSFER");
     // TODO: need to consider errors taking ownership
@@ -206,6 +206,9 @@ void Ownership::_takeOwnership(const bf::path &p)
 
 void Ownership::takeOwnership(const bf::path &p)
 {
+   if (!bf::is_directory(metadataPrefix/p))
+        return;
+
     boost::unique_lock<boost::mutex> s(mutex);
     
     auto it = ownedPrefixes.find(p);

--- a/storage-manager/src/Ownership.cpp
+++ b/storage-manager/src/Ownership.cpp
@@ -192,7 +192,6 @@ void Ownership::releaseOwnership(const bf::path &p, bool isDtor)
 void Ownership::_takeOwnership(const bf::path &p)
 {
     logger->log(LOG_DEBUG, "Ownership: taking ownership of %s", p.string().c_str());
-    //bf::create_directories(metadataPrefix/p);
     DELETE(p, "FLUSHING");
     DELETE(p, "REQUEST_TRANSFER");
     // TODO: need to consider errors taking ownership
@@ -206,7 +205,8 @@ void Ownership::_takeOwnership(const bf::path &p)
 
 void Ownership::takeOwnership(const bf::path &p)
 {
-   if (!bf::is_directory(metadataPrefix/p))
+    // If the prefix doesn't exist, ownership isn't possible yet.
+    if (!bf::is_directory(metadataPrefix/p))
         return;
 
     boost::unique_lock<boost::mutex> s(mutex);

--- a/storage-manager/src/smcat.cpp
+++ b/storage-manager/src/smcat.cpp
@@ -44,7 +44,7 @@ bool SMOnline()
     int err = ::connect(clientSocket, (const struct sockaddr *) &addr, sizeof(addr));
     if (err >= 0)
     {
-        ::close(err);
+        ::close(clientSocket);
         return true;
     }
     return false;
@@ -55,7 +55,7 @@ void catFileOffline(const char *filename)
     uint8_t data[8192];
     off_t offset = 0;
     int read_err, write_err, count;
-    IOCoordinator *ioc = IOCoordinator::get();
+    boost::scoped_ptr<IOCoordinator> ioc(IOCoordinator::get());
     
     do {
         count = 0;
@@ -79,7 +79,6 @@ void catFileOffline(const char *filename)
         }
         offset += read_err;
     } while (read_err > 0);
-    delete ioc;
 }
 
 void catFileOnline(const char *filename)

--- a/storage-manager/src/smcat.cpp
+++ b/storage-manager/src/smcat.cpp
@@ -17,7 +17,13 @@
 
 #include <iostream>
 #include "IOCoordinator.h"
+#include "messageFormat.h"
+#include "SMDataFile.h"
 #include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <fcntl.h>
 
 using namespace std;
 using namespace storagemanager;
@@ -28,7 +34,23 @@ void usage(const char *progname)
     cerr << "Usage: " << progname << " file1 file2 ... fileN" << endl;
 }
 
-void catFile(const char *filename)
+bool SMOnline()
+{
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strcpy(&addr.sun_path[1], &socket_name[1]);   // first char is null...
+    int clientSocket = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    int err = ::connect(clientSocket, (const struct sockaddr *) &addr, sizeof(addr));
+    if (err >= 0)
+    {
+        ::close(err);
+        return true;
+    }
+    return false;
+}
+
+void catFileOffline(const char *filename)
 {
     uint8_t data[8192];
     off_t offset = 0;
@@ -38,6 +60,38 @@ void catFile(const char *filename)
     do {
         count = 0;
         read_err = ioc->read(filename, data, offset, 8192);
+        if (read_err < 0)
+        {
+            int l_errno = errno;
+            cerr << "Error reading " << filename << ": " << strerror_r(l_errno, (char *) data, 8192) << endl;
+        }
+
+        while (count < read_err)
+        {
+            write_err = write(STDOUT_FILENO, &data[count], read_err - count);
+            if (write_err < 0)
+            {
+                int l_errno = errno;
+                cerr << "Error writing to stdout: " << strerror_r(l_errno, (char *) data, 8192) << endl;
+                exit(1);
+            }
+            count += write_err;
+        }
+        offset += read_err;
+    } while (read_err > 0);
+    delete ioc;
+}
+
+void catFileOnline(const char *filename)
+{
+    uint8_t data[8192];
+    off_t offset = 0;
+    int read_err, write_err, count;
+    idbdatafile::SMDataFile df(filename, O_RDONLY, 0);
+    
+    do {
+        count = 0;
+        read_err = df.read(data, 8192);
         if (read_err < 0)
         {
             int l_errno = errno;
@@ -68,7 +122,12 @@ int main(int argc, char **argv)
     }
 
     for (int i = 1; i < argc; i++)
-        catFile(argv[i]);
+    {
+        if (SMOnline())
+            catFileOnline(argv[i]);
+        else
+            catFileOffline(argv[i]);
+    }
     
     return 0;
 }

--- a/storage-manager/src/smls.cpp
+++ b/storage-manager/src/smls.cpp
@@ -48,7 +48,7 @@ bool SMOnline()
     int err = ::connect(clientSocket, (const struct sockaddr *) &addr, sizeof(addr));
     if (err >= 0)
     {
-        ::close(err);
+        ::close(clientSocket);
         return true;
     }
     return false;
@@ -56,16 +56,12 @@ bool SMOnline()
 
 void lsOffline(const char *path)
 {
-    IOCoordinator *ioc = IOCoordinator::get();
+    boost::scoped_ptr<IOCoordinator> ioc(IOCoordinator::get());
     vector<string> listing;
-    char buf[80];
+    
     int err = ioc->listDirectory(path, &listing);
     if (err)
-    {
-        int l_errno = errno;
-        cerr << strerror_r(l_errno, buf, 80) << endl;
         exit(1);
-    }
     
     struct stat _stat;
     boost::filesystem::path base(path);
@@ -92,22 +88,16 @@ void lsOffline(const char *path)
             cout << right << "error" << left <<  " " << entry << endl;
         }
     }
-    delete ioc;
 }
 
 void lsOnline(const char *path)
 {
     idbdatafile::SMFileSystem fs;
     list<string> listing;
-    char buf[80];
     
     int err = fs.listDirectory(path, listing);
     if (err)
-    {
-        int l_errno = errno;
-        cerr << strerror_r(l_errno, buf, 80) << endl;
         exit(1);
-    }
     
     boost::filesystem::path base(path);
     boost::filesystem::path p;
@@ -130,7 +120,6 @@ void lsOnline(const char *path)
         }
         else
         {
-            cout << strerror_r(errno, buf, 80) << endl;
             cout.width(15);
             cout << right << "error" << left <<  " " << entry << endl;
         }

--- a/storage-manager/src/smrm.cpp
+++ b/storage-manager/src/smrm.cpp
@@ -17,6 +17,13 @@
 
 #include <iostream>
 #include "IOCoordinator.h"
+#include "messageFormat.h"
+#include "SMFileSystem.h"
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
 
 using namespace std;
 using namespace storagemanager;
@@ -27,7 +34,38 @@ void usage(const char *progname)
     cerr << "Usage: " << progname << " file-or-dir1 file-or-dir2 .. file-or-dirN" << endl;
 }
 
-int main(int argc, char **argv)
+bool SMOnline()
+{
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strcpy(&addr.sun_path[1], &socket_name[1]);   // first char is null...
+    int clientSocket = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    int err = ::connect(clientSocket, (const struct sockaddr *) &addr, sizeof(addr));
+    if (err >= 0)
+    {
+        ::close(clientSocket);
+        return true;
+    }
+    return false;
+}
+
+void rmOffline(int argCount, const char **args)
+{
+    boost::scoped_ptr<IOCoordinator> ioc(IOCoordinator::get());
+    for (int i = 1; i < argCount; i++)
+        ioc->unlink(args[i]);
+}
+
+void rmOnline(int argCount, const char **args)
+{
+    idbdatafile::SMFileSystem fs;
+    
+    for (int i = 1; i < argCount; i++)
+        fs.remove(args[i]);
+}
+
+int main(int argc, const char **argv)
 {
     if (argc < 2)
     {
@@ -35,9 +73,9 @@ int main(int argc, char **argv)
         return 1;
     }
     
-    IOCoordinator *ioc = IOCoordinator::get();
-    for (int i = 1; i < argc; i++)
-        ioc->unlink(argv[i]);
-        
+    if (SMOnline())
+        rmOnline(argc, argv);
+    else
+        rmOffline(argc, argv);
     return 0;
 }


### PR DESCRIPTION
This includes an important typo fix i noticed in IOC.

Since CS & SM are GPL and in the same repo now, I used the CS-side mechanisms for interacting with SM.  Much better than cobbling together strings of bytes to send to it.  Downside.  These little tools now have to include practically every header file in CS, and link to practically every lib in CS to do things like list a directory.  Yes, joblist is now necessary to list a directory.  LOL! 