### PR TITLE
MCOL-3621 Fix a few cppcheck issues

### DIFF
--- a/dbcon/execplan/calpontsystemcatalog.h
+++ b/dbcon/execplan/calpontsystemcatalog.h
@@ -430,9 +430,9 @@ public:
     struct TableAliasName
     {
         TableAliasName (): fisColumnStore (true) {}
-        TableAliasName (std::string sch, std::string tb, std::string al) :
+        TableAliasName (const std::string &sch, const std::string &tb, const std::string &al) :
             schema (sch), table (tb), alias (al), fisColumnStore(true) {}
-        TableAliasName (std::string sch, std::string tb, std::string al, std::string v) :
+        TableAliasName (const std::string &sch, const std::string &tb, const std::string &al, const std::string &v) :
             schema (sch), table (tb), alias (al), view(v), fisColumnStore(true) {}
         std::string schema;
         std::string table;

--- a/dbcon/joblist/pdictionaryscan.cpp
+++ b/dbcon/joblist/pdictionaryscan.cpp
@@ -310,11 +310,8 @@ void pDictionaryScan::addFilter(int8_t COP, const string& value)
     }
     else
     {
-        uint8_t* s = (uint8_t*)alloca(value.size() * sizeof(uint8_t));
-
-        memcpy(s, value.data(), value.size());
         fFilterString << (uint16_t) value.size();
-        fFilterString.append(s, value.size());
+        fFilterString.append((const uint8_t*)value.data(), value.size());
     }
 }
 

