### PR TITLE
MCOL-3448 Corrected datatype in predicate for RowItem

### DIFF
--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -1369,7 +1369,7 @@ bool buildRowColumnFilter(gp_walk_info* gwip, RowColumn* rhs, RowColumn* lhs, It
                 if (!cc)
                     break;
 
-                sop->setOpType(sc->resultType(), valVec[j]->resultType());
+                sop->setOpType(sc->resultType(), valVec[j]->columnVec()[i]->resultType());
                 cf->pushFilter(new SimpleFilter(sop, sc->clone(),
                                                 valVec[j]->columnVec()[i]->clone()));
             }


### PR DESCRIPTION
RowItem compares, such as (c1,c2) IN ((v11, v21), (v12, v22)) gave bad answers due to a typo getting the wrong datatype.