### PR TITLE
    MCOL-3769 This commit divides create_SH in two parts: before rewr…

### DIFF
--- a/dbcon/mysql/ha_mcs.h
+++ b/dbcon/mysql/ha_mcs.h
@@ -23,6 +23,7 @@
 #include "ha_mcs_sysvars.h"
 
 extern handlerton* mcs_hton;
+#define CS_WARNING_ID 9999
 
 /** @brief
   COLUMNSTORE_SHARE is a structure that will be shared among all open handlers.


### PR DESCRIPTION
…ites and

    after rewrites. We can safely fallback from SH to DH and table mode from
    'before rewrites' part. We also returns meaningful warning.