### PR TITLE
Squash merge of the multithreaded PM hash table construction

### DIFF
--- a/dbcon/joblist/batchprimitiveprocessor-jl.h
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.h
@@ -312,9 +312,11 @@ private:
     uint16_t status;
 
     /* for Joiner serialization */
+    bool pickNextJoinerNum();
     uint32_t pos, joinerNum;
     boost::shared_ptr<joiner::Joiner> joiner;
     boost::shared_ptr<std::vector<ElementType> > smallSide;
+    boost::scoped_array<uint32_t> posByJoinerNum;
 
     /* for RowGroup return type */
     rowgroup::RowGroup inputRG, projectionRG;

--- a/dbcon/joblist/rowestimator.cpp
+++ b/dbcon/joblist/rowestimator.cpp
@@ -499,14 +499,13 @@ uint64_t RowEstimator::estimateRows(const vector<ColumnCommandJL*>& cpColVec,
     rowsInLastExtent = ((hwm + 1) * fBlockSize / colCmd->getColType().colWidth) % fRowsPerExtent;
 
     // Sum up the total number of scanned rows.
-    uint32_t idx = scanFlags.size() - 1;
-    bool done = false;
+    int32_t idx = scanFlags.size() - 1;
 
-    while (!done)
+    while (idx >= 0)
     {
         if (scanFlags[idx])
         {
-            extentRows = (idx == scanFlags.size() - 1 ? rowsInLastExtent : fRowsPerExtent);
+            extentRows = (idx == (int) scanFlags.size() - 1 ? rowsInLastExtent : fRowsPerExtent);
 
             // Get the predicate factor.
 #if ROW_EST_DEBUG
@@ -549,26 +548,28 @@ uint64_t RowEstimator::estimateRows(const vector<ColumnCommandJL*>& cpColVec,
 #endif
         }
 
-        if (extentsSampled == fExtentsToSample || idx == 0)
-        {
-            done = true;
-        }
-        else
-        {
+        //if (extentsSampled == fExtentsToSample || idx == 0)
+        //{
+            //done = true;
+        //}
+        //else
+        //{
             idx--;
-        }
+        //}
     }
 
     // If there are more extents than we sampled, add the row counts for the qualifying extents
     // that we didn't sample to the count of rows that will be scanned.
-    if ((extentsSampled >= fExtentsToSample) && (idx > 0))
+	// XXXPAT: Modified this fcn to sample all extents.  Leaving this here due to level of arcana
+	// involved.  :)
+    if (false && (extentsSampled >= fExtentsToSample) && (idx > 0))
     {
         factor = (1.0 * estimatedRowCount) / (1.0 * totalRowsToBeScanned);
 #if ROW_EST_DEBUG
         cout << "overall factor-" << factor << endl;
 #endif
 
-        for (uint32_t i = 0; i < idx; i++)
+        for (int32_t i = 0; i < idx; i++)
         {
             if (scanFlags[i])
             {
@@ -611,4 +612,3 @@ uint64_t RowEstimator::estimateRowsForNonCPColumn(ColumnCommandJL& colCmd)
 }
 
 } //namespace joblist
-

--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -29,8 +29,6 @@
 /**
  * @file
  */
-#include "config.h"
-
 
 #include <unistd.h>
 #include <iterator>
@@ -214,11 +212,6 @@ typedef struct _thread_data_t
 
 int main(int argc, char* argv[])
 {
-// print a warning if this is a developer build
-#ifdef SKIP_OAM_INIT
-    cout << "SKIP_OAM_INIT is set" << endl;
-    sleep(2);
-#endif
     Oam oam;
     string parentOAMModuleHostName;
     ChildModuleList childmodulelist;

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -159,7 +159,7 @@ int8_t setupCwd(Config* cf)
 
     if (rc < 0 || access(".", W_OK) != 0)
         rc = chdir("/tmp");
-    
+
     return rc;
 }
 

--- a/utils/common/poolallocator.cpp
+++ b/utils/common/poolallocator.cpp
@@ -65,32 +65,18 @@ void PoolAllocator::newBlock()
         nextAlloc = mem.front().get();
 }
 
-void* PoolAllocator::allocate(uint64_t size)
+void * PoolAllocator::allocOOB(uint64_t size)
 {
-    void* ret;
+    OOBMemInfo memInfo;
 
-    if (size > allocSize)
-    {
-        OOBMemInfo memInfo;
-
-        memUsage += size;
-        memInfo.mem.reset(new uint8_t[size]);
-        memInfo.size = size;
-        ret = (void*) memInfo.mem.get();
-        oob[ret] = memInfo;
-        return ret;
-    }
-
-    if (size > capacityRemaining)
-        newBlock();
-
-    ret = (void*) nextAlloc;
-    nextAlloc += size;
-    capacityRemaining -= size;
     memUsage += size;
+    memInfo.mem.reset(new uint8_t[size]);
+    memInfo.size = size;
+    void *ret = (void*) memInfo.mem.get();
+    oob[ret] = memInfo;
     return ret;
 }
-
+        
 void PoolAllocator::deallocate(void* p)
 {
     OutOfBandMap::iterator it = oob.find(p);

--- a/utils/common/poolallocator.h
+++ b/utils/common/poolallocator.h
@@ -31,7 +31,7 @@
 #include <vector>
 #include <map>
 #include <boost/shared_array.hpp>
-#include <boost/atomic.hpp>
+#include <atomic>
 
 namespace utils
 {
@@ -90,7 +90,7 @@ private:
     uint64_t memUsage;
     uint8_t* nextAlloc;
     bool useLock;
-    boost::atomic<bool> lock;
+    std::atomic<bool> lock;
 
     struct OOBMemInfo
     {
@@ -107,14 +107,14 @@ inline void* PoolAllocator::allocate(uint64_t size)
     bool _false = false;
 
     if (useLock)
-        while (!lock.compare_exchange_weak(_false, true, boost::memory_order_acquire))
+        while (!lock.compare_exchange_weak(_false, true, std::memory_order_acquire))
             _false = false;
 
     if (size > allocSize)
     {
         ret = allocOOB(size);
         if (useLock)
-            lock.store(false, boost::memory_order_release);
+            lock.store(false, std::memory_order_release);
         return ret;
     }
 
@@ -126,7 +126,7 @@ inline void* PoolAllocator::allocate(uint64_t size)
     capacityRemaining -= size;
     memUsage += size;
     if (useLock)
-        lock.store(false, boost::memory_order_release);
+        lock.store(false, std::memory_order_release);
     return ret;
 }
 

--- a/utils/common/simpleallocator.h
+++ b/utils/common/simpleallocator.h
@@ -117,20 +117,20 @@ public:
 
     ~SimpleAllocator() throw() { }
 
-    pointer address(reference x) const
+    inline pointer address(reference x) const
     {
         return &x;
     }
-    const_pointer address(const_reference x) const
+    inline const_pointer address(const_reference x) const
     {
         return &x;
     }
 
-    pointer allocate(size_type n, const void* = 0)
+    inline pointer allocate(size_type n, const void* = 0)
     {
         return static_cast<pointer>(fPool->allocate(n * sizeof(T)));
     }
-    void deallocate(pointer p, size_type n)
+    inline void deallocate(pointer p, size_type n)
     {
         fPool->deallocate(p, n * sizeof(T));
     }
@@ -142,21 +142,21 @@ public:
         return std::numeric_limits<size_type>::max();
     }
 #else
-    size_type max_size() const throw()
+    inline size_type max_size() const throw()
     {
         return fPool->max_size() / sizeof(T);
     }
 #endif
-    void construct(pointer ptr, const T& val)
+    inline void construct(pointer ptr, const T& val)
     {
         new ((void*)ptr) T(val);
     }
-    void destroy(pointer ptr)
+    inline void destroy(pointer ptr)
     {
         ptr->T::~T();
     }
 
-    void setPool(SimplePool* pool)
+    inline void setPool(SimplePool* pool)
     {
         fPool = pool;
     }

--- a/utils/common/stlpoolallocator.h
+++ b/utils/common/stlpoolallocator.h
@@ -83,7 +83,7 @@ public:
     void construct(pointer p, const T& val);
     void destroy(pointer p);
 
-    static const uint32_t DEFAULT_SIZE = 4096 * sizeof(T);
+    static const uint32_t DEFAULT_SIZE = 32768 * sizeof(T);
 
     boost::shared_ptr<utils::PoolAllocator> pa;
 };

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -48,21 +48,21 @@ TupleJoiner::TupleJoiner(
 {
     if (smallRG.getColTypes()[smallJoinColumn] == CalpontSystemCatalog::LONGDOUBLE)
     {
-        STLPoolAllocator<pair<const long double, Row::Pointer> > alloc(64 * 1024 * 1024 + 1);
+        STLPoolAllocator<pair<const long double, Row::Pointer> > alloc;
         _pool = alloc.getPoolAllocator();
 
         ld.reset(new ldhash_t(10, hasher(), ldhash_t::key_equal(), alloc));
     }
     else if (smallRG.usesStringTable())
     {
-        STLPoolAllocator<pair<const int64_t, Row::Pointer> > alloc(64 * 1024 * 1024 + 1);
+        STLPoolAllocator<pair<const int64_t, Row::Pointer> > alloc;
         _pool = alloc.getPoolAllocator();
 
         sth.reset(new sthash_t(10, hasher(), sthash_t::key_equal(), alloc));
     }
     else
     {
-        STLPoolAllocator<pair<const int64_t, uint8_t*> > alloc(64 * 1024 * 1024 + 1);
+        STLPoolAllocator<pair<const int64_t, uint8_t*> > alloc;
         _pool = alloc.getPoolAllocator();
 
         h.reset(new hash_t(10, hasher(), hash_t::key_equal(), alloc));
@@ -112,7 +112,7 @@ TupleJoiner::TupleJoiner(
     smallKeyColumns(smallJoinColumns), largeKeyColumns(largeJoinColumns),
     bSignedUnsignedJoin(false), uniqueLimit(100), finished(false)
 {
-    STLPoolAllocator<pair<const TypelessData, Row::Pointer> > alloc(64 * 1024 * 1024 + 1);
+    STLPoolAllocator<pair<const TypelessData, Row::Pointer> > alloc;
     _pool = alloc.getPoolAllocator();
 
     ht.reset(new typelesshash_t(10, hasher(), typelesshash_t::key_equal(), alloc));
@@ -1352,7 +1352,7 @@ void TupleJoiner::setTableName(const string& tname)
 
 void TupleJoiner::clearData()
 {
-    STLPoolAllocator<pair<const TypelessData, Row::Pointer> > alloc(64 * 1024 * 1024 + 1);
+    STLPoolAllocator<pair<const TypelessData, Row::Pointer> > alloc;
     _pool = alloc.getPoolAllocator();
 
     if (typelessJoin)

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -359,7 +359,7 @@ public:
     template<int len> void setUintField_offset(uint64_t val, uint32_t offset);
     inline void nextRow(uint32_t size);
     inline void prevRow(uint32_t size, uint64_t number);
-    
+
     inline void setUintField(uint64_t val, uint32_t colIndex);
     template<int len> void setIntField(int64_t, uint32_t colIndex);
     inline void setIntField(int64_t, uint32_t colIndex);
@@ -1803,7 +1803,8 @@ inline std::string StringStore::getString(uint64_t off) const
 
     if (off & 0x8000000000000000)
     {
-        off = off - 0x8000000000000000;
+        //off = off - 0x8000000000000000;
+        off &= ~0x8000000000000000;
 
         if (longStrings.size() <= off)
             return joblist::CPNULLSTRMARK;
@@ -1842,7 +1843,8 @@ inline const uint8_t* StringStore::getPointer(uint64_t off) const
 
     if (off & 0x8000000000000000)
     {
-        off = off - 0x8000000000000000;
+        //off = off - 0x8000000000000000;
+        off &= ~0x8000000000000000;
 
         if (longStrings.size() <= off)
             return (const uint8_t*) joblist::CPNULLSTRMARK.c_str();
@@ -1910,10 +1912,10 @@ inline bool StringStore::equals(const std::string& str, uint64_t off) const
 
     if (off & 0x8000000000000000)
     {
-        if (longStrings.size() <= (off - 0x8000000000000000))
+        if (longStrings.size() <= (off & ~0x8000000000000000))
             return false;
 
-        mc = (MemChunk*) longStrings[off - 0x8000000000000000].get();
+        mc = (MemChunk*) longStrings[off & ~0x8000000000000000].get();
 
         memcpy(&length, mc->data, 4);
 
@@ -1948,7 +1950,8 @@ inline uint32_t StringStore::getStringLength(uint64_t off)
 
     if (off & 0x8000000000000000)
     {
-        off = off - 0x8000000000000000;
+        //off = off - 0x8000000000000000;
+        off &= ~0x8000000000000000;
 
         if (longStrings.size() <= off)
             return 0;
@@ -2015,4 +2018,3 @@ inline void RGData::getRow(uint32_t num, Row* row)
 
 #endif
 // vim:ts=4 sw=4:
-


### PR DESCRIPTION
I noticed a few diffs vs baseline in the working_tpch1_compareLogOnly/windowFunctions tests, but has nothing to do with the join code.

This was written initially as a proof of concept.  I've improved it since.  Feel free to reject if there is something that needs further cleaning.  :D  Huh.  Github has emojis?  :dancer: 

Squashed commit of the following:

commit fe4cc375faf1588e30471062f78403e81229cd02
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Fri Nov 1 13:38:11 2019 -0400

    Added some code comments to the new join code.

commit a7a82d093be4db3dfb44d33e4f514fd104b25f71
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Fri Nov 1 13:17:47 2019 -0400

    Fixed an error down a path I think is unused.

commit 4e6c7c266a9aefd54c384ae2b466645770c81a5d
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Fri Nov 1 13:12:12 2019 -0400

    std::atomic doesn't exist in C7, -> boost::atomic.

commit ed0996c3f4548fff0e19d43852d429ada1a72510
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Wed Oct 16 12:47:32 2019 -0500

    Addition to the previous fix (join dependency projection).

commit 97bb806be9211e4688893460437f539c46f3796f
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Tue Oct 15 15:22:09 2019 -0500

    Found and fixed a bad mem access, which may have been there for 8 years.

commit d8b0432d2abd70f28de5276daad758c494e4b04b
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Tue Oct 15 14:04:48 2019 -0500

    Minor optimization in some code I happened to look at.

commit b6ec8204bf71670c7a8882464289e700aa5f7e33
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Tue Oct 15 14:04:11 2019 -0500

    Fixed a compiler warning.

commit 0bf3e5218f71d92460ddc88090e3af77ecf28c35
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Tue Oct 15 10:11:09 2019 -0500

    Undid part of the previous commit.

commit 5dfa1d23980e245c77c1644015b553aa4bcdf908
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Mon Oct 14 18:00:21 2019 -0500

    Proofread the diff vs base, added some comments, removed some debugging stuff.

commit 411fd955ebbae97ddab210a7b17fe5708538001d
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Fri Oct 11 13:55:39 2019 -0500

    If a dev build (SKIP_OAM_INIT), made postConfigure exit before trying
    to start the system, because that won't work.

commit 634b1b8a7340b55fcaee045fd6d00b3e3a9269fa
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Mon Sep 30 14:55:45 2019 -0500

    Reduced crit section of BPP::addToJoiner a little.

commit 31f30c64dd95942f2c7a247cc81feaa5933c1a07
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Wed Sep 18 11:09:27 2019 -0500

    Checkpointing.  make the add joiner stuff free tmp mem quickly.

commit 9b7e788690546af7ddc4c921a0ab441ee9a8df02
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Wed Sep 18 10:38:57 2019 -0500

    Checkpoint.  Removed tmp hardcoding of bucket count.

commit fda4d8b7fb30d0431dc15e473042abb3d8121b19
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Wed Sep 18 10:20:09 2019 -0500

    Checkpoint.  Adjusted unproductive loop wait time.

commit 7b9a67df7d192f240e9e558e6e66c7aa9f1e8687
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Wed Sep 18 10:10:43 2019 -0500

    Checkpointing add'l optimizations.

    If we promote bpp::processorThreads / bucket count to a power of 2, we can
    use a bitmask instead of a mod operation to decide a bucket.

    Also, boosted utilization by not waiting for a bucket lock to become free.
    There are likely more gains to be had there with a smarter strategy.
    Maybe have each thread generate a random bucket access pattern to reduce
    chance of collision.  TBD.

commit abe7dab8661b5120f6ee268abc005dd66cd643e2
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Tue Sep 17 16:15:51 2019 -0500

    Multithreaded PM hash table construction likely works here.

    A couple more fixes.
     - missed a mod after a hash in one place.
     - Made the PoolAllocator thread safe (small degree of performance hit
       there in threaded env).  May need to circle back to the table
       construction code to eliminate contention for the allocators instead.

commit ab308762fbd873dbf246a6d1574223087cd0d5f6
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Tue Sep 17 12:14:14 2019 -0500

    Checkpointing.  Did some initial testing, fixed a couple things.

    Not done testing yet.

commit 3b161d74fa859edb8b5ba84bb905e586ac0586e6
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Tue Sep 17 11:24:55 2019 -0500

    Checkpointing.  First cut of multithreaded PM join table building.

    Builds but is untested.

commit cb7e6e1c2761fc6c33b3b1c6b6cda488d7792bca
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Mon Sep 16 13:03:50 2019 -0500

    Increase the STLPoolAllocator window size to reduce destruction time.

commit b0ddaaae71a0a4959ad15c87579d85ed88e17e1f
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Fri Sep 13 11:52:51 2019 -0500

    Fixed a bug preventing parallel table loading.  works now.

commit b87039604e312c1ddb88cdb226228b1c3addf018
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Thu Sep 12 22:04:15 2019 -0500

    Checkpointing some experimental changes.

     - Made the allocator type used by PM joins the STLPoolAllocator
     - Changed the default chunk size used by STLPoolAlloc based on a few test
        runs
     - Made BPP-JL interleave the PM join data by join # to take advantage
        of new locking env on PM.
     - While I was at it, fixed MCOL-1758.

commit fd4b09cc383d2b96959a8e5ca490c940bacb3d37
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Thu Sep 12 16:03:30 2019 -0500

    Speculative change.  Row estimator was stopping at 20 extents.

    Removed that limitation.

commit 7dcdd5b5455f9ac06121dd3cf1ba722150f3ee56
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Thu Sep 5 09:10:28 2019 -0500

    Inlined some hot simpleallocator fcns.

commit 6d84daceecc5499f6286cf3468c118b8b1d28d8f
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Wed Sep 4 17:02:29 2019 -0500

    Some optimizations to PM hash table creation.

    - made locks more granular.
    - reduced logic per iteration when adding elements.

commit b20bf54ed97c5a0a88d414a4dd844a0afc2e27f3
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Wed Sep 4 15:32:32 2019 -0500

    Reduced granularity of djLock in PrimProc.

commit 6273a8f3c4c62b87ef91c77a829033426e38e4d4
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Wed Sep 4 14:45:58 2019 -0500

    Added a timer to PM hash table construction

    signal USR1 will print cumulative wall time to stdout & reset the timer.