### PR TITLE
MCOL-3563: fix compiler warnings / type errors.

### DIFF
--- a/storage-manager/src/CopyTask.cpp
+++ b/storage-manager/src/CopyTask.cpp
@@ -43,7 +43,7 @@ CopyTask::~CopyTask()
 
 bool CopyTask::run()
 {
-    bool success;
+    int success;
     SMLogging* logger = SMLogging::get();
 
     uint8_t buf[2048] = {0};
@@ -83,8 +83,7 @@ bool CopyTask::run()
     
     sm_response *resp = (sm_response *) buf;
     resp->returnCode = 0;
-    success = write(*resp, 0);
-    return success;
+    return write(*resp, 0);
 }
 
 }

--- a/storage-manager/src/ListDirectoryTask.cpp
+++ b/storage-manager/src/ListDirectoryTask.cpp
@@ -37,7 +37,7 @@ ListDirectoryTask::~ListDirectoryTask()
 }
 
 #define check_error(msg, ret) \
-    if (success<0) \
+    if (!success) \
     { \
         handleError(msg, errno); \
         return ret; \
@@ -85,8 +85,12 @@ bool ListDirectoryTask::run()
         return true;
     }
     
-    success = read(buf, getLength());
-    check_error("ListDirectoryTask read", false);
+    err = read(buf, getLength());
+    if (err<0)
+    {
+        handleError("ListDirectoryTask read", errno);
+        return false;
+    }
     listdir_cmd *cmd = (listdir_cmd *) buf;
     
     #ifdef SM_TRACE

--- a/storage-manager/src/OpenTask.cpp
+++ b/storage-manager/src/OpenTask.cpp
@@ -45,7 +45,7 @@ bool OpenTask::run()
         return the result
     */
     SMLogging* logger = SMLogging::get();
-    bool success;
+    int success;
     uint8_t buf[1024] = {0};
     
     if (getLength() > 1023)
@@ -55,7 +55,7 @@ bool OpenTask::run()
     }
     
     success = read(buf, getLength());
-    if (!success)
+    if (success<0)
     {
         handleError("OpenTask read2", errno);
         return false;

--- a/storage-manager/src/PingTask.cpp
+++ b/storage-manager/src/PingTask.cpp
@@ -43,8 +43,8 @@ bool PingTask::run()
         return true;
     }
     // consume the msg
-    bool success = read(&buf, getLength());
-    if (!success)
+    int success = read(&buf, getLength());
+    if (success<0)
     {
         handleError("PingTask", errno);
         return false;

--- a/storage-manager/src/ReadTask.cpp
+++ b/storage-manager/src/ReadTask.cpp
@@ -54,7 +54,7 @@ bool ReadTask::run()
         return true;
     }
     
-    bool success;
+    int success;
     success = read(buf, getLength());
     check_error("ReadTask read cmd", false);
     read_cmd *cmd = (read_cmd *) buf;
@@ -103,8 +103,7 @@ bool ReadTask::run()
     }
     if (resp->returnCode >= 0)
         payloadLen = resp->returnCode;
-    success = write(*resp, payloadLen);
-    return success;
+    return write(*resp, payloadLen);
 }
 
 

--- a/storage-manager/src/SessionManager.cpp
+++ b/storage-manager/src/SessionManager.cpp
@@ -51,6 +51,8 @@ namespace storagemanager
 SessionManager::SessionManager()
 {
     crp = ClientRequestProcessor::get();
+    socketCtrl[0] = -1;
+    socketCtrl[1] = -1;
 }
 
 SessionManager::~SessionManager()
