### PR TITLE
Right trim whitespaces for a string ConstantColumn in a where clause

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -5164,6 +5164,10 @@ void gp_walk(const Item* item, void* arg)
                                 cval.assign(str->ptr(), str->length());
                             }
 
+                            // Trim the trailing white space from the constant
+                            // string value in the where clause
+                            boost::algorithm::trim_right(cval);
+
                             gwip->rcWorkStack.push(new ConstantColumn(cval));
                             (dynamic_cast<ConstantColumn*>(gwip->rcWorkStack.top()))->timeZone(gwip->thd->variables.time_zone->get_name()->ptr());
                             break;


### PR DESCRIPTION
Fixes working_tpch1/misc/bug3669.sql.