### PR TITLE
Noticed a potential deadlock problem in poolallocator.

### DIFF
--- a/utils/common/poolallocator.cpp
+++ b/utils/common/poolallocator.cpp
@@ -71,16 +71,11 @@ void * PoolAllocator::allocOOB(uint64_t size)
     bool _false = false;
     OOBMemInfo memInfo;
 
-    if (useLock)
-        while (!lock.compare_exchange_weak(_false, true, std::memory_order_acquire))
-            _false = false;
     memUsage += size;
     memInfo.mem.reset(new uint8_t[size]);
     memInfo.size = size;
     void *ret = (void*) memInfo.mem.get();
     oob[ret] = memInfo;
-    if (useLock)
-        lock.store(false, std::memory_order_release);
     return ret;
 }
 

--- a/utils/common/poolallocator.cpp
+++ b/utils/common/poolallocator.cpp
@@ -93,7 +93,11 @@ void PoolAllocator::deallocate(void* p)
     OutOfBandMap::iterator it = oob.find(p);
 
     if (it == oob.end())
+    {
+        if (useLock)
+            lock.store(false, std::memory_order_release);
         return;
+    }
 
     memUsage -= it->second.size;
     oob.erase(it);


### PR DESCRIPTION
Would be a problem if we ever did a deallocate() call when useLock=true.  We don't right now.