### PR TITLE
Follow up to PR 858

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -5166,7 +5166,7 @@ void gp_walk(const Item* item, void* arg)
 
                             // Trim the trailing white space from the constant
                             // string value in the where clause
-                            boost::algorithm::trim_right(cval);
+                            boost::trim_right_if(cval, boost::is_any_of(" "));
 
                             gwip->rcWorkStack.push(new ConstantColumn(cval));
                             (dynamic_cast<ConstantColumn*>(gwip->rcWorkStack.top()))->timeZone(gwip->thd->variables.time_zone->get_name()->ptr());


### PR DESCRIPTION
PR 858 was truncating all types of spaces, including tabs. This is not an expected behaviour, as this truncation should only be applied to whitespaces. This PR fixes it.

Fixes working_tpch1/misc/bug3669.sql and working_tpch1/misc/MCOL-1246.sql.