### PR TITLE
MCOL-2178 Separate ha_mcs_pushdown.cpp compilation.

### DIFF
--- a/dbcon/execplan/functioncolumn.cpp
+++ b/dbcon/execplan/functioncolumn.cpp
@@ -112,7 +112,7 @@ ostream& operator<<(ostream& output, const FunctionColumn& rhs)
 const string FunctionColumn::toString() const
 {
     ostringstream output;
-    output << "FunctionColumn: " << fFunctionName << endl;
+    output << std::endl << "FunctionColumn: " << fFunctionName << endl;
 
     if (fAlias.length() > 0) output << "/Alias: " << fAlias;
 

--- a/dbcon/mysql/CMakeLists.txt
+++ b/dbcon/mysql/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories( ${ENGINE_COMMON_INCLUDES}
 SET ( libcalmysql_SRCS
     ha_mcs_sysvars.cpp
     ha_mcs_client_udfs.cpp
+    ha_mcs_pushdown.cpp
     ha_calpont.cpp
     ha_calpont_impl.cpp
     ha_calpont_dml.cpp

--- a/dbcon/mysql/ha_calpont.cpp
+++ b/dbcon/mysql/ha_calpont.cpp
@@ -20,9 +20,9 @@
 #include "ha_calpont.h"
 #include "columnstoreversion.h"
 
+#include "ha_mcs_pushdown.h"
 #define NEED_CALPONT_EXTERNS
 #include "ha_calpont_impl.h"
-#include "ha_mcs_pushdown.h"
 
 static handler* calpont_create_handler(handlerton* hton,
                                        TABLE_SHARE* table,
@@ -36,13 +36,13 @@ handlerton* mcs_hton;
 
 // handlers creation function for hton.
 // Look into ha_mcs_pushdown.* for more details.
-static group_by_handler*
+group_by_handler*
 create_calpont_group_by_handler(THD* thd, Query* query);
 
-static derived_handler*
+derived_handler*
 create_columnstore_derived_handler(THD* thd, TABLE_LIST *derived);
 
-static select_handler*
+select_handler*
 create_columnstore_select_handler(THD* thd, SELECT_LEX* sel);
 
 /* Variables for example share methods */
@@ -890,7 +890,6 @@ int ha_calpont::create(const char* name, TABLE* table_arg,
     DBUG_ENTER("ha_calpont::create");
 
     int rc = ha_calpont_impl_create(name, table_arg, create_info);
-//  table_arg->s->write_frm_image();
     DBUG_RETURN(rc);
 }
 
@@ -903,8 +902,6 @@ const COND* ha_calpont::cond_push(const COND* cond)
 
 struct st_mysql_storage_engine columnstore_storage_engine =
 { MYSQL_HANDLERTON_INTERFACE_VERSION };
-
-#include "ha_mcs_pushdown.cpp"
 
 mysql_declare_plugin(columnstore)
 {

--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -3175,7 +3175,7 @@ ReturnedColumn* buildReturnedColumn(Item* item, gp_walk_info& gwi, bool& nonSupp
                     String val, *str = item->val_str(&val);
                     string valStr;
                     valStr.assign(str->ptr(), str->length());
-            rc = new ConstantColumn(valStr, ConstantColumn::NUM);
+                    rc = new ConstantColumn(valStr);
                     break;
                 }
                 case REAL_RESULT:

--- a/dbcon/mysql/ha_calpont_impl.cpp
+++ b/dbcon/mysql/ha_calpont_impl.cpp
@@ -4152,8 +4152,10 @@ int ha_calpont_impl_rnd_pos(uchar* buf, uchar* pos)
  *    0 if success
  *    others if something went wrong whilst getting the result set
  ***********************************************************/
-int ha_calpont_impl_group_by_init(ha_calpont_group_by_handler* group_hand, TABLE* table)
+int ha_calpont_impl_group_by_init(mcs_handler_info *handler_info, TABLE* table)
 {
+    ha_calpont_group_by_handler *group_hand= 
+      reinterpret_cast<ha_calpont_group_by_handler*>(handler_info->hndl_ptr);
     string tableName = group_hand->table_list->table->s->table_name.str;
     IDEBUG( cout << "group_by_init for table " << tableName << endl );
     THD* thd = current_thd;
@@ -4590,7 +4592,7 @@ internal_error:
  *    HA_ERR_END_OF_FILE if the record set has come to an end
  *    others if something went wrong whilst getting the result set
  ***********************************************************/
-int ha_calpont_impl_group_by_next(ha_calpont_group_by_handler* group_hand, TABLE* table)
+int ha_calpont_impl_group_by_next(TABLE* table)
 {
     THD* thd = current_thd;
 
@@ -4678,7 +4680,7 @@ int ha_calpont_impl_group_by_next(ha_calpont_group_by_handler* group_hand, TABLE
     return rc;
 }
 
-int ha_calpont_impl_group_by_end(ha_calpont_group_by_handler* group_hand, TABLE* table)
+int ha_calpont_impl_group_by_end(TABLE* table)
 {
     int rc = 0;
     THD* thd = current_thd;

--- a/dbcon/mysql/ha_calpont_impl.h
+++ b/dbcon/mysql/ha_calpont_impl.h
@@ -20,9 +20,10 @@
 #define HA_CALPONT_IMPL_H__
 
 #include "idb_mysql.h"
-#include "ha_mcs_pushdown.h"
 
 #ifdef NEED_CALPONT_EXTERNS
+// Forward declaration.
+struct mcs_handler_info;
 extern int ha_calpont_impl_discover_existence(const char* schema, const char* name);
 extern int ha_calpont_impl_create(const char* name, TABLE* table_arg, HA_CREATE_INFO* create_info);
 extern int ha_calpont_impl_delete_table(const char* name);
@@ -43,11 +44,11 @@ extern int ha_calpont_impl_external_lock(THD* thd, TABLE* table, int lock_type);
 extern int ha_calpont_impl_update_row();
 extern int ha_calpont_impl_delete_row();
 extern int ha_calpont_impl_rnd_pos(uchar* buf, uchar* pos);
-extern int ha_calpont_impl_group_by_init(ha_calpont_group_by_handler* group_hand, TABLE* table);
-extern int ha_calpont_impl_group_by_next(ha_calpont_group_by_handler* group_hand, TABLE* table);
-extern int ha_calpont_impl_group_by_end(ha_calpont_group_by_handler* group_hand, TABLE* table);
-extern int ha_cs_impl_pushdown_init(mcs_handler_info* handler_info , TABLE* table);
+extern int ha_cs_impl_pushdown_init(mcs_handler_info* handler_info, TABLE* table);
 extern int ha_cs_impl_select_next(uchar *buf, TABLE *table);
+extern int ha_calpont_impl_group_by_init(mcs_handler_info *handler_info, TABLE* table);
+extern int ha_calpont_impl_group_by_next(TABLE* table);
+extern int ha_calpont_impl_group_by_end(TABLE* table);
 
 #endif
 
@@ -55,7 +56,6 @@ extern int ha_cs_impl_select_next(uchar *buf, TABLE *table);
 #include "ha_calpont_impl_if.h"
 #include "calpontsystemcatalog.h"
 #include "ha_calpont.h"
-#include "ha_mcs_pushdown.h"
 extern int ha_calpont_impl_rename_table_(const char* from, const char* to, cal_impl_if::cal_connection_info& ci);
 extern int ha_calpont_impl_write_row_(const uchar* buf, TABLE* table, cal_impl_if::cal_connection_info& ci, ha_rows& rowsInserted);
 extern int ha_calpont_impl_write_batch_row_(const uchar* buf, TABLE* table, cal_impl_if::cal_connection_info& ci);
@@ -72,10 +72,6 @@ extern std::string  ha_calpont_impl_droppartition_ (execplan::CalpontSystemCatal
 
 extern std::string  ha_calpont_impl_viewtablelock( cal_impl_if::cal_connection_info& ci, execplan::CalpontSystemCatalog::TableName& tablename);
 extern std::string  ha_calpont_impl_cleartablelock( cal_impl_if::cal_connection_info& ci, uint64_t tableLockID);
-extern int ha_calpont_impl_group_by_init(ha_calpont_group_by_handler* group_hand, TABLE* table);
-extern int ha_calpont_impl_group_by_next(ha_calpont_group_by_handler* group_hand, TABLE* table);
-extern int ha_calpont_impl_group_by_end(ha_calpont_group_by_handler* group_hand, TABLE* table);
-extern int ha_cs_impl_derived_next(TABLE* table);
 #endif
 
 #endif

--- a/dbcon/mysql/ha_mcs_pushdown.h
+++ b/dbcon/mysql/ha_mcs_pushdown.h
@@ -20,6 +20,9 @@
 
 #include "idb_mysql.h"
 #include "ha_calpont.h"
+#include "ha_mcs_sysvars.h"
+#define NEED_CALPONT_EXTERNS
+#include "ha_calpont_impl.h"
 
 void mutate_optimizer_flags(THD *thd_);
 void restore_optimizer_flags(THD *thd_);


### PR DESCRIPTION
Set a proper type for string literals on ConstantColumn ctor
to fix the regression produced by MCOL-174.

Removed OPTIMIZER_SWITCH_EXISTS_TO_IN b/c MDB produces
unsupported optimization with it and CS couldn't create
ExistsFilter.