### PR TITLE
MCOL-3764 Fix RENAME TABLE

### DIFF
--- a/dbcon/ddlpackage/ddl.l
+++ b/dbcon/ddlpackage/ddl.l
@@ -70,7 +70,7 @@ self			[,()\[\].;\:\+\-\*\/\%\^\<\>\=]
 whitespace ({space}+|{comment})
 
 digit [0-9]
-ident_start [A-Za-z\200-\377_0-9]
+ident_start [A-Za-z\200-\377_0-9#]
 ident_cont [A-Za-z\200-\377_0-9\$]
 identifier {ident_start}{ident_cont}*
 extended_identifier {ident_start}{extended_ident_cont}*

--- a/dbcon/mysql/ha_mcs_ddl.cpp
+++ b/dbcon/mysql/ha_mcs_ddl.cpp
@@ -390,32 +390,6 @@ bool validateNextValue( int type, int64_t value )
     return validValue;
 }
 
-static void decode_objectname(char *buf, const char *path, size_t buf_size)
-{
-    size_t new_path_len = filename_to_tablename(path, buf, buf_size);
-    buf[new_path_len] = '\0';
-}
-
-static void decode_file_path(const char *path, char *decoded_dbname,
-    char *decoded_tbname)
-{
-  // The format cont ains './' in the beginning of a path.
-  char *dbname_start = (char*) path + 2;
-  char *dbname_end = dbname_start;
-  while (*dbname_end != '/')
-    dbname_end++;
-
-  int cnt = dbname_end - dbname_start;
-  char *dbname = (char *)my_alloca(cnt + 1);
-  memcpy(dbname, dbname_start, cnt);
-  dbname[cnt] = '\0';
-  decode_objectname(decoded_dbname, dbname, FN_REFLEN);
-  my_afree(dbname);
-
-  char *tbname_start = dbname_end + 1;
-  decode_objectname(decoded_tbname, tbname_start, FN_REFLEN);
-}
-
 bool anyRowInTable(string& schema, string& tableName, int sessionID)
 {
     //find a column in the table
@@ -913,18 +887,6 @@ int ProcessDDLStatement(string& ddlStatement, string& schema, const string& tabl
         if ( typeid ( stmt ) == typeid ( CreateTableStatement ) )
         {
             CreateTableStatement* createTable = dynamic_cast <CreateTableStatement*> ( &stmt );
-
-            //@Bug 5767. To handle key words inside `` for a tablename.
-            if (!(boost::iequals(schema, createTable->fTableDef->fQualifiedName->fSchema)) || !(boost::iequals(table, createTable->fTableDef->fQualifiedName->fName)))
-            {
-                rc = 1;
-                thd->get_stmt_da()->set_overwrite_status(true);
-
-                thd->raise_error_printf(ER_CHECK_NOT_IMPLEMENTED, (IDBErrorInfo::instance()->errorMsg(ERR_CREATE_DATATYPE_NOT_SUPPORT)).c_str());
-                ci->alterTableState = cal_connection_info::NOT_ALTER;
-                ci->isAlter = false;
-                return rc;
-            }
 
             bool matchedCol = false;
             bool isFirstTimestamp = true;
@@ -2466,7 +2428,7 @@ int ha_mcs_impl_create_(const char* name, TABLE* table_arg, HA_CREATE_INFO* crea
 		char datatype_buf[MAX_FIELD_WIDTH], def_value_buf[MAX_FIELD_WIDTH];
 		String datatype, def_value;
 		ostringstream  oss;
-		string tbl_name = string(share->db.str) + "." + string(share->table_name.str);
+        string tbl_name = string(share->db.str) + "." + string(share->table_name.str);
 
 		// Save the current read_set map and mark it for read
 		old_map= tmp_use_all_columns(table_arg, table_arg->read_set);
@@ -2634,21 +2596,27 @@ int ha_mcs_impl_rename_table_(const char* from, const char* to, cal_connection_i
     THD* thd = current_thd;
     string emsg;
 
-    string dbFrom, tblFrom, dbTo, tblTo;
-    char decodedDbFrom[FN_REFLEN];
-    char decodedTblFrom[FN_REFLEN];
-    char decodedDbTo[FN_REFLEN];
-    char decodedTblTo[FN_REFLEN];
-    decode_file_path(from, decodedDbFrom, decodedTblFrom);
-    decode_file_path(to, decodedDbTo, decodedTblTo);
-    string stmt;
+    string tblFrom (from+2);
+    size_t pos = tblFrom.find("/");
+    std::string dbFrom = tblFrom.substr(0, pos);
+    tblFrom = tblFrom.erase(0, pos + 1);
 
-    // This case is already handled
-    if (thd->lex->create_info.used_fields & HA_CREATE_USED_ENGINE)
-		return 0;
+    string tblTo (to+2);
+    pos = tblTo.find("/");
+    std::string dbTo = tblTo.substr(0, pos);
+    tblTo = tblTo.erase(0, pos + 1);
+
+    string stmt;
 
     if (thd->slave_thread && !get_replication_slave(thd))
         return 0;
+
+    // This is a temporary table rename, we don't use the temporary table name
+    // so this is a NULL op
+    if (tblFrom.compare(0, 4, "#sql") == 0)
+    {
+        return 0;
+    }
 
     //@bug 5660. Error out REAL DDL/DML on slave node.
     // When the statement gets here, it's NOT SSO or RESTRICT
@@ -2659,24 +2627,21 @@ int ha_mcs_impl_rename_table_(const char* from, const char* to, cal_connection_i
         return 1;
     }
 
-    // User moves tables b/w namespaces.
-    size_t tblFromLength= strlen(decodedTblFrom);
-    if (!memcmp(decodedTblFrom, decodedTblTo, tblFromLength))
-    {
-        return 0;
-    }
-
-    stmt.assign("alter table `"); 
-    stmt.append(decodedTblFrom); 
+    stmt.assign("alter table `");
+    stmt.append(dbFrom);
+    stmt.append("`.`");
+    stmt.append(tblFrom);
     stmt.append("` rename to `");
-    stmt.append(decodedTblTo);
+    stmt.append(dbTo);
+    stmt.append("`.`");
+    stmt.append(tblTo);
     stmt.append("`;");
 
     string db;
     if (thd->db.length)
          db = thd->db.str;
      else
-        db.assign(decodedDbFrom);
+        db.assign(dbFrom);
 
     int rc = ProcessDDLStatement(stmt, db, "", tid2sid(thd->thread_id), emsg);
 


### PR DESCRIPTION
When ALTER TABLE ... ENGINE= is called the following happens:

1. A temporary table is created in the new engine with the real table
   name but a temporary file name supplied
2. A bulk insert is started from old to new table
3. The old table is dropped
4. The new table is renamed

For #1 we use the real table name instead of the temporary file name
(otherwise step #2 breaks), we were therefore trying to skip #4.
This broke regular RENAME TABLE commands.

With this patch we detect if the rename is for a temporary to real table
and skip it. Since this is the only instance where we support temporary
tables.

This patch also fixes issues with extracting table names from file
names and some other irrelevant stuff.

Longer term if we want to support temporary tables we need to store the
provided filename in our metadata since it could be different from table
name.