### PR TITLE
Allow a window function in the ORDER BY clause.

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -361,9 +361,10 @@ bool sortItemIsInGrouping(Item* sort_item, ORDER* groupcol)
         Item_func *ifp = reinterpret_cast<Item_func*>(sort_item);
         ifp->traverse_cond(check_sum_func_item, &found, Item::POSTFIX);
     }
-    else if (sort_item->type() == Item::CONST_ITEM)
+    else if (sort_item->type() == Item::CONST_ITEM ||
+             sort_item->type() == Item::WINDOW_FUNC_ITEM)
     {
-        found= true;
+        found = true;
     }
 
     for (; !found && groupcol; groupcol = groupcol->next)


### PR DESCRIPTION
Fixes 5 tests in working_tpch1/windowFunctions:

working_tpch1/windowFunctions/q0027.sql                                                 
working_tpch1/windowFunctions/q0032.sql
working_tpch1/windowFunctions/q0032b.sql                                                
working_tpch1/windowFunctions/q0033.sql                                                 
working_tpch1/windowFunctions/q0335.sql
