### PR TITLE
Revert "MCOL-1734 This patch fixes the error for NOT IN + subquery wh…

### DIFF
--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -1190,7 +1190,7 @@ void BatchPrimitiveProcessor::executeTupleJoin()
                  */
 
                 if (((!found || isNull) && !(joinTypes[j] & (LARGEOUTER | ANTI))) ||
-                        ((joinTypes[j] & ANTI) && ((isNull && !(joinTypes[j] & MATCHNULLS)) || (found && !isNull))))
+                        ((joinTypes[j] & ANTI) && ((isNull && (joinTypes[j] & MATCHNULLS)) || (found && !isNull))))
                 {
                     //cout << " - not in the result set\n";
                     break;


### PR DESCRIPTION
…en outer query has NULLs in a key"

This reverts commit 5174c40bfe6a8c041c5d6056b4795ac12752e21c.