### PR TITLE
MCOL 3474 Fix TIMEDIFF w/ non-temporal data types

### DIFF
--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -3005,6 +3005,14 @@ int64_t DataConvert::intToDatetime(int64_t data, bool* date)
     else
     {
         y = atoi(year.c_str());
+
+        // special handling for 2-byte year
+        if (year.length() == 2)
+        {
+            y += 2000;
+            if (y > 2069)
+                y -= 100;
+        }
     }
 
     m = atoi(month.c_str());
@@ -3056,10 +3064,10 @@ int64_t DataConvert::intToTime(int64_t data, bool fromString)
 #if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation="
-    snprintf( buf, 15, "%llu", (long long unsigned int)data);
+    snprintf( buf, 15, "%lld", (long long int)data);
 #pragma GCC diagnostic pop
 #else
-    snprintf( buf, 15, "%llu", (long long unsigned int)data);
+    snprintf( buf, 15, "%lld", (long long int)data);
 #endif
 
     //string date = buf;
@@ -3090,8 +3098,8 @@ int64_t DataConvert::intToTime(int64_t data, bool fromString)
 
         case 7:
             hour = string(bufread, 3);
-            min = string(bufread + 2, 2);
-            sec = string(bufread + 4, 2);
+            min = string(bufread + 3, 2);
+            sec = string(bufread + 5, 2);
             break;
 
         case 6:
@@ -3152,7 +3160,7 @@ int64_t DataConvert::intToTime(int64_t data, bool fromString)
     atime.msecond = ms;
     atime.is_neg = isNeg;
 
-    return *(reinterpret_cast<uint64_t*>(&atime));
+    return *(reinterpret_cast<int64_t*>(&atime));
 }
 
 int64_t DataConvert::stringToTime(const string& data)

--- a/utils/funcexp/func_timediff.cpp
+++ b/utils/funcexp/func_timediff.cpp
@@ -94,6 +94,14 @@ const string timediff( int64_t time1, int64_t time2, bool isDateTime)
 }
 }
 
