### PR TITLE
Revert "MCOL-2102 Set CrossEngineSupport Port number when setting MyS…

### DIFF
--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -792,7 +792,6 @@ int main(int argc, char* argv[])
         try
         {
             sysConfig->setConfig(InstallSection, "MySQLPort", mysqlPort);
-            sysConfig->setConfig("CrossEngineSupport", "Port", mysqlPort);
         }
         catch (...)
         {}


### PR DESCRIPTION
…QLPort via postConfigure -port"

This reverts commit 755efb3dfbc88cbbfa222cb2454779cbe0a8d250.

It causes certain use case issues.