### PR TITLE
Mcol-3716: Wrong min/max after cpimport which causes wrong select results

### DIFF
--- a/utils/common/poolallocator.cpp
+++ b/utils/common/poolallocator.cpp
@@ -68,7 +68,6 @@ void PoolAllocator::newBlock()
 
 void * PoolAllocator::allocOOB(uint64_t size)
 {
-    bool _false = false;
     OOBMemInfo memInfo;
 
     memUsage += size;

--- a/writeengine/bulk/we_bulkloadbuffer.cpp
+++ b/writeengine/bulk/we_bulkloadbuffer.cpp
@@ -719,7 +719,7 @@ void BulkLoadBuffer::convert(char* field, int fieldLength,
                     errno   = 0;
 
                     origVal = strtoll(field, 0, 10);
-                    
+
                     if (errno == ERANGE)
                         bSatVal = true;
                 }
@@ -804,7 +804,7 @@ void BulkLoadBuffer::convert(char* field, int fieldLength,
                         strcpy(field, "1");
                         fieldLength = 1;
                     }
-                    
+
                     if ( (column.dataType == CalpontSystemCatalog::DECIMAL ) ||
                             (column.dataType == CalpontSystemCatalog::UDECIMAL))
                     {
@@ -979,7 +979,7 @@ void BulkLoadBuffer::convert(char* field, int fieldLength,
                             strcpy(field, "1");
                             fieldLength = 1;
                         }
-                        
+
                         if ( (column.dataType == CalpontSystemCatalog::DECIMAL) ||
                                 (column.dataType == CalpontSystemCatalog::UDECIMAL))
                         {
@@ -1411,7 +1411,7 @@ void BulkLoadBuffer::convert(char* field, int fieldLength,
                             strcpy(field, "1");
                             fieldLength = 1;
                         }
-                    
+
                         if ( (column.dataType == CalpontSystemCatalog::DECIMAL) ||
                                 (column.dataType == CalpontSystemCatalog::UDECIMAL))
                         {
@@ -1642,7 +1642,7 @@ int  BulkLoadBuffer::parseCol(ColumnInfo& columnInfo)
                 tokenNullFlag = true;
             }
 
-            // convert the data into appropriate format.
+            // convert the data into appropriate format and update CP values
             convert(field, tokenLength, tokenNullFlag,
                     buf + i * columnInfo.column.width,
                     columnInfo.column, bufStats);
@@ -1673,7 +1673,7 @@ int  BulkLoadBuffer::parseCol(ColumnInfo& columnInfo)
 
                 lastInputRowInExtent += columnInfo.rowsPerExtent();
 
-                if (isUnsigned(columnInfo.column.dataType))
+                if (isUnsigned(columnInfo.column.dataType) || isCharType(columnInfo.column.dataType))
                 {
                     bufStats.minBufferVal = static_cast<int64_t>(MAX_UBIGINT);
                     bufStats.maxBufferVal = static_cast<int64_t>(MIN_UBIGINT);

--- a/writeengine/bulk/we_bulkloadbuffer.h
+++ b/writeengine/bulk/we_bulkloadbuffer.h
@@ -44,7 +44,7 @@ public:
     int64_t satCount;
     BLBufferStats(ColDataType colDataType) : satCount(0)
     {
-        if (isUnsigned(colDataType))
+        if (isUnsigned(colDataType) || isCharType(colDataType))
         {
             minBufferVal = static_cast<int64_t>(MAX_UBIGINT);
             maxBufferVal = static_cast<int64_t>(MIN_UBIGINT);


### PR DESCRIPTION
To fix, I changed the init value cpimport uses to track CP updates for string values.

cpimport does unsigned comparisons for short strings, but the init value for the max field is signed.  No ascii string would be > than a negative value cast to unsigned, so cpimport would never update it.