### PR TITLE
MCOL-3328 Disable distributed installation for non-root user

### DIFF
--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -405,6 +405,12 @@ int main(int argc, char* argv[])
 		}
 		else if( string("-d") == argv[i] )
 		{
+            if (!rootUser)
+            {
+                cout << "   ERROR: Distributed installation for a non-root user is not supported" << endl;
+                exit (1);
+            }
+            
 			nonDistribute = false;
 			nonDistributeFlag = true;
 		}


### PR DESCRIPTION
Distributed installation for non-root users is no longer supported in 1.2. Disabling this option.