### PR TITLE
MCOL-3812 remove call to thd_set_ha_data()

### DIFF
--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -3912,8 +3912,6 @@ int ha_mcs_impl_close_connection (handlerton* hton, THD* thd)
         ci->cal_conn_hndl = 0;
     }
 
-    thd_set_ha_data(thd, hton, NULL);
-
     return rc;
 }
 


### PR DESCRIPTION
MariaDB 10.5 doesn't want us to call this.