### PR TITLE
MCOL-2178 CS now sets optimizer flags like it did in the fork-era.

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -7779,8 +7779,9 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex,
                hash join, giving less number of rows in the output result set than expected.
                We therefore do not allow limit set to 1 here for such queries.
             */
-            if (gwi.subSelectType != CalpontSelectExecutionPlan::IN_SUBS &&
-                select_lex.master_unit()->global_parameters()->explicit_limit)
+            if (gwi.subSelectType != CalpontSelectExecutionPlan::IN_SUBS
+                 && gwi.subSelectType != CalpontSelectExecutionPlan::EXISTS_SUBS
+                 && select_lex.master_unit()->global_parameters()->explicit_limit)
             {
                 if (select_lex.master_unit()->global_parameters()->offset_limit)
                 {

--- a/dbcon/mysql/ha_calpont_impl.cpp
+++ b/dbcon/mysql/ha_calpont_impl.cpp
@@ -2747,12 +2747,6 @@ int ha_calpont_impl_rnd_end(TABLE* table, bool is_pushdown_hand)
             ((thd->lex)->sql_command == SQLCOM_UPDATE_MULTI))
         return rc;
 
-    if (((thd->lex)->sql_command == SQLCOM_INSERT) ||
-            ((thd->lex)->sql_command == SQLCOM_INSERT_SELECT) )
-    {
-       force_close_fep_conn(thd, ci, true); // checking prev command rc
-    }
-
     if (!ci)
     {
         set_fe_conn_info_ptr((void*)new cal_connection_info());
@@ -4042,7 +4036,11 @@ int ha_calpont_impl_external_lock(THD* thd, TABLE* table, int lock_type)
 
 
     CalTableMap::iterator mapiter = ci->tableMap.find(table);
-    if (mapiter != ci->tableMap.end() && lock_type == 2) // make sure it's the release lock (2nd) call
+    // make sure this is a release lock (2nd) call called in
+    // the table mode.
+    if (mapiter != ci->tableMap.end()
+          && (mapiter->second.condInfo && mapiter->second.csep)
+          && lock_type == 2)
     {
         // table mode
         if (mapiter->second.conn_hndl)
@@ -4068,14 +4066,18 @@ int ha_calpont_impl_external_lock(THD* thd, TABLE* table, int lock_type)
         // Clean up the tableMap and physTablesList
         ci->tableMap.erase(table);
         ci->physTablesList.erase(table);
+        thd->variables.in_subquery_conversion_threshold = IN_SUBQUERY_CONVERSION_THRESHOLD;
+        restore_optimizer_flags(thd);
     }
     else
     {
-        if (lock_type == 0) 
+        if (lock_type == 0)
         {
             ci->physTablesList.insert(table);
             // MCOL-2178 Disable Conversion of Big IN Predicates Into Subqueries
-            thd->variables.in_subquery_conversion_threshold=~0;
+            thd->variables.in_subquery_conversion_threshold=~ 0;
+            // Early optimizer_switch changes to avoid unsupported opt-s.
+            mutate_optimizer_flags(thd);
         }
         else if (lock_type == 2)
         {
@@ -4100,6 +4102,15 @@ int ha_calpont_impl_external_lock(THD* thd, TABLE* table, int lock_type)
                 // MCOL-3247 Use THD::ha_data as a per-plugin per-session
                 // storage for cal_conn_hndl to use it later in close_connection
                 thd_set_ha_data(thd, mcs_hton, get_fe_conn_info_ptr());
+                // Clean up all tableMap entries made by cond_push
+                for (auto &tme: ci->tableMap)
+                {
+                    if (tme.second.condInfo)
+                    {
+                        delete tme.second.condInfo;
+                        tme.second.condInfo= 0;
+                    }
+                }
                 ci->tableMap.clear();
                 // MCOL-2178 Enable Conversion of Big IN Predicates Into Subqueries
                 thd->variables.in_subquery_conversion_threshold = IN_SUBQUERY_CONVERSION_THRESHOLD;

--- a/dbcon/mysql/ha_exists_sub.cpp
+++ b/dbcon/mysql/ha_exists_sub.cpp
@@ -112,7 +112,7 @@ execplan::ParseTree* ExistsSub::transform()
         return NULL;
     }
 
-    if (getSelectPlan(gwi, *(fSub->get_select_lex()), csep) != 0)
+    if (getSelectPlan(gwi, *(fSub->get_select_lex()), csep, false, true) != 0)
     {
         fGwip.fatalParseError = true;
 

--- a/dbcon/mysql/ha_in_sub.cpp
+++ b/dbcon/mysql/ha_in_sub.cpp
@@ -148,7 +148,7 @@ execplan::ParseTree* InSub::transform()
     gwi.tbList.insert(gwi.tbList.begin(), fGwip.tbList.begin(), fGwip.tbList.end());
     gwi.derivedTbList.insert(gwi.derivedTbList.begin(), fGwip.derivedTbList.begin(), fGwip.derivedTbList.end());
 
-    if (getSelectPlan(gwi, *(fSub->get_select_lex()), csep) != 0)
+    if (getSelectPlan(gwi, *(fSub->get_select_lex()), csep, false, true) != 0)
     {
         fGwip.fatalParseError = true;
 

--- a/dbcon/mysql/ha_scalar_sub.cpp
+++ b/dbcon/mysql/ha_scalar_sub.cpp
@@ -253,7 +253,7 @@ execplan::ParseTree* ScalarSub::buildParseTree(PredicateOperator* op)
     gwi.tbList.insert(gwi.tbList.begin(), fGwip.tbList.begin(), fGwip.tbList.end());
     gwi.derivedTbList.insert(gwi.derivedTbList.begin(), fGwip.derivedTbList.begin(), fGwip.derivedTbList.end());
 
-    if (getSelectPlan(gwi, *(fSub->get_select_lex()), csep) != 0)
+    if (getSelectPlan(gwi, *(fSub->get_select_lex()), csep, false, true) != 0)
     {
         //@todo more in error handling
         if (!gwi.fatalParseError)

--- a/dbcon/mysql/ha_select_sub.cpp
+++ b/dbcon/mysql/ha_select_sub.cpp
@@ -77,7 +77,7 @@ SCSEP SelectSubQuery::transform()
     gwi.tbList.insert(gwi.tbList.begin(), fGwip.tbList.begin(), fGwip.tbList.end());
     gwi.derivedTbList.insert(gwi.derivedTbList.begin(), fGwip.derivedTbList.begin(), fGwip.derivedTbList.end());
 
-    if (getSelectPlan(gwi, *(fSelSub->get_select_lex()), csep) != 0)
+    if (getSelectPlan(gwi, *(fSelSub->get_select_lex()), csep, false, true) != 0)
     {
         if (!gwi.fatalParseError)
         {


### PR DESCRIPTION
This happens in external_lock() whilst locking the table.

Fixes LIMIT=1 optimization for EXISTS_SUBS subqueries.

external_lock() contains if condition that gives false positive
for SH + pushed conditions.

external_lock() now resets in_subquery_conversion_threshold
variable that governs IN_INTO_SUBQUERY optimization for
queries run in table mode.

external_lock() now purges dynamicall allocated condInfo for
SH and DH execution path.

Commented out UNION check b/c if condition gives false positives
and silently enables table mode execution for queries w/o
UNION.