### PR TITLE
Minor fixes

### DIFF
--- a/oamapps/postConfigure/installer.cpp
+++ b/oamapps/postConfigure/installer.cpp
@@ -713,7 +713,9 @@ int main(int argc, char* argv[])
 
             if (getenv("SKIP_OAM_INIT"))
             {
-                cout << "SKIP_OAM_INIT is set, so will not start ColumnStore or init the system catalog" << endl;
+                cout << "(2) SKIP_OAM_INIT is set, so will not start ColumnStore or init the system catalog" << endl;
+                sysConfig->setConfig("Installation", "MySQLRep", "n");
+                sysConfig->write();
                 exit(0);
             }
 
@@ -740,7 +742,9 @@ int main(int argc, char* argv[])
 
             if (getenv("SKIP_OAM_INIT"))
             {
-                cout << "SKIP_OAM_INIT is set, so will not start ColumnStore or init the system catalog" << endl;
+                cout << "(3) SKIP_OAM_INIT is set, so will not start ColumnStore or init the system catalog" << endl;
+                sysConfig->setConfig("Installation", "MySQLRep", "n");
+                sysConfig->write();
                 exit(0);
             }
 

--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -3732,7 +3732,9 @@ int main(int argc, char* argv[])
 
     if (getenv("SKIP_OAM_INIT"))
     {
-        cout << "SKIP_OAM_INIT is set, so will not start ColumnStore or init the system catalog" << endl;
+        cout << "(1) SKIP_OAM_INIT is set, so will not start ColumnStore or init the system catalog" << endl;
+        sysConfig->setConfig("Installation", "MySQLRep", "n");
+        sysConfig->write();
         exit(0);
     }
 

--- a/utils/common/poolallocator.cpp
+++ b/utils/common/poolallocator.cpp
@@ -68,7 +68,6 @@ void PoolAllocator::newBlock()
 
 void * PoolAllocator::allocOOB(uint64_t size)
 {
-    bool _false = false;
     OOBMemInfo memInfo;
 
     memUsage += size;


### PR DESCRIPTION
 - fixed a compiler warning in poolallocator that was preventing debugging builds
 - made the early exit code in postConfig (SKIP is set) turn off replication in the config file.