### PR TITLE
Don't use calpontsys as default db before creation

### DIFF
--- a/oam/install_scripts/post-mysql-install
+++ b/oam/install_scripts/post-mysql-install
@@ -25,7 +25,7 @@ checkForError() {
         mysql \
                 --user=root \
                 --execute='show engines;' \
-                calpontsys | grep -i columnstore
+                | grep -i columnstore
 
         #
         # Add compressiontype column to SYSCOLUMN if applicable


### PR DESCRIPTION
We don't need to use calpontsys as the default DB for SHOW ENGINES, it
likely isn't created yet so don't do it.