### PR TITLE
Fix limit processing.

### DIFF
--- a/dbcon/joblist/jlf_subquery.cpp
+++ b/dbcon/joblist/jlf_subquery.cpp
@@ -767,10 +767,6 @@ int doFromSubquery(CalpontExecutionPlan* ep, const string& alias, const string& 
 
 void addOrderByAndLimit(CalpontSelectExecutionPlan* csep, JobInfo& jobInfo)
 {
-    // make sure there is a LIMIT
-    if (csep->orderByCols().size() > 0 && csep->limitNum() == (uint64_t) - 1)
-        return;
-
     jobInfo.limitStart = csep->limitStart();
     jobInfo.limitCount = csep->limitNum();
 

--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -7842,26 +7842,13 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex,
                 }
             }
 
-            // relate to bug4848. let mysql drive limit when limit session variable set.
-            // do not set in csep. @bug5096. ignore session limit setting for dml
-            if (gwi.thd->variables.select_limit == (uint64_t) - 1 &&
-                !csep->hasOrderBy())
-            {
-                csep->limitStart(limitOffset);
-                csep->limitNum(limitNum);
-            }
-            // Pushdown queries w ORDER BY and LIMIT
-            else if (isPushdownHand && csep->hasOrderBy())
-            {
-                csep->limitStart(limitOffset);
-                csep->limitNum(limitNum);
-            }
+            csep->limitStart(limitOffset);
+            csep->limitNum(limitNum);
         }
-        // Pushdown queries with ORDER BY w/o explicit limit
-        else if (isPushdownHand && csep->hasOrderBy())
+        // If an explicit limit is not specified, use the system variable value
+        else
         {
-            // We must set this to activate LimitedOrderBy in ExeMgr
-            csep->limitNum((uint64_t) - 2);
+            csep->limitNum(gwi.thd->variables.select_limit);
         }
 
         // We don't currently support limit with correlated subquery


### PR DESCRIPTION
Previously, limit would only work when sql_select_limit system variable was set to (2^64 - 1) and not for other values. This PR fixes this issue. We now also use the system variable value if an explicit limit is not specified in the query.