### PR TITLE
MCOL-2072 QueryStats creates a mysql_use_result() warning

### DIFF
--- a/utils/libmysql_client/libmysql_client.cpp
+++ b/utils/libmysql_client/libmysql_client.cpp
@@ -96,7 +96,7 @@ int LibMySQL::init(const char* h, unsigned int p, const char* u, const char* w, 
 }
 
 
-int LibMySQL::run(const char* query)
+int LibMySQL::run(const char* query, bool resultExpected)
 {
     int ret = 0;
 
@@ -109,7 +109,7 @@ int LibMySQL::run(const char* query)
 
     fRes = mysql_use_result(fCon);
 
-    if (fRes == NULL)
+    if (fRes == NULL && resultExpected)
     {
         fErrStr = "fatal error running mysql_use_result() or empty result set in libmysql_client lib";
         ret = -1;

--- a/utils/libmysql_client/libmysql_client.h
+++ b/utils/libmysql_client/libmysql_client.h
@@ -36,7 +36,7 @@ public:
     int init(const char*, unsigned int, const char*, const char*, const char*);
 
     // run the query
-    int run(const char* q);
+    int run(const char* q, bool resultExpected = true);
 
     void handleMySqlError(const char*, int);
 

--- a/utils/querystats/querystats.cpp
+++ b/utils/querystats/querystats.cpp
@@ -228,7 +228,7 @@ void QueryStats::insert()
     insert << fNumFiles << ", ";
     insert << fFileBytes << ")"; // the last 2 fields are not populated yet
 
-    ret = mysql.run(insert.str().c_str());
+    ret = mysql.run(insert.str().c_str(), false);
 
     if (ret != 0)
         mysql.handleMySqlError(mysql.getError().c_str(), ret);


### PR DESCRIPTION
Added a flag to LibMysql::run to be used to suppress warning when no result is expected. The flag is a default parameter called resultExpected which is set to true by default but is set to false when called from querystats.