### PR TITLE
MCOL-3672 Fix double-DML execution

### DIFF
--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -260,7 +260,8 @@ struct cal_connection_info
         useXbit(false),
         utf8(false),
         useCpimport(1),
-        delimiter('\7')
+        delimiter('\7'),
+        affectedRows(0)
     {
         // check if this is a slave mysql daemon
         isSlaveNode = checkSlave();
@@ -331,6 +332,7 @@ struct cal_connection_info
     std::vector <execplan::CalpontSystemCatalog::ColType> columnTypes;
     // MCOL-1101 remove compilation unit variable rmParms
     std::vector <execplan::RMParam> rmParms;
+    long long affectedRows;
 };
 
 const std::string infinidb_err_msg = "\nThe query includes syntax that is not supported by MariaDB Columnstore. Use 'show warnings;' to get more information. Review the MariaDB Columnstore Syntax guide for additional information on supported distributed syntax or consider changing the MariaDB Columnstore Operating Mode (infinidb_vtable_mode).";


### PR DESCRIPTION
Direct update/delete executed doUpdateDelete as well as the regular
execution route for doUpdateDelete.

This patch only executes doUpdateDelete the first time and direct
update/delete collects the counts.