+bool treatIntAsDatetime(const std::string &text)
+{
+    // min used when converting into to datetime is YYYYMMDD
+    // note: time diffing an int perceived to be in the format YYMMDD is actually treated as HHMMSS. Same functionality as MDB
+    bool isNeg = text.find("-") == 0;
+    return (text.length() > 8) || (text.length() >= 8 && !isNeg); 
+}
+
 CalpontSystemCatalog::ColType Func_timediff::operationType( FunctionParm& fp, CalpontSystemCatalog::ColType& resultType )
 {
     return resultType;
@@ -163,13 +171,9 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::TEXT:
             text = parm[0]->data()->getStrVal(row, isNull);
             
-            if (text.length() >= 14) // datetime has length at least 14
+            if (text.length() >= 12) // datetime has length at least 12 (YYMMDDHHMMSS), convert others to time
             {
                 val1 = dataconvert::DataConvert::stringToDatetime(text, &isDate1);
-            }
-            else if (text.length() == 8 && text.find("-") == string::npos && text.find(":") == string::npos) // special case, this is exactly a date
-            {                
-                val1 = dataconvert::DataConvert::intToDatetime(parm[0]->data()->getIntVal(row, isNull), &isDate1);
             }
             else
             {
@@ -184,7 +188,7 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::TINYINT:
         case execplan::CalpontSystemCatalog::SMALLINT:
             text = parm[0]->data()->getStrVal(row, isNull);
-            if (text.length() >= 14) // datetime has length at least 14
+            if (treatIntAsDatetime(text))
                 val1 = dataconvert::DataConvert::intToDatetime(parm[0]->data()->getIntVal(row, isNull), &isDate1);            
             else 
             {
@@ -202,7 +206,7 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
             else
             {
                 text = parm[0]->data()->getStrVal(row, isNull);
-                if (text.length() >= 14) // datetime has length at least 14
+                if (treatIntAsDatetime(text))
                     val1 = dataconvert::DataConvert::intToDatetime(parm[0]->data()->getIntVal(row, isNull), &isDate1);
                 else 
                 {
@@ -252,13 +256,9 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::CHAR:
         case execplan::CalpontSystemCatalog::TEXT:
             text = parm[1]->data()->getStrVal(row, isNull);
-            if (text.length() >= 14) // datetime has length at least 14
+            if (text.length() >= 12) // datetime has length at least 12 (YYMMDDHHMMSS), convert others to time
             {
                 val2 = dataconvert::DataConvert::stringToDatetime(text, &isDate2);
-            }
-            else if (text.length() == 8 && text.find("-") == string::npos && text.find(":") == string::npos) // special case, this is exactly a date
-            {                
-                val2 = dataconvert::DataConvert::intToDatetime(parm[1]->data()->getIntVal(row, isNull), &isDate2);
             }
             else
             {
@@ -273,7 +273,7 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::TINYINT:
         case execplan::CalpontSystemCatalog::SMALLINT:
             text = parm[1]->data()->getStrVal(row, isNull);
-            if (text.length() >= 14) // datetime has length at least 14
+            if (treatIntAsDatetime(text))
                 val2 = dataconvert::DataConvert::intToDatetime(parm[1]->data()->getIntVal(row, isNull), &isDate2);
             else 
             {
@@ -291,7 +291,7 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
             else
             {
                 text = parm[1]->data()->getStrVal(row, isNull);
-                if (text.length() >= 14) // datetime has length at least 14
+                if (treatIntAsDatetime(text))
                     val2 = dataconvert::DataConvert::intToDatetime(parm[1]->data()->getIntVal(row, isNull), &isDate2);
                 else 
                 {
@@ -362,8 +362,6 @@ double Func_timediff::getDoubleVal(rowgroup::Row& row,
     //return (double)dataconvert::DataConvert::datetimeToInt(getStrVal(row, fp, isNull, op_ct));
     return atof(getStrVal(row, fp, isNull, op_ct).c_str());
 }
-
-
 
 } // namespace funcexp
 // vim:ts=4 sw=4:

--- a/utils/funcexp/func_timediff.cpp
+++ b/utils/funcexp/func_timediff.cpp
@@ -45,7 +45,7 @@ namespace funcexp
 namespace helpers
 {
 
-const string timediff( int64_t time1, int64_t time2)
+const string timediff( int64_t time1, int64_t time2, bool isDateTime)
 {
     long long seconds;
     long long microseconds;
@@ -56,9 +56,9 @@ const string timediff( int64_t time1, int64_t time2)
         l_sign = -l_sign;
 
     if ( time1 > time2 )
-        helpers::calc_time_diff(time1, time2, l_sign, &seconds, &microseconds);
+        helpers::calc_time_diff(time1, time2, l_sign, &seconds, &microseconds, isDateTime);
     else
-        helpers::calc_time_diff(time2, time1, l_sign, &seconds, &microseconds);
+        helpers::calc_time_diff(time2, time1, l_sign, &seconds, &microseconds, isDateTime);
 
     long t_seconds;
     int hour = seconds / 3600L;
@@ -162,8 +162,20 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::CHAR:
         case execplan::CalpontSystemCatalog::TEXT:
             text = parm[0]->data()->getStrVal(row, isNull);
-            isTime1 = std::count(text.begin(), text.end(), '-') <= 1; // Time can have at most 1 dash (signifies negative)
-            val1 = dataconvert::DataConvert::stringToDatetime(text, &isDate1);
+            
+            if (text.length() >= 14) // datetime has length at least 14
+            {
+                val1 = dataconvert::DataConvert::stringToDatetime(text, &isDate1);
+            }
+            else if (text.length() == 8 && text.find("-") == string::npos && text.find(":") == string::npos) // special case, this is exactly a date
+            {                
+                val1 = dataconvert::DataConvert::intToDatetime(parm[0]->data()->getIntVal(row, isNull), &isDate1);
+            }
+            else
+            {
+                val1 = dataconvert::DataConvert::stringToTime(text);
+                isTime1 = true;
+            }
             break;
 
         case execplan::CalpontSystemCatalog::BIGINT:
@@ -171,7 +183,14 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::MEDINT:
         case execplan::CalpontSystemCatalog::TINYINT:
         case execplan::CalpontSystemCatalog::SMALLINT:
-            val1 = dataconvert::DataConvert::intToDatetime(parm[0]->data()->getIntVal(row, isNull), &isDate1);
+            text = parm[0]->data()->getStrVal(row, isNull);
+            if (text.length() >= 14) // datetime has length at least 14
+                val1 = dataconvert::DataConvert::intToDatetime(parm[0]->data()->getIntVal(row, isNull), &isDate1);            
+            else 
+            {
+                val1 = dataconvert::DataConvert::intToTime(parm[0]->data()->getIntVal(row, isNull));
+                isTime1 = true;
+            }
             break;
 
         case execplan::CalpontSystemCatalog::DECIMAL:
@@ -182,7 +201,14 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
             }
             else
             {
-                val1 = dataconvert::DataConvert::intToDatetime(parm[0]->data()->getIntVal(row, isNull), &isDate1);
+                text = parm[0]->data()->getStrVal(row, isNull);
+                if (text.length() >= 14) // datetime has length at least 14
+                    val1 = dataconvert::DataConvert::intToDatetime(parm[0]->data()->getIntVal(row, isNull), &isDate1);
+                else 
+                {
+                    val1 = dataconvert::DataConvert::intToTime(parm[0]->data()->getIntVal(row, isNull));
+                    isTime1 = true;
+                }
                 break;
             }
 
@@ -226,8 +252,19 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::CHAR:
         case execplan::CalpontSystemCatalog::TEXT:
             text = parm[1]->data()->getStrVal(row, isNull);
-            isTime2 = std::count(text.begin(), text.end(), '-') <= 1; // Time can have at most 1 dash (signifies negative)
-            val2 = dataconvert::DataConvert::stringToDatetime(text, &isDate2);
+            if (text.length() >= 14) // datetime has length at least 14
+            {
+                val2 = dataconvert::DataConvert::stringToDatetime(text, &isDate2);
+            }
+            else if (text.length() == 8 && text.find("-") == string::npos && text.find(":") == string::npos) // special case, this is exactly a date
+            {                
+                val2 = dataconvert::DataConvert::intToDatetime(parm[1]->data()->getIntVal(row, isNull), &isDate2);
+            }
+            else
+            {
+                val2 = dataconvert::DataConvert::stringToTime(text);
+                isTime2 = true;
+            }
             break;
 
         case execplan::CalpontSystemCatalog::BIGINT:
@@ -235,7 +272,14 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
         case execplan::CalpontSystemCatalog::MEDINT:
         case execplan::CalpontSystemCatalog::TINYINT:
         case execplan::CalpontSystemCatalog::SMALLINT:
-            val2 = dataconvert::DataConvert::intToDatetime(parm[1]->data()->getIntVal(row, isNull), &isDate2);
+            text = parm[1]->data()->getStrVal(row, isNull);
+            if (text.length() >= 14) // datetime has length at least 14
+                val2 = dataconvert::DataConvert::intToDatetime(parm[1]->data()->getIntVal(row, isNull), &isDate2);
+            else 
+            {
+                val2 = dataconvert::DataConvert::intToTime(parm[1]->data()->getIntVal(row, isNull));
+                isTime2 = true;
+            }
             break;
 
         case execplan::CalpontSystemCatalog::DECIMAL:
@@ -246,7 +290,14 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
             }
             else
             {
-                val2 = dataconvert::DataConvert::intToDatetime(parm[1]->data()->getIntVal(row, isNull), &isDate2);
+                text = parm[1]->data()->getStrVal(row, isNull);
+                if (text.length() >= 14) // datetime has length at least 14
+                    val2 = dataconvert::DataConvert::intToDatetime(parm[1]->data()->getIntVal(row, isNull), &isDate2);
+                else 
+                {
+                    val2 = dataconvert::DataConvert::intToTime(parm[1]->data()->getIntVal(row, isNull));
+                    isTime2 = true;
+                }
                 break;
             }
 
@@ -262,7 +313,7 @@ string Func_timediff::getStrVal(rowgroup::Row& row,
 
     // both date format or both datetime format. Diff between time and datetime returns NULL in MariaDB
     if ((isDate1 && isDate2) || ((!isDate1 && !isDate2) && (isTime1 == isTime2)))
-        return helpers::timediff( val1, val2);
+        return helpers::timediff( val1, val2, !isTime1);
 
     isNull = true;
     return "";

--- a/utils/funcexp/funchelpers.h
+++ b/utils/funcexp/funchelpers.h
@@ -393,21 +393,42 @@ inline bool calc_time_diff(int64_t time1, int64_t time2, int l_sign, long long* 
              sec2 = 0,
              msec2 = 0;
 
-    year1 = isDateTime ? (uint32_t)((time1 >> 48) & 0xffff) : 0;
-    month1 = isDateTime ? (uint32_t)((time1 >> 44) & 0xf) : 0;
-    day1 = isDateTime ? (uint32_t)((time1 >> 38) & 0x3f) : (uint32_t)((time1 >> 52) & 0x7ff);
-    hour1 = isDateTime ? (uint32_t)((time1 >> 32) & 0x3f) : (uint32_t)((time1 >> 40) & 0xfff);
-    min1 = isDateTime ? (uint32_t)((time1 >> 26) & 0x3f) : (uint32_t)((time1 >> 32) & 0xff);
-    sec1 = isDateTime ? (uint32_t)((time1 >> 20) & 0x3f) : (uint32_t)((time1 >> 24) & 0xff);
-    msec1 = isDateTime ? (uint32_t)((time1 & 0xfffff)) : (uint32_t)(time1 & 0xffffff);
+    if (isDateTime)
+    {
+        year1 = (uint32_t)((time1 >> 48) & 0xffff);
+        month1 = (uint32_t)((time1 >> 44) & 0xf);
+        day1 = (uint32_t)((time1 >> 38) & 0x3f);
+        hour1 = (uint32_t)((time1 >> 32) & 0x3f);
+        min1 = (uint32_t)((time1 >> 26) & 0x3f);
+        sec1 = (uint32_t)((time1 >> 20) & 0x3f);
+        msec1 = (uint32_t)((time1 & 0xfffff));
 
-    year2 = isDateTime ? (uint32_t)((time2 >> 48) & 0xffff) : 0;
-    month2 = isDateTime ? (uint32_t)((time2 >> 44) & 0xf) : 0;
-    day2 = isDateTime ? (uint32_t)((time2 >> 38) & 0x3f) : (uint32_t)((time2 >> 52) & 0x7ff);;
-    hour2 = isDateTime ? (uint32_t)((time2 >> 32) & 0x3f) : (uint32_t)((time2 >> 40) & 0xfff);
-    min2 = isDateTime ? (uint32_t)((time2 >> 26) & 0x3f) : (uint32_t)((time2 >> 32) & 0xff);
-    sec2 = isDateTime ? (uint32_t)((time2 >> 20) & 0x3f) : (uint32_t)((time2 >> 24) & 0xff);
-    msec2 = isDateTime ? (uint32_t)((time2 & 0xfffff)) : (uint32_t)(time2 & 0xffffff);
+        year2 = (uint32_t)((time2 >> 48) & 0xffff);
+        month2 = (uint32_t)((time2 >> 44) & 0xf);
+        day2 = (uint32_t)((time2 >> 38) & 0x3f);
+        hour2 = (uint32_t)((time2 >> 32) & 0x3f);
+        min2 = (uint32_t)((time2 >> 26) & 0x3f);
+        sec2 = (uint32_t)((time2 >> 20) & 0x3f);
+        msec2 = (uint32_t)(time2 & 0xfffff); 
+    }
+    else 
+    {
+        year1 = 0;
+        month1 = 0;
+        day1 = (time1 >> 52) & 0x7ff;
+        hour1 = (time1 >> 40) & 0xfff;
+        min1 = (time1 >> 32) & 0xff;
+        sec1 = (time1 >> 24) & 0xff;
+        msec1 = time1 & 0xffffff;
+
+        year2 = 0;
+        month2 = 0;
+        day2 = (time2 >> 52) & 0x7ff;
+        hour2 = (time2 >> 40) & 0xfff;
+        min2 = (time2 >> 32) & 0xff;
+        sec2 = (time2 >> 24) & 0xff;
+        msec2 = time2 & 0xffffff;
+    }
 
     days = calc_mysql_daynr(year1, month1, day1);
 

--- a/utils/funcexp/funchelpers.h
+++ b/utils/funcexp/funchelpers.h
@@ -371,7 +371,7 @@ inline uint32_t calc_mysql_week( uint32_t year, uint32_t month, uint32_t day,
     return days / 7 + 1;
 }
 
-inline bool calc_time_diff(int64_t time1, int64_t time2, int l_sign, long long* seconds_out, long long* microseconds_out)
+inline bool calc_time_diff(int64_t time1, int64_t time2, int l_sign, long long* seconds_out, long long* microseconds_out, bool isDateTime = true)
 {
     int64_t days;
     bool neg;
@@ -393,21 +393,21 @@ inline bool calc_time_diff(int64_t time1, int64_t time2, int l_sign, long long* 
              sec2 = 0,
              msec2 = 0;
 
-    year1 = (uint32_t)((time1 >> 48) & 0xffff);
-    month1 = (uint32_t)((time1 >> 44) & 0xf);
-    day1 = (uint32_t)((time1 >> 38) & 0x3f);
-    hour1 = (uint32_t)((time1 >> 32) & 0x3f);
-    min1 = (uint32_t)((time1 >> 26) & 0x3f);
-    sec1 = (uint32_t)((time1 >> 20) & 0x3f);
-    msec1 = (uint32_t)((time1 & 0xfffff));
+    year1 = isDateTime ? (uint32_t)((time1 >> 48) & 0xffff) : 0;
+    month1 = isDateTime ? (uint32_t)((time1 >> 44) & 0xf) : 0;
+    day1 = isDateTime ? (uint32_t)((time1 >> 38) & 0x3f) : (uint32_t)((time1 >> 52) & 0x7ff);
+    hour1 = isDateTime ? (uint32_t)((time1 >> 32) & 0x3f) : (uint32_t)((time1 >> 40) & 0xfff);
+    min1 = isDateTime ? (uint32_t)((time1 >> 26) & 0x3f) : (uint32_t)((time1 >> 32) & 0xff);
+    sec1 = isDateTime ? (uint32_t)((time1 >> 20) & 0x3f) : (uint32_t)((time1 >> 24) & 0xff);
+    msec1 = isDateTime ? (uint32_t)((time1 & 0xfffff)) : (uint32_t)(time1 & 0xffffff);
 
-    year2 = (uint32_t)((time2 >> 48) & 0xffff);
-    month2 = (uint32_t)((time2 >> 44) & 0xf);
-    day2 = (uint32_t)((time2 >> 38) & 0x3f);
-    hour2 = (uint32_t)((time2 >> 32) & 0x3f);
-    min2 = (uint32_t)((time2 >> 26) & 0x3f);
-    sec2 = (uint32_t)((time2 >> 20) & 0x3f);
-    msec2 = (uint32_t)((time2 & 0xfffff));
+    year2 = isDateTime ? (uint32_t)((time2 >> 48) & 0xffff) : 0;
+    month2 = isDateTime ? (uint32_t)((time2 >> 44) & 0xf) : 0;
+    day2 = isDateTime ? (uint32_t)((time2 >> 38) & 0x3f) : (uint32_t)((time2 >> 52) & 0x7ff);;
+    hour2 = isDateTime ? (uint32_t)((time2 >> 32) & 0x3f) : (uint32_t)((time2 >> 40) & 0xfff);
+    min2 = isDateTime ? (uint32_t)((time2 >> 26) & 0x3f) : (uint32_t)((time2 >> 32) & 0xff);
+    sec2 = isDateTime ? (uint32_t)((time2 >> 20) & 0x3f) : (uint32_t)((time2 >> 24) & 0xff);
+    msec2 = isDateTime ? (uint32_t)((time2 & 0xfffff)) : (uint32_t)(time2 & 0xffffff);
 
     days = calc_mysql_daynr(year1, month1, day1);
 
@@ -768,7 +768,7 @@ string longDoubleToString(long double ld)
 
 uint64_t dateAdd( uint64_t time, const std::string& expr, execplan::IntervalColumn::interval_type unit, bool dateType, execplan::OpType funcType );
 const std::string IDB_date_format(const dataconvert::DateTime&, const std::string&);
-const std::string timediff(int64_t, int64_t);
+const std::string timediff(int64_t, int64_t, bool isDateTime = true);
 const char* convNumToStr(int64_t, char*, int);
 
 } //namespace funcexp::helpers


### PR DESCRIPTION
The following changes were made to non-temporal data types after investigating the inconsistencies when running queries using MDB and columnstore engine. New regression tests added as well to verify changes allow columnstore to match mdb.

Regression tests PR: mariadb-corporation/mariadb-columnstore-regression-test#168