### PR TITLE
Set constant value of type DECIMAL_RESULT/REAL_RESULT in an update statement.

### DIFF
--- a/dbcon/mysql/ha_calpont_impl.cpp
+++ b/dbcon/mysql/ha_calpont_impl.cpp
@@ -1359,7 +1359,9 @@ uint32_t doUpdateDelete(THD* thd, gp_walk_info& gwi)
 
             if (value->type() ==  Item::CONST_ITEM)
             {
-                if (value->cmp_type() == STRING_RESULT)
+                if (value->cmp_type() == STRING_RESULT ||
+                    value->cmp_type() == DECIMAL_RESULT ||
+                    value->cmp_type() == REAL_RESULT)
                 {
                     //@Bug 2587 use val_str to replace value->name to get rid of 255 limit
                     String val, *str;


### PR DESCRIPTION
Fixes tests working_tpch1_compareLogOnly/misc/vtabledml.sql and working_tpch1_compareLogOnly/unsigned/basicunsigned.sql.