### PR TITLE
MCOL-3605 Blocks are not being completely filled in dictionaries

### DIFF
--- a/writeengine/dictionary/we_dctnry.cpp
+++ b/writeengine/dictionary/we_dctnry.cpp
@@ -663,9 +663,9 @@ int Dctnry::insertDctnry2(Signature& sig)
 
     while (sig.size > 0)
     {
-        if (sig.size > (m_freeSpace - m_totalHdrBytes))
+        if (sig.size > (m_freeSpace - HDR_UNIT_SIZE))
         {
-            write_size = (m_freeSpace - m_totalHdrBytes);
+            write_size = (m_freeSpace - HDR_UNIT_SIZE);
         }
         else
         {
@@ -887,8 +887,8 @@ int Dctnry::insertDctnry(const char* buf,
         //...String not found in cache, so proceed.
         //   If room is available in current block then insert into block.
         // @bug 3960: Add MAX_OP_COUNT check to handle case after bulk rollback
-        if ( ((totalUseSize <= m_freeSpace) ||
-                ((curSig.size > 8176) && (m_freeSpace > m_totalHdrBytes))) &&
+        if ( ((totalUseSize <= m_freeSpace - HDR_UNIT_SIZE) ||
+                ((curSig.size > 8176) && (m_freeSpace > HDR_UNIT_SIZE))) &&
                 (m_curOp      < (MAX_OP_COUNT - 1)) )
         {
             RETURN_ON_ERROR(insertDctnry2(curSig)); //m_freeSpace updated!
@@ -1111,14 +1111,14 @@ int Dctnry::insertDctnry(const int& sgnature_size,
     for (i = m_lastFbo; i < m_numBlocks; i++)
     {
         // @bug 3960: Add MAX_OP_COUNT check to handle case after bulk rollback
-        if ( ((m_freeSpace >= size) ||
-                ((size > 8176) && (m_freeSpace > m_totalHdrBytes))) &&
+        if ( ((m_freeSpace - HDR_UNIT_SIZE >= size) ||
+                ((size > 8176) && (m_freeSpace > HDR_UNIT_SIZE))) &&
                 (m_curOp    <  (MAX_OP_COUNT - 1)) )
         {
             // found the perfect block; signature size fit in this block
-            if (size > (m_freeSpace - m_totalHdrBytes))
+            if (size > (m_freeSpace - HDR_UNIT_SIZE))
             {
-                write_size = (m_freeSpace - m_totalHdrBytes);
+                write_size = (m_freeSpace - HDR_UNIT_SIZE);
             }
             else
             {


### PR DESCRIPTION
m_totalHdrBytes is already subtracted from m_freeSpace upon initialization, so subtracting m_totalHdrBytes when comparing if signature size fits in a block is counting the header twice and allowing blocks to possibly have up to 12 free bytes when filling accross multiple blocks. We instead should only be checking to make sure the 2 byte offset fits.