### PR TITLE
MCOL-1950: join & aggregation mem reduction

### DIFF
--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -274,7 +274,7 @@ void TupleHashJoinStep::startSmallRunners(uint index)
     joiners[index] = joiner;
 
     /* check for join types unsupported on the PM. */
-    if (true || !largeBPS || !isExeMgr)
+    if (!largeBPS || !isExeMgr)
         joiner->setInUM(rgData[index]);
 
     /*

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -274,7 +274,7 @@ void TupleHashJoinStep::startSmallRunners(uint index)
     joiners[index] = joiner;
 
     /* check for join types unsupported on the PM. */
-    if (!largeBPS || !isExeMgr)
+    if (true || !largeBPS || !isExeMgr)
         joiner->setInUM(rgData[index]);
 
     /*

--- a/primitives/primproc/batchprimitiveprocessor.h
+++ b/primitives/primproc/batchprimitiveprocessor.h
@@ -34,11 +34,7 @@
 #include <boost/scoped_array.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
-#ifndef _MSC_VER
-#include <tr1/unordered_map>
-#else
 #include <unordered_map>
-#endif
 #include <boost/thread.hpp>
 
 #include "errorcodes.h"
@@ -281,11 +277,11 @@ private:
     bool hasRowGroup;
 
     /* Rowgroups + join */
-    typedef std::tr1::unordered_multimap<uint64_t, uint32_t,
+    typedef std::unordered_multimap<uint64_t, uint32_t,
             joiner::TupleJoiner::hasher, std::equal_to<uint64_t>,
             utils::STLPoolAllocator<std::pair<const uint64_t, uint32_t> > > TJoiner;
 
-    typedef std::tr1::unordered_multimap<joiner::TypelessData,
+    typedef std::unordered_multimap<joiner::TypelessData,
             uint32_t, joiner::TupleJoiner::hasher, std::equal_to<joiner::TypelessData>,
             utils::STLPoolAllocator<std::pair<const joiner::TypelessData, uint32_t> > > TLJoiner;
 

--- a/primitives/primproc/batchprimitiveprocessor.h
+++ b/primitives/primproc/batchprimitiveprocessor.h
@@ -51,7 +51,7 @@
 
 namespace primitiveprocessor
 {
-typedef std::tr1::unordered_map<int64_t, BRM::VSSData> VSSCache;
+typedef std::unordered_map<int64_t, BRM::VSSData> VSSCache;
 };
 
 #include "primitiveserver.h"

--- a/utils/common/stlpoolallocator.h
+++ b/utils/common/stlpoolallocator.h
@@ -86,29 +86,24 @@ public:
     static const uint32_t DEFAULT_SIZE = 32768 * sizeof(T);
 
     boost::shared_ptr<utils::PoolAllocator> pa;
-    uint64_t nodeCount;
 };
 
 template<class T>
 STLPoolAllocator<T>::STLPoolAllocator() throw()
 {
-    std::cout << "STLPoolAllocator: size of T = " << sizeof(T) << std::endl;
     pa.reset(new PoolAllocator(DEFAULT_SIZE));
-    nodeCount = 0;
 }
 
 template<class T>
 STLPoolAllocator<T>::STLPoolAllocator(const STLPoolAllocator<T>& s) throw()
 {
     pa = s.pa;
-    nodeCount = s.nodeCount;
 }
 
 template<class T>
 STLPoolAllocator<T>::STLPoolAllocator(uint32_t capacity) throw()
 {
     pa.reset(new PoolAllocator(capacity));
-    nodeCount = 0;
 }
 
 template<class T>
@@ -116,14 +111,11 @@ template<class U>
 STLPoolAllocator<T>::STLPoolAllocator(const STLPoolAllocator<U>& s) throw()
 {
     pa = s.pa;
-    nodeCount = s.nodeCount;
 }
 
 template<class T>
 STLPoolAllocator<T>::~STLPoolAllocator()
 {
-    std::cout << "STLPoolAllocator: size of T = " << sizeof(T) << " node count = " <<
-        nodeCount << " final size = " << getMemUsage() << std::endl;
 }
 
 template<class T>
@@ -142,7 +134,6 @@ typename STLPoolAllocator<T>::pointer
 STLPoolAllocator<T>::allocate(typename STLPoolAllocator<T>::size_type s,
                               typename std::allocator<void>::const_pointer hint)
 {
-    nodeCount++;
     return (pointer) pa->allocate(s * sizeof(T), s != 1);
 }
 

--- a/utils/common/stlpoolallocator.h
+++ b/utils/common/stlpoolallocator.h
@@ -86,24 +86,29 @@ public:
     static const uint32_t DEFAULT_SIZE = 32768 * sizeof(T);
 
     boost::shared_ptr<utils::PoolAllocator> pa;
