### PR TITLE
MCOL-3474 TIMEDIFF() returns incorrect result fix

### DIFF
--- a/utils/funcexp/func_timediff.cpp
+++ b/utils/funcexp/func_timediff.cpp
@@ -119,9 +119,7 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::TIME:
         case execplan::CalpontSystemCatalog::DATETIME:
             // Diff between time and datetime returns NULL in MariaDB
-            if ((type2 == execplan::CalpontSystemCatalog::TIME ||
-                 type2 == execplan::CalpontSystemCatalog::DATETIME) &&
-                 type1 != type2)
+            if (type1 != type2)
             {
                 isNull = true;
                 break;


### PR DESCRIPTION
MCOL-3474. Fixes cases where a datatype that is not TIME or DATETIME is being DATEDIFFed with a TIME or DATETIME. Should return null when types are not the same, just like MariaDB