### PR TITLE
Use signed integer comparison for TIME data type in the ORDER BY clause.

### DIFF
--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -268,6 +268,7 @@ void CompareRule::compileRules(const std::vector<IdbSortSpec>& spec, const rowgr
             case CalpontSystemCatalog::BIGINT:
             case CalpontSystemCatalog::DECIMAL:
             case CalpontSystemCatalog::UDECIMAL:
+            case CalpontSystemCatalog::TIME:
             {
                 Compare* c = new IntCompare(*i);
                 fCompares.push_back(c);
@@ -319,7 +320,6 @@ void CompareRule::compileRules(const std::vector<IdbSortSpec>& spec, const rowgr
             case CalpontSystemCatalog::DATE:
             case CalpontSystemCatalog::DATETIME:
             case CalpontSystemCatalog::TIMESTAMP:
-            case CalpontSystemCatalog::TIME:
             {
                 Compare* c = new UintCompare(*i);
                 fCompares.push_back(c);


### PR DESCRIPTION
Fixes working_tpch1/qa_fe_postProcessedFunctions/TIMEDIFF.DM.sql.