### PR TITLE
MCOL-3760 + Fix multiple rands in statement with or without ORDER BY

### DIFF
--- a/utils/funcexp/func_rand.cpp
+++ b/utils/funcexp/func_rand.cpp
@@ -53,6 +53,7 @@ double Func_rand::getRand()
         fSeed1 += 23;
 
     fSeed2 = (fSeed1 + fSeed2 + 33) % maxValue;
+    fSeeds[fSeedIndex] = std::make_pair(fSeed1, fSeed2);
     return (((double) fSeed1) / (double)maxValue);
 }
 
@@ -70,6 +71,37 @@ double Func_rand::getDoubleVal(rowgroup::Row& row,
     // NOTE: this function needs to use 32bit ints otherwise it will break for negative values
     uint32_t seedParm = 0;
 
+    // Still on first row, multiple rands exist in statement. Need an additional seed.
+    if(fFirstRow == row.getData())
+    {
+        fSeedSet = false;
+        fSeedIndex += 1;
+    }
+    else if (fFirstRow == 0)
+    {
+        // Store first row
+        fFirstRow = row.getData();
+        fSeedIndex = 0;
+    }
+    else
+    {
+        // No longer on first row. Disable additional seeding
+        if (!fMultipleSeedsSet)
+        {
+            fMultipleSeedsSet = true;
+            fSeedIndex = 0;
+        }
+        else
+        {
+            fSeedIndex += 1;
+
+            if (fSeedIndex == fSeeds.size())
+            {
+                fSeedIndex = 0;
+            }
+        }
+    }
+
     // rand with parameter. if the parm is constanct, then a column is attached for fetching
     if (parm.size() == 1 || parm.size() == 2)
     {
@@ -82,6 +114,13 @@ double Func_rand::getDoubleVal(rowgroup::Row& row,
             fSeed1 = (uint32_t)(seedParm * 0x10001L + 55555555L);
             fSeed2 = (uint32_t)(seedParm * 0x10000001L);
             fSeedSet = true;
+            fSeeds.push_back(std::make_pair(fSeed1, fSeed2));
+        }
+        else
+        {
+            const std::pair<uint64_t, uint64_t> &seedPair = fSeeds[fSeedIndex];
+            fSeed1 = seedPair.first;
+            fSeed2 = seedPair.second;
         }
     }
     // rand without parameter. thd->rand are passed in. The 3rd is a simple column for fetching
@@ -94,6 +133,9 @@ double Func_rand::getDoubleVal(rowgroup::Row& row,
             fSeed1 = parm[0]->data()->getIntVal(row, isNull);
             fSeed2 = parm[1]->data()->getIntVal(row, isNull);
             fSeedSet = true;
+
+            // Special case: statement such as select rand(), rand(1) so need to keep rand(1) seeded correctly
+            fSeeds.push_back(std::make_pair(fSeed1, fSeed2));
         }
     }
 

--- a/utils/funcexp/functor_export.h
+++ b/utils/funcexp/functor_export.h
@@ -26,6 +26,8 @@
 
 #include "functor.h"
 
+#include <utility>
+#include <vector>
 
 namespace funcexp
 {
@@ -36,13 +38,15 @@ namespace funcexp
 class Func_rand : public Func
 {
 public:
-    Func_rand() : Func("rand"), fSeed1(0), fSeed2(0), fSeedSet(false) {}
+    Func_rand() : Func("rand"), fSeed1(0), fSeed2(0), fSeedSet(false), fMultipleSeedsSet(false), fFirstRow(nullptr){}
     virtual ~Func_rand() {}
 
     double getRand();
     void seedSet(bool seedSet)
     {
         fSeedSet = seedSet;
+        fMultipleSeedsSet = seedSet;
+        fFirstRow = nullptr;
     }
     execplan::CalpontSystemCatalog::ColType operationType(FunctionParm& fp, execplan::CalpontSystemCatalog::ColType& resultType);
 
@@ -79,6 +83,10 @@ private:
     uint64_t fSeed1;
     uint64_t fSeed2;
     bool     fSeedSet;
+    bool     fMultipleSeedsSet;
+    uint8_t* fFirstRow;
+    uint16_t fSeedIndex;
+    std::vector<std::pair<uint64_t, uint64_t> > fSeeds;
 };
 
 


### PR DESCRIPTION
After investigating MCOL-3760, and the rand function, it turns out MDB Server uses separate seeds for each rand() in a statement, while columnstore uses only one set of seeds used across all rands.

This was hidden from us in develop-1.2 regressions because 
a. we did not have tests using multiple rands in a statement
b. we did not handle ORDER BY rand (this was done on server) so our test that included a
`SELECT rand(2) FROM table ORDER BY rand(1)` passed in 1.2.

Solution: For each rand function in statement, store a set of seeds used when computing rand for that column. 
e.g., `SELECT rand(1), rand(2) FROM table` will contain separate seeds for rand(1) and rand(2). 

I added some regression tests inside working_tpch1/qa_fe_cnxFunctions/RAND.sql. PR is 
https://github.com/mariadb-corporation/mariadb-columnstore-regression-test/pull/184

This will also be needed in develop-1.2, in the case of multiple rands in a select statement, which i will PR into shortly after this is approved.