### PR TITLE
MCOL-3585 update some defaults in config file

### DIFF
--- a/dbcon/joblist/resourcemanager.h
+++ b/dbcon/joblist/resourcemanager.h
@@ -261,7 +261,8 @@ public:
     }
     uint32_t  	getJlMaxOutstandingRequests() const
     {
-        return  getUintVal(fJobListStr, "MaxOutstandingRequests", defaultMaxOutstandingRequests);
+        return  fJlMaxOutstandingRequests;
+        //getUintVal(fJobListStr, "MaxOutstandingRequests", defaultMaxOutstandingRequests);
     }
     uint32_t  	getJlJoinerChunkSize() const
     {
@@ -577,6 +578,7 @@ private:
     uint32_t fJlProcessorThreadsPerScan;
     uint32_t fJlNumScanReceiveThreads;
     uint8_t fTwNumThreads;
+    uint32_t fJlMaxOutstandingRequests;
 
     /* old HJ support */
     ResourceDistributor	fHJUmMaxMemorySmallSideDistributor;

--- a/oam/etc/Columnstore.xml
+++ b/oam/etc/Columnstore.xml
@@ -486,8 +486,8 @@
 	<HashJoin>
 		<MaxBuckets>128</MaxBuckets>
 		<MaxElems>128K</MaxElems>  <!-- 128 buckets * 128K * 16 = 256 MB -->
-		<FifoSizeLargeSide>128</FifoSizeLargeSide>
-		<PmMaxMemorySmallSide>64M</PmMaxMemorySmallSide><!-- divide by 48 to getapproximate row count -->
+		<FifoSizeLargeSide>64</FifoSizeLargeSide>
+		<PmMaxMemorySmallSide>1G</PmMaxMemorySmallSide><!-- divide by 48 to getapproximate row count -->
 		<TotalUmMemory>50%</TotalUmMemory>
 		<TotalPmUmMemory>10%</TotalPmUmMemory>
 		<CPUniqueLimit>100</CPUniqueLimit>
@@ -500,7 +500,7 @@
 	</HashJoin>
 	<JobList>
 		<FlushInterval>16K</FlushInterval>
-		<FifoSize>32</FifoSize>
+		<FifoSize>16</FifoSize>
 		<RequestSize>1</RequestSize>  <!-- Number of extents per request, should be 
 			  less than MaxOutstandingRequests. Otherwise, default value 1 is used. -->
 		<!--  ProcessorThreadsPerScan is the number of jobs issued to process
@@ -510,7 +510,7 @@
 			  ProcessorThreadsPerScan * MaxOutstandingRequests should be at least
 			  as many threads are available across all PMs.  -->
 		<!-- <ProcessorThreadsPerScan>16</ProcessorThreadsPerScan> --> 
-		<MaxOutstandingRequests>20</MaxOutstandingRequests> 
+		<!-- <MaxOutstandingRequests>20</MaxOutstandingRequests>  -->
 		<ThreadPoolSize>100</ThreadPoolSize>
 	</JobList>
 	<TupleWSDL>

--- a/oam/etc/Columnstore.xml.singleserver
+++ b/oam/etc/Columnstore.xml.singleserver
@@ -477,8 +477,8 @@
 	<HashJoin>
 		<MaxBuckets>128</MaxBuckets>
 		<MaxElems>128K</MaxElems>  <!-- 128 buckets * 128K * 16 = 256 MB -->
-		<FifoSizeLargeSide>128</FifoSizeLargeSide>
-		<PmMaxMemorySmallSide>64M</PmMaxMemorySmallSide><!-- divide by 48 to get element count -->
+		<FifoSizeLargeSide>64</FifoSizeLargeSide>
+		<PmMaxMemorySmallSide>1G</PmMaxMemorySmallSide><!-- divide by 48 to get element count -->
 		<TotalUmMemory>25%</TotalUmMemory>
 		<TotalPmUmMemory>10%</TotalPmUmMemory>
 		<CPUniqueLimit>100</CPUniqueLimit>
@@ -491,7 +491,7 @@
 	</HashJoin>
 	<JobList>
 		<FlushInterval>16K</FlushInterval>
-		<FifoSize>32</FifoSize>
+		<FifoSize>16</FifoSize>
 		<RequestSize>1</RequestSize>  <!-- Number of extents per request, should be
 			  less than MaxOutstandingRequests. Otherwise, default value 1 is used. -->
 		<!--  ProcessorThreadsPerScan is the number of jobs issued to process
@@ -501,7 +501,7 @@
 			  ProcessorThreadsPerScan * MaxOutstandingRequests should be at least
 			  as many threads are available across all PMs.  -->
 		<!-- <ProcessorThreadsPerScan>16</ProcessorThreadsPerScan> -->
-		<MaxOutstandingRequests>20</MaxOutstandingRequests>
+		<!-- <MaxOutstandingRequests>20</MaxOutstandingRequests> -->
 		<ThreadPoolSize>100</ThreadPoolSize>
 	</JobList>
 	<TupleWSDL>

--- a/tools/configMgt/autoConfigure.cpp
+++ b/tools/configMgt/autoConfigure.cpp
@@ -2122,7 +2122,6 @@ int main(int argc, char* argv[])
     {
         ColScanReadAheadBlocks = sysConfigOld->getConfig("PrimitiveServers", "ColScanReadAheadBlocks");
         PrefetchThreshold = sysConfigOld->getConfig("PrimitiveServers", "PrefetchThreshold");
-        MaxOutstandingRequests = sysConfigOld->getConfig("JobList", "MaxOutstandingRequests");
         PmMaxMemorySmallSide = sysConfigOld->getConfig("HashJoin", "PmMaxMemorySmallSide");
         ThreadPoolSize = sysConfigOld->getConfig("JobList", "ThreadPoolSize");
     }
@@ -2133,7 +2132,6 @@ int main(int argc, char* argv[])
     {
         sysConfigNew->setConfig("PrimitiveServers", "ColScanReadAheadBlocks", ColScanReadAheadBlocks);
         sysConfigNew->setConfig("PrimitiveServers", "PrefetchThreshold", PrefetchThreshold);
-        sysConfigNew->setConfig("JobList", "MaxOutstandingRequests", MaxOutstandingRequests);
         sysConfigNew->setConfig("HashJoin", "PmMaxMemorySmallSide", PmMaxMemorySmallSide);
         sysConfigNew->setConfig("JobList", "ThreadPoolSize", ThreadPoolSize);
     }


### PR DESCRIPTION
Updated PmMaxMemorySmall, FifoSizeLargeSize, and FifoSize settings from Columnstore.xml and Columnstore.xml.singleserver.

Decreasing FifoSize and FifoSizeLargeSide did not cause any performance hit. I ran regression suite test001 to confirm this w/ and w/o new settings.

RowAggrThreads and RowAggrBuckets are already being automated. I just updated what the values were being set to inside resourcemanager.cpp Now automating MaxOutstandingRequests as well.

