### PR TITLE
MCOL-3702 Fix replication config file changes

### DIFF
--- a/dbcon/mysql/columnstore.cnf
+++ b/dbcon/mysql/columnstore.cnf
@@ -16,6 +16,7 @@ plugin-load-add=ha_columnstore.so
 
 # Required for Schema Sync
 #server-id = 1
+#log_bin
 
 # Uncomment for this UM to apply slave DML on ColumnStore tables
 #columnstore_replication_slave=ON

--- a/oam/install_scripts/mariadb-command-line.sh.in
+++ b/oam/install_scripts/mariadb-command-line.sh.in
@@ -50,7 +50,7 @@ cat >${tmpdir}/mariadb-command-line.sql <<EOD
 $command;
 EOD
 
-cat${tmpdir}/mariadb-command-line.sql >> ${tmpdir}/mariadb-command-line.log
+cat ${tmpdir}/mariadb-command-line.sql >> ${tmpdir}/mariadb-command-line.log
 mysql \
 	--user=root \
 	calpontsys < ${tmpdir}/mariadb-command-line.sql >> ${tmpdir}/mariadb-command-line.log 2>&1

--- a/oamapps/postConfigure/helpers.cpp
+++ b/oamapps/postConfigure/helpers.cpp
@@ -411,7 +411,7 @@ int sendReplicationRequest(int IserverTypeInstall, std::string password, bool pm
 
                             if ( returnStatus != API_SUCCESS)
                             {
-                                cout << endl << "ERROR: Error return in running the MariaDB ColumnStore Master replication, check " + tmpDir + "master-rep*.logs on " << masterModule << endl;
+                                cout << endl << "ERROR: Error return in running the MariaDB ColumnStore Master replication, check " + tmpDir + "/master-rep*.logs on " << masterModule << endl;
                                 return returnStatus;
                             }
 

--- a/procmon/processmonitor.cpp
+++ b/procmon/processmonitor.cpp
@@ -4804,6 +4804,12 @@ int ProcessMonitor::changeMyCnf(std::string type)
             }
         }
 
+        pos = buf.find("log_bin", 0);
+        if ( pos != string::npos )
+        {
+            buf = "log_bin";
+        }
+
         // set local query flag if on pm
         if ( (PMwithUM == "y") && config.moduleType() == "pm" )
         {
@@ -4870,13 +4876,12 @@ int ProcessMonitor::changeMyCnf(std::string type)
     system(cmd.c_str());
 
     // restart mysql
-    /*	try {
+	try {
     		oam.actionMysqlCalpont(MYSQL_RESTART);
     		sleep(5);	// give after mysql restart
     	}
     	catch(...)
     	{}
-    */
     log.writeLog(__LINE__, "changeMyCnf function successfully completed", LOG_TYPE_DEBUG);
 
     return oam::API_SUCCESS;
@@ -5076,10 +5081,11 @@ int ProcessMonitor::runMasterRep(std::string& masterLogFile, std::string& master
         while (file.getline(line, 200))
         {
             buf = line;
-            string::size_type pos = buf.find("mysql-bin", 0);
+            string::size_type pos = buf.find("000", 0);
 
             if ( pos != string::npos )
             {
+                pos = 0;
                 string::size_type pos1 = buf.find("\t", pos);
 
                 if ( pos1 != string::npos )


### PR DESCRIPTION
log_bin is missing from columnstore.cnf. This causes a search for the
master log file to fail and replication doesn't apply.

This patch adds a commented out log_bin which is enabled as needed.

It also fixes an error message.