### PR TITLE
Revert commit 98e90ed as the proper fix is applied as part of MCOL-1559.

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -5221,10 +5221,6 @@ void gp_walk(const Item* item, void* arg)
                                 cval.assign(str->ptr(), str->length());
                             }
 
-                            // Trim the trailing white space from the constant
-                            // string value in the where clause
-                            boost::trim_right_if(cval, boost::is_any_of(" "));
-
                             gwip->rcWorkStack.push(new ConstantColumn(cval));
                             (dynamic_cast<ConstantColumn*>(gwip->rcWorkStack.top()))->timeZone(gwip->thd->variables.time_zone->get_name()->ptr());
                             break;


### PR DESCRIPTION
David Hall's patch for MCOL-1559 is handling all edge cases for whitespaces. Hence reverting PR 859.