### PR TITLE
MCOL-3613 Fix params in columnstore_installer

### DIFF
--- a/oamapps/postConfigure/installer.cpp
+++ b/oamapps/postConfigure/installer.cpp
@@ -129,14 +129,12 @@ int main(int argc, char* argv[])
 
     string numBlocksPctParam = "";
     string totalUmMemoryParam = "";
-    if (argc >= 12) {
-        if (argc >= 14) {
-            if (string(argv[12]) != "-") {
-                numBlocksPctParam = argv[13];
-            }
-            if (string(argv[13]) != "-") {
-                totalUmMemoryParam = argv[14];
-            }
+    if (argc >= 14) {
+        if (string(argv[12]) != "-") {
+            numBlocksPctParam = argv[12];
+        }
+        if (string(argv[13]) != "-") {
+            totalUmMemoryParam = argv[13];
         }
     }
 


### PR DESCRIPTION
Typo in arg count meant that -numBlocksPct and -totalUmMemory were not
processed correctly. Fixed the arg handling.