### PR TITLE
MCOL-2178 Moving MDEV-19831 logic into the plugin code.

### DIFF
--- a/dbcon/mysql/CMakeLists.txt
+++ b/dbcon/mysql/CMakeLists.txt
@@ -23,7 +23,7 @@ SET ( libcalmysql_SRCS
 
 add_definitions(-DMYSQL_DYNAMIC_PLUGIN)
 
-set_source_files_properties(ha_calpont.cpp PROPERTIES COMPILE_FLAGS "-fno-rtti -fno-implicit-templates")
+set_source_files_properties(ha_calpont.cpp PROPERTIES COMPILE_FLAGS "-fno-implicit-templates")
 
 add_library(calmysql SHARED ${libcalmysql_SRCS})
 

--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -5893,8 +5893,6 @@ void parse_item (Item* item, vector<Item_field*>& field_vec,
                         Item_field* ifp = reinterpret_cast<Item_field*>(*(ref->ref));
                         field_vec.push_back(ifp);
                     }
-                    else
-                        hasNonSupportItem = true;
                     break;
                 }
                 else if ((*(ref->ref))->type() == Item::FUNC_ITEM)
@@ -5957,7 +5955,7 @@ void parse_item (Item* item, vector<Item_field*>& field_vec,
         case Item::EXPR_CACHE_ITEM:
         {
             // item is a Item_cache_wrapper. Shouldn't get here.
-            // WIP Why
+            // DRRTUY TODO Why
             IDEBUG(std::cerr << "EXPR_CACHE_ITEM in parse_item\n" << std::endl);
             gwi->fatalParseError = true;
             // DRRTUY The questionable error text. I've seen
@@ -6107,10 +6105,6 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex,
     {
         for (; table_ptr; table_ptr = table_ptr->next_local)
         {
-            // mysql put vtable here for from sub. we ignore it
-            if (string(table_ptr->table_name.str).find("$vtable") != string::npos)
-                continue;
-
             // Until we handle recursive cte:
             // Checking here ensures we catch all with clauses in the query.
             if (table_ptr->is_recursive_with_table())
@@ -6279,9 +6273,6 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex,
 
         csep->unionVec(unionVec);
         csep->distinctUnionNum(distUnionNum);
-
-        if (unionVec.empty())
-            gwi.cs_vtable_impossible_where_on_union = true;
     }
 
     gwi.clauseType = WHERE;
@@ -6307,7 +6298,7 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex,
             Item_equal *cur_item_eq;
             while ((cur_item_eq= li++))
             {
-                // WIP replace the block with 
+                // DRRTUY TODO replace the block with
                 //cur_item_eq->traverse_cond(debug_walk, gwip, Item::POSTFIX);
                 std::cerr << "item_equal(";
                 Item *item;

--- a/dbcon/mysql/ha_calpont_impl.h
+++ b/dbcon/mysql/ha_calpont_impl.h
@@ -47,6 +47,7 @@ extern int ha_calpont_impl_group_by_init(ha_calpont_group_by_handler* group_hand
 extern int ha_calpont_impl_group_by_next(ha_calpont_group_by_handler* group_hand, TABLE* table);
 extern int ha_calpont_impl_group_by_end(ha_calpont_group_by_handler* group_hand, TABLE* table);
 extern int ha_cs_impl_pushdown_init(mcs_handler_info* handler_info , TABLE* table);
+extern int ha_cs_impl_select_next(uchar *buf, TABLE *table);
 
 #endif
 

--- a/dbcon/mysql/ha_from_sub.cpp
+++ b/dbcon/mysql/ha_from_sub.cpp
@@ -349,7 +349,9 @@ SCSEP FromSubQuery::transform()
     csep->derivedTbAlias(fAlias); // always lower case
     csep->derivedTbView(fGwip.viewName.alias);
 
-    if (getSelectPlan(gwi, *fFromSub, csep, fPushdownHand) != 0)
+    // DRRTUY isUnion - false. fPushdownHand could be safely set to true
+    // b/c only pushdowns get here.
+    if (getSelectPlan(gwi, *fFromSub, csep, false, fPushdownHand) != 0)
     {
         fGwip.fatalParseError = true;
 

--- a/dbcon/mysql/ha_mcs_sysvars.cpp
+++ b/dbcon/mysql/ha_mcs_sysvars.cpp
@@ -98,7 +98,14 @@ static MYSQL_THDVAR_BOOL(
     1
 );
 
-
+static MYSQL_THDVAR_BOOL(
+    processing_handlers_fallback,
+    PLUGIN_VAR_NOCMDARG,
+    "Enable/Disable the unsupported features check in handlers.",
+    NULL,
+    NULL,
+    0
+);
 
 // legacy system variables
 static MYSQL_THDVAR_ULONG(
@@ -269,15 +276,6 @@ static MYSQL_THDVAR_BOOL(
     1 // default
 );
 
-static MYSQL_THDVAR_BOOL(
-    use_legacy_sysvars,
-    PLUGIN_VAR_NOCMDARG,
-    "Control CS behavior using legacy * sysvars",
-    NULL, // check
-    NULL, // update
-    0 // default
-);
-
 st_mysql_sys_var* mcs_system_variables[] =
 {
   MYSQL_SYSVAR(compression_type),
@@ -285,6 +283,7 @@ st_mysql_sys_var* mcs_system_variables[] =
   MYSQL_SYSVAR(original_optimizer_flags),
   MYSQL_SYSVAR(select_handler),
   MYSQL_SYSVAR(derived_handler),
+  MYSQL_SYSVAR(processing_handlers_fallback),
   MYSQL_SYSVAR(group_by_handler),
   MYSQL_SYSVAR(decimal_scale),
   MYSQL_SYSVAR(use_decimal_scale),
@@ -300,7 +299,6 @@ st_mysql_sys_var* mcs_system_variables[] =
   MYSQL_SYSVAR(use_import_for_batchinsert),
   MYSQL_SYSVAR(import_for_batchinsert_delimiter),
   MYSQL_SYSVAR(import_for_batchinsert_enclosed_by),
-  MYSQL_SYSVAR(use_legacy_sysvars),
   MYSQL_SYSVAR(varbin_always_hex),
   NULL
 };
@@ -323,8 +321,7 @@ void set_fe_conn_info_ptr(void* ptr, THD* thd)
 
 ulonglong get_original_optimizer_flags(THD* thd)
 {
-    return ( current_thd == NULL && thd == NULL ) ? NULL :
-        THDVAR(current_thd, original_optimizer_flags);
+    return THDVAR(current_thd, original_optimizer_flags);
 }
 
 void set_original_optimizer_flags(ulonglong ptr, THD* thd)
@@ -364,7 +361,16 @@ void set_group_by_handler(THD* thd, bool value)
     THDVAR(thd, group_by_handler) = value;
 }
 
-void set_compression_type(THD* thd, ulong value)
+bool get_fallback_knob(THD* thd)
+{
+    return ( thd == NULL ) ? false : THDVAR(thd, processing_handlers_fallback);
+}
+void set_fallback_knob(THD* thd, bool value)
+{
+    THDVAR(thd, processing_handlers_fallback) = value;
+}
+
+    void set_compression_type(THD* thd, ulong value)
 {
     THDVAR(thd, compression_type) = value;
 }

--- a/dbcon/mysql/ha_mcs_sysvars.h
+++ b/dbcon/mysql/ha_mcs_sysvars.h
@@ -52,6 +52,9 @@ void set_derived_handler(THD* thd, bool value);
 bool get_group_by_handler(THD* thd);
 void set_group_by_handler(THD* thd, bool value);
 
+bool get_fallback_knob(THD* thd);
+void set_fallback_knob(THD* thd, bool value);
+
 bool get_use_decimal_scale(THD* thd);
 void set_use_decimal_scale(THD* thd, bool value);
 

--- a/dbcon/mysql/ha_view.cpp
+++ b/dbcon/mysql/ha_view.cpp
@@ -110,8 +110,6 @@ void View::transform()
                 // for nested view, the view name is vout.vin... format
                 CalpontSystemCatalog::TableAliasName tn = make_aliasview(table_ptr->db.str, table_ptr->table_name.str, table_ptr->alias.str, viewName);
                 gwi.viewName = make_aliastable(table_ptr->db.str, table_ptr->table_name.str, viewName);
-                // WIP MCOL-2178 CS could mess with the SELECT_LEX unit so better
-                // use a copy.
                 View* view = new View(*table_ptr->view->first_select_lex(), &gwi);
                 view->viewName(gwi.viewName);
                 gwi.viewList.push_back(view);

--- a/dbcon/mysql/my.cnf
+++ b/dbcon/mysql/my.cnf
@@ -45,6 +45,7 @@ thread_stack = 512K
 lower_case_table_names=1
 group_concat_max_len=512
 sql_mode="ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
+#columnstore_processing_handlers_fallback = OFF;
 
 # Enable compression by default on create, set to 0 to turn off
 #columnstore_compression_type=2

--- a/dbcon/mysql/sm.cpp
+++ b/dbcon/mysql/sm.cpp
@@ -288,7 +288,7 @@ tpl_open ( tableid_t tableid,
     SMDEBUGLOG << "tpl_open: ntplh: " << ntplh << " conn_hdl: " << conn_hdl << " tableid: " << tableid << endl;
 
     // if first time enter this function for a statement, set
-    // queryState to QUERY_IN_PRCOESS and get execution plan.
+    // queryState to QUERY_IN_PROCESS and get execution plan.
     if (conn_hdl->queryState == NO_QUERY)
     {
         conn_hdl->queryState = QUERY_IN_PROCESS;


### PR DESCRIPTION
    MCOL-2178 SH now allows to fallback to other pushdown handlers.
    SH query execution migrated from SH::init() into create_SH().
    There is a session variable columnstore_processing_handlers_fallback
    that allows to fallback to DH, GBH if SH fails. DH now uses semantic
    tree check for unsupported features to allow to fallback to GBH or
    storage API.
    
    Fixed GBH related bug when create_GBH() returns a handler for
    queries with impossible WHERE/HAVING.
    
    Fixed bug in FromSubquery::transform() where isUnion is set to true.
    
    Enabled RTTI b/c server team enabled it for MDB.
    
    Removed unused code supposed to be used with vtable.
    MCOL-2178 CS now explicitly calls MDB's optimizer using JOIN::optimizer_inner
    call.
    
    CS doesn't use SH for SELECT..INTO OUTFILE queries.
    
    Clean up gwi::physTableList when processing Storage API request.
    
    CS now explicitly set an execution error in THD::stmt_da to detect that SH fails to run 
    the query.
    
    SH now set queryState in select_next() to mark a begging of the execution properly.