### PR TITLE
MCOL-3438. SM Toolkit usability

### DIFF
--- a/storage-manager/src/IOCoordinator.cpp
+++ b/storage-manager/src/IOCoordinator.cpp
@@ -648,7 +648,7 @@ int IOCoordinator::listDirectory(const char *dirname, vector<string> *listing)
     {
         if (bf::is_directory(it->path()))
             listing->push_back(it->path().filename().string());
-        else
+        else if (it->path().extension() == ".meta")
             listing->push_back(it->path().stem().string());
     }
     return 0;

--- a/storage-manager/src/IOCoordinator.cpp
+++ b/storage-manager/src/IOCoordinator.cpp
@@ -628,7 +628,7 @@ int IOCoordinator::open(const char *_filename, int openmode, struct stat *out)
 
 int IOCoordinator::listDirectory(const char *dirname, vector<string> *listing)
 {
-    bf::path p(metaPath / ownership.get(dirname));
+    bf::path p(metaPath / ownership.get(dirname, false));
     ++listingCount;
     
     listing->clear();
@@ -656,7 +656,7 @@ int IOCoordinator::listDirectory(const char *dirname, vector<string> *listing)
 
 int IOCoordinator::stat(const char *_path, struct stat *out)
 {
-    bf::path filename = ownership.get(_path);
+    bf::path filename = ownership.get(_path, false);
     
     if (bf::is_directory(metaPath/filename))
         return ::stat((metaPath/filename).string().c_str(), out);

--- a/storage-manager/src/Ownership.cpp
+++ b/storage-manager/src/Ownership.cpp
@@ -75,7 +75,7 @@ bf::path Ownership::get(const bf::path &p)
 {
     bf::path ret, prefix, normalizedPath(p);
     bf::path::const_iterator pit;
-    uint i;
+    uint i, levels;
 
     normalizedPath.normalize();
     //cerr << "Ownership::get() param = " << p.string() << endl;
@@ -86,13 +86,15 @@ bf::path Ownership::get(const bf::path &p)
         if (pit != normalizedPath.end())
             prefix = *pit;
         //cerr << "prefix is " << prefix.string() << endl;
-        for (; pit != normalizedPath.end(); ++pit)
+        for (levels = 0; pit != normalizedPath.end(); ++levels, ++pit)
             ret /= *pit;
         if (ret.empty())
         {
             //cerr << "returning ''" << endl;
             return ret;
         }
+        else if (levels == 1)
+            throw runtime_error("Ownership: given path " + p.string() + " does not have minimum number of directories");
     }
     else
     {

--- a/storage-manager/src/Ownership.cpp
+++ b/storage-manager/src/Ownership.cpp
@@ -71,14 +71,14 @@ Ownership::~Ownership()
         releaseOwnership(it.first, true);
 }
 
-bf::path Ownership::get(const bf::path &p)
+bf::path Ownership::get(const bf::path &p, bool getOwnership)
 {
     bf::path ret, prefix, normalizedPath(p);
     bf::path::const_iterator pit;
     uint i, levels;
 
     normalizedPath.normalize();
-    //cerr << "Ownership::get() param = " << p.string() << endl;
+    //cerr << "Ownership::get() param = " << normalizedPath.string() << endl;
     if (prefixDepth > 0)
     {
         for (i = 0, pit = normalizedPath.begin(); i <= prefixDepth && pit != normalizedPath.end(); ++i, ++pit)
@@ -88,19 +88,20 @@ bf::path Ownership::get(const bf::path &p)
         //cerr << "prefix is " << prefix.string() << endl;
         for (levels = 0; pit != normalizedPath.end(); ++levels, ++pit)
             ret /= *pit;
-        if (ret.empty())
-        {
-            //cerr << "returning ''" << endl;
+        if (!getOwnership)
             return ret;
-        }
-        else if (levels == 1)
-            throw runtime_error("Ownership: given path " + p.string() + " does not have minimum number of directories");
+        if (levels <= 1)
+            throw runtime_error("Ownership: given path " + normalizedPath.string() + 
+                " does not have minimum number of directories");
     }
     else
     {
         ret = normalizedPath;
         prefix = *(normalizedPath.begin());
     }
+    
+    if (!getOwnership)
+        return ret;
     
     mutex.lock();
     if (ownedPrefixes.find(prefix) == ownedPrefixes.end())

--- a/storage-manager/src/Ownership.h
+++ b/storage-manager/src/Ownership.h
@@ -37,8 +37,10 @@ class Ownership : public boost::noncopyable
 
         bool sharedFS();
         // returns the path "right shifted" by prefixDepth, and with ownership of that path.
-        // on error it returns an empty path.
-        boost::filesystem::path get(const boost::filesystem::path &);
+        // on error it throws a runtime exception
+        // setting getOwnership to false will return the modified path but not also take ownership
+        // of the returned prefix.
+        boost::filesystem::path get(const boost::filesystem::path &, bool getOwnership=true);
         
         
     private:


### PR DESCRIPTION
Some changes to the toolkit to make the view that Ownership imposes look sane.

Under the covers, it's prepending X subdirs (where x = ObjectStorage/common_prefix_depth) so that Ownership doesn't complain, reject, or try to take ownership of something it shouldn't.  Also disables the need to get ownership for listDir and stat ops so that smls works w/o grabbing ownership.  There's a small race on that stat op though.  If the resident SM doesn't own that prefix already, and another SM happens to write to the metadata file at the same time that it's being stat'd, stat() may throw an exception.  It's harmless, but GTK.