### PR TITLE
Wrote a version of mergejournal that uses more mem but reduces the io op requirement.

### DIFF
--- a/storage-manager/src/AppendTask.cpp
+++ b/storage-manager/src/AppendTask.cpp
@@ -68,7 +68,8 @@ bool AppendTask::run()
     
     ssize_t readCount = 0, writeCount = 0;
     vector<uint8_t> databuf;
-    uint bufsize = min(1 << 20, cmd->count);   // 1 MB
+    uint bufsize = min(100 << 20, cmd->count);   // 100 MB
+    //uint bufsize = cmd->count;
     databuf.resize(bufsize);
     
     while (readCount < cmd->count)

--- a/storage-manager/src/IOCoordinator.h
+++ b/storage-manager/src/IOCoordinator.h
@@ -63,8 +63,13 @@ class IOCoordinator : public boost::noncopyable
         boost::shared_array<uint8_t> mergeJournal(const char *objectPath, const char *journalPath, off_t offset, 
             size_t len, size_t *sizeRead) const;
         
-        // this version modifies object data in memory, given the journal filename
+        // this version modifies object data in memory, given the journal filename.  Processes the whole object
+        // and whole journal file.
         int mergeJournalInMem(boost::shared_array<uint8_t> &objData, size_t len, const char *journalPath, 
+            size_t *sizeRead) const;
+        
+        // this version of MJIM has a higher IOPS requirement and lower mem usage.
+        int mergeJournalInMem_bigJ(boost::shared_array<uint8_t> &objData, size_t len, const char *journalPath, 
             size_t *sizeRead) const;
         
         // this version takes already-open file descriptors, and an already-allocated buffer as input.

--- a/storage-manager/src/PosixTask.cpp
+++ b/storage-manager/src/PosixTask.cpp
@@ -108,7 +108,7 @@ bool PosixTask::read(uint8_t *buf, uint length)
     while (count < length)
     {
         err = ::recv(sock, &buf[count], length - count, 0);
-        if (err <= 0)
+        if (err < 0)
             return false;
 
         count += err;
@@ -207,7 +207,7 @@ void PosixTask::consumeMsg()
     
     while (remainingLengthInStream > 0)
     {
-        logger->log(LOG_ERR,"ERROR: eating data.");
+        logger->log(LOG_WARNING, "PosixTask::consumeMsg(): Discarding the tail end of a partial msg.");
         err = ::recv(sock, buf, min(remainingLengthInStream, 1024), 0);
         if (err <= 0) {
             remainingLengthInStream = 0;

--- a/storage-manager/src/Synchronizer.cpp
+++ b/storage-manager/src/Synchronizer.cpp
@@ -669,7 +669,8 @@ void Synchronizer::synchronizeWithJournal(const string &sourceFile, list<string>
             count += err;
         }
         numBytesWritten += size;
-        cache->rename(prefix, cloudKey, newCloudKey, size - bf::file_size(oldCachePath));
+        assert(bf::file_size(oldCachePath) == MetadataFile:getLengthFromKey(cloudKey));
+        cache->rename(prefix, cloudKey, newCloudKey, size - MetadataFile::getLengthFromKey(cloudKey));
         replicator->remove(oldCachePath);
     }
     

--- a/storage-manager/src/WriteTask.cpp
+++ b/storage-manager/src/WriteTask.cpp
@@ -68,7 +68,8 @@ bool WriteTask::run()
             
     ssize_t readCount = 0, writeCount = 0;
     vector<uint8_t> databuf;
-    uint bufsize = min(1 << 20, cmd->count);   // 1 MB
+    uint bufsize = min(100 << 20, cmd->count);   // 100 MB
+    //uint bufsize = cmd->count;
     databuf.resize(bufsize);
 
     while (readCount < cmd->count)

--- a/storage-manager/src/smls.cpp
+++ b/storage-manager/src/smls.cpp
@@ -157,12 +157,12 @@ int main(int argc, char **argv)
     }
     
     char prefix[8192];
-    makePathPrefix(prefix, 8192);
+    int prefixlen = makePathPrefix(prefix, 8192);
     
     if (SMOnline())
-        lsOnline(strncat(prefix, argv[1], 8192));
+        lsOnline(strncat(prefix, argv[1], 8192 - prefixlen));
     else
-        lsOffline(strncat(prefix, argv[1], 8192));
+        lsOffline(strncat(prefix, argv[1], 8192 - prefixlen));
     
     return 0;
 }

--- a/storage-manager/src/smput.cpp
+++ b/storage-manager/src/smput.cpp
@@ -172,9 +172,9 @@ int main(int argc, char **argv)
     int prefixlen = makePathPrefix(prefix, 8192);
     
     if (SMOnline())
-        putOnline(strncat(prefix, argv[1], 8192), prefixlen);
+        putOnline(strncat(prefix, argv[1], 8192 - prefixlen), prefixlen);
     else
-        putOffline(strncat(prefix, argv[1], 8192), prefixlen);
+        putOffline(strncat(prefix, argv[1], 8192 - prefixlen), prefixlen);
     return 0;
 }
     


### PR DESCRIPTION
Wrote a version of mergejournal that uses more mem but reduces the io op
requirement.  Added a safety valve; if the journal file is > 100MB, it
will fall back to the previous IO op heavy but mem friendly version.

This also includes a compiler warning fix for smls & smput.

D'oh.  Added MCOL-3460 to this by mistake.  Eh, BFD.