### PR TITLE
MCOL-3707 Packaging pre/post functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,10 @@ IF (INSTALL_LAYOUT)
         else ()
             SETA(CPACK_RPM_columnstore-platform_PACKAGE_REQUIRES "expect" "boost >= 1.53.0" "MariaDB-columnstore-libs" "snappy" "jemalloc" "net-tools" PARENT_SCOPE)
         endif()
+
+        SET(CPACK_RPM_columnstore-platform_POST_INSTALL_SCRIPT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/build/postInstall_platform.sh PARENT_SCOPE)
+        SET(CPACK_RPM_columnstore-platform_PRE_UNINSTALL_SCRIPT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/build/preUn_platform.sh PARENT_SCOPE)
+
     ENDIF ()
 ELSE ()
     # MariaDB has its own packaging routines

--- a/build/preUn_platform.sh
+++ b/build/preUn_platform.sh
@@ -1,3 +1,5 @@
+
+mcsadmin shutdown y
 rpmmode=upgrade
 if  [ "$1" -eq "$1" 2> /dev/null ]; then
 	if [ $1 -ne 1 ]; then


### PR DESCRIPTION
Adds support for:
* columnstore-post-install on RPM install
* MCOL-3708 mcsadmin shutdown on uninstall

There is a counterpart for the server tree to propagate the RPM settings
up and add Debian packaging support.