### PR TITLE
MCOL-2276 "Unable to insert certain row." Fix

### DIFF
--- a/writeengine/dictionary/we_dctnry.cpp
+++ b/writeengine/dictionary/we_dctnry.cpp
@@ -1111,7 +1111,7 @@ int Dctnry::insertDctnry(const int& sgnature_size,
     for (i = m_lastFbo; i < m_numBlocks; i++)
     {
         // @bug 3960: Add MAX_OP_COUNT check to handle case after bulk rollback
-        if ( ((m_freeSpace >= (size + m_totalHdrBytes)) ||
+        if ( ((m_freeSpace >= size) ||
                 ((size > 8176) && (m_freeSpace > m_totalHdrBytes))) &&
                 (m_curOp    <  (MAX_OP_COUNT - 1)) )
         {


### PR DESCRIPTION
When we initialize m_freeSpace we subtract m_totalHdrBytes from it so the comparison 

`(m_freeSpace >= (size + m_totalHdrBytes)`

is incorrect and was actually causing the bug. This bug occurs whenever we're looking for a block of size at most 14 bytes (m_totalHdrBytes) smaller than 8176 bytes (the block boundary size for TEXT) . 