### PR TITLE
MCOL-2178 Fix for handlers fallback mechanism patch.

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -7865,8 +7865,7 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex,
         }
 
         // We don't currently support limit with correlated subquery
-        if (csep->limitNum() != (uint64_t) - 1 &&
-                gwi.subQuery && !gwi.correlatedTbNameVec.empty())
+        if (gwi.subQuery && !gwi.correlatedTbNameVec.empty() && csep->hasOrderBy())
         {
             gwi.fatalParseError = true;
             gwi.parseErrorText = IDBErrorInfo::instance()->errorMsg(ERR_NON_SUPPORT_LIMIT_SUB);


### PR DESCRIPTION
I returned if predicate that guards FE-BE initial connection
block. This predicated had been removed by accident in cb36041

Since we switched to internal ORDER BY FE now reduces the
default limit value to uint64-2 this broke a predicate check
for correlated subqueries. I replaced a predicate with more
reasonable to avoid false positives.