@@ -164,7 +166,7 @@ int SessionManager::start()
                 {
                     //logger->log(LOG_DEBUG,"Error! revents = %d", fds[socketIncr].revents,);
                     if (fds[socketIncr].fd == -1)
-                        cout << "!= POLLIN, closing fd -1" << endl;
+                        logger->log(LOG_DEBUG,"!= POLLIN, closing fd -1");
                     close(fds[socketIncr].fd);
                     fds[socketIncr].fd = -1;
                     continue;
@@ -239,7 +241,7 @@ int SessionManager::start()
                                 if (fds[i].fd == socket)
                                 {
                                     if (socket == -1)
-                                        cout << "REMOVEFD told to remove fd -1" << endl;
+                                        logger->log(LOG_DEBUG,"REMOVEFD told to remove fd -1");
                                     close(socket);
                                     fds[i].fd = -1;
                                     break;
@@ -376,7 +378,7 @@ int SessionManager::start()
                     if (closeConn)
                     {
                         if (fds[socketIncr].fd == -1)
-                            cout << "closeConn closing fd -1" << endl;
+                            logger->log(LOG_DEBUG,"closeConn closing fd -1");
                         close(fds[socketIncr].fd);
                         fds[socketIncr].fd = -1;
                     }

--- a/storage-manager/src/StatTask.cpp
+++ b/storage-manager/src/StatTask.cpp
@@ -48,7 +48,7 @@ StatTask::~StatTask()
 bool StatTask::run()
 {
     SMLogging* logger = SMLogging::get();
-    bool success;
+    int success;
     uint8_t buf[1024] = {0};
     
     if (getLength() > 1023) {
@@ -84,8 +84,7 @@ bool StatTask::run()
         payloadLen = 4;
         *((int32_t *) resp->payload) = errno;
     }
-    success = write(*resp, payloadLen);
-    return success;
+    return write(*resp, payloadLen);
 }
 
 }

--- a/storage-manager/src/SyncTask.cpp
+++ b/storage-manager/src/SyncTask.cpp
@@ -43,8 +43,8 @@ bool SyncTask::run()
         return true;
     }
     // consume the msg
-    bool success = read(&buf, getLength());
-    if (!success)
+    int success = read(&buf, getLength());
+    if (success<0)
     {
         handleError("SyncTask", errno);
         return false;

--- a/storage-manager/src/TruncateTask.cpp
+++ b/storage-manager/src/TruncateTask.cpp
@@ -44,7 +44,7 @@ TruncateTask::~TruncateTask()
 bool TruncateTask::run()
 {
     SMLogging* logger = SMLogging::get();
-    bool success;
+    int success;
     uint8_t buf[1024] = {0};
     
     if (getLength() > 1023) {
@@ -79,8 +79,7 @@ bool TruncateTask::run()
     
     sm_response *resp = (sm_response *) buf;
     resp->returnCode = 0;
-    success = write(*resp, 0);
-    return success;
+    return write(*resp, 0);
 }
 
 }

--- a/storage-manager/src/UnlinkTask.cpp
+++ b/storage-manager/src/UnlinkTask.cpp
@@ -45,7 +45,7 @@ UnlinkTask::~UnlinkTask()
 bool UnlinkTask::run()
 {
     SMLogging* logger = SMLogging::get();
-    bool success;
+    int success;
     uint8_t buf[1024] = {0};
     
     if (getLength() > 1023) {
@@ -81,8 +81,7 @@ bool UnlinkTask::run()
     
     sm_response *resp = (sm_response *) buf;
     resp->returnCode = 0;
-    success = write(*resp, 0);
-    return success;
+    return write(*resp, 0);
 }
 
 }

--- a/storage-manager/src/unit_tests.cpp
+++ b/storage-manager/src/unit_tests.cpp
@@ -190,7 +190,7 @@ void makeConnection()
     t.join();
 }
     
