### PR TITLE
MCOL-3672 Fix regression in deletes

### DIFF
--- a/dbcon/mysql/ha_mcs.cpp
+++ b/dbcon/mysql/ha_mcs.cpp
@@ -360,14 +360,14 @@ int ha_mcs::direct_update_rows_init(List<Item> *update_fields)
 int ha_mcs::direct_update_rows(ha_rows *update_rows)
 {
     DBUG_ENTER("ha_mcs::direct_update_rows");
-    int rc = ha_mcs_impl_direct_update_delete_rows(update_rows);
+    int rc = ha_mcs_impl_direct_update_delete_rows(false, update_rows);
     DBUG_RETURN(rc);
 }
 
 int ha_mcs::direct_update_rows(ha_rows *update_rows, ha_rows *found_rows)
 {
     DBUG_ENTER("ha_mcs::direct_update_rows");
-    int rc = ha_mcs_impl_direct_update_delete_rows(update_rows);
+    int rc = ha_mcs_impl_direct_update_delete_rows(false, update_rows);
     *found_rows = *update_rows;
     DBUG_RETURN(rc);
 }
@@ -381,7 +381,7 @@ int ha_mcs::direct_delete_rows_init()
 int ha_mcs::direct_delete_rows(ha_rows *deleted_rows)
 {
     DBUG_ENTER("ha_mcs::direct_delete_rows");
-    int rc = ha_mcs_impl_direct_update_delete_rows(deleted_rows);
+    int rc = ha_mcs_impl_direct_update_delete_rows(true, deleted_rows);
     DBUG_RETURN(rc);
 }
 /**

--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -2281,11 +2281,17 @@ int ha_mcs_impl_discover_existence(const char* schema, const char* name)
     return 0;
 }
 
-int ha_mcs_impl_direct_update_delete_rows(ha_rows *affected_rows)
+int ha_mcs_impl_direct_update_delete_rows(bool execute, ha_rows *affected_rows)
 {
     THD* thd = current_thd;
+    int rc = 0;
     cal_impl_if::gp_walk_info gwi;
     gwi.thd = thd;
+
+    if (execute)
+    {
+        rc = doUpdateDelete(thd, gwi);
+    }
 
     cal_connection_info* ci = reinterpret_cast<cal_connection_info*>(get_fe_conn_info_ptr());
     if (ci)

--- a/dbcon/mysql/ha_mcs_impl.h
+++ b/dbcon/mysql/ha_mcs_impl.h
@@ -42,7 +42,7 @@ extern int ha_mcs_impl_close_connection (handlerton* hton, THD* thd);
 extern COND* ha_mcs_impl_cond_push(COND* cond, TABLE* table);
 extern int ha_mcs_impl_external_lock(THD* thd, TABLE* table, int lock_type);
 extern int ha_mcs_impl_update_row();
-extern int ha_mcs_impl_direct_update_delete_rows(ha_rows *affected_rows);
+extern int ha_mcs_impl_direct_update_delete_rows(bool execute, ha_rows *affected_rows);
 extern int ha_mcs_impl_delete_row();
 extern int ha_mcs_impl_rnd_pos(uchar* buf, uchar* pos);
 extern int ha_cs_impl_pushdown_init(mcs_handler_info* handler_info, TABLE* table);


### PR DESCRIPTION
Deletes appear to only use the direct delete path. This allows that to
happen.