### PR TITLE
MCOL-3721 Allow collate and warn on ORDER BY

### DIFF
--- a/dbcon/ddlpackage/ddl.l
+++ b/dbcon/ddlpackage/ddl.l
@@ -171,6 +171,7 @@ FLOAT {return IDB_FLOAT;}
 DOUBLE {return DOUBLE;}
 REAL {return REAL;}
 CHARSET {return CHARSET;}
+COLLATE {return COLLATE;}
 IF {return IDB_IF;}
 EXISTS {return EXISTS;}
 CHANGE {return CHANGE;}

--- a/dbcon/ddlpackage/ddl.y
+++ b/dbcon/ddlpackage/ddl.y
@@ -111,7 +111,7 @@ MATCH MAX_ROWS MEDIUMBLOB MEDIUMTEXT
 MIN_ROWS MODIFY NO NOT NULL_TOK NUMBER NUMERIC ON PARTIAL PRECISION PRIMARY
 REFERENCES RENAME RESTRICT SET SMALLINT TABLE TEXT TINYBLOB TINYTEXT
 TINYINT TO UNIQUE UNSIGNED UPDATE USER SESSION_USER SYSTEM_USER VARCHAR VARBINARY
-VARYING WITH ZONE DOUBLE IDB_FLOAT REAL CHARSET IDB_IF EXISTS CHANGE TRUNCATE
+VARYING WITH ZONE DOUBLE IDB_FLOAT REAL CHARSET COLLATE IDB_IF EXISTS CHANGE TRUNCATE
 BOOL BOOLEAN MEDIUMINT TIMESTAMP
 
 %token <str> DQ_IDENT IDENT FCONST SCONST CP_SEARCH_CONDITION_TEXT ICONST DATE TIME
@@ -485,8 +485,14 @@ table_option:
     }
  	|
  	DEFAULT CHARSET opt_equal ident {$$ = new pair<string,string>("default charset", $4);}
+    |
+    CHARSET opt_equal ident {$$ = new pair<string, string>("default charset", $3);}
  	|
  	DEFAULT IDB_CHAR SET opt_equal ident {$$ = new pair<string,string>("default charset", $5);}
+    |
+    DEFAULT COLLATE opt_equal ident {$$ = new pair<string, string>("default collate", $4);}
+    |
+    COLLATE opt_equal ident {$$ = new pair<string, string>("default collate", $3);}
 	;
 
 alter_table_statement:

--- a/dbcon/ddlpackage/ddl.y
+++ b/dbcon/ddlpackage/ddl.y
@@ -732,13 +732,25 @@ optional_braces:
 	| '(' ')' {}
 	;
 
+opt_column_charset:
+    /* empty */ {}
+    |
+    IDB_CHAR SET ident {}
+    ;
+
+opt_column_collate:
+    /* empty */ {}
+    |
+    COLLATE ident {}
+    ;
+
 data_type:
-	character_string_type
+	character_string_type opt_column_charset opt_column_collate
 	| binary_string_type
 	| numeric_type
 	| datetime_type
 	| blob_type
-	| text_type
+	| text_type opt_column_charset opt_column_collate
 	| IDB_BLOB
 	{
 		$$ = new ColumnType(DDL_BLOB);

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -7555,6 +7555,11 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex,
                     {
                         gwi.fatalParseError = true;
                     }
+                    else if  ((ord_item->type() == Item::FUNC_ITEM) && (((Item_func*)ord_item)->functype() == Item_func::COLLATE_FUNC))
+                    {
+                        push_warning(gwi.thd, Sql_condition::WARN_LEVEL_NOTE, WARN_OPTION_IGNORED, "COLLATE is ignored in ColumnStore");
+                        continue;
+                    }
                     else
                     {
                         rc = buildReturnedColumn(ord_item, gwi, gwi.fatalParseError);


### PR DESCRIPTION
COLLATE is now allowed but ignored on DDL and ORDER BY. For an ORDER BY
query a note is generated.