### PR TITLE
Add status variables to show ColumnStore version and commit hash.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,16 +322,16 @@ IF( WITH_SHARED_COMP_TESTS )
     ADD_SUBDIRECTORY(writeengine/shared)
 ENDIF( WITH_SHARED_COMP_TESTS )
 
+exec_program("git"
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ARGS "describe --match=NeVeRmAtCh --always --dirty"
+    OUTPUT_VARIABLE GIT_VERSION)
+
 # releasenum is used by external scripts for various tasks. Leave it alone.
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/build/releasenum.in ${CMAKE_CURRENT_BINARY_DIR}/build/releasenum IMMEDIATE)
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/build/releasenum DESTINATION ${INSTALL_ENGINE} COMPONENT platform)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/columnstoreversion.h.in ${CMAKE_CURRENT_SOURCE_DIR}/columnstoreversion.h)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
-
-exec_program("git"
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ARGS "describe --match=NeVeRmAtCh --always --dirty"
-    OUTPUT_VARIABLE GIT_VERSION)
 
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/gitversionEngine.in ${CMAKE_CURRENT_BINARY_DIR}/gitversionEngine IMMEDIATE)
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/gitversionEngine DESTINATION ${INSTALL_ENGINE} COMPONENT platform)

--- a/columnstoreversion.h.in
+++ b/columnstoreversion.h.in
@@ -3,5 +3,6 @@
 #include <string>
 const std::string columnstore_version("${VERSION}");
 const std::string columnstore_release("${PACKAGE_RELEASE}");
+const std::string columnstore_commit_hash("${GIT_VERSION}");
 #endif
 

--- a/dbcon/mysql/ha_calpont.cpp
+++ b/dbcon/mysql/ha_calpont.cpp
@@ -33,6 +33,8 @@ static int calpont_commit(handlerton* hton, THD* thd, bool all);
 static int calpont_rollback(handlerton* hton, THD* thd, bool all);
 static int calpont_close_connection ( handlerton* hton, THD* thd );
 handlerton* mcs_hton;
+char cs_version[25];
+char cs_commit_hash[41]; // a commit hash is 40 characters
 
 // handlers creation function for hton.
 // Look into ha_mcs_pushdown.* for more details.
@@ -127,6 +129,12 @@ static int columnstore_init_func(void* p)
             tm.tm_hour, tm.tm_min, tm.tm_sec);
 
     fprintf(stderr, "Columnstore: Started; Version: %s-%s\n", columnstore_version.c_str(), columnstore_release.c_str());
+
+    strncpy(cs_version, columnstore_version.c_str(), sizeof(cs_version));
+    cs_version[sizeof(cs_version) - 1] = 0;
+
+    strncpy(cs_commit_hash, columnstore_commit_hash.c_str(), sizeof(cs_commit_hash));
+    cs_commit_hash[sizeof(cs_commit_hash) - 1] = 0;
 
     mcs_hton = (handlerton*)p;
 #ifndef _MSC_VER
@@ -914,7 +922,7 @@ mysql_declare_plugin(columnstore)
     columnstore_init_func,                        /* Plugin Init */
     columnstore_done_func,                        /* Plugin Deinit */
     0x0100 /* 1.0 */,
-    NULL,                                         /* status variables */
+    mcs_status_variables,                         /* status variables */
     mcs_system_variables,                         /* system variables */
     NULL,                                         /* reserved */
     0                                             /* config flags */
@@ -931,7 +939,7 @@ maria_declare_plugin(columnstore)
   columnstore_init_func,
   columnstore_done_func,
   0x0100, /* 1.0 */
-  NULL,                          /* status variables                */
+  mcs_status_variables,          /* status variables                */
   mcs_system_variables,          /* system variables                */
   "1.0",                         /* string version */
   MariaDB_PLUGIN_MATURITY_STABLE /* maturity */

--- a/dbcon/mysql/ha_mcs_sysvars.cpp
+++ b/dbcon/mysql/ha_mcs_sysvars.cpp
@@ -303,6 +303,13 @@ st_mysql_sys_var* mcs_system_variables[] =
   NULL
 };
 
+st_mysql_show_var mcs_status_variables[] =
+{
+  {"columnstore_version", (char*)&cs_version, SHOW_CHAR},
+  {"columnstore_commit_hash", (char*)&cs_commit_hash, SHOW_CHAR},
+  {0, 0, (enum_mysql_show_type)0}
+};
+
 void* get_fe_conn_info_ptr(THD* thd)
 {
     return ( current_thd == NULL && thd == NULL ) ? NULL :

--- a/dbcon/mysql/ha_mcs_sysvars.h
+++ b/dbcon/mysql/ha_mcs_sysvars.h
@@ -23,6 +23,9 @@
 #include "idb_mysql.h"
 
 extern st_mysql_sys_var* mcs_system_variables[];
+extern st_mysql_show_var mcs_status_variables[];
+extern char cs_version[];
+extern char cs_commit_hash[];
 
 // compression_type
 enum mcs_compression_type_t {


### PR DESCRIPTION
2 new status variables are added:
  "Columnstore_commit_hash": Displays the abbreviated commit hash of the HEAD of the version tree.
  "Columnstore_version": Displays the CS version based on parsing of the VERSION file in cmake.