### PR TITLE
Gcc9 namespace fixes

### DIFF
--- a/dbcon/execplan/clientrotator.cpp
+++ b/dbcon/execplan/clientrotator.cpp
@@ -214,7 +214,7 @@ void ClientRotator::write(const ByteStream& msg)
 
 ByteStream ClientRotator::read()
 {
-    mutex::scoped_lock lk(fClientLock);
+    boost::mutex::scoped_lock lk(fClientLock);
 
     ByteStream bs;
 

--- a/dbcon/joblist/distributedenginecomm.cpp
+++ b/dbcon/joblist/distributedenginecomm.cpp
@@ -224,7 +224,7 @@ DistributedEngineComm::~DistributedEngineComm()
 void DistributedEngineComm::Setup()
 {
     // This is here to ensure that this function does not get invoked multiple times simultaneously.
-    mutex::scoped_lock setupLock(fSetupMutex);
+    boost::mutex::scoped_lock setupLock(fSetupMutex);
 
     makeBusy(true);
 
@@ -310,7 +310,7 @@ void DistributedEngineComm::Setup()
     // for every entry in newClients up to newPmCount, scan for the same ip in the
     // first pmCount.  If there is no match, it's a new node,
     //    call the event listeners' newPMOnline() callbacks.
-    mutex::scoped_lock lock(eventListenerLock);
+    boost::mutex::scoped_lock lock(eventListenerLock);
 
     for (uint32_t i = 0; i < newPmCount; i++)
     {
@@ -386,7 +386,7 @@ void DistributedEngineComm::Listen(boost::shared_ptr<MessageQueueClient> client,
 Error:
     // @bug 488 - error condition! push 0 length bs to messagequeuemap and
     // eventually let jobstep error out.
-    /*	mutex::scoped_lock lk(fMlock);
+    /*	boost::mutex::scoped_lock lk(fMlock);
     	//cout << "WARNING: DEC READ 0 LENGTH BS FROM " << client->otherEnd()<< endl;
 
     	MessageQueueMap::iterator map_tok;
@@ -404,7 +404,7 @@ Error:
     	ClientList tempConns;
 
     	{
-    		mutex::scoped_lock onErrLock(fOnErrMutex);
+    		boost::mutex::scoped_lock onErrLock(fOnErrMutex);
     		string moduleName = client->moduleName();
     		//cout << "moduleName=" << moduleName << endl;
     		for ( uint32_t i = 0; i < fPmConnections.size(); i++)
@@ -438,7 +438,7 @@ void DistributedEngineComm::addQueue(uint32_t key, bool sendACKs)
 {
     bool b;
 
-    mutex* lock = new mutex();
+	boost::mutex* lock = new boost::mutex();
     condition* cond = new condition();
     boost::shared_ptr<MQE> mqe(new MQE(pmCount));
 
@@ -446,7 +446,7 @@ void DistributedEngineComm::addQueue(uint32_t key, bool sendACKs)
     mqe->sendACKs = sendACKs;
     mqe->throttled = false;
 
-    mutex::scoped_lock lk ( fMlock );
+    boost::mutex::scoped_lock lk ( fMlock );
     b = fSessionMessages.insert(pair<uint32_t, boost::shared_ptr<MQE> >(key, mqe)).second;
 
     if (!b)
@@ -459,7 +459,7 @@ void DistributedEngineComm::addQueue(uint32_t key, bool sendACKs)
 
 void DistributedEngineComm::removeQueue(uint32_t key)
 {
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator map_tok = fSessionMessages.find(key);
 
     if (map_tok == fSessionMessages.end())
@@ -472,7 +472,7 @@ void DistributedEngineComm::removeQueue(uint32_t key)
 
 void DistributedEngineComm::shutdownQueue(uint32_t key)
 {
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator map_tok = fSessionMessages.find(key);
 
     if (map_tok == fSessionMessages.end())
@@ -487,7 +487,7 @@ void DistributedEngineComm::read(uint32_t key, SBS& bs)
     boost::shared_ptr<MQE> mqe;
 
     //Find the StepMsgQueueList for this session
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator map_tok = fSessionMessages.find(key);
 
     if (map_tok == fSessionMessages.end())
@@ -506,7 +506,7 @@ void DistributedEngineComm::read(uint32_t key, SBS& bs)
 
     if (bs && mqe->sendACKs)
     {
-        mutex::scoped_lock lk(ackLock);
+        boost::mutex::scoped_lock lk(ackLock);
 
         if (mqe->throttled && !mqe->hasBigMsgs && queueSize.size <= disableThreshold)
             setFlowControl(false, key, mqe);
@@ -526,7 +526,7 @@ const ByteStream DistributedEngineComm::read(uint32_t key)
     boost::shared_ptr<MQE> mqe;
 
     //Find the StepMsgQueueList for this session
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator map_tok = fSessionMessages.find(key);
 
     if (map_tok == fSessionMessages.end())
@@ -544,7 +544,7 @@ const ByteStream DistributedEngineComm::read(uint32_t key)
 
     if (sbs && mqe->sendACKs)
     {
-        mutex::scoped_lock lk(ackLock);
+        boost::mutex::scoped_lock lk(ackLock);
 
         if (mqe->throttled && !mqe->hasBigMsgs && queueSize.size <= disableThreshold)
             setFlowControl(false, key, mqe);
@@ -564,7 +564,7 @@ void DistributedEngineComm::read_all(uint32_t key, vector<SBS>& v)
 {
     boost::shared_ptr<MQE> mqe;
 
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator map_tok = fSessionMessages.find(key);
 
     if (map_tok == fSessionMessages.end())
@@ -581,7 +581,7 @@ void DistributedEngineComm::read_all(uint32_t key, vector<SBS>& v)
 
     if (mqe->sendACKs)
     {
-        mutex::scoped_lock lk(ackLock);
+        boost::mutex::scoped_lock lk(ackLock);
         sendAcks(key, v, mqe, 0);
     }
 }
@@ -591,7 +591,7 @@ void DistributedEngineComm::read_some(uint32_t key, uint32_t divisor, vector<SBS
 {
     boost::shared_ptr<MQE> mqe;
 
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator map_tok = fSessionMessages.find(key);
 
     if (map_tok == fSessionMessages.end())
@@ -612,7 +612,7 @@ void DistributedEngineComm::read_some(uint32_t key, uint32_t divisor, vector<SBS
 
     if (mqe->sendACKs)
     {
-        mutex::scoped_lock lk(ackLock);
+        boost::mutex::scoped_lock lk(ackLock);
 
         if (mqe->throttled && !mqe->hasBigMsgs && queueSize.size <= disableThreshold)
             setFlowControl(false, key, mqe);
@@ -876,7 +876,7 @@ void DistributedEngineComm::write(messageqcpp::ByteStream& msg, uint32_t connect
     PrimitiveHeader* pm = (PrimitiveHeader*) (ism + 1);
     uint32_t senderID = pm->UniqueID;
 
-    mutex::scoped_lock lk(fMlock, defer_lock_t());
+    boost::mutex::scoped_lock lk(fMlock, boost::defer_lock_t());
     MessageQueueMap::iterator it;
     // This keeps mqe's stats from being freed until end of function
     boost::shared_ptr<MQE> mqe;
@@ -909,7 +909,7 @@ void DistributedEngineComm::addDataToOutput(SBS sbs, uint32_t connIndex, Stats* 
     uint32_t uniqueId = p->UniqueID;
     boost::shared_ptr<MQE> mqe;
 
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator map_tok = fSessionMessages.find(uniqueId);
 
     if (map_tok == fSessionMessages.end())
@@ -931,7 +931,7 @@ void DistributedEngineComm::addDataToOutput(SBS sbs, uint32_t connIndex, Stats* 
 
     if (mqe->sendACKs)
     {
-        mutex::scoped_lock lk(ackLock);
+        boost::mutex::scoped_lock lk(ackLock);
         uint64_t msgSize = sbs->lengthWithHdrOverhead();
 
         if (!mqe->throttled && msgSize > (targetRecvQueueSize / 2))
@@ -956,7 +956,7 @@ void DistributedEngineComm::doHasBigMsgs(boost::shared_ptr<MQE> mqe, uint64_t ta
 
 int DistributedEngineComm::writeToClient(size_t index, const ByteStream& bs, uint32_t sender, bool doInterleaving)
 {
-    mutex::scoped_lock lk(fMlock, defer_lock_t());
+    boost::mutex::scoped_lock lk(fMlock, boost::defer_lock_t());
     MessageQueueMap::iterator it;
     // Keep mqe's stats from being freed early
     boost::shared_ptr<MQE> mqe;
@@ -992,7 +992,7 @@ int DistributedEngineComm::writeToClient(size_t index, const ByteStream& bs, uin
 
         if (!client->isAvailable()) return 0;
 
-        mutex::scoped_lock lk(*(fWlock[index]));
+        boost::mutex::scoped_lock lk(*(fWlock[index]));
         client->write(bs, NULL, senderStats);
         return 0;
     }
@@ -1019,7 +1019,7 @@ int DistributedEngineComm::writeToClient(size_t index, const ByteStream& bs, uin
         		ClientList tempConns;
         		{
         			//cout << "WARNING: DEC WRITE BROKEN PIPE " << fPmConnections[index]->otherEnd()<< endl;
-        			mutex::scoped_lock onErrLock(fOnErrMutex);
+        			boost::mutex::scoped_lock onErrLock(fOnErrMutex);
         			string moduleName = fPmConnections[index]->moduleName();
         			//cout << "module name = " << moduleName << endl;
         			if (index >= fPmConnections.size()) return 0;
@@ -1051,7 +1051,7 @@ int DistributedEngineComm::writeToClient(size_t index, const ByteStream& bs, uin
 
 uint32_t DistributedEngineComm::size(uint32_t key)
 {
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator map_tok = fSessionMessages.find(key);
 
     if (map_tok == fSessionMessages.end())
@@ -1065,13 +1065,13 @@ uint32_t DistributedEngineComm::size(uint32_t key)
 
 void DistributedEngineComm::addDECEventListener(DECEventListener* l)
 {
-    mutex::scoped_lock lk(eventListenerLock);
+    boost::mutex::scoped_lock lk(eventListenerLock);
     eventListeners.push_back(l);
 }
 
 void DistributedEngineComm::removeDECEventListener(DECEventListener* l)
 {
-    mutex::scoped_lock lk(eventListenerLock);
+    boost::mutex::scoped_lock lk(eventListenerLock);
     std::vector<DECEventListener*> newListeners;
     uint32_t s = eventListeners.size();
 
@@ -1084,7 +1084,7 @@ void DistributedEngineComm::removeDECEventListener(DECEventListener* l)
 
 Stats DistributedEngineComm::getNetworkStats(uint32_t uniqueID)
 {
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator it;
     Stats empty;
 

--- a/dbcon/joblist/resourcemanager.cpp
+++ b/dbcon/joblist/resourcemanager.cpp
@@ -57,11 +57,11 @@ const string ResourceManager::fExtentMapStr("ExtentMap");
 const string ResourceManager::fOrderByLimitStr("OrderByLimit");
 
 ResourceManager* ResourceManager::fInstance = NULL;
-mutex mx;
+boost::mutex mx;
 
 ResourceManager* ResourceManager::instance(bool runningInExeMgr)
 {
-    mutex::scoped_lock lk(mx);
+    boost::mutex::scoped_lock lk(mx);
 
     if (!fInstance)
         fInstance = new ResourceManager(runningInExeMgr);

--- a/dbcon/joblist/tuple-bps.cpp
+++ b/dbcon/joblist/tuple-bps.cpp
@@ -927,7 +927,7 @@ void TupleBPS::prepCasualPartitioning()
 {
     uint32_t i;
     int64_t min, max, seq;
-    mutex::scoped_lock lk(cpMutex);
+	boost::mutex::scoped_lock lk(cpMutex);
 
     for (i = 0; i < scannedExtents.size(); i++)
     {
@@ -3312,7 +3312,7 @@ void TupleBPS::abort_nolock()
 
 void TupleBPS::abort()
 {
-    boost::mutex::scoped_lock scoped(mutex);
+    boost::mutex::scoped_lock scoped(boost::mutex);
     abort_nolock();
 }
 

--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -414,7 +414,7 @@ void TupleAggregateStep::initializeMultiThread()
 
     for (i = 0; i < fNumOfBuckets; i++)
     {
-        mutex* lock = new mutex();
+		boost::mutex* lock = new boost::mutex();
         fAgg_mutex.push_back(lock);
         fRowGroupOuts[i] = fRowGroupOut;
         rgData.reinit(fRowGroupOut);

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -142,7 +142,7 @@ void TupleHashJoinStep::run()
 {
     uint32_t i;
 
-    mutex::scoped_lock lk(jlLock);
+    boost::mutex::scoped_lock lk(jlLock);
 
     if (runRan)
         return;
@@ -183,7 +183,7 @@ void TupleHashJoinStep::run()
 
 void TupleHashJoinStep::join()
 {
-    mutex::scoped_lock lk(jlLock);
+    boost::mutex::scoped_lock lk(jlLock);
 
     if (joinRan)
         return;

--- a/dbcon/joblist/tupleunion.cpp
+++ b/dbcon/joblist/tupleunion.cpp
@@ -226,7 +226,7 @@ void TupleUnion::readInput(uint32_t which)
 
                 l_tmpRG.getRow(0, &tmpRow);
                 {
-                    mutex::scoped_lock lk(uniquerMutex);
+                    boost::mutex::scoped_lock lk(uniquerMutex);
                     getOutput(&l_outputRG, &outRow, &outRGData);
                     memUsageBefore = allocator.getMemUsage();
 
@@ -294,8 +294,8 @@ void TupleUnion::readInput(uint32_t which)
             more = dl->next(it, &inRGData);
 
     {
-        mutex::scoped_lock lock1(uniquerMutex);
-        mutex::scoped_lock lock2(sMutex);
+        boost::mutex::scoped_lock lock1(uniquerMutex);
+        boost::mutex::scoped_lock lock2(sMutex);
 
         if (!distinct && l_outputRG.getRowCount() > 0)
             output->insert(outRGData);
@@ -395,7 +395,7 @@ void TupleUnion::addToOutput(Row* r, RowGroup* rg, bool keepit,
     if (rg->getRowCount() == 8192)
     {
         {
-            mutex::scoped_lock lock(sMutex);
+            boost::mutex::scoped_lock lock(sMutex);
             output->insert(data);
         }
         data = RGData(*rg);
@@ -1182,7 +1182,7 @@ void TupleUnion::run()
 {
     uint32_t i;
 
-    mutex::scoped_lock lk(jlLock);
+    boost::mutex::scoped_lock lk(jlLock);
 
     if (runRan)
         return;
@@ -1225,7 +1225,7 @@ void TupleUnion::run()
 
 void TupleUnion::join()
 {
-    mutex::scoped_lock lk(jlLock);
+    boost::mutex::scoped_lock lk(jlLock);
 
     if (joinRan)
         return;

--- a/oam/oamcpp/oamcache.cpp
+++ b/oam/oamcpp/oamcache.cpp
@@ -39,7 +39,7 @@ using namespace boost;
 namespace
 {
 oam::OamCache* oamCache = 0;
-mutex cacheLock;
+boost::mutex cacheLock;
 }
 
 namespace oam
@@ -47,7 +47,7 @@ namespace oam
 
 OamCache* OamCache::makeOamCache()
 {
-    mutex::scoped_lock lk(cacheLock);
+    boost::mutex::scoped_lock lk(cacheLock);
 
     if (oamCache == 0)
         oamCache = new OamCache();
@@ -226,7 +226,7 @@ void OamCache::checkReload()
 
 OamCache::dbRootPMMap_t OamCache::getDBRootToPMMap()
 {
-    mutex::scoped_lock lk(cacheLock);
+    boost::mutex::scoped_lock lk(cacheLock);
 
     checkReload();
     return dbRootPMMap;
@@ -234,7 +234,7 @@ OamCache::dbRootPMMap_t OamCache::getDBRootToPMMap()
 
 OamCache::dbRootPMMap_t OamCache::getDBRootToConnectionMap()
 {
-    mutex::scoped_lock lk(cacheLock);
+    boost::mutex::scoped_lock lk(cacheLock);
 
     checkReload();
     return dbRootConnectionMap;
@@ -242,7 +242,7 @@ OamCache::dbRootPMMap_t OamCache::getDBRootToConnectionMap()
 
 OamCache::PMDbrootsMap_t OamCache::getPMToDbrootsMap()
 {
-    mutex::scoped_lock lk(cacheLock);
+    boost::mutex::scoped_lock lk(cacheLock);
 
     checkReload();
     return pmDbrootsMap;
@@ -250,7 +250,7 @@ OamCache::PMDbrootsMap_t OamCache::getPMToDbrootsMap()
 
 uint32_t OamCache::getDBRootCount()
 {
-    mutex::scoped_lock lk(cacheLock);
+    boost::mutex::scoped_lock lk(cacheLock);
 
     checkReload();
     return numDBRoots;
@@ -258,7 +258,7 @@ uint32_t OamCache::getDBRootCount()
 
 DBRootConfigList& OamCache::getDBRootNums()
 {
-    mutex::scoped_lock lk(cacheLock);
+    boost::mutex::scoped_lock lk(cacheLock);
 
     checkReload();
     return dbroots;
@@ -266,7 +266,7 @@ DBRootConfigList& OamCache::getDBRootNums()
 
 std::vector<int>& OamCache::getModuleIds()
 {
-    mutex::scoped_lock lk(cacheLock);
+    boost::mutex::scoped_lock lk(cacheLock);
 
     checkReload();
     return moduleIds;
@@ -274,7 +274,7 @@ std::vector<int>& OamCache::getModuleIds()
 
 std::string OamCache::getOAMParentModuleName()
 {
-    mutex::scoped_lock lk(cacheLock);
+    boost::mutex::scoped_lock lk(cacheLock);
 
     checkReload();
     return OAMParentModuleName;
@@ -282,7 +282,7 @@ std::string OamCache::getOAMParentModuleName()
 
 int OamCache::getLocalPMId()
 {
-    mutex::scoped_lock lk(cacheLock);
+    boost::mutex::scoped_lock lk(cacheLock);
 
     // This comes from the file /var/lib/columnstore/local/module, not from the xml.
     // Thus, it's not refreshed during checkReload().
@@ -324,7 +324,7 @@ int OamCache::getLocalPMId()
 
 string OamCache::getSystemName()
 {
-    mutex::scoped_lock lk(cacheLock);
+    boost::mutex::scoped_lock lk(cacheLock);
 
     checkReload();
     return systemName;
@@ -332,7 +332,7 @@ string OamCache::getSystemName()
 
 string OamCache::getModuleName()
 {
-    mutex::scoped_lock lk(cacheLock);
+    boost::mutex::scoped_lock lk(cacheLock);
 
     if (!moduleName.empty())
         return moduleName;

--- a/utils/cacheutils/cacheutils.cpp
+++ b/utils/cacheutils/cacheutils.cpp
@@ -52,7 +52,7 @@ namespace
 {
 
 //Only one of the cacheutils fcns can run at a time
-mutex CacheOpsMutex;
+boost::mutex CacheOpsMutex;
 
 //This global is updated only w/ atomic ops
 volatile uint32_t MultiReturnCode;
@@ -148,7 +148,7 @@ namespace cacheutils
  */
 int flushPrimProcCache()
 {
-    mutex::scoped_lock lk(CacheOpsMutex);
+    boost::mutex::scoped_lock lk(CacheOpsMutex);
 
     try
     {
@@ -176,7 +176,7 @@ int flushPrimProcBlocks(const BRM::BlockList_t& list)
 {
     if (list.empty()) return 0;
 
-    mutex::scoped_lock lk(CacheOpsMutex);
+    boost::mutex::scoped_lock lk(CacheOpsMutex);
 
 #if defined(__LP64__) || defined(_WIN64)
 
@@ -233,7 +233,7 @@ int flushPrimProcAllverBlocks(const vector<LBID_t>& list)
 
     try
     {
-        mutex::scoped_lock lk(CacheOpsMutex);
+        boost::mutex::scoped_lock lk(CacheOpsMutex);
         rc = sendToAll(bs);
         return rc;
     }
@@ -252,7 +252,7 @@ int flushOIDsFromCache(const vector<BRM::OID_t>& oids)
      *    uint32_t * - OID array
      */
 
-    mutex::scoped_lock lk(CacheOpsMutex, defer_lock_t());
+    boost::mutex::scoped_lock lk(CacheOpsMutex, boost::defer_lock_t());
 
     ByteStream bs;
     ISMPacketHeader ism;
@@ -281,7 +281,7 @@ int flushPartition(const std::vector<BRM::OID_t>& oids, set<BRM::LogicalPartitio
      * 		uint32_t * - OID array
      */
 
-    mutex::scoped_lock lk(CacheOpsMutex, defer_lock_t());
+    boost::mutex::scoped_lock lk(CacheOpsMutex, boost::defer_lock_t());
 
     ByteStream bs;
     ISMPacketHeader ism;
@@ -309,7 +309,7 @@ int dropPrimProcFdCache()
 
     try
     {
-        mutex::scoped_lock lk(CacheOpsMutex);
+        boost::mutex::scoped_lock lk(CacheOpsMutex);
         int rc = sendToAll(bs);
         return rc;
     }

--- a/utils/configcpp/configcpp.cpp
+++ b/utils/configcpp/configcpp.cpp
@@ -81,7 +81,7 @@ Config* Config::makeConfig(const string& cf)
 
 Config* Config::makeConfig(const char* cf)
 {
-    mutex::scoped_lock lk(fInstanceMapMutex);
+    boost::mutex::scoped_lock lk(fInstanceMapMutex);
 
     static string defaultFilePath;
 
@@ -218,7 +218,7 @@ void Config::closeConfig(void)
 
 const string Config::getConfig(const string& section, const string& name)
 {
-    recursive_mutex::scoped_lock lk(fLock);
+    boost::recursive_mutex::scoped_lock lk(fLock);
 
     if (section.length() == 0 || name.length() == 0)
         throw invalid_argument("Config::getConfig: both section and name must have a length");
@@ -245,7 +245,7 @@ const string Config::getConfig(const string& section, const string& name)
 
 void Config::getConfig(const string& section, const string& name, vector<string>& values)
 {
-    recursive_mutex::scoped_lock lk(fLock);
+    boost::recursive_mutex::scoped_lock lk(fLock);
 
     if (section.length() == 0)
         throw invalid_argument("Config::getConfig: section must have a length");
@@ -270,7 +270,7 @@ void Config::getConfig(const string& section, const string& name, vector<string>
 
 void Config::setConfig(const string& section, const string& name, const string& value)
 {
-    recursive_mutex::scoped_lock lk(fLock);
+    boost::recursive_mutex::scoped_lock lk(fLock);
 
     if (section.length() == 0 || name.length() == 0 )
         throw invalid_argument("Config::setConfig: all of section and name must have a length");
@@ -300,7 +300,7 @@ void Config::setConfig(const string& section, const string& name, const string& 
 
 void Config::delConfig(const string& section, const string& name)
 {
-    recursive_mutex::scoped_lock lk(fLock);
+    boost::recursive_mutex::scoped_lock lk(fLock);
 
     if (section.length() == 0 || name.length() == 0)
         throw invalid_argument("Config::delConfig: both section and name must have a length");
@@ -328,7 +328,7 @@ void Config::delConfig(const string& section, const string& name)
 
 void Config::writeConfig(const string& configFile) const
 {
-    recursive_mutex::scoped_lock lk(fLock);
+    boost::recursive_mutex::scoped_lock lk(fLock);
     FILE* fi;
 
     if (fDoc == 0)
@@ -445,7 +445,7 @@ void Config::writeConfig(const string& configFile) const
 
 void Config::write(void) const
 {
-    mutex::scoped_lock lk(fWriteXmlLock);
+    boost::mutex::scoped_lock lk(fWriteXmlLock);
 #ifdef _MSC_VER
     writeConfig(fConfigFile);
 #else
@@ -540,7 +540,7 @@ void Config::writeConfigFile(messageqcpp::ByteStream msg) const
 /* static */
 void Config::deleteInstanceMap()
 {
-    mutex::scoped_lock lk(fInstanceMapMutex);
+    boost::mutex::scoped_lock lk(fInstanceMapMutex);
 
     for (Config::configMap_t::iterator iter = fInstanceMap.begin();
             iter != fInstanceMap.end(); ++iter)
@@ -602,7 +602,7 @@ int64_t Config::fromText(const std::string& text)
 
 time_t Config::getCurrentMTime()
 {
-    recursive_mutex::scoped_lock lk(fLock);
+    boost::recursive_mutex::scoped_lock lk(fLock);
 
     struct stat statbuf;
 
@@ -614,7 +614,7 @@ time_t Config::getCurrentMTime()
 
 const vector<string> Config::enumConfig()
 {
-    recursive_mutex::scoped_lock lk(fLock);
+    boost::recursive_mutex::scoped_lock lk(fLock);
 
     if (fDoc == 0)
     {
@@ -638,7 +638,7 @@ const vector<string> Config::enumConfig()
 
 const vector<string> Config::enumSection(const string& section)
 {
-    recursive_mutex::scoped_lock lk(fLock);
+    boost::recursive_mutex::scoped_lock lk(fLock);
 
     if (fDoc == 0)
     {

--- a/utils/loggingcpp/idberrorinfo.cpp
+++ b/utils/loggingcpp/idberrorinfo.cpp
@@ -47,11 +47,11 @@ namespace logging
 {
 
 IDBErrorInfo* IDBErrorInfo::fInstance = 0;
-mutex mx;
+boost::mutex mx;
 
 IDBErrorInfo* IDBErrorInfo::instance()
 {
-    mutex::scoped_lock lk(mx);
+    boost::mutex::scoped_lock lk(mx);
 
     if (!fInstance)
         fInstance = new IDBErrorInfo();

--- a/utils/loggingcpp/logger.cpp
+++ b/utils/loggingcpp/logger.cpp
@@ -51,7 +51,7 @@ const string Logger::logMessage(LOG_TYPE logLevel, Message::MessageID mid, const
 
     return logMessage(logLevel, msg, logInfo);
     /*
-    mutex::scoped_lock lk(fLogLock);
+    boost::mutex::scoped_lock lk(fLogLock);
     fMl1.logData(logInfo);
 
     switch (logLevel)
@@ -79,7 +79,7 @@ const string Logger::logMessage(LOG_TYPE logLevel, Message::MessageID mid, const
 
 const std::string Logger::logMessage(LOG_TYPE logLevel, const Message& msg, const LoggingID& logInfo)
 {
-    mutex::scoped_lock lk(fLogLock);
+    boost::mutex::scoped_lock lk(fLogLock);
     fMl1.logData(logInfo);
 
     switch (logLevel)

--- a/utils/loggingcpp/message.cpp
+++ b/utils/loggingcpp/message.cpp
@@ -44,7 +44,7 @@ using namespace config;
 namespace
 {
 
-mutex mx;
+boost::mutex mx;
 bool catalogLoaded = false;
 
 typedef map<int, string> CatMap;
@@ -190,7 +190,7 @@ const string Message::lookupMessage(const MessageID& msgid)
 {
     if (!catalogLoaded)
     {
-        mutex::scoped_lock lock(mx);
+        boost::mutex::scoped_lock lock(mx);
 
         if (!catalogLoaded)
         {

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -98,7 +98,7 @@ uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
         return numeric_limits<uint64_t>::max();
 
     //@bug6065, make StringStore::storeString() thread safe
-    boost::mutex::scoped_lock lk(fMutex, defer_lock);
+    boost::mutex::scoped_lock lk(fMutex, boost::defer_lock);
 
     if (fUseStoreStringMutex)
         lk.lock();
@@ -254,7 +254,7 @@ uint32_t UserDataStore::storeUserData(mcsv1sdk::mcsv1Context& context,
         return numeric_limits<uint32_t>::max();
     }
 
-    boost::mutex::scoped_lock lk(fMutex, defer_lock);
+    boost::mutex::scoped_lock lk(fMutex, boost::defer_lock);
 
     if (fUseUserDataMutex)
         lk.lock();

--- a/utils/startup/installdir.cpp
+++ b/utils/startup/installdir.cpp
@@ -43,14 +43,14 @@ namespace startup
 {
 
 /* static */
-mutex StartUp::fTmpDirLock;
+boost::mutex StartUp::fTmpDirLock;
 /* static */
 string* StartUp::fTmpDirp = 0;
 
 /* static */
 const string StartUp::tmpDir()
 {
-    mutex::scoped_lock lk(fTmpDirLock);
+	boost::mutex::scoped_lock lk(fTmpDirLock);
 
     if (fTmpDirp)
         return *fTmpDirp;

--- a/utils/threadpool/prioritythreadpool.cpp
+++ b/utils/threadpool/prioritythreadpool.cpp
@@ -73,7 +73,7 @@ PriorityThreadPool::~PriorityThreadPool()
 void PriorityThreadPool::addJob(const Job& job, bool useLock)
 {
     boost::thread* newThread;
-    mutex::scoped_lock lk(mutex, defer_lock_t());
+    boost::mutex::scoped_lock lk(mutex, boost::defer_lock_t());
 
     if (useLock)
         lk.lock();
@@ -115,7 +115,7 @@ void PriorityThreadPool::removeJobs(uint32_t id)
 {
     list<Job>::iterator it;
 
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
 
     for (uint32_t i = 0; i < _COUNT; i++)
         for (it = jobQueues[i].begin(); it != jobQueues[i].end();)
@@ -152,7 +152,7 @@ void PriorityThreadPool::threadFcn(const Priority preferredQueue) throw()
         while (!_stop)
         {
 
-            mutex::scoped_lock lk(mutex);
+            boost::mutex::scoped_lock lk(mutex);
 
             queue = pickAQueue(preferredQueue);
 

--- a/versioning/BRM/autoincrementmanager.cpp
+++ b/versioning/BRM/autoincrementmanager.cpp
@@ -45,7 +45,7 @@ AutoincrementManager::~AutoincrementManager()
 void AutoincrementManager::startSequence(uint32_t oid, uint64_t firstNum, uint32_t colWidth,
         execplan::CalpontSystemCatalog::ColDataType colDataType)
 {
-    mutex::scoped_lock lk(lock);
+    boost::mutex::scoped_lock lk(lock);
     map<uint64_t, sequence>::iterator it;
     sequence s;
 
@@ -70,7 +70,7 @@ void AutoincrementManager::startSequence(uint32_t oid, uint64_t firstNum, uint32
 
 bool AutoincrementManager::getAIRange(uint32_t oid, uint64_t count, uint64_t* firstNum)
 {
-    mutex::scoped_lock lk(lock);
+    boost::mutex::scoped_lock lk(lock);
     map<uint64_t, sequence>::iterator it;
 
     it = sequences.find(oid);
@@ -91,7 +91,7 @@ bool AutoincrementManager::getAIRange(uint32_t oid, uint64_t count, uint64_t* fi
 
 void AutoincrementManager::resetSequence(uint32_t oid, uint64_t value)
 {
-    mutex::scoped_lock lk(lock);
+    boost::mutex::scoped_lock lk(lock);
     map<uint64_t, sequence>::iterator it;
 
     it = sequences.find(oid);
@@ -104,7 +104,7 @@ void AutoincrementManager::resetSequence(uint32_t oid, uint64_t value)
 
 void AutoincrementManager::getLock(uint32_t oid)
 {
-    mutex::scoped_lock lk(lock);
+    boost::mutex::scoped_lock lk(lock);
     map<uint64_t, sequence>::iterator it;
     ptime stealTime = microsec_clock::local_time() + seconds(lockTime);
 
@@ -130,7 +130,7 @@ void AutoincrementManager::getLock(uint32_t oid)
 
 void AutoincrementManager::releaseLock(uint32_t oid)
 {
-    mutex::scoped_lock lk(lock);
+    boost::mutex::scoped_lock lk(lock);
     map<uint64_t, sequence>::iterator it;
 
     it = sequences.find(oid);
@@ -145,7 +145,7 @@ void AutoincrementManager::releaseLock(uint32_t oid)
 
 void AutoincrementManager::deleteSequence(uint32_t oid)
 {
-    mutex::scoped_lock lk(lock);
+    boost::mutex::scoped_lock lk(lock);
     map<uint64_t, sequence>::iterator it;
 
     it = sequences.find(oid);

--- a/versioning/BRM/extentmap.cpp
+++ b/versioning/BRM/extentmap.cpp
@@ -1439,7 +1439,7 @@ void ExtentMap::save(const string& filename)
 /* always returns holding the EM lock, and with the EM seg mapped */
 void ExtentMap::grabEMEntryTable(OPS op)
 {
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
 
     if (op == READ)
         fEMShminfo = fMST.getTable_read(MasterSegmentTable::EMTable);
@@ -1496,7 +1496,7 @@ void ExtentMap::grabEMEntryTable(OPS op)
 /* always returns holding the FL lock */
 void ExtentMap::grabFreeList(OPS op)
 {
-    mutex::scoped_lock lk(mutex, defer_lock);
+    boost::mutex::scoped_lock lk(mutex, boost::defer_lock);
 
     if (op == READ)
     {

--- a/versioning/BRM/sessionmanagerserver.cpp
+++ b/versioning/BRM/sessionmanagerserver.cpp
@@ -237,7 +237,7 @@ const QueryContext SessionManagerServer::verID()
 {
     QueryContext ret;
 
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
     ret.currentScn = _verID;
 
     for (iterator i = activeTxns.begin(); i != activeTxns.end(); ++i)
@@ -250,7 +250,7 @@ const QueryContext SessionManagerServer::sysCatVerID()
 {
     QueryContext ret;
 
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
     ret.currentScn = _sysCatVerID;
 
     for (iterator i = activeTxns.begin(); i != activeTxns.end(); ++i)
@@ -264,7 +264,7 @@ const TxnID SessionManagerServer::newTxnID(const SID session, bool block, bool i
     TxnID ret; //ctor must set valid = false
     iterator it;
 
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
 
     // if it already has a txn...
     it = activeTxns.find(session);
@@ -299,7 +299,7 @@ const TxnID SessionManagerServer::newTxnID(const SID session, bool block, bool i
 void SessionManagerServer::finishTransaction(TxnID& txn)
 {
     iterator it;
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
     bool found = false;
 
     if (!txn.valid)
@@ -335,7 +335,7 @@ const TxnID SessionManagerServer::getTxnID(const SID session)
     TxnID ret;
     iterator it;
 
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
 
     it = activeTxns.find(session);
 
@@ -352,7 +352,7 @@ shared_array<SIDTIDEntry> SessionManagerServer::SIDTIDMap(int& len)
 {
     int j;
     shared_array<SIDTIDEntry> ret;
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
     iterator it;
 
     ret.reset(new SIDTIDEntry[activeTxns.size()]);
@@ -371,7 +371,7 @@ shared_array<SIDTIDEntry> SessionManagerServer::SIDTIDMap(int& len)
 
 void SessionManagerServer::setSystemState(uint32_t state)
 {
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
 
     systemState |= state;
     saveSystemState();
@@ -379,7 +379,7 @@ void SessionManagerServer::setSystemState(uint32_t state)
 
 void SessionManagerServer::clearSystemState(uint32_t state)
 {
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
 
     systemState &= ~state;
     saveSystemState();
@@ -387,7 +387,7 @@ void SessionManagerServer::clearSystemState(uint32_t state)
 
 uint32_t SessionManagerServer::getTxnCount()
 {
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
     return activeTxns.size();
 }
 

--- a/versioning/BRM/tablelockserver.cpp
+++ b/versioning/BRM/tablelockserver.cpp
@@ -40,7 +40,7 @@ namespace BRM
 
 TableLockServer::TableLockServer(SessionManagerServer* sm) : sms(sm)
 {
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
     config::Config* config = config::Config::makeConfig();
 
     filename = config->getConfig("SystemConfig", "TableLockSaveFile");
@@ -135,7 +135,7 @@ uint64_t TableLockServer::lock(TableLockInfo* tli)
     set<uint32_t> dbroots;
     lit_t it;
     uint32_t i;
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
 
     for (i = 0; i < tli->dbrootList.size(); i++)
         dbroots.insert(tli->dbrootList[i]);
@@ -177,7 +177,7 @@ bool TableLockServer::unlock(uint64_t id)
     std::map<uint64_t, TableLockInfo>::iterator it;
     TableLockInfo tli;
 
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
     it = locks.find(id);
 
     if (it != locks.end())
@@ -204,7 +204,7 @@ bool TableLockServer::unlock(uint64_t id)
 bool TableLockServer::changeState(uint64_t id, LockState state)
 {
     lit_t it;
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
     LockState old;
 
     it = locks.find(id);
@@ -232,7 +232,7 @@ bool TableLockServer::changeOwner(uint64_t id, const string& ownerName, uint32_t
                                   int32_t txnID)
 {
     lit_t it;
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
     string oldName;
     uint32_t oldPID;
     int32_t oldSession;
@@ -271,7 +271,7 @@ bool TableLockServer::changeOwner(uint64_t id, const string& ownerName, uint32_t
 vector<TableLockInfo> TableLockServer::getAllLocks() const
 {
     vector<TableLockInfo> ret;
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
     constlit_t it;
 
     for (it = locks.begin(); it != locks.end(); ++it)
@@ -284,7 +284,7 @@ void TableLockServer::releaseAllLocks()
 {
     std::map<uint64_t, TableLockInfo> tmp;
 
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
     tmp.swap(locks);
 
     try
@@ -301,7 +301,7 @@ void TableLockServer::releaseAllLocks()
 bool TableLockServer::getLockInfo(uint64_t id, TableLockInfo* out) const
 {
     constlit_t it;
-    mutex::scoped_lock lk(mutex);
+    boost::mutex::scoped_lock lk(mutex);
 
     it = locks.find(id);
 

--- a/writeengine/client/we_clients.cpp
+++ b/writeengine/client/we_clients.cpp
@@ -382,7 +382,7 @@ void WEClients::Listen ( boost::shared_ptr<MessageQueueClient> client, uint32_t 
 Error:
     // error condition! push 0 length bs to messagequeuemap and
     // eventually let jobstep error out.
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
 
     MessageQueueMap::iterator map_tok;
     sbs.reset(new ByteStream(0));
@@ -398,7 +398,7 @@ Error:
 
     // reset the pmconnection map
     {
-        mutex::scoped_lock onErrLock(fOnErrMutex);
+        boost::mutex::scoped_lock onErrLock(fOnErrMutex);
         string moduleName = client->moduleName();
         ClientList::iterator itor = fPmConnections.begin();
 
@@ -430,13 +430,13 @@ void WEClients::addQueue(uint32_t key)
 {
     bool b;
 
-    mutex* lock = new mutex();
+	boost::mutex* lock = new boost::mutex();
     condition* cond = new condition();
     boost::shared_ptr<MQE> mqe(new MQE(pmCount));
 
     mqe->queue = WESMsgQueue(lock, cond);
 
-    mutex::scoped_lock lk ( fMlock );
+    boost::mutex::scoped_lock lk ( fMlock );
     b = fSessionMessages.insert(pair<uint32_t, boost::shared_ptr<MQE> >(key, mqe)).second;
 
     if (!b)
@@ -449,7 +449,7 @@ void WEClients::addQueue(uint32_t key)
 
 void WEClients::removeQueue(uint32_t key)
 {
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator map_tok = fSessionMessages.find(key);
 
     if (map_tok == fSessionMessages.end())
@@ -462,7 +462,7 @@ void WEClients::removeQueue(uint32_t key)
 
 void WEClients::shutdownQueue(uint32_t key)
 {
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator map_tok = fSessionMessages.find(key);
 
     if (map_tok == fSessionMessages.end())
@@ -477,7 +477,7 @@ void WEClients::read(uint32_t key, SBS& bs)
     boost::shared_ptr<MQE> mqe;
 
     //Find the StepMsgQueueList for this session
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator map_tok = fSessionMessages.find(key);
 
     if (map_tok == fSessionMessages.end())
@@ -557,7 +557,7 @@ void WEClients::addDataToOutput(SBS sbs, uint32_t connIndex)
     *sbs >> uniqueId;
     boost::shared_ptr<MQE> mqe;
 
-    mutex::scoped_lock lk(fMlock);
+    boost::mutex::scoped_lock lk(fMlock);
     MessageQueueMap::iterator map_tok = fSessionMessages.find(uniqueId);
 
     if (map_tok == fSessionMessages.end())

--- a/writeengine/redistribute/we_redistributecontrol.cpp
+++ b/writeengine/redistribute/we_redistributecontrol.cpp
@@ -77,7 +77,7 @@ const string PlanFileName("/redistribute.plan");
 RedistributeControl* RedistributeControl::instance()
 {
     // The constructor is protected by instanceMutex lock.
-    mutex::scoped_lock lock(instanceMutex);
+    boost::mutex::scoped_lock lock(instanceMutex);
 
     if (fInstance == NULL)
         fInstance = new RedistributeControl();
@@ -132,7 +132,7 @@ RedistributeControl::~RedistributeControl()
 
 int RedistributeControl::handleUIMsg(messageqcpp::ByteStream& bs, messageqcpp::IOSocket& so)
 {
-    mutex::scoped_lock sessionLock(fSessionMutex);
+    boost::mutex::scoped_lock sessionLock(fSessionMutex);
 
     uint32_t status = RED_STATE_UNDEF;
     const RedistributeMsgHeader* h = (const RedistributeMsgHeader*) bs.buf();
@@ -402,7 +402,7 @@ uint32_t RedistributeControl::getCurrentState()
 {
     uint32_t status = RED_STATE_UNDEF;
     ostringstream oss;
-    mutex::scoped_lock lock(fInfoFileMutex);
+    boost::mutex::scoped_lock lock(fInfoFileMutex);
 
     if (!fInfoFilePtr)
     {
@@ -475,7 +475,7 @@ bool RedistributeControl::getStartOptions(messageqcpp::ByteStream& bs)
 
 void RedistributeControl::updateState(uint32_t s)
 {
-    mutex::scoped_lock lock(fInfoFileMutex);
+    boost::mutex::scoped_lock lock(fInfoFileMutex);
 
     // allowed state change:
     //   idle    ->  active
@@ -666,7 +666,7 @@ void RedistributeControl::updateState(uint32_t s)
 
 void RedistributeControl::setEntryCount(uint32_t entryCount)
 {
-    mutex::scoped_lock lock(fInfoFileMutex);
+    boost::mutex::scoped_lock lock(fInfoFileMutex);
     fRedistributeInfo.planned = entryCount;
 
     rewind(fInfoFilePtr);
@@ -677,7 +677,7 @@ void RedistributeControl::setEntryCount(uint32_t entryCount)
 
 void RedistributeControl::updateProgressInfo(uint32_t s, time_t t)
 {
-    mutex::scoped_lock lock(fInfoFileMutex);
+    boost::mutex::scoped_lock lock(fInfoFileMutex);
     fRedistributeInfo.endTime = t;
 
     switch (s)
@@ -703,7 +703,7 @@ void RedistributeControl::updateProgressInfo(uint32_t s, time_t t)
 
 int RedistributeControl::handleJobMsg(messageqcpp::ByteStream& bs, messageqcpp::IOSocket& so)
 {
-//	mutex::scoped_lock jobLock(fJobMutex);
+//	boost::mutex::scoped_lock jobLock(fJobMutex);
 
     uint32_t status = RED_TRANS_SUCCESS;
 

--- a/writeengine/redistribute/we_redistributecontrolthread.cpp
+++ b/writeengine/redistribute/we_redistributecontrolthread.cpp
@@ -73,7 +73,7 @@ string RedistributeControlThread::fWesInUse;
 
 void RedistributeControlThread::setStopAction(bool s)
 {
-    mutex::scoped_lock lock(fActionMutex);
+    boost::mutex::scoped_lock lock(fActionMutex);
     fStopAction = s;
 }
 
@@ -153,7 +153,7 @@ void RedistributeControlThread::doRedistribute()
         fControl->logMessage(fErrorMsg + " @controlThread::doRedistribute");
 
     {
-        mutex::scoped_lock lock(fActionMutex);
+        boost::mutex::scoped_lock lock(fActionMutex);
         fWesInUse.clear();
     }
 }
@@ -776,7 +776,7 @@ int  RedistributeControlThread::connectToWes(int dbroot)
 
     try
     {
-        mutex::scoped_lock lock(fActionMutex);
+        boost::mutex::scoped_lock lock(fActionMutex);
         fWesInUse = oss.str();
         fMsgQueueClient.reset(new MessageQueueClient(fWesInUse, fConfig));
     }
@@ -793,7 +793,7 @@ int  RedistributeControlThread::connectToWes(int dbroot)
 
     if (ret != 0)
     {
-        mutex::scoped_lock lock(fActionMutex);
+        boost::mutex::scoped_lock lock(fActionMutex);
         fWesInUse.clear();
 
         fMsgQueueClient.reset();
@@ -808,7 +808,7 @@ void RedistributeControlThread::doStopAction()
     fConfig = Config::makeConfig();
     fControl = RedistributeControl::instance();
 
-    mutex::scoped_lock lock(fActionMutex);
+    boost::mutex::scoped_lock lock(fActionMutex);
 
     if (!fWesInUse.empty())
     {

--- a/writeengine/redistribute/we_redistributeworkerthread.cpp
+++ b/writeengine/redistribute/we_redistributeworkerthread.cpp
@@ -99,7 +99,7 @@ RedistributeWorkerThread::RedistributeWorkerThread(ByteStream& bs, IOSocket& ios
 
 RedistributeWorkerThread::~RedistributeWorkerThread()
 {
-    mutex::scoped_lock lock(fActionMutex);
+    boost::mutex::scoped_lock lock(fActionMutex);
 
     if (fNewFilePtr)
         closeFile(fNewFilePtr);
@@ -140,7 +140,7 @@ void RedistributeWorkerThread::handleRequest()
     {
         // clear stop flag if ever set.
         {
-            mutex::scoped_lock lock(fActionMutex);
+            boost::mutex::scoped_lock lock(fActionMutex);
             fStopAction = false;
             fCommitted = false;
         }
@@ -188,7 +188,7 @@ void RedistributeWorkerThread::handleRequest()
 
     sendResponse(RED_ACTN_REQUEST);
 
-    mutex::scoped_lock lock(fActionMutex);
+    boost::mutex::scoped_lock lock(fActionMutex);
     fWesInUse.clear();
     fMsgQueueClient.reset();
 
@@ -910,7 +910,7 @@ int  RedistributeWorkerThread::updateDbrm()
 {
     int rc1 = BRM::ERR_OK;
     int rc2 = BRM::ERR_OK;
-    mutex::scoped_lock lock(fActionMutex);
+    boost::mutex::scoped_lock lock(fActionMutex);
 
     // cannot stop after extent map is updated.
     if (!fStopAction)
@@ -1113,7 +1113,7 @@ void RedistributeWorkerThread::addToDirSet(const char* fileName, bool isSource)
 
 void RedistributeWorkerThread::handleStop()
 {
-    mutex::scoped_lock lock(fActionMutex);
+    boost::mutex::scoped_lock lock(fActionMutex);
 
     // cannot stop after extent map is updated.
     if (!fCommitted)

--- a/writeengine/shared/we_brm.cpp
+++ b/writeengine/shared/we_brm.cpp
@@ -1691,7 +1691,7 @@ int BRMWrapper::writeVB(IDBDataFile* pSourceFile, const VER_t transID, const OID
     fileInfo.fSegment = 0;
 //    fileInfo.fDbRoot = (freeList[0].vbOID % rootCnt) + 1;
     fileInfo.fDbRoot = dbRoot;
-    mutex::scoped_lock lk(vbFileLock);
+    boost::mutex::scoped_lock lk(vbFileLock);
     pTargetFile = openFile(fileInfo, "r+b", true);
 
     if (pTargetFile == NULL)


### PR DESCRIPTION
fixes for compiling on gcc 9.2. Not complete though, the make does not finish, it get stuck below, was hoping to get a resolution here to finish the build and submit the merge.

 
 69%] Building CXX object dbcon/mysql/CMakeFiles/ha_columnstore.dir/ha_mcs_client_udfs.cpp.o
In file included from columnstore_exp/mariadb-columnstore-engine/../mariadb-columnstore-server/sql/mariadb.h:29,
                 from columnstore_exp/mariadb-columnstore-engine/../mariadb-columnstore-server/sql/sql_plugin.h:29,
                 from columnstore_exp/mariadb-columnstore-engine/dbcon/mysql/idb_mysql.h:66,
                 from columnstore_exp/mariadb-columnstore-engine/dbcon/mysql/ha_mcs_impl.h:22,
                 from columnstore_exp/mariadb-columnstore-engine/dbcon/mysql/ha_mcs_client_udfs.cpp:20:
columnstore_exp/mariadb-columnstore-engine/../mariadb-columnstore-server/include/my_global.h:399:36: error: expected identifier before ‘(’ token
  399 | #define likely(x) __builtin_expect(((x) != 0 ) ,1)
      |                                    ^
columnstore_exp/mariadb-columnstore-engine/../mariadb-columnstore-server/include/my_global.h:399:41: error: expected ‘)’ before ‘!=’ token
  399 | #define likely(x) __builtin_expect(((x) != 0 ) ,1)
      |                                    ~    ^~
columnstore_exp/mariadb-columnstore-engine/../mariadb-columnstore-server/include/my_global.h:399:41: error: expected ‘)’ before ‘!=’ token
columnstore_exp/mariadb-columnstore-engine/../mariadb-columnstore-server/include/my_global.h:399:39: error: expected ‘;’ at end of member declaration
  399 | #define likely(x) __builtin_expect(((x) != 0 ) ,1)
      |                                       ^
columnstore_exp/mariadb-columnstore-engine/../mariadb-columnstore-server/include/my_global.h:399:41: error: expected unqualified-id before ‘!=’ token
  399 | #define likely(x) __builtin_expect(((x) != 0 ) ,1)
      |                                         ^~
/usr/include/boost/date_time/time_parsing.hpp: In function ‘time_type boost::date_time::parse_iso_time(const string&, char)’:
columnstore_exp/mariadb-columnstore-engine/../mariadb-columnstore-server/include/my_global.h:399:41: error: no match for ‘operator!=’ (operand types are ‘const string’ {aka ‘const std::__cxx11::basic_string<char>’} and ‘int’)
  399 | #define likely(x) __builtin_expect(((x) != 0 ) ,1)
      |                                     ~~~ ^~ ~
      |                                            |
      |                                            int
In file included from /usr/include/boost/shared_ptr.hpp:17,
                 from columnstore_exp/mariadb-columnstore-engine/dbcon/mysql/ha_mcs_impl_if.h:30,
                 from columnstore_exp/mariadb-columnstore-engine/dbcon/mysql/ha_mcs_impl.h:57,
                 from columnstore_exp/mariadb-columnstore-engine/dbcon/mysql/ha_mcs_client_udfs.cpp:20:
/usr/include/boost/smart_ptr/shared_ptr.hpp:828:40: note: candidate: ‘template<class T, class U> bool boost::operator!=(const boost::shared_ptr<X>&, const boost::shared_ptr<U>&)’
  828 | template<class T, class U> inline bool operator!=(shared_ptr<T> const & a, shared_ptr<U> const & b) BOOST_SP_NOEXCEPT


