### PR TITLE
MCOL-2139 Fix subquery not being filtered when using view

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -5664,7 +5664,9 @@ void gp_walk(const Item* item, void* arg)
                 
                 if (col->type() == Item::FIELD_ITEM)
                 {
-                    gwip->columnMap.insert(CalpontSelectExecutionPlan::ColumnMap::value_type(string(((Item_field*)item)->field_name.str), scsp));
+                    const auto &field_name = string(((Item_field*)item)->field_name.str);
+                    auto col = CalpontSelectExecutionPlan::ColumnMap::value_type(field_name, scsp);
+                    gwip->columnMap.insert(col);
                 }
             }
 

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -5661,6 +5661,11 @@ void gp_walk(const Item* item, void* arg)
             {
                 boost::shared_ptr<SimpleColumn> scsp(sc->clone());
                 gwip->scsp = scsp;
+                
+                if (col->type() == Item::FIELD_ITEM)
+                {
+                    gwip->columnMap.insert(CalpontSelectExecutionPlan::ColumnMap::value_type(string(((Item_field*)item)->field_name.str), scsp));
+                }
             }
 
             bool cando = true;

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -5665,8 +5665,8 @@ void gp_walk(const Item* item, void* arg)
                 if (col->type() == Item::FIELD_ITEM)
                 {
                     const auto &field_name = string(((Item_field*)item)->field_name.str);
-                    auto col = CalpontSelectExecutionPlan::ColumnMap::value_type(field_name, scsp);
-                    gwip->columnMap.insert(col);
+                    auto colMap = CalpontSelectExecutionPlan::ColumnMap::value_type(field_name, scsp);
+                    gwip->columnMap.insert(colMap);
                 }
             }
 


### PR DESCRIPTION
columnMap was empty when building predicate, which fails to build predicate on update or delete because it assumes this operation is on two constants (see https://github.com/mariadb-corporation/mariadb-columnstore-engine/pull/1018/files#diff-01ac5c8ba99c34e7b0cfd87552768908R2188) to view this code that fails to create predicate.


PR into develop-1.2 https://github.com/mariadb-corporation/mariadb-columnstore-engine/pull/1019

Code bases are a bit different (e.g., ha_mcs_execplan.cpp was ha_calpont_execplan.cpp)