### PR TITLE
MCOL 3596 conv() result string not matching reference

### DIFF
--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -649,6 +649,7 @@ int fetchNextRow(uchar* buf, cal_table_info& ti, cal_connection_info* ci, bool h
                             break;
 
                         default:
+                            (*f)->field_length = 255; // reserve enough space for varchar, was previously displaying only 21 characters
                             f2->store((const char*)row.getStringPointer(s), row.getStringLength(s), f2->charset());
                     }
 


### PR DESCRIPTION
This patch fixes a bug where only a max of 21 characters would be displayed when returned from conv function to MDB.

Test cases from working_tpch1/qa_fe_cnxFunctions/conv.sql from MCS Regression Test were used to verify working patch.