### PR TITLE
MCOL-1734 CS now behaves similar to MDB in case of NOT IN + correlated subquery if the subquery returns empty set.

### DIFF
--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -2303,7 +2303,7 @@ int ha_mcs_impl_direct_update_delete_rows(bool execute, ha_rows *affected_rows)
         *affected_rows = ci->affectedRows;
     }
 
-    return 0;
+    return rc;
 }
 
 int ha_mcs_impl_rnd_init(TABLE* table)

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -1174,6 +1174,7 @@ void BatchPrimitiveProcessor::executeTupleJoin()
                     break;
             }
 
+
             if (LIKELY(!typelessJoin[j]))
             {
                 //cout << "not typeless join\n";
@@ -1186,6 +1187,8 @@ void BatchPrimitiveProcessor::executeTupleJoin()
                     largeKey = oldRow.getIntField(colIndex);
                 uint bucket = bucketPicker((char *) &largeKey, 8, bpSeed) & ptMask;
 
+                bool joinerIsEmpty = tJoiners[j][bucket]->empty() ? true : false; 
+
                 found = (tJoiners[j][bucket]->find(largeKey) != tJoiners[j][bucket]->end());
                 isNull = oldRow.isNullValue(colIndex);
                 /* These conditions define when the row is NOT in the result set:
@@ -1195,7 +1198,7 @@ void BatchPrimitiveProcessor::executeTupleJoin()
                  */
 
                 if (((!found || isNull) && !(joinTypes[j] & (LARGEOUTER | ANTI))) ||
-                        ((joinTypes[j] & ANTI) && ((isNull && (joinTypes[j] & MATCHNULLS)) || (found && !isNull))))
+                        ((joinTypes[j] & ANTI) && !joinerIsEmpty && ((isNull && (joinTypes[j] & MATCHNULLS)) || (found && !isNull))))
                 {
                     //cout << " - not in the result set\n";
                     break;


### PR DESCRIPTION
CS now returns full outer record set.

gcc 8.2 complains about unused variable in ha_mcs_impl.cc