+    uint64_t nodeCount;
 };
 
 template<class T>
 STLPoolAllocator<T>::STLPoolAllocator() throw()
 {
+    std::cout << "STLPoolAllocator: size of T = " << sizeof(T) << std::endl;
     pa.reset(new PoolAllocator(DEFAULT_SIZE));
+    nodeCount = 0;
 }
 
 template<class T>
 STLPoolAllocator<T>::STLPoolAllocator(const STLPoolAllocator<T>& s) throw()
 {
     pa = s.pa;
+    nodeCount = s.nodeCount;
 }
 
 template<class T>
 STLPoolAllocator<T>::STLPoolAllocator(uint32_t capacity) throw()
 {
     pa.reset(new PoolAllocator(capacity));
+    nodeCount = 0;
 }
 
 template<class T>
@@ -111,11 +116,14 @@ template<class U>
 STLPoolAllocator<T>::STLPoolAllocator(const STLPoolAllocator<U>& s) throw()
 {
     pa = s.pa;
+    nodeCount = s.nodeCount;
 }
 
 template<class T>
 STLPoolAllocator<T>::~STLPoolAllocator()
 {
+    std::cout << "STLPoolAllocator: size of T = " << sizeof(T) << " node count = " <<
+        nodeCount << " final size = " << getMemUsage() << std::endl;
 }
 
 template<class T>
@@ -134,14 +142,15 @@ typename STLPoolAllocator<T>::pointer
 STLPoolAllocator<T>::allocate(typename STLPoolAllocator<T>::size_type s,
                               typename std::allocator<void>::const_pointer hint)
 {
-    return (pointer) pa->allocate(s * sizeof(T));
+    nodeCount++;
+    return (pointer) pa->allocate(s * sizeof(T), s != 1);
 }
 
 template<class T>
 void STLPoolAllocator<T>::deallocate(typename STLPoolAllocator<T>::pointer p,
                                      typename STLPoolAllocator<T>::size_type n)
 {
-    pa->deallocate((void*) p);
+    pa->deallocate((void*) p, n != 1);
 }
 
 template<class T>

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -20,11 +20,8 @@
 #include <algorithm>
 #include <vector>
 #include <limits>
-#ifdef _MSC_VER
 #include <unordered_set>
-#else
-#include <tr1/unordered_set>
-#endif
+
 #include "hasher.h"
 #include "lbidlist.h"
 #include "spinlock.h"
@@ -655,6 +652,7 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
 
 void TupleJoiner::doneInserting()
 {
+    cout << "done inserting, node count = " << size() << " mem usage = " << getMemUsage() << endl;
 
     // a minor textual cleanup
 #ifdef TJ_DEBUG
@@ -677,8 +675,8 @@ void TupleJoiner::doneInserting()
 
     for (col = 0; col < smallKeyColumns.size(); col++)
     {
-        tr1::unordered_set<int64_t> uniquer;
-        tr1::unordered_set<int64_t>::iterator uit;
+        unordered_set<int64_t> uniquer;
+        unordered_set<int64_t>::iterator uit;
         sthash_t::iterator sthit;
         hash_t::iterator hit;
         ldhash_t::iterator ldit;

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -652,8 +652,6 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
 
 void TupleJoiner::doneInserting()
 {
-    cout << "done inserting, node count = " << size() << " mem usage = " << getMemUsage() << endl;
-
     // a minor textual cleanup
 #ifdef TJ_DEBUG
 #define CHECKSIZE \

--- a/utils/joiner/tuplejoiner.h
+++ b/utils/joiner/tuplejoiner.h
@@ -25,11 +25,7 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_array.hpp>
 #include <boost/scoped_array.hpp>
-#ifdef _MSC_VER
 #include <unordered_map>
-#else
-#include <tr1/unordered_map>
-#endif
 
 #include "rowgroup.h"
 #include "joiner.h"
@@ -344,14 +340,14 @@ public:
     void setConvertToDiskJoin();
 
 private:
-    typedef std::tr1::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
+    typedef std::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
             utils::STLPoolAllocator<std::pair<const int64_t, uint8_t*> > > hash_t;
-    typedef std::tr1::unordered_multimap<int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
+    typedef std::unordered_multimap<int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
             utils::STLPoolAllocator<std::pair<const int64_t, rowgroup::Row::Pointer> > > sthash_t;
-    typedef std::tr1::unordered_multimap<TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
+    typedef std::unordered_multimap<TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
             utils::STLPoolAllocator<std::pair<const TypelessData, rowgroup::Row::Pointer> > > typelesshash_t;
     // MCOL-1822 Add support for Long Double AVG/SUM small side
-    typedef std::tr1::unordered_multimap<long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
+    typedef std::unordered_multimap<long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
             utils::STLPoolAllocator<std::pair<const long double, rowgroup::Row::Pointer> > > ldhash_t;
 
     typedef hash_t::iterator iterator;


### PR DESCRIPTION
Made our allocators capable of distinguishing between nodes and tables being allocatoed.  Nodes get allocated from the pool, tables get allocated (and more importantly, deallocated) by the system allocator.  In my test case, it reduced mem usage by 70% and boosted performance somewhat.  See the ticket for more info.