### PR TITLE
Enable Item::SUBSELECT_ITEM in the order by clause and Do not set the limit to 1 for "exists" in a subquery.

### DIFF
--- a/dbcon/joblist/jlf_subquery.cpp
+++ b/dbcon/joblist/jlf_subquery.cpp
@@ -809,6 +809,17 @@ void addOrderByAndLimit(CalpontSelectExecutionPlan* csep, JobInfo& jobInfo)
                 if (sc->colPosition() == -1)
                 {
                     sc = dynamic_cast<SimpleColumn*>(jobInfo.deliveredCols[sc->orderPos()].get());
+
+                    // TODO Investigate why this could be NULL
+                    if (sc == NULL)
+                    {
+                        const ReturnedColumn* rc = dynamic_cast<const ReturnedColumn*>(orderByCols[i].get());
+                        uint64_t eid = rc->expressionId();
+                        CalpontSystemCatalog::ColType ct = rc->resultType();
+                        tupleKey = getExpTupleKey(jobInfo, eid);
+                        jobInfo.orderByColVec.push_back(make_pair(tupleKey, orderByCols[i]->asc()));
+                        continue;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Fixes working_tpch1/misc/bug4827.sql and working_tpch1/misc/fluffycat.sql