--- a/primitives/linux-port/dictionary.cpp
+++ b/primitives/linux-port/dictionary.cpp
@@ -682,7 +682,7 @@ inline bool PrimitiveProcessor::isEscapedChar(char c)
 int PrimitiveProcessor::convertToRegexp(idb_regex_t* regex, const p_DataValue* str)
 {
     //In the worst case, every char is quadrupled, plus some leading/trailing cruft...
-    char* cBuf = (char*)alloca(((4 * str->len) + 3) * sizeof(char));
+    char* cBuf = new char[(4 * str->len) + 3];
     char c;
     int i, cBufIdx = 0;
     // translate to regexp symbols
@@ -763,6 +763,7 @@ int PrimitiveProcessor::convertToRegexp(idb_regex_t* regex, const p_DataValue* s
     regex->regex = cBuf;
 #endif
     regex->used = true;
+    delete [] cBuf;
     return 0;
 }
 

--- a/storage-manager/src/SMLogging.cpp
+++ b/storage-manager/src/SMLogging.cpp
@@ -65,6 +65,7 @@ void SMLogging::log(int priority,const char *format, ...)
     va_copy(args2, args);
     vfprintf(stderr, format, args2);
     fprintf(stderr, "\n");
+    va_end(args2);
     #endif
     vsyslog(priority, format, args);
 

--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -2011,7 +2011,7 @@ int64_t DataConvert::convertColumnTimestamp(
     unsigned int dataOrgLen,
     const std::string& timeZone )
 {
-
+    char tmbuf[64];
     std::string dataOrgTemp = dataOrg;
     if (dataOrgTemp.substr(0, 19) == "0000-00-00 00:00:00")
     {
@@ -2023,7 +2023,6 @@ int64_t DataConvert::convertColumnTimestamp(
     if (strcmp(dataOrg, "current_timestamp() ON UPDATE current_timestamp()") == 0)
     {
         struct timeval tv;
-        char tmbuf[64];
         gettimeofday(&tv, 0);
         MySQLTime time;
         gmtSecToMySQLTime(tv.tv_sec, time, timeZone);

--- a/utils/dataconvert/dataconvert.h
+++ b/utils/dataconvert/dataconvert.h
@@ -268,7 +268,7 @@ bool isDateValid ( int day, int month, int year)
 {
     bool valid = true;
 
-    if ( year == 0 && month == 0 && year == 0 )
+    if ( day == 0 && month == 0 && year == 0 )
     {
         return true;
     }
@@ -1319,7 +1319,7 @@ inline void DataConvert::trimWhitespace(int64_t& charData)
 inline std::string DataConvert::constructRegexp(const std::string& str)
 {
     //In the worst case, every char is quadrupled, plus some leading/trailing cruft...
-    char* cBuf = (char*)alloca(((4 * str.length()) + 3) * sizeof(char));
+    char* cBuf = new char[(4 * str.length()) + 3];
     char c;
     uint32_t i, cBufIdx = 0;
     // translate to regexp symbols
@@ -1392,7 +1392,9 @@ inline std::string DataConvert::constructRegexp(const std::string& str)
 #ifdef VERBOSE
     cerr << "regexified string is " << cBuf << endl;
 #endif
-    return cBuf;
+    std::string ret(cBuf);
+    delete [] cBuf;
+    return ret;
 }
 
 } // namespace dataconvert

--- a/utils/funcexp/func_char_length.cpp
+++ b/utils/funcexp/func_char_length.cpp
@@ -83,9 +83,9 @@ int64_t Func_char_length::getIntVal(rowgroup::Row& row,
                 return 0;
 
             size_t strwclen = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
-            wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+            wchar_t* wcbuf = new wchar_t[strwclen];
             strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen);
-
+            delete [] wcbuf;
             return (int64_t)strwclen;
         }
 

--- a/utils/funcexp/func_concat_ws.cpp
+++ b/utils/funcexp/func_concat_ws.cpp
@@ -57,7 +57,7 @@ string Func_concat_ws::getStrVal(Row& row,
 #ifdef STRCOLL_ENH__
     wstring wstr;
     size_t strwclen = utf8::idb_mbstowcs(0, delim.c_str(), 0) + 1;
-    wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+    wchar_t* wcbuf = new wchar_t[strwclen];
     strwclen = utf8::idb_mbstowcs(wcbuf, delim.c_str(), strwclen);
     wstring wdelim(wcbuf, strwclen);
 
@@ -75,14 +75,15 @@ string Func_concat_ws::getStrVal(Row& row,
             wstr += wdelim;
 
         size_t strwclen1 = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
-        wchar_t* wcbuf1 = (wchar_t*)alloca(strwclen1 * sizeof(wchar_t));
+        wchar_t* wcbuf1 = new wchar_t[strwclen1];
         strwclen1 = utf8::idb_mbstowcs(wcbuf1, tstr.c_str(), strwclen1);
         wstring str1(wcbuf1, strwclen1);
         wstr += str1;
+        delete [] wcbuf1;
     }
 
     size_t strmblen = utf8::idb_wcstombs(0, wstr.c_str(), 0) + 1;
-    char* outbuf = (char*)alloca(strmblen * sizeof(char));
+    char* outbuf = new char[strmblen];
     strmblen = utf8::idb_wcstombs(outbuf, wstr.c_str(), strmblen);
 
     if (strmblen == 0)
@@ -90,7 +91,10 @@ string Func_concat_ws::getStrVal(Row& row,
     else
         isNull = false;
 
-    return string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+    delete [] outbuf;
+    delete [] wcbuf;
+    return ret;
 
 #else
     string str;

--- a/utils/funcexp/func_lcase.cpp
+++ b/utils/funcexp/func_lcase.cpp
@@ -68,7 +68,7 @@ std::string Func_lcase::getStrVal(rowgroup::Row& row,
         return "";
 
     size_t strwclen = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
-    wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+    wchar_t* wcbuf = new wchar_t[strwclen];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen);
     wstring wstr(wcbuf, strwclen);
 
@@ -76,9 +76,12 @@ std::string Func_lcase::getStrVal(rowgroup::Row& row,
         wstr[i] = std::towlower(wstr[i]);
 
     size_t strmblen = utf8::idb_wcstombs(0, wstr.c_str(), 0) + 1;
-    char* outbuf = (char*)alloca(strmblen * sizeof(char));
+    char* outbuf = new char[strmblen];
     strmblen = utf8::idb_wcstombs(outbuf, wstr.c_str(), strmblen);
-    return string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+    delete [] outbuf;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_left.cpp
+++ b/utils/funcexp/func_left.cpp
@@ -56,7 +56,7 @@ std::string Func_left::getStrVal(rowgroup::Row& row,
         return "";
 
     size_t strwclen = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
-    wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+    wchar_t* wcbuf = new wchar_t[strwclen];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen);
     wstring str(wcbuf, strwclen);
 
@@ -70,9 +70,12 @@ std::string Func_left::getStrVal(rowgroup::Row& row,
 
     wstring out = str.substr(0, pos + 1);
     size_t strmblen = utf8::idb_wcstombs(0, out.c_str(), 0) + 1;
-    char* outbuf = (char*)alloca(strmblen * sizeof(char));
+    char* outbuf = new char[strmblen];
     strmblen = utf8::idb_wcstombs(outbuf, out.c_str(), strmblen);
-    return string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+    delete [] outbuf;
+    delete [] wcbuf;
+    return ret;
 
 //	return str.substr(0, pos+1);
 }

--- a/utils/funcexp/func_lpad.cpp
+++ b/utils/funcexp/func_lpad.cpp
@@ -155,10 +155,10 @@ std::string Func_lpad::getStrVal(rowgroup::Row& row,
     if (strwclen > len)
         alen = strwclen;
 
-    size_t bufsize = (alen + 1) * sizeof(wchar_t);
+    size_t bufsize = alen + 1;
 
     // Convert to wide characters. Do all further work in wide characters
-    wchar_t* wcbuf = (wchar_t*)alloca(bufsize);
+    wchar_t* wcbuf = new wchar_t[bufsize];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen + 1);
 
     size_t strSize = strwclen;    // The number of significant characters
@@ -190,8 +190,8 @@ std::string Func_lpad::getStrVal(rowgroup::Row& row,
 
     // Convert the pad string to wide
     padwclen = pad->length();  // A guess to start.
-    size_t padbufsize = (padwclen + 1) * sizeof(wchar_t);
-    wchar_t* wcpad = (wchar_t*)alloca(padbufsize);
+    size_t padbufsize = padwclen + 1;
+    wchar_t* wcpad = new wchar_t[padbufsize];
     // padwclen+1 is for giving count for the terminating null
     size_t padlen = utf8::idb_mbstowcs(wcpad, pad->c_str(), padwclen + 1);
 
@@ -234,7 +234,10 @@ std::string Func_lpad::getStrVal(rowgroup::Row& row,
 
     wstring padded = wstring(wcbuf, len);
     // Turn back to a string
-    return utf8::wstring_to_utf8(padded.c_str());
+    std::string ret(utf8::wstring_to_utf8(padded.c_str()));
+    delete [] wcpad;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_ltrim.cpp
+++ b/utils/funcexp/func_ltrim.cpp
@@ -74,10 +74,10 @@ std::string Func_ltrim::getStrVal(rowgroup::Row& row,
     // determine the size of buffer to allocate, we can be sure the wide
     // char string won't be longer than:
     strwclen = tstr.length(); // a guess to start with. This will be >= to the real count.
-    int bufsize = (strwclen + 1) * sizeof(wchar_t);
+    int bufsize = strwclen + 1;
 
     // Convert the string to wide characters. Do all further work in wide characters
-    wchar_t* wcbuf = (wchar_t*)alloca(bufsize);
+    wchar_t* wcbuf = new wchar_t[bufsize];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen + 1);
 
     // idb_mbstowcs can return -1 if there is bad mbs char in tstr
@@ -86,8 +86,8 @@ std::string Func_ltrim::getStrVal(rowgroup::Row& row,
 
     // Convert the trim string to wide
     trimwclen = trim.length();  // A guess to start.
-    int trimbufsize = (trimwclen + 1) * sizeof(wchar_t);
-    wchar_t* wctrim = (wchar_t*)alloca(trimbufsize);
+    int trimbufsize = trimwclen + 1;
+    wchar_t* wctrim = new wchar_t[trimbufsize];
     size_t trimlen = utf8::idb_mbstowcs(wctrim, trim.c_str(), trimwclen + 1);
 
     // idb_mbstowcs can return -1 if there is bad mbs char in tstr
@@ -123,7 +123,10 @@ std::string Func_ltrim::getStrVal(rowgroup::Row& row,
     size_t aLen = strwclen - (aPtr - oPtr);
     wstring trimmed = wstring(aPtr, aLen);
     // Turn back to a string
-    return utf8::wstring_to_utf8(trimmed.c_str());
+    std::string ret(utf8::wstring_to_utf8(trimmed.c_str()));
+    delete [] wctrim;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_repeat.cpp
+++ b/utils/funcexp/func_repeat.cpp
@@ -81,8 +81,7 @@ std::string Func_repeat::getStrVal(rowgroup::Row& row,
     int size = str.length() * count;
 
     //allocate memory
-    char* result = NULL;
-    result = (char*) alloca(size * sizeof(char) + 1);
+    char* result = new char[size + 1];
 
     if (result == NULL)
     {
@@ -97,7 +96,9 @@ std::string Func_repeat::getStrVal(rowgroup::Row& row,
             return "";
     }
 
-    return result;
+    std::string res(result);
+    delete [] result;
+    return res;
 }
 
 

--- a/utils/funcexp/func_right.cpp
+++ b/utils/funcexp/func_right.cpp
@@ -65,7 +65,7 @@ std::string Func_right::getStrVal(rowgroup::Row& row,
 
     size_t strwclen = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
     //wchar_t wcbuf[strwclen];
-    wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+    wchar_t* wcbuf = new wchar_t[strwclen];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen);
     wstring str(wcbuf, strwclen);
 
@@ -75,9 +75,12 @@ std::string Func_right::getStrVal(rowgroup::Row& row,
     wstring out = str.substr(strwclen - pos, strwclen);
     size_t strmblen = utf8::idb_wcstombs(0, out.c_str(), 0) + 1;
     //char outbuf[strmblen];
-    char* outbuf = (char*)alloca(strmblen * sizeof(char));
+    char* outbuf = new char[strmblen];
     strmblen = utf8::idb_wcstombs(outbuf, out.c_str(), strmblen);
-    return string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+    delete [] outbuf;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_rpad.cpp
+++ b/utils/funcexp/func_rpad.cpp
@@ -155,10 +155,10 @@ std::string Func_rpad::getStrVal(rowgroup::Row& row,
     if (strwclen > len)
         alen = strwclen;
 
-    int bufsize = (alen + 1) * sizeof(wchar_t);
+    int bufsize = alen + 1;
 
     // Convert to wide characters. Do all further work in wide characters
-    wchar_t* wcbuf = (wchar_t*)alloca(bufsize);
+    wchar_t* wcbuf = new wchar_t[bufsize];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen + 1);
 
     unsigned int strSize = strwclen;    // The number of significant characters
@@ -190,8 +190,8 @@ std::string Func_rpad::getStrVal(rowgroup::Row& row,
 
     // Convert the pad string to wide
     padwclen = pad->length();  // A guess to start.
-    int padbufsize = (padwclen + 1) * sizeof(wchar_t);
-    wchar_t* wcpad = (wchar_t*)alloca(padbufsize);
+    int padbufsize = padwclen + 1;
+    wchar_t* wcpad = new wchar_t[padbufsize];
     size_t padlen = utf8::idb_mbstowcs(wcpad, pad->c_str(), padwclen + 1);
 
     // How many chars do we need?
@@ -221,7 +221,10 @@ std::string Func_rpad::getStrVal(rowgroup::Row& row,
     wstring padded = wstring(wcbuf, len);
 
     // Bug 5110 : strings were getting truncated since enough bytes not allocated.
-    return utf8::wstring_to_utf8(padded.c_str());
+    std::string ret(utf8::wstring_to_utf8(padded.c_str()));
+    delete [] wcpad;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_rtrim.cpp
+++ b/utils/funcexp/func_rtrim.cpp
@@ -73,10 +73,10 @@ std::string Func_rtrim::getStrVal(rowgroup::Row& row,
     // determine the size of buffer to allocate, we can be sure the wide
     // char string won't be longer than:
     strwclen = tstr.length(); // a guess to start with. This will be >= to the real count.
-    int bufsize = (strwclen + 1) * sizeof(wchar_t);
+    int bufsize = strwclen + 1;
 
     // Convert the string to wide characters. Do all further work in wide characters
-    wchar_t* wcbuf = (wchar_t*)alloca(bufsize);
+    wchar_t* wcbuf = new wchar_t[bufsize];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen + 1);
 
     // utf8::idb_mbstowcs could return -1 if there is bad chars
@@ -85,8 +85,8 @@ std::string Func_rtrim::getStrVal(rowgroup::Row& row,
 
     // Convert the trim string to wide
     trimwclen = trim.length();  // A guess to start.
-    int trimbufsize = (trimwclen + 1) * sizeof(wchar_t);
-    wchar_t* wctrim = (wchar_t*)alloca(trimbufsize);
+    int trimbufsize = trimwclen + 1;
+    wchar_t* wctrim = new wchar_t[trimbufsize];
     size_t trimlen = utf8::idb_mbstowcs(wctrim, trim.c_str(), trimwclen + 1);
 
     // idb_mbstowcs could return -1 if there is bad chars
@@ -128,7 +128,10 @@ std::string Func_rtrim::getStrVal(rowgroup::Row& row,
     size_t aLen = strwclen - trimCnt;
     wstring trimmed = wstring(aPtr, aLen);
     // Turn back to a string
-    return utf8::wstring_to_utf8(trimmed.c_str());
+    std::string ret(utf8::wstring_to_utf8(trimmed.c_str()));
+    delete [] wctrim;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_substr.cpp
+++ b/utils/funcexp/func_substr.cpp
@@ -59,7 +59,7 @@ std::string Func_substr::getStrVal(rowgroup::Row& row,
         return "";
 
     size_t strwclen = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
-    wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+    wchar_t* wcbuf = new wchar_t[strwclen];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen);
     wstring str(wcbuf, strwclen);
 
@@ -98,9 +98,12 @@ std::string Func_substr::getStrVal(rowgroup::Row& row,
 
     wstring out = str.substr(start, n);
     size_t strmblen = utf8::idb_wcstombs(0, out.c_str(), 0) + 1;
-    char* outbuf = (char*)alloca(strmblen * sizeof(char));
+    char* outbuf = new char[strmblen];
     strmblen = utf8::idb_wcstombs(outbuf, out.c_str(), strmblen);
-    return string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+    delete [] outbuf;
+    delete [] wcbuf;
+    return ret;
 #else
     const string& str = fp[0]->data()->getStrVal(row, isNull);
 

--- a/utils/funcexp/func_trim.cpp
+++ b/utils/funcexp/func_trim.cpp
@@ -72,10 +72,10 @@ std::string Func_trim::getStrVal(rowgroup::Row& row,
     // determine the size of buffer to allocate, we can be sure the wide
     // char string won't be longer than:
     strwclen = tstr.length(); // a guess to start with. This will be >= to the real count.
-    int bufsize = (strwclen + 1) * sizeof(wchar_t);
+    int bufsize = strwclen + 1;
 
     // Convert the string to wide characters. Do all further work in wide characters
-    wchar_t* wcbuf = (wchar_t*)alloca(bufsize);
+    wchar_t* wcbuf = new wchar_t[bufsize];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen + 1);
 
     // Bad char in mbc can return -1
@@ -84,8 +84,8 @@ std::string Func_trim::getStrVal(rowgroup::Row& row,
 
     // Convert the trim string to wide
     trimwclen = trim.length();  // A guess to start.
-    int trimbufsize = (trimwclen + 1) * sizeof(wchar_t);
-    wchar_t* wctrim = (wchar_t*)alloca(trimbufsize);
+    int trimbufsize = trimwclen + 1;
+    wchar_t* wctrim = new wchar_t[trimbufsize];
     size_t trimlen = utf8::idb_mbstowcs(wctrim, trim.c_str(), trimwclen + 1);
 
     // Bad char in mbc can return -1
@@ -144,7 +144,10 @@ std::string Func_trim::getStrVal(rowgroup::Row& row,
     size_t aLen = strwclen - trimCnt;
     wstring trimmed = wstring(aPtr, aLen);
     // Turn back to a string
-    return utf8::wstring_to_utf8(trimmed.c_str());
+    std::string ret(utf8::wstring_to_utf8(trimmed.c_str()));
+    delete [] wctrim;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_ucase.cpp
+++ b/utils/funcexp/func_ucase.cpp
@@ -67,7 +67,7 @@ std::string Func_ucase::getStrVal(rowgroup::Row& row,
         return "";
 
     size_t strwclen = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
-    wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+    wchar_t* wcbuf = new wchar_t[strwclen];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen);
     wstring wstr(wcbuf, strwclen);
 
@@ -75,9 +75,12 @@ std::string Func_ucase::getStrVal(rowgroup::Row& row,
         wstr[i] = std::towupper(wstr[i]);
 
     size_t strmblen = utf8::idb_wcstombs(0, wstr.c_str(), 0) + 1;
-    char* outbuf = (char*)alloca(strmblen * sizeof(char));
+    char* outbuf = new char[strmblen];
     strmblen = utf8::idb_wcstombs(outbuf, wstr.c_str(), strmblen);
-    return string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+    delete [] outbuf;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/utils_utf8.h
+++ b/utils/funcexp/utils_utf8.h
@@ -217,10 +217,10 @@ size_t idb_wcstombs(char* dest, const wchar_t* src, size_t max)
 inline
 std::wstring utf8_to_wstring (const std::string& str)
 {
-    int bufsize = (int)((str.length() + 1) * sizeof(wchar_t));
+    size_t bufsize = str.length() + 1;
 
     // Convert to wide characters. Do all further work in wide characters
-    wchar_t* wcbuf = (wchar_t*)alloca(bufsize);
+    wchar_t* wcbuf = new wchar_t[bufsize];
     // Passing +1 so that windows is happy to see extra position to place NULL
     size_t strwclen = idb_mbstowcs(wcbuf, str.c_str(), str.length() + 1);
 
@@ -229,7 +229,10 @@ std::wstring utf8_to_wstring (const std::string& str)
     if ( strwclen == static_cast<size_t>(-1) )
         strwclen = 0;
 
-    return std::wstring(wcbuf, strwclen);
+    std::wstring ret(wcbuf, strwclen);
+
+    delete [] wcbuf;
+    return ret;
 }
 
 
@@ -237,7 +240,7 @@ std::wstring utf8_to_wstring (const std::string& str)
 inline
 std::string wstring_to_utf8 (const std::wstring& str)
 {
-    char* outbuf = (char*)alloca((str.length() * MAX_UTF8_BYTES_PER_CHAR) + 1);
+    char* outbuf = new char[(str.length() * MAX_UTF8_BYTES_PER_CHAR) + 1];
     // Passing +1 so that windows is happy to see extra position to place NULL
     size_t strmblen = idb_wcstombs(outbuf, str.c_str(), str.length() * MAX_UTF8_BYTES_PER_CHAR + 1);
 
@@ -246,7 +249,10 @@ std::string wstring_to_utf8 (const std::wstring& str)
     if ( strmblen == static_cast<size_t>(-1) )
         strmblen = 0;
 
-    return std::string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+
+    delete [] outbuf;
+    return ret;
 }
 
 inline

--- a/writeengine/bulk/we_colbuf.cpp
+++ b/writeengine/bulk/we_colbuf.cpp
@@ -133,7 +133,7 @@ int ColumnBuffer::writeToFile(int startOffset, int writeSize, bool fillUpWEmptie
 
     if (nitems != 1)
     {
-        delete newBuf;
+        delete [] newBuf;
         return ERR_FILE_WRITE;
     }
 
@@ -141,7 +141,7 @@ int ColumnBuffer::writeToFile(int startOffset, int writeSize, bool fillUpWEmptie
     Stats::stopParseEvent(WE_STATS_WRITE_COL);
 #endif
 
-    delete newBuf;
+    delete [] newBuf;
     return NO_ERROR;
 }
 

--- a/writeengine/bulk/we_columninfocompressed.cpp
+++ b/writeengine/bulk/we_columninfocompressed.cpp
@@ -411,6 +411,7 @@ int ColumnInfoCompressed::truncateDctnryStore(
             fLog->logMsg( oss.str(), rc, MSGLVL_ERROR );
             fTruncateDctnryFileOp.closeFile( dFile );
 
+            delete [] pointerHdr;
             return rc;
         }
 


### PR DESCRIPTION
Found the following:

* Potential stack explosions with alloca() usage on potentially large
strings
* Memory leaks in WriteEngineServer
* Stack usage out of scope in dataconvert
* A typo in an 'if' statement in dataconvert