### PR TITLE
Runtime disable oam

### DIFF
--- a/cmake/configureEngine.cmake
+++ b/cmake/configureEngine.cmake
@@ -716,9 +716,9 @@ IF (NOT INLINE)
 SET (inline "")
 ENDIF()
 
-IF($ENV{SKIP_OAM_INIT})
-    set(SKIP_OAM_INIT 1 CACHE BOOL "Skip OAM initialization" FORCE)
-ENDIF()
+#IF($ENV{SKIP_OAM_INIT})
+#    set(SKIP_OAM_INIT 1 CACHE BOOL "Skip OAM initialization" FORCE)
+#ENDIF()
 
 EXECUTE_PROCESS(
     COMMAND rm -f conftest.data conftest.file conftest.sym

--- a/cmake/configureEngine.cmake
+++ b/cmake/configureEngine.cmake
@@ -716,10 +716,6 @@ IF (NOT INLINE)
 SET (inline "")
 ENDIF()
 
-#IF($ENV{SKIP_OAM_INIT})
-#    set(SKIP_OAM_INIT 1 CACHE BOOL "Skip OAM initialization" FORCE)
-#ENDIF()
-
 EXECUTE_PROCESS(
     COMMAND rm -f conftest.data conftest.file conftest.sym
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/exemgr/main.cpp
+++ b/exemgr/main.cpp
@@ -76,10 +76,7 @@
 #include <thread>
 #include <condition_variable>
 
-#if defined(SKIP_OAM_INIT)
 #include "dbrm.h"
-#endif
-
 
 namespace
 {
@@ -1646,11 +1643,12 @@ int main(int argc, char* argv[])
         {
         }
     }
-#if defined(SKIP_OAM_INIT)
-    BRM::DBRM *dbrm = new BRM::DBRM();
-    dbrm->setSystemQueryReady(true);
-    delete dbrm;
-#endif
+    if (getenv("SKIP_OAM_INIT"))
+    {
+        BRM::DBRM *dbrm = new BRM::DBRM();
+        dbrm->setSystemQueryReady(true);
+        delete dbrm;
+    }
 
     threadpool::ThreadPool exeMgrThreadPool(serverThreads, 0);
     exeMgrThreadPool.setName("ExeMgrServer");

--- a/mcsconfig.h.in
+++ b/mcsconfig.h.in
@@ -2,9 +2,6 @@
 #ifndef TEST_MCSCONFIG_H
 #define TEST_MCSCONFIG_H
 
-/* Define to 1 to let the system come up without using OAM */
-// #cmakedefine SKIP_OAM_INIT 1
-
 /* Define to 1 if you have the `alarm' function. */
 #cmakedefine HAVE_ALARM 1
 

--- a/mcsconfig.h.in
+++ b/mcsconfig.h.in
@@ -3,7 +3,7 @@
 #define TEST_MCSCONFIG_H
 
 /* Define to 1 to let the system come up without using OAM */
-#cmakedefine SKIP_OAM_INIT 1
+// #cmakedefine SKIP_OAM_INIT 1
 
 /* Define to 1 if you have the `alarm' function. */
 #cmakedefine HAVE_ALARM 1

--- a/oam/oamcpp/liboamcpp.cpp
+++ b/oam/oamcpp/liboamcpp.cpp
@@ -1255,7 +1255,7 @@ void Oam::addModule(DeviceNetworkList devicenetworklist, const std::string passw
     bool storeHostnames)
 {
     // build and send msg
-    int returnStatus = sendAddModuleToProcMgr(ADDMODULE, devicenetworklist, FORCEFUL, ACK_YES, storeHostnames, 
+    int returnStatus = sendAddModuleToProcMgr(ADDMODULE, devicenetworklist, FORCEFUL, ACK_YES, storeHostnames,
         password, mysqlpw);
 
     if (returnStatus != API_SUCCESS)
@@ -1953,9 +1953,9 @@ void Oam::getProcessConfig(SystemProcessConfig& systemprocessconfig)
     Config* proConfig = Config::makeConfig(ProcessConfigFile.c_str());
     Config *csConfig = Config::makeConfig();
     string strStorageManagerEnabled = csConfig->getConfig("StorageManager", "Enabled");
-    bool storageManagerEnabled = !strStorageManagerEnabled.empty() && (strStorageManagerEnabled[0] == 'Y' || 
+    bool storageManagerEnabled = !strStorageManagerEnabled.empty() && (strStorageManagerEnabled[0] == 'Y' ||
         strStorageManagerEnabled[0] == 'y' || strStorageManagerEnabled[0] == 'T' || strStorageManagerEnabled[0] == 't');
-    
+
     for (int processID = 1; processID < MAX_PROCESS + 1; processID++)
     {
         ProcessConfig processconfig;
@@ -1969,7 +1969,7 @@ void Oam::getProcessConfig(SystemProcessConfig& systemprocessconfig)
                               processconfig );
 
         // hide StorageManager from everything else if it is disabled
-        if (processconfig.ProcessName.empty() || 
+        if (processconfig.ProcessName.empty() ||
           (!storageManagerEnabled && processconfig.ProcessName == "StorageManager"))
             continue;
 
@@ -2370,7 +2370,8 @@ void Oam::setProcessStatus(const std::string process, const std::string module, 
 void Oam::processInitComplete(std::string processName, int state)
 {
 //This method takes too long on Windows and doesn't do anything there anyway...
-#if !defined(_MSC_VER) && !defined(SKIP_OAM_INIT)
+    if (getenv("SKIP_OAM_INIT") != NULL)
+        return;
     // get current Module name
     string moduleName;
     oamModuleInfo_t st;
@@ -2414,7 +2415,6 @@ void Oam::processInitComplete(std::string processName, int state)
 
     writeLog("processInitComplete: Status update failed", LOG_TYPE_ERROR );
     exceptionControl("processInitComplete", API_FAILURE);
-#endif
 }
 
 /********************************************************************
@@ -10716,7 +10716,7 @@ void Oam::mountDBRoot(dbrootList dbrootConfigList, bool mount)
     // nothing to do here
     if (DBRootStorageType == "storagemanager")
         return;
-    
+
     string DataRedundancyConfig = "n";
 
     try
@@ -11197,4 +11197,3 @@ namespace procheartbeat
 */
 } // end of namespace
 // vim:ts=4 sw=4:
-

--- a/oam/oamcpp/oamcache.cpp
+++ b/oam/oamcpp/oamcache.cpp
@@ -111,7 +111,7 @@ void OamCache::checkReload()
     // Restore for Windows when we support multiple PMs
     while (it != uniquePids.end())
     {
-#if  !defined(SKIP_OAM_INIT)
+        if (getenv("SKIP_OAM_INIT") == NULL)
         {
             try
             {
@@ -180,10 +180,11 @@ void OamCache::checkReload()
                 break;
             }
         }
-#else
-        pmToConnectionMap[*it] = i++;
-        moduleIds.push_back(*it);
-#endif
+        else
+        {
+            pmToConnectionMap[*it] = i++;
+            moduleIds.push_back(*it);
+        }
         it++;
 
     }
@@ -346,4 +347,3 @@ string OamCache::getModuleName()
 }
 
 } /* namespace oam */
-

--- a/oamapps/mcsadmin/mcsadmin.cpp
+++ b/oamapps/mcsadmin/mcsadmin.cpp
@@ -174,11 +174,12 @@ void setupSignalHandlers()
 int main(int argc, char* argv[])
 {
 
-// print a warning if this is a developer build
-#ifdef SKIP_OAM_INIT
-    cout << "SKIP_OAM_INIT is set" << endl;
-    sleep(2);
-#endif
+    // print a warning if this is a developer build
+    if (getenv("SKIP_OAM_INIT"))
+    {
+        cout << "SKIP_OAM_INIT is set" << endl;
+        sleep(2);
+    }
 
 #ifndef _MSC_VER
     setuid(0); // set effective ID to root; ignore return status
@@ -246,7 +247,7 @@ int main(int argc, char* argv[])
 
     if (user != 0)
         rootUser = false;
-        
+
     // create/open command log file if not created
 
     logFile.open(DEFAULT_LOG_FILE.c_str(), ios::app);
@@ -2622,7 +2623,7 @@ int processCommand(string* arguments)
                 if ( DBRootStorageType == "hdfs")
                 {
 					string logFile = tmpDir + "/cc-stop.pdsh";
-					
+
                     cmd = "pdsh -a 'columnstore stop' > " + logFile + " 2>&1";
                     system(cmd.c_str());
 
@@ -4932,7 +4933,7 @@ int processCommand(string* arguments)
         case 39: // getSystemDirectories
         {
 			cout << endl << "System Installation and Temporary File Directories" << endl << endl;
-			
+
 			cout << "System Temporary File Directory = " << tmpDir << endl << endl;
         }
         break;
@@ -5695,7 +5696,7 @@ int processCommand(string* arguments)
             umStorageNames umstoragenames;
             int hostArg;
             int dbrootPerPM = 0;
-            
+
             //check if module type or module name was entered
             if ( arguments[1].size() == 2 )
             {
@@ -5711,7 +5712,7 @@ int processCommand(string* arguments)
                 moduleType = arguments[1];
                 moduleCount = atoi(arguments[2].c_str());
                 hostArg = 4;
-                
+
                 // MCOL-1607.  Check whether we should store host names or IP addresses.
                 if (arguments[3] != "" && (arguments[3][0] == 'y' || arguments[3][0] == 'Y'))
                     storeHostnames = true;
@@ -5746,7 +5747,7 @@ int processCommand(string* arguments)
                 // MCOL-1607.  Check whether we should store host names or IP addresses.
                 if (arguments[2] != "" && (arguments[2][0] == 'y' || arguments[2][0] == 'Y'))
                     storeHostnames = true;
-                
+
                 if (arguments[4] != "")
                     password = arguments[4];
                 else
@@ -6024,7 +6025,7 @@ int processCommand(string* arguments)
                                 // prompt for IP Address
                                 string prompt = "IP Address of " + hostName + " not found, enter IP Address or enter 'abort'";
                                 IPAddress = dataPrompt(prompt);
-    
+
                                 if ( IPAddress == "abort" || !oam.isValidIP(IPAddress) )
                                     return 1;
                             }
@@ -6065,7 +6066,7 @@ int processCommand(string* arguments)
                         DataRedundancyHostname = dataPrompt(prompt);
                         if (storeHostnames)
                             DataRedundancyIPAddress = DataRedundancyHostname;
-                        else 
+                        else
                         {
                             DataRedundancyIPAddress = oam.getIPAddress(DataRedundancyHostname);
 
@@ -6074,7 +6075,7 @@ int processCommand(string* arguments)
                                 // prompt for IP Address
                                 string prompt = "IP Address of " + DataRedundancyHostname + " not found, enter IP Address";
                                 DataRedundancyIPAddress = dataPrompt(prompt);
-    
+
                                 if (!oam.isValidIP(DataRedundancyIPAddress))
                                     return 1;
                             }
@@ -7896,7 +7897,7 @@ int processCommand(string* arguments)
 							gracefulTemp = oam::FORCEFUL;
 							int returnStatus = oam.restartSystem(gracefulTemp, ackTemp);
 							switch (returnStatus)
-							{ 
+							{
 								case API_SUCCESS:
 									if ( waitForActive() )
 										cout << endl << "   Successful restart of System " << endl << endl;
@@ -10034,4 +10035,3 @@ bool SendToWES(Oam& oam, ByteStream bs)
     return true;
 }
 // vim:ts=4 sw=4:
-

--- a/oamapps/postConfigure/installer.cpp
+++ b/oamapps/postConfigure/installer.cpp
@@ -183,14 +183,14 @@ int main(int argc, char* argv[])
 
     if (p && *p)
         USER = p;
-        
+
     string tmpDir = startup::StartUp::tmpDir();
 
     // setup to start on reboot, for non-root amazon installs
     if ( !rootUser )
     {
     	system("sed -i -e 's/#runuser/runuser/g' /etc/rc.d/rc.local >/dev/null 2>&1");
-    }   
+    }
 
     //copy Columnstore.xml.rpmsave if upgrade option is selected
     if ( installType == "upgrade" )
@@ -694,6 +694,12 @@ int main(int argc, char* argv[])
         cmd = "chmod 755 -R /var/lib/columnstore/data1/systemFiles/dbrm > /dev/null 2>&1";
         system(cmd.c_str());
     }
+    
+    if (getenv("SKIP_OAM_INIT"))
+    {
+        cout << "SKIP_OAM_INIT is set, so will not start ColumnStore or init the system catalog" << endl;
+        exit(0);
+    }
 
     string idbstartcmd = "columnstore start";
 
@@ -778,7 +784,7 @@ int main(int argc, char* argv[])
                 exit (1);
             }
 		}
-		
+
         cout << endl << "MariaDB ColumnStore Install Successfully Completed, System is Active" << endl << endl;
 
         cout << "Enter the following command to define MariaDB ColumnStore Alias Commands" << endl << endl;
@@ -990,7 +996,7 @@ bool updateProcessConfig(int serverTypeInstall)
  */
 bool makeRClocal(string moduleName, int IserverTypeInstall)
 {
-  
+
       return true;
 
     string moduleType = moduleName.substr(0, MAX_MODULE_TYPE_SIZE);
@@ -1175,4 +1181,3 @@ bool uncommentCalpontXml( string entry)
 }
 
 // vim:ts=4 sw=4:
-

--- a/oamapps/postConfigure/installer.cpp
+++ b/oamapps/postConfigure/installer.cpp
@@ -695,12 +695,6 @@ int main(int argc, char* argv[])
         system(cmd.c_str());
     }
     
-    if (getenv("SKIP_OAM_INIT"))
-    {
-        cout << "SKIP_OAM_INIT is set, so will not start ColumnStore or init the system catalog" << endl;
-        exit(0);
-    }
-
     string idbstartcmd = "columnstore start";
 
     {
@@ -716,6 +710,12 @@ int main(int argc, char* argv[])
             // call the mysql setup scripts
             mysqlSetup();
             sleep(5);
+
+            if (getenv("SKIP_OAM_INIT"))
+            {
+                cout << "SKIP_OAM_INIT is set, so will not start ColumnStore or init the system catalog" << endl;
+                exit(0);
+            }
 
             //start on local module
             int rtnCode = system(idbstartcmd.c_str());
@@ -737,6 +737,12 @@ int main(int argc, char* argv[])
             // call the mysql setup scripts
             mysqlSetup();
             sleep(5);
+
+            if (getenv("SKIP_OAM_INIT"))
+            {
+                cout << "SKIP_OAM_INIT is set, so will not start ColumnStore or init the system catalog" << endl;
+                exit(0);
+            }
 
             //startup mysqld and infinidb processes
             cout << endl;

--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -3731,7 +3731,10 @@ int main(int argc, char* argv[])
     //
 
     if (getenv("SKIP_OAM_INIT"))
+    {
+        cout << "SKIP_OAM_INIT is set, so will not start ColumnStore or init the system catalog" << endl;
         exit(0);
+    }
 
     if ( IserverTypeInstall != oam::INSTALL_COMBINE_DM_UM_PM ||
             pmNumber > 1 )

--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -3730,9 +3730,8 @@ int main(int argc, char* argv[])
     // startup MariaDB ColumnStore
     //
 
-    #ifdef SKIP_OAM_INIT
-    exit(0);
-    #endif
+    if (getenv("SKIP_OAM_INIT"))
+        exit(0);
 
     if ( IserverTypeInstall != oam::INSTALL_COMBINE_DM_UM_PM ||
             pmNumber > 1 )

--- a/writeengine/redistribute/we_redistributecontrolthread.cpp
+++ b/writeengine/redistribute/we_redistributecontrolthread.cpp
@@ -618,34 +618,34 @@ int RedistributeControlThread::executeRedistributePlan()
         try
         {
 // skip system status check in case no OAM
-#if !defined(_MSC_VER) && !defined(SKIP_OAM_INIT)
-            // make sure system is in active state
-            bool isActive = false;
-
-            while (!isActive)
+            if (getenv("SKIP_OAM_INIT") == NULL)
             {
-                bool noExcept = true;
-                SystemStatus systemstatus;
+                // make sure system is in active state
+                bool isActive = false;
 
-                try
+                while (!isActive)
                 {
-                    fControl->fOam->getSystemStatus(systemstatus);
-                }
-                catch (const std::exception& ex)
-                {
-                    fErrorMsg += ex.what();
-                    noExcept = false;
-                }
-                catch (...)
-                {
-                    noExcept = false;
-                }
+                    bool noExcept = true;
+                    SystemStatus systemstatus;
 
-                if (noExcept && ((isActive = (systemstatus.SystemOpState == oam::ACTIVE)) == false))
-                    sleep(1);;
+                    try
+                    {
+                        fControl->fOam->getSystemStatus(systemstatus);
+                    }
+                    catch (const std::exception& ex)
+                    {
+                        fErrorMsg += ex.what();
+                        noExcept = false;
+                    }
+                    catch (...)
+                    {
+                        noExcept = false;
+                    }
+
+                    if (noExcept && ((isActive = (systemstatus.SystemOpState == oam::ACTIVE)) == false))
+                        sleep(1);;
+                }
             }
-
-#endif
 
             if (fStopAction)
                 return RED_EC_USER_STOP;
@@ -851,4 +851,3 @@ void RedistributeControlThread::doStopAction()
 } // namespace
 
 // vim:ts=4 sw=4:
-

--- a/writeengine/splitter/we_sdhandler.cpp
+++ b/writeengine/splitter/we_sdhandler.cpp
@@ -547,7 +547,7 @@ void WESDHandler::setup()
     }
 
 // getModuleStatus will take too long. Also to test in development
-#if !defined(_MSC_VER) && !defined(SKIP_OAM_INIT)
+    if (getenv("SKIP_OAM_INIT") == NULL)
     {
         vector<unsigned int>& aVec = fRef.fCmdArgs.getPmVec();
 
@@ -578,8 +578,6 @@ void WESDHandler::setup()
             }
         }
     }
-#endif
-
 
     int rtn = fDbrm.getSystemReady();
 
@@ -2997,4 +2995,3 @@ void WESDHandler::setDisconnectFailure(bool Flag)
 //------------------------------------------------------------------------------
 
 } /* namespace WriteEngine */
-


### PR DESCRIPTION
Made the SKIP_OAM_INIT build parameter a runtime parameter.  Now you toggle that behavior by setting or unsetting SKIP_OAM_INIT as an envvar.

I apologize for my editor changing various bits of whitespace.