### PR TITLE
MCOL-3791 This patch implicitly enables disk space preallocation for …

### DIFF
--- a/writeengine/shared/we_fileop.cpp
+++ b/writeengine/shared/we_fileop.cpp
@@ -1130,7 +1130,7 @@ int FileOp::initColumnExtent(
         // Couldn't avoid preallocation for full extents,
         // e.g. ADD COLUMN DDL b/c CS has to fill the file
         // with empty magics.
-        if ( !bOptExtension )
+        if ( !bOptExtension || !m_compressionType )
         {
 #ifdef PROFILE
             Stats::startParseEvent(WE_STATS_INIT_COL_EXTENT);


### PR DESCRIPTION
…non-compressed

abbreviated extents as it worked before MCOL-498.