### PR TITLE
MCOL-1734 For develop.

### DIFF
--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -1190,7 +1190,7 @@ void BatchPrimitiveProcessor::executeTupleJoin()
                  */
 
                 if (((!found || isNull) && !(joinTypes[j] & (LARGEOUTER | ANTI))) ||
-                        ((joinTypes[j] & ANTI) && ((isNull && (joinTypes[j] & MATCHNULLS)) || (found && !isNull))))
+                        ((joinTypes[j] & ANTI) && ((isNull && !(joinTypes[j] & MATCHNULLS)) || (found && !isNull))))
                 {
                     //cout << " - not in the result set\n";
                     break;


### PR DESCRIPTION
I forgot we follow downmerge policy thus I'm pushing this patch into develop.

This patch fixes the error for NOT IN + subquery when outer query has NULLs in a key

column.
The if statement that decides whether to add the Row into a result set
or not has a logic error thus produces false positives for the case
described in MCOL-1734.