### PR TITLE
MCOL-2178 Fix having and partially distinctAggregationAndGroupBy

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -348,16 +348,13 @@ bool sortItemIsInGrouping(Item* sort_item, ORDER* groupcol)
         found = true;
     }
 
-    // An "if" function that contains an aggregate function
+    // A function that contains an aggregate function
     // can be included in the ORDER BY clause
     // e.g. select a, if (sum(b) > 1, 2, 1) from t1 group by 1 order by 2;
     if (sort_item->type() == Item::FUNC_ITEM)
     {
         Item_func *ifp = reinterpret_cast<Item_func*>(sort_item);
-        if (string(ifp->func_name()) == "if")
-        {
-            ifp->traverse_cond(check_sum_func_item, &found, Item::POSTFIX);
-        }
+        ifp->traverse_cond(check_sum_func_item, &found, Item::POSTFIX);
     }
 
     for (; !found && groupcol; groupcol = groupcol->next)

--- a/dbcon/mysql/ha_mcs_pushdown.cpp
+++ b/dbcon/mysql/ha_mcs_pushdown.cpp
@@ -26,7 +26,8 @@ void mutate_optimizer_flags(THD *thd_)
     set_original_optimizer_flags(thd_->variables.optimizer_switch, thd_);
     thd_->variables.optimizer_switch = OPTIMIZER_SWITCH_IN_TO_EXISTS |
         OPTIMIZER_SWITCH_EXISTS_TO_IN |
-        OPTIMIZER_SWITCH_COND_PUSHDOWN_FOR_DERIVED;
+        OPTIMIZER_SWITCH_COND_PUSHDOWN_FOR_DERIVED |
+        OPTIMIZER_SWITCH_COND_PUSHDOWN_FROM_HAVING;
 }
 
 void restore_optimizer_flags(THD *thd_)


### PR DESCRIPTION
Fix distinctAggregationAndGroupBy by allowing to traverse into any
function in projection looking for either aggregation function or
GROUP BY key column.

MDB doesn't convert Item_equal into corresponding Item_func_eq w/o
OPTIMIZER_SWITCH_COND_PUSHDOWN_FROM_HAVING optimizer flag.
Activation of the flag fixes queries from having test scenario w
equal operator in HAVING, e.g. HAVING c1 = 50.