### PR TITLE
Replication improvements

### DIFF
--- a/dbcon/mysql/ha_mcs_ddl.cpp
+++ b/dbcon/mysql/ha_mcs_ddl.cpp
@@ -2360,7 +2360,7 @@ int ha_mcs_impl_create_(const char* name, TABLE* table_arg, HA_CREATE_INFO* crea
     if ( schemaSyncOnly && isCreate)
         return rc;
 
-    if (thd->slave_thread && !ci.replicationEnabled)
+    if (thd->slave_thread && !get_replication_slave(thd))
         return rc;
 
     //@bug 5660. Error out REAL DDL/DML on slave node.
@@ -2558,7 +2558,7 @@ int ha_mcs_impl_delete_table_(const char* db, const char* name, cal_connection_i
         return 0;
     }
 
-    if (thd->slave_thread && !ci.replicationEnabled)
+    if (thd->slave_thread && !get_replication_slave(thd))
         return 0;
 
     //@bug 5660. Error out REAL DDL/DML on slave node.
@@ -2697,7 +2697,7 @@ int ha_mcs_impl_rename_table_(const char* from, const char* to, cal_connection_i
     pair<string, string> toPair;
     string stmt;
 
-    if (thd->slave_thread && !ci.replicationEnabled)
+    if (thd->slave_thread && !get_replication_slave(thd))
         return 0;
 
     //@bug 5660. Error out REAL DDL/DML on slave node.

--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -262,18 +262,10 @@ struct cal_connection_info
         useXbit(false),
         utf8(false),
         useCpimport(1),
-        delimiter('\7'),
-        replicationEnabled(false)
+        delimiter('\7')
     {
         // check if this is a slave mysql daemon
         isSlaveNode = checkSlave();
-
-        std::string option = config::Config::makeConfig()->getConfig("SystemConfig", "ReplicationEnabled");
-
-        if (!option.compare("Y"))
-        {
-            replicationEnabled = true;
-        }
     }
 
     static bool checkSlave()
@@ -339,7 +331,6 @@ struct cal_connection_info
     char delimiter;
     char enclosed_by;
     std::vector <execplan::CalpontSystemCatalog::ColType> columnTypes;
-    bool replicationEnabled;
     // MCOL-1101 remove compilation unit variable rmParms
     std::vector <execplan::RMParam> rmParms;
 };

--- a/dbcon/mysql/ha_mcs_sysvars.cpp
+++ b/dbcon/mysql/ha_mcs_sysvars.cpp
@@ -276,6 +276,15 @@ static MYSQL_THDVAR_BOOL(
     1 // default
 );
 
+static MYSQL_THDVAR_BOOL(
+    replication_slave,
+    PLUGIN_VAR_NOCMDARG | PLUGIN_VAR_READONLY,
+    "Allow this MariaDB server to apply replication changes to ColumnStore",
+    NULL,
+    NULL,
+    0
+);
+
 st_mysql_sys_var* mcs_system_variables[] =
 {
   MYSQL_SYSVAR(compression_type),
@@ -300,6 +309,7 @@ st_mysql_sys_var* mcs_system_variables[] =
   MYSQL_SYSVAR(import_for_batchinsert_delimiter),
   MYSQL_SYSVAR(import_for_batchinsert_enclosed_by),
   MYSQL_SYSVAR(varbin_always_hex),
+  MYSQL_SYSVAR(replication_slave),
   NULL
 };
 
@@ -519,4 +529,13 @@ ulong get_import_for_batchinsert_enclosed_by(THD* thd)
 void set_import_for_batchinsert_enclosed_by(THD* thd, ulong value)
 {
     THDVAR(thd, import_for_batchinsert_enclosed_by) = value;
+}
+
+bool get_replication_slave(THD* thd)
+{
+    return ( thd == NULL ) ? false : THDVAR(thd, replication_slave);
+}
+void set_replication_slave(THD* thd, bool value)
+{
+    THDVAR(thd, replication_slave) = value;
 }

--- a/dbcon/mysql/ha_mcs_sysvars.h
+++ b/dbcon/mysql/ha_mcs_sysvars.h
@@ -102,5 +102,8 @@ void set_import_for_batchinsert_delimiter(THD* thd, ulong value);
 
 ulong get_import_for_batchinsert_enclosed_by(THD* thd);
 void set_import_for_batchinsert_enclosed_by(THD* thd, ulong value);
-  
+
+bool get_replication_slave(THD* thd);
+void set_replication_slave(THD* thd, bool value);
+
 #endif

--- a/utils/loggingcpp/ErrorMessage.txt
+++ b/utils/loggingcpp/ErrorMessage.txt
@@ -143,6 +143,7 @@
 4016	ERR_DML_DDL_SLAVE	DML and DDL statements for Columnstore tables can only be run from the replication master.
 4017	ERR_DML_DDL_LOCAL	DML and DDL statements are not allowed when columnstore_local_query is greater than 0.
 4018	ERR_NON_SUPPORT_SYNTAX	The statement is not supported in Columnstore.
+4019    ERR_RBR_EVENT Row based replication events are not supported in Columnstore.
 
 # UDF
 5001	ERR_FUNC_NON_IMPLEMENT	%1%:%2% is not implemented.


### PR DESCRIPTION
This patch fixes:

MCOL-3557 - Row Based Replication events to ColumnStore tables will no
longer cause MariaDB to crash, it will error instead.

MCOL-3556 - Remove the Columnstore.xml variable to turn on ColumnStore
tables applying replication events and instead make it a system variable
that can be set in my.cnf called "columnstore_replication_slave". This
allows it to be set per-UM.