### PR TITLE
A couple random SM things

### DIFF
--- a/oam/etc/Columnstore.xml
+++ b/oam/etc/Columnstore.xml
@@ -549,6 +549,7 @@
 	</QueryTele>
     <StorageManager>
         <MaxSockets>30</MaxSockets>
+        <Enabled>N</Enabled>
     </StorageManager>
 </Columnstore>
 

--- a/oam/etc/Columnstore.xml.singleserver
+++ b/oam/etc/Columnstore.xml.singleserver
@@ -540,5 +540,6 @@
 	</QueryTele>
     <StorageManager>
         <MaxSockets>30</MaxSockets>
+        <Enabled>N</Enabled>
     </StorageManager>
 </Columnstore>

--- a/storage-manager/CMakeLists.txt
+++ b/storage-manager/CMakeLists.txt
@@ -82,20 +82,29 @@ add_executable(StorageManager src/main.cpp)
 target_link_libraries(StorageManager storagemanager)
 set_property(TARGET StorageManager PROPERTY CXX_STANDARD 11)
 
-add_custom_command(
-	TARGET StorageManager PRE_BUILD
-	COMMAND ${CMAKE_COMMAND} -E make_directory
-		${CMAKE_CURRENT_BINARY_DIR}/storage-manager/test_data)
-add_custom_command(
-	TARGET StorageManager POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-                ${CMAKE_SOURCE_DIR}/storage-manager/test_data
-		${CMAKE_CURRENT_BINARY_DIR}/storage-manager/test_data)
+set(TMPDIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+
 add_executable(unit_tests src/unit_tests.cpp)
 target_compile_definitions(unit_tests PUBLIC BOOST_NO_CXX11_SCOPED_ENUMS)
-add_dependencies(unit_tests test_files)
 target_link_libraries(unit_tests storagemanager)
 set_property(TARGET unit_tests PROPERTY CXX_STANDARD 11)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${TMPDIR})
+
+add_custom_command(
+	TARGET unit_tests PRE_BUILD
+	COMMAND ${CMAKE_COMMAND} -E make_directory
+		${CMAKE_CURRENT_BINARY_DIR}/test_data
+)
+add_custom_command(
+	TARGET unit_tests POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+                ${CMAKE_CURRENT_SOURCE_DIR}/test_data
+		        ${CMAKE_CURRENT_BINARY_DIR}/test_data
+#        COMMAND ${CMAKE_COMMAND} -E copy
+#                ../bin/unit_tests      # what is putting our bins in ../bin?
+#                ${CMAKE_CURRENT_BINARY_DIR} 
+)
 
 # The includes and lib linkages required to link against cloudio ... 
 # pretty crazy.  When lib dependencies are eventually config'd right,

--- a/storage-manager/CMakeLists.txt
+++ b/storage-manager/CMakeLists.txt
@@ -83,6 +83,7 @@ target_link_libraries(StorageManager storagemanager)
 set_property(TARGET StorageManager PROPERTY CXX_STANDARD 11)
 
 set(TMPDIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(unit_tests src/unit_tests.cpp)
 target_compile_definitions(unit_tests PUBLIC BOOST_NO_CXX11_SCOPED_ENUMS)

--- a/storage-manager/src/ReadTask.cpp
+++ b/storage-manager/src/ReadTask.cpp
@@ -65,7 +65,9 @@ bool ReadTask::run()
     
     // read from IOC, write to the socket
     vector<uint8_t> outbuf;
-    outbuf.resize(max(cmd->count, 4) + sizeof(sm_response));
+    if (cmd->count > (100 << 20))
+        cmd->count = (100 << 20);   // cap a read request at 100MB
+    outbuf.resize(max(cmd->count, 4) + sizeof(sm_response));  
     sm_response *resp = (sm_response *) &outbuf[0];
     
     resp->returnCode = 0;


### PR DESCRIPTION
- Re-added the StorageManager/Enabled key in the default config file.
  Thought I had switched all that stuff to only look at DBRootStorageType
  but I was wrong.
- Made the unit_tests bin for SM stay in the SM dir
- Collapsed one level of build dirs for SM.  For some reason it was
  putting test data in storage-manager/storage-manager/testData
- Limited a single read() call to 100MB as a paranoid safety measure.
  Normal usage won't read that much at once anyway.