### PR TITLE
MCOL-3488.  Writeengine getting IDB-FS an odd way

### DIFF
--- a/writeengine/redistribute/we_redistributeworkerthread.cpp
+++ b/writeengine/redistribute/we_redistributeworkerthread.cpp
@@ -486,8 +486,9 @@ int RedistributeWorkerThread::sendData()
     int16_t source = fPlanEntry.source;
     int16_t dest = fPlanEntry.destination;
 
-    IDBDataFile::Types fileType =
-        (IDBPolicy::useHdfs() ? IDBDataFile::HDFS : IDBDataFile::UNBUFFERED);
+    IDBDataFile::Types fileType = (IDBPolicy::useHdfs() ? IDBDataFile::HDFS :
+            IDBPolicy::useCloud() ? IDBDataFile::CLOUD : IDBDataFile::UNBUFFERED);
+
     IDBFileSystem& fs = IDBFileSystem::getFs( fileType );
 
     if ((remotePM) && (fileType != IDBDataFile::HDFS))
@@ -1519,8 +1520,11 @@ void RedistributeWorkerThread::handleDataAbort(SBS& sbs, size_t& size)
     if (fNewFilePtr != NULL)
         closeFile(fNewFilePtr);
 
-    IDBFileSystem& fs = IDBFileSystem::getFs(
-                            (IDBPolicy::useHdfs() ? IDBDataFile::HDFS : IDBDataFile::UNBUFFERED) );
+    IDBFileSystem& fs = (IDBPolicy::useHdfs() ?
+        IDBFileSystem::getFs(IDBDataFile::HDFS) :
+        IDBPolicy::useCloud() ?
+            IDBFileSystem::getFs(IDBDataFile::CLOUD) :
+            IDBFileSystem::getFs(IDBDataFile::BUFFERED));
 
     // remove local files
     for (set<string>::iterator i = fNewDirSet.begin(); i != fNewDirSet.end(); i++)

--- a/writeengine/redistribute/we_redistributeworkerthread.cpp
+++ b/writeengine/redistribute/we_redistributeworkerthread.cpp
@@ -1050,8 +1050,11 @@ void RedistributeWorkerThread::confirmToPeer()
         }
     }
 
-    IDBFileSystem& fs = IDBFileSystem::getFs(
-                            (IDBPolicy::useHdfs() ? IDBDataFile::HDFS : IDBDataFile::UNBUFFERED) );
+    IDBFileSystem& fs = (IDBPolicy::useHdfs() ?
+        IDBFileSystem::getFs(IDBDataFile::HDFS) :
+        IDBPolicy::useCloud() ?
+            IDBFileSystem::getFs(IDBDataFile::CLOUD) :
+            IDBFileSystem::getFs(IDBDataFile::BUFFERED));
 
     uint32_t confirmCode = RED_DATA_COMMIT;
 

--- a/writeengine/server/we_getfilesizes.cpp
+++ b/writeengine/server/we_getfilesizes.cpp
@@ -183,6 +183,8 @@ struct ColumnThread
 
         if (bUsingHdfs)
             fileType = IDBDataFile::HDFS;
+        else if (IDBPolicy::useCloud())
+            fileType = IDBDataFile::CLOUD;
         else
             fileType = IDBDataFile::UNBUFFERED;
 

--- a/writeengine/shared/we_chunkmanager.cpp
+++ b/writeengine/shared/we_chunkmanager.cpp
@@ -47,6 +47,7 @@ using namespace execplan;
 
 #include "IDBDataFile.h"
 #include "IDBPolicy.h"
+#include "cloudio/SMFileSystem.h"
 using namespace idbdatafile;
 
 namespace
@@ -96,7 +97,9 @@ ChunkManager::ChunkManager() : fMaxActiveChunkNum(100), fLenCompressed(0), fIsBu
     fLocalModuleId(Config::getLocalModuleID()),
     fFs(fIsHdfs ?
         IDBFileSystem::getFs(IDBDataFile::HDFS) :
-        IDBFileSystem::getFs(IDBDataFile::BUFFERED))
+        IDBPolicy::useCloud() ?
+            IDBFileSystem::getFs(IDBDataFile::CLOUD) :
+            IDBFileSystem::getFs(IDBDataFile::BUFFERED))
 {
     fUserPaddings = Config::getNumCompressedPadBlks() * BYTE_PER_BLOCK;
     fCompressor.numUserPaddingBytes(fUserPaddings);
@@ -2316,7 +2319,7 @@ int ChunkManager::swapTmpFile(const string& src, const string& dest)
 {
     // return value
     int rc = NO_ERROR;
-
+    
     // if no change to the cdf, the tmp may not exist, no need to swap.
     if (!fFs.exists(src.c_str()))
         return rc;

--- a/writeengine/shared/we_confirmhdfsdbfile.cpp
+++ b/writeengine/shared/we_confirmhdfsdbfile.cpp
@@ -49,9 +49,11 @@ namespace WriteEngine
 // on useHdfs() to tell me which FileSystem reference to get.
 //------------------------------------------------------------------------------
 ConfirmHdfsDbFile::ConfirmHdfsDbFile() :
-    fFs( (idbdatafile::IDBPolicy::useHdfs()) ?
-         idbdatafile::IDBFileSystem::getFs(idbdatafile::IDBDataFile::HDFS) :
-         idbdatafile::IDBFileSystem::getFs(idbdatafile::IDBDataFile::BUFFERED))
+    fFs(idbdatafile::IDBPolicy::useHdfs() ?
+        idbdatafile::IDBFileSystem::getFs(idbdatafile::IDBDataFile::HDFS) :
+        idbdatafile::IDBPolicy::useCloud() ?
+            idbdatafile::IDBFileSystem::getFs(idbdatafile::IDBDataFile::CLOUD) :
+            idbdatafile::IDBFileSystem::getFs(idbdatafile::IDBDataFile::BUFFERED))
 {
 }
 


### PR DESCRIPTION
Found that writeengine was getting an IDBFilesystem instance in a way different than other components.  Errors would only show up during test112, when a compression chunk needs to expand (lots of updates in the same region of the table).

Made those instances get an SMFilesystem (the cloud type) instance when appropriate.