-bool opentask(bool connectionTest=false, bool errorHandle=false)
+bool opentask(bool connectionTest=false)
 {
     // going to rely on msgs being smaller than the buffer here
 	int err=0;
@@ -211,31 +211,31 @@ bool opentask(bool connectionTest=false, bool errorHandle=false)
     cout << "open file " << filename << endl;
     ::unlink(filename);
     
+    // set payload to be shorter than actual message lengh
+    // and send a shortened message.
     if (connectionTest)
         hdr->payloadLen -= 2;
 
     size_t result = ::write(sessionSock, cmd, hdr->payloadLen);
     assert(result==(hdr->payloadLen));
 
-    if (errorHandle)
-        clientSock = 9999999;
+    // set payload to be correct length again
     if (connectionTest)
         hdr->payloadLen += 2;
 
+    // process task will look for the full length and
+    // will wait on the rest of the message.
     ProcessTask pt(clientSock, hdr->payloadLen);
     boost::thread t(pt);
 
     if (connectionTest)
     {
+        // make sure the thread is waiting for the rest of the data
+        // then kill the connection. This will trigger the task thread
+        // to exit on an error handling path
         sleep(1);
         close(sessionSock);
         close(clientSock);
-        err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
-        assert(err == -1);
-        t.join();
-    }
-    else if (errorHandle)
-    {
         err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
         assert(err == -1);
         t.join();
@@ -507,7 +507,7 @@ bool appendtask()
     return true;
 }
 
-void unlinktask(bool connectionTest=false, bool errorHandle=false)
+void unlinktask(bool connectionTest=false)
 {
 	int err=0;
     // make a meta file and delete it
@@ -532,31 +532,31 @@ void unlinktask(bool connectionTest=false, bool errorHandle=false)
     cmd->flen = strlen(filename);
     memcpy(&cmd->filename, filename, cmd->flen);
     
+    // set payload to be shorter than actual message lengh
+    // and send a shortened message.
     if (connectionTest)
         cmd->flen -= 2;
 
     size_t result = ::write(sessionSock, cmd, sizeof(unlink_cmd) + cmd->flen);
     assert(result==(sizeof(unlink_cmd) + cmd->flen));
 
-    if (errorHandle)
-        clientSock = 9999999;
+    // set payload to be correct length again
     if (connectionTest)
         cmd->flen += 2;
 
+    // process task will look for the full length and
+    // will wait on the rest of the message.
     ProcessTask pt(clientSock, sizeof(unlink_cmd) + cmd->flen);
     boost::thread t(pt);
 
     if (connectionTest)
     {
+        // make sure the thread is waiting for the rest of the data
+        // then kill the connection. This will trigger the task thread
+        // to exit on an error handling path
         sleep(1);
         close(sessionSock);
         close(clientSock);
-        err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
-        assert(err == -1);
-        t.join();
-    }
-    else if (errorHandle)
-    {
         err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
         assert(err == -1);
         t.join();
@@ -608,7 +608,7 @@ void unlinktask(bool connectionTest=false, bool errorHandle=false)
     cout << "unlink task OK" << endl;
 }
 
-bool stattask(bool connectionTest=false, bool errorHandle=false)
+bool stattask(bool connectionTest=false)
 {
 	int err=0;
     bf::path fullPath = homepath / prefix / "stattest1";
@@ -627,32 +627,31 @@ bool stattask(bool connectionTest=false, bool errorHandle=false)
     cmd->flen = filename.length();
     strcpy((char *) cmd->filename, filename.c_str());
     
+    // set payload to be shorter than actual message lengh
+    // and send a shortened message.
     if (connectionTest)
         cmd->flen -= 2;
 
     size_t result = ::write(sessionSock, cmd, sizeof(*cmd) + cmd->flen);
     assert(result==(sizeof(*cmd) + cmd->flen));
 
-    
-    if (errorHandle)
-        clientSock = 9999999;
+    // set payload to be correct length again
     if (connectionTest)
         cmd->flen += 2;
 
+    // process task will look for the full length and
+    // will wait on the rest of the message.
     ProcessTask pt(clientSock, sizeof(*cmd) + cmd->flen);
     boost::thread t(pt);
 
     if (connectionTest)
     {
+        // make sure the thread is waiting for the rest of the data
+        // then kill the connection. This will trigger the task thread
+        // to exit on an error handling path
         sleep(1);
         close(sessionSock);
         close(clientSock);
-        err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
-        assert(err == -1);
-        t.join();
-    }
-    else if (errorHandle)
-    {
         err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
         assert(err == -1);
         t.join();
@@ -822,7 +821,7 @@ bool IOCTruncate()
 }
 
 
-bool truncatetask(bool connectionTest=false, bool errorHandle=false)
+bool truncatetask(bool connectionTest=false)
 {
     IOCoordinator *ioc = IOCoordinator::get();
     Cache *cache = Cache::get();
@@ -846,31 +845,31 @@ bool truncatetask(bool connectionTest=false, bool errorHandle=false)
     cmd->flen = strlen(filename);
     strcpy((char *) cmd->filename, filename);
     
+    // set payload to be shorter than actual message lengh
+    // and send a shortened message.
     if (connectionTest)
         cmd->flen -= 2;
 
     size_t result = ::write(sessionSock, cmd, sizeof(*cmd) + cmd->flen);
     assert(result==(sizeof(*cmd) + cmd->flen));
     
-    if (errorHandle)
-        clientSock = 9999999;
+    // set payload to be correct length again
     if (connectionTest)
         cmd->flen += 2;
 
+    // process task will look for the full length and
+    // will wait on the rest of the message.
     ProcessTask pt(clientSock, sizeof(*cmd) + cmd->flen);
     boost::thread t(pt);
 
     if (connectionTest)
     {
+        // make sure the thread is waiting for the rest of the data
+        // then kill the connection. This will trigger the task thread
+        // to exit on an error handling path
         sleep(1);
         close(sessionSock);
         close(clientSock);
-        err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
-        assert(err == -1);
-        t.join();
-    }
-    else if (errorHandle)
-    {
         err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
         assert(err == -1);
         t.join();
@@ -897,7 +896,7 @@ bool truncatetask(bool connectionTest=false, bool errorHandle=false)
     return true;
 }
 
-bool listdirtask(bool connectionTest=false,bool errorHandle=false)
+bool listdirtask(bool connectionTest=false)
 {
     IOCoordinator *ioc = IOCoordinator::get();
     const bf::path metaPath = ioc->getMetadataPath();
@@ -932,34 +931,33 @@ bool listdirtask(bool connectionTest=false,bool errorHandle=false)
     cmd->plen = strlen(relPath);
     memcpy(cmd->path, relPath, cmd->plen);
 
+    // set payload to be shorter than actual message lengh
+    // and send a shortened message.
     if (connectionTest)
         cmd->plen -= 2;
 
     size_t result = ::write(sessionSock, cmd, sizeof(*cmd) + cmd->plen);
     assert(result==(sizeof(*cmd) + cmd->plen));
 
-    if (errorHandle)
-        clientSock = 9999999;
+    // set payload to be correct length again
     if (connectionTest)
         cmd->plen += 2;
-    //ListDirectoryTask l(clientSock, sizeof(*cmd) + cmd->plen);
-    //l.run();
+
+    // process task will look for the full length and
+    // will wait on the rest of the message.
     ProcessTask pt(clientSock, sizeof(*cmd) + cmd->plen);
     boost::thread t(pt);
 
     if (connectionTest)
     {
+        // make sure the thread is waiting for the rest of the data
+        // then kill the connection. This will trigger the task thread
+        // to exit on an error handling path
         sleep(1);
     	close(sessionSock);
         close(clientSock);
     	err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
     	assert(err == -1);
-        t.join();
-    }
-    else if (errorHandle)
-    {
-        err = ::recv(sessionSock, buf, 8192, MSG_DONTWAIT);
-        assert(err == -1);
         t.join();
     }
     else
@@ -998,7 +996,7 @@ bool listdirtask(bool connectionTest=false,bool errorHandle=false)
     return true;
 }
 
-void pingtask(bool connectionTest=false, bool errorHandle=false)
+void pingtask(bool connectionTest=false)
 {
 	int err=0;
     uint8_t buf[1024];
@@ -1007,31 +1005,31 @@ void pingtask(bool connectionTest=false, bool errorHandle=false)
     
     size_t len = sizeof(*cmd);
 
+    // set payload to be shorter than actual message lengh
+    // and send a shortened message.
     if (connectionTest)
         len -= 2;
 
     ssize_t result = ::write(sessionSock, cmd, sizeof(*cmd));
     assert(result==(sizeof(*cmd)));
     
-    if (errorHandle)
-        clientSock = 9999999;
+    // set payload to be correct length again
     if (connectionTest)
         len += 2;
 
+    // process task will look for the full length and
+    // will wait on the rest of the message.
     ProcessTask pt(clientSock, len);
     boost::thread t(pt);
 
     if (connectionTest)
     {
+        // make sure the thread is waiting for the rest of the data
+        // then kill the connection. This will trigger the task thread
+        // to exit on an error handling path
         sleep(1);
         close(sessionSock);
         close(clientSock);
-        err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
-        assert(err == -1);
-        t.join();
-    }
-    else if (errorHandle)
-    {
         err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
         assert(err == -1);
         t.join();
@@ -1052,7 +1050,7 @@ void pingtask(bool connectionTest=false, bool errorHandle=false)
     cout << "pingtask OK" << endl;
 }
 
-bool copytask(bool connectionTest=false, bool errorHandle=false)
+bool copytask(bool connectionTest=false)
 {
     /*  
         make a file
@@ -1083,6 +1081,8 @@ bool copytask(bool connectionTest=false, bool errorHandle=false)
     
     uint len = (uint64_t) &file2->filename[file2->flen] - (uint64_t) buf;
 
+    // set payload to be shorter than actual message lengh
+    // and send a shortened message.
     if (connectionTest)
         len -= 2;
 
@@ -1091,25 +1091,23 @@ bool copytask(bool connectionTest=false, bool errorHandle=false)
 
     int err=0;
 
-    if (errorHandle)
-        clientSock = 9999999;
+    // set payload to be correct length again
     if (connectionTest)
         len += 2;
 
+    // process task will look for the full length and
+    // will wait on the rest of the message.
     ProcessTask pt(clientSock, len);
     boost::thread t(pt);
 
     if (connectionTest)
     {
+        // make sure the thread is waiting for the rest of the data
+        // then kill the connection. This will trigger the task thread
+        // to exit on an error handling path
         sleep(1);
         close(sessionSock);
         close(clientSock);
-        err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
-        assert(err == -1);
-        t.join();
-    }
-    else if (errorHandle)
-    {
         err = ::recv(sessionSock, buf, 1024, MSG_DONTWAIT);
         assert(err == -1);
         t.join();
@@ -2001,31 +1999,17 @@ int main(int argc, char* argv[])
     //opentask();
     opentask(true);
     makeConnection();
-    opentask(false,true);
-    makeConnection();
     unlinktask(true);
-    makeConnection();
-    unlinktask(false,true);
     makeConnection();
     stattask(true);
     makeConnection();
-    stattask(false,true);
-    makeConnection();
     truncatetask(true);
-    makeConnection();
-    truncatetask(false,true);
     makeConnection();
     listdirtask(true);
     makeConnection();
-    listdirtask(false,true);
-    makeConnection();
     pingtask(true);
     makeConnection();
-    pingtask(false,true);
-    makeConnection();
     copytask(true);
-    makeConnection();
-    copytask(false,true);
 
     (Cache::get())->shutdown();
     delete (Synchronizer::get());


### PR DESCRIPTION
A previous commit made posix::read changed return value
from bool to int. However some callers still expected
bool and compared a bool<0 which is always false.