### PR TITLE
MCOL-3784 Add boost/scoped_ptr.hpp to rowaggregation.h

### DIFF
--- a/utils/rowgroup/rowaggregation.h
+++ b/utils/rowgroup/rowaggregation.h
@@ -42,6 +42,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/shared_array.hpp>
 #include <boost/scoped_array.hpp>
+#include <boost/scoped_ptr.hpp>
 
 #include "serializeable.h"
 #include "bytestream.h"


### PR DESCRIPTION
We were inadvertantly relying on boost/regex.hpp to include boost/scoped_ptr.hpp. When we removed boost regex, we lost scoped_ptr too.