### PR TITLE
MCOL-3499

### DIFF
--- a/storage-manager/src/PrefixCache.cpp
+++ b/storage-manager/src/PrefixCache.cpp
@@ -361,7 +361,7 @@ void PrefixCache::newObject(const string &key, size_t size)
     {
         //This should never happen but was in MCOL-3499
         //Remove this when PrefixCache ctor can call populate() synchronous with write calls
-        logger->log(LOG_ERR, "PrefixCache::newObject(): key exists in m_lru already.",key.c_str());
+        logger->log(LOG_ERR, "PrefixCache::newObject(): key exists in m_lru already %s",key.c_str());
     }
     //_makeSpace(size);
     lru.push_back(key);

--- a/storage-manager/src/WriteTask.cpp
+++ b/storage-manager/src/WriteTask.cpp
@@ -111,7 +111,6 @@ bool WriteTask::run()
         payloadLen = 4;
         resp->returnCode = -1;
         *((int *) &resp[1]) = errno;
-        success = write(*resp, payloadLen);
     }
     else
         resp->returnCode = writeCount;


### PR DESCRIPTION
WriteTask failure was sending 2 responses and fix race between prefixCache::populate and writing new S3 objects.