### PR TITLE
MCOL-3598 Use signed int64_t for comparing two TIME values in the order by clause.

### DIFF
--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -455,15 +455,19 @@ int TimeCompare::operator()(IdbCompare* l, Row::Pointer r1, Row::Pointer r2)
     l->row1().setData(r1);
     l->row2().setData(r2);
 
-    int ret = 0;
-    uint64_t v1 = l->row1().getUintField(fSpec.fIndex);
-    uint64_t v2 = l->row2().getUintField(fSpec.fIndex);
+    int64_t v1 = l->row1().getIntField(fSpec.fIndex);
+    int64_t v2 = l->row2().getIntField(fSpec.fIndex);
 
-    if (v1 == joblist::TIMENULL || v2 == joblist::TIMENULL)
+    bool b1 = (joblist::TIMENULL == (uint64_t) v1);
+    bool b2 = (joblist::TIMENULL == (uint64_t) v2);
+
+    int ret = 0;
+
+    if (b1 == true || b2 == true)
     {
-        if (v1 != joblist::TIMENULL && v2 == joblist::TIMENULL)
+        if (b1 == false && b2 == true)
             ret = fSpec.fNf;
-        else if (v1 == joblist::TIMENULL && v2 != joblist::TIMENULL)
+        else if (b1 == true && b2 == false)
             ret = -fSpec.fNf;
     }
     else


### PR DESCRIPTION
Fixes tests working_tpch1/qa_fe_postProcessedFunctions/SEC_TO_TIME.NS.sql and working_tpch1/qa_fe_postProcessedFunctions/TIMEDIFF.DM.sql