### PR TITLE
MCOL-1950 - UM join & agg mem reduction

### DIFF
--- a/primitives/primproc/batchprimitiveprocessor.h
+++ b/primitives/primproc/batchprimitiveprocessor.h
@@ -34,11 +34,7 @@
 #include <boost/scoped_array.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
-#ifndef _MSC_VER
-#include <tr1/unordered_map>
-#else
 #include <unordered_map>
-#endif
 #include <boost/thread.hpp>
 
 #include "errorcodes.h"
@@ -55,7 +51,7 @@
 
 namespace primitiveprocessor
 {
-typedef std::tr1::unordered_map<int64_t, BRM::VSSData> VSSCache;
+typedef std::unordered_map<int64_t, BRM::VSSData> VSSCache;
 };
 
 #include "primitiveserver.h"
@@ -281,11 +277,11 @@ private:
     bool hasRowGroup;
 
     /* Rowgroups + join */
-    typedef std::tr1::unordered_multimap<uint64_t, uint32_t,
+    typedef std::unordered_multimap<uint64_t, uint32_t,
             joiner::TupleJoiner::hasher, std::equal_to<uint64_t>,
             utils::STLPoolAllocator<std::pair<const uint64_t, uint32_t> > > TJoiner;
 
-    typedef std::tr1::unordered_multimap<joiner::TypelessData,
+    typedef std::unordered_multimap<joiner::TypelessData,
             uint32_t, joiner::TupleJoiner::hasher, std::equal_to<joiner::TypelessData>,
             utils::STLPoolAllocator<std::pair<const joiner::TypelessData, uint32_t> > > TLJoiner;
 

--- a/utils/common/poolallocator.h
+++ b/utils/common/poolallocator.h
@@ -61,8 +61,8 @@ public:
 
     PoolAllocator& operator=(const PoolAllocator&);
 
-    void* allocate(uint64_t size);
-    void deallocate(void* p);
+    void* allocate(uint64_t size, bool isOOB = false);
+    void deallocate(void* p, bool isOOB = true);
     void deallocateAll();
 
     inline uint64_t getMemUsage() const
@@ -101,7 +101,7 @@ private:
     OutOfBandMap oob;  // for mem chunks bigger than the window size; these can be dealloc'd
 };
 
-inline void* PoolAllocator::allocate(uint64_t size)
+inline void* PoolAllocator::allocate(uint64_t size, bool isOOB)
 {
     void *ret;
     bool _false = false;
@@ -110,7 +110,7 @@ inline void* PoolAllocator::allocate(uint64_t size)
         while (!lock.compare_exchange_weak(_false, true, std::memory_order_acquire))
             _false = false;
 
-    if (size > allocSize)
+    if (isOOB || size > allocSize)
     {
         ret = allocOOB(size);
         if (useLock)

--- a/utils/common/stlpoolallocator.h
+++ b/utils/common/stlpoolallocator.h
@@ -134,14 +134,14 @@ typename STLPoolAllocator<T>::pointer
 STLPoolAllocator<T>::allocate(typename STLPoolAllocator<T>::size_type s,
                               typename std::allocator<void>::const_pointer hint)
 {
-    return (pointer) pa->allocate(s * sizeof(T));
+    return (pointer) pa->allocate(s * sizeof(T), s != 1);
 }
 
 template<class T>
 void STLPoolAllocator<T>::deallocate(typename STLPoolAllocator<T>::pointer p,
                                      typename STLPoolAllocator<T>::size_type n)
 {
-    pa->deallocate((void*) p);
+    pa->deallocate((void*) p, n != 1);
 }
 
 template<class T>

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -20,11 +20,8 @@
 #include <algorithm>
 #include <vector>
 #include <limits>
-#ifdef _MSC_VER
 #include <unordered_set>
-#else
-#include <tr1/unordered_set>
-#endif
+
 #include "hasher.h"
 #include "lbidlist.h"
 #include "spinlock.h"
@@ -655,7 +652,6 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
 
 void TupleJoiner::doneInserting()
 {
-
     // a minor textual cleanup
 #ifdef TJ_DEBUG
 #define CHECKSIZE \
@@ -677,8 +673,8 @@ void TupleJoiner::doneInserting()
 
     for (col = 0; col < smallKeyColumns.size(); col++)
     {
-        tr1::unordered_set<int64_t> uniquer;
-        tr1::unordered_set<int64_t>::iterator uit;
+        unordered_set<int64_t> uniquer;
+        unordered_set<int64_t>::iterator uit;
         sthash_t::iterator sthit;
         hash_t::iterator hit;
         ldhash_t::iterator ldit;

--- a/utils/joiner/tuplejoiner.h
+++ b/utils/joiner/tuplejoiner.h
@@ -25,11 +25,7 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_array.hpp>
 #include <boost/scoped_array.hpp>
-#ifdef _MSC_VER
 #include <unordered_map>
-#else
-#include <tr1/unordered_map>
-#endif
 
 #include "rowgroup.h"
 #include "joiner.h"
@@ -344,14 +340,14 @@ public:
     void setConvertToDiskJoin();
 
 private:
-    typedef std::tr1::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
+    typedef std::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
             utils::STLPoolAllocator<std::pair<const int64_t, uint8_t*> > > hash_t;
-    typedef std::tr1::unordered_multimap<int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
+    typedef std::unordered_multimap<int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
             utils::STLPoolAllocator<std::pair<const int64_t, rowgroup::Row::Pointer> > > sthash_t;
-    typedef std::tr1::unordered_multimap<TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
+    typedef std::unordered_multimap<TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
             utils::STLPoolAllocator<std::pair<const TypelessData, rowgroup::Row::Pointer> > > typelesshash_t;
     // MCOL-1822 Add support for Long Double AVG/SUM small side
-    typedef std::tr1::unordered_multimap<long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
+    typedef std::unordered_multimap<long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
             utils::STLPoolAllocator<std::pair<const long double, rowgroup::Row::Pointer> > > ldhash_t;
 
     typedef hash_t::iterator iterator;


### PR DESCRIPTION
Made the allocators capable of distinguishing between node and table
allocations.  Only nodes will be allocated from the pool, tables will
be allocated and deallocated by the system allocator.  Being able
to dealloc the tables saves a good deal of mem.

This automatically reduces the mem usage of UM & PM joins, aggregation,
unions, and distinct ops.  Anything using STLPoolAllocator in a hash table.

Squashed commit of the following:

commit ef6c821093f1b0694690d649b2de105dc2e60f8c
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Fri Jan 3 11:48:35 2020 -0500

    Removed debugging printouts & KPIs.

commit 4ff6092148ea88ba7030997d1333094a9cdec2ea
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Thu Jan 2 14:48:04 2020 -0500

    Changed hash join hash table type from tr1::unordered_map to std::unordered_map

    It seems the tr1 version ends up running the allocator's dtor on every
    node creation.  Messed up my test case, where I have the allocator
    printing kpis.

commit 86ff8ba318d696c077fb56ce5524f9eb6fc200c5
Author: Patrick LeBlanc <patrick.leblanc@mariadb.com>
Date:   Thu Jan 2 13:51:43 2020 -0500

    Changed the allocators s.t. the hash table is always stored
    'out of band', and only nodes go into the pool.