### PR TITLE
Fix RPM building

### DIFF
--- a/cmake/cpackEngineRPM.cmake
+++ b/cmake/cpackEngineRPM.cmake
@@ -119,6 +119,8 @@ SET(ignored
     "%ignore /usr/lib64/mysql"
     "%ignore /usr/lib64/mysql/plugin"
     "%ignore /etc/my.cnf.d"
+    "%ignore /var/lib"
+    "%ignore /var"
 )
 
 #SET(CPACK_RPM_SPEC_MORE_DEFINE "


### PR DESCRIPTION
Changing the module file path cause RPMs to not install due to trying to
create /var/lib and /var