### PR TITLE
2020 3 1.4 to 1.2 merge

### DIFF
--- a/dbcon/ddlpackage/CMakeLists.txt
+++ b/dbcon/ddlpackage/CMakeLists.txt
@@ -10,6 +10,8 @@ ADD_CUSTOM_COMMAND(
 
 ADD_CUSTOM_TARGET(ddl-lexer DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/ddl-scan.cpp)
 ADD_CUSTOM_TARGET(ddl-parser DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/ddl-gram.cpp)
+set_source_files_properties(ddl-scan.cpp PROPERTIES COMPILE_FLAGS -Wno-sign-compare)
+
 # Parser puts extra info to stderr.
 INCLUDE(../../check_compiler_flag.cmake)
 MY_CHECK_AND_SET_COMPILER_FLAG("-DYYDEBUG=1" DEBUG)

--- a/dbcon/dmlpackage/CMakeLists.txt
+++ b/dbcon/dmlpackage/CMakeLists.txt
@@ -11,6 +11,7 @@ ADD_CUSTOM_COMMAND(
 
 ADD_CUSTOM_TARGET(dml-lexer DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/dml-scan.cpp)
 ADD_CUSTOM_TARGET(dml-parser DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/dml-gram.cpp)
+set_source_files_properties(dml-scan.cpp PROPERTIES COMPILE_FLAGS -Wno-sign-compare)
 
 ########### next target ###############
 

--- a/dbcon/execplan/calpontsystemcatalog.h
+++ b/dbcon/execplan/calpontsystemcatalog.h
@@ -425,9 +425,9 @@ public:
     struct TableAliasName
     {
         TableAliasName (): fIsInfiniDB (true) {}
-        TableAliasName (std::string sch, std::string tb, std::string al) :
+        TableAliasName (const std::string &sch, const std::string &tb, const std::string &al) :
             schema (sch), table (tb), alias (al), fIsInfiniDB(true) {}
-        TableAliasName (std::string sch, std::string tb, std::string al, std::string v) :
+        TableAliasName (const std::string &sch, const std::string &tb, const std::string &al, const std::string &v) :
             schema (sch), table (tb), alias (al), view(v), fIsInfiniDB(true) {}
         std::string schema;
         std::string table;

--- a/dbcon/execplan/windowfunctioncolumn.cpp
+++ b/dbcon/execplan/windowfunctioncolumn.cpp
@@ -381,7 +381,8 @@ void WindowFunctionColumn::adjustResultType()
         fResultType = fFunctionParms[0]->resultType();
 
     if (boost::iequals(fFunctionName, "SUM") ||
-        boost::iequals(fFunctionName, "AVG"))
+        boost::iequals(fFunctionName, "AVG") ||
+        boost::iequals(fFunctionName, "AVG_DISTINCT"))
     {
         fResultType.colDataType = CalpontSystemCatalog::LONGDOUBLE;
         fResultType.colWidth = sizeof(long double);

--- a/dbcon/execplan/windowfunctioncolumn.cpp
+++ b/dbcon/execplan/windowfunctioncolumn.cpp
@@ -381,8 +381,7 @@ void WindowFunctionColumn::adjustResultType()
         fResultType = fFunctionParms[0]->resultType();
 
     if (boost::iequals(fFunctionName, "SUM") ||
-        boost::iequals(fFunctionName, "AVG") ||
-        boost::iequals(fFunctionName, "AVG_DISTINCT"))
+        boost::iequals(fFunctionName, "AVG"))
     {
         fResultType.colDataType = CalpontSystemCatalog::LONGDOUBLE;
         fResultType.colWidth = sizeof(long double);

--- a/dbcon/joblist/groupconcat.cpp
+++ b/dbcon/joblist/groupconcat.cpp
@@ -751,7 +751,7 @@ void GroupConcatOrderBy::initialize(const rowgroup::SP_GroupConcat& gcc)
 uint64_t GroupConcatOrderBy::getKeyLength() const
 {
     // only distinct the concatenated columns
-    return fConcatColumns.size() - 1; // cols 0 to fConcatColumns will be conpared
+    return fConcatColumns.size(); // cols 0 to fConcatColumns.size() - 1 will be compared
 }
 
 

--- a/dbcon/joblist/limitedorderby.cpp
+++ b/dbcon/joblist/limitedorderby.cpp
@@ -101,7 +101,7 @@ void LimitedOrderBy::initialize(const RowGroup& rg, const JobInfo& jobInfo, bool
 // not just a column count.
 uint64_t LimitedOrderBy::getKeyLength() const
 {
-    return fOrderByCond.size();
+    return fRow0.getColumnCount();
 }
 
 

--- a/dbcon/joblist/pdictionaryscan.cpp
+++ b/dbcon/joblist/pdictionaryscan.cpp
@@ -310,11 +310,8 @@ void pDictionaryScan::addFilter(int8_t COP, const string& value)
     }
     else
     {
-        uint8_t* s = (uint8_t*)alloca(value.size() * sizeof(uint8_t));
-
-        memcpy(s, value.data(), value.size());
         fFilterString << (uint16_t) value.size();
-        fFilterString.append(s, value.size());
+        fFilterString.append((const uint8_t*)value.data(), value.size());
     }
 }
 

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -1828,8 +1828,6 @@ void TupleHashJoinStep::segregateJoiners()
     bool anyTooLarge = false;
     uint32_t smallSideCount = smallDLs.size();
 
-    boost::mutex::scoped_lock sl(djsLock);
-
     for (i = 0; i < smallSideCount; i++)
     {
         allInnerJoins &= (joinTypes[i] == INNER);
@@ -1861,6 +1859,8 @@ void TupleHashJoinStep::segregateJoiners()
     	return;
     }
     */
+
+    boost::mutex::scoped_lock sl(djsLock);
 
     /* For now if there is no largeBPS all joins need to either be DJS or not, not mixed */
     if (!largeBPS)

--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -3002,6 +3002,11 @@ ReturnedColumn* buildReturnedColumn(Item* item, gp_walk_info& gwi, bool& nonSupp
                 case Item::WINDOW_FUNC_ITEM:
                     return buildWindowFunctionColumn(*(ref->ref), gwi, nonSupport);
 
+                case Item::SUBSELECT_ITEM:
+                    gwi.fatalParseError = true;
+                    gwi.parseErrorText = IDBErrorInfo::instance()->errorMsg(ERR_NON_SUPPORT_SELECT_SUB);
+                    break;
+                    
                 default:
                     gwi.fatalParseError = true;
                     gwi.parseErrorText = "Unknown REF item";

--- a/dbcon/mysql/ha_calpont_execplan.cpp
+++ b/dbcon/mysql/ha_calpont_execplan.cpp
@@ -4219,10 +4219,9 @@ ReturnedColumn* buildAggregateColumn(Item* item, gp_walk_info& gwi)
     if (gwi.clauseType == SELECT)
         gwi.aggOnSelect = true;
 
-    // N.B. argument_count() is the # of formal parms to the agg fcn. InifniDB only supports 1 argument
-    // TODO: Support more than one parm
-#if 0
-
+    // Argument_count() is the # of formal parms to the agg fcn. Columnstore
+    // only supports 1 argument except UDAnF and GROUP_CONCAT
+    // TODO: Support more than one parm for COUNT(DISTINCT)
     if (isp->argument_count() != 1 && isp->sum_func() != Item_sum::GROUP_CONCAT_FUNC
             && isp->sum_func() != Item_sum::UDF_SUM_FUNC)
     {
@@ -4231,7 +4230,6 @@ ReturnedColumn* buildAggregateColumn(Item* item, gp_walk_info& gwi)
         return NULL;
     }
 
-#endif
     AggregateColumn* ac = NULL;
 
     if (isp->sum_func() == Item_sum::GROUP_CONCAT_FUNC)

--- a/oam/install_scripts/run.sh
+++ b/oam/install_scripts/run.sh
@@ -48,8 +48,27 @@ if [ $vflg -gt 0 ]; then
 	echo "starting $exename $args with sleep=$sopt and tries=$topt"
 fi
 
+which_jemalloc() {
+	LD_PRELOAD="$1" /bin/true >& /tmp/jemalloc_test
+	grep -i error /tmp/jemalloc_test >& /dev/null
+	if [ $? -ne 0 ] ; then
+		JEMALLOC="$1"
+	else
+		unset JEMALLOC
+	fi
+	rm /tmp/jemalloc_test
+}
+
+which_jemalloc libjemalloc.so
+if [ -z "$JEMALLOC" ] ; then
+	which_jemalloc libjemalloc.so.1
+fi
+if [ -z "$JEMALLOC" ] ; then
+	which_jemalloc libjemalloc.so.2
+fi
+
 while [ $keep_going -ne 0 ]; do
-	$exename $args
+	LD_PRELOAD=$JEMALLOC $exename $args
 	if [ -e ${lopt}/StopColumnstore ]; then
 		exit 0
 	fi

--- a/oamapps/postConfigure/installer.cpp
+++ b/oamapps/postConfigure/installer.cpp
@@ -988,7 +988,7 @@ int main(int argc, char* argv[])
         system(cmd.c_str());
 
         if (oam.checkLogStatus(logFile, "System Catalog created") )
-            cout << endl << "System Catalog Successfull Created" << endl;
+            cout << endl << "System Catalog Successfully Created" << endl;
         else
         {
             if ( oam.checkLogStatus(logFile, "System catalog appears to exist") )

--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -58,6 +58,7 @@
 
 #include <string.h> /* for strncpy */
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <sys/ioctl.h>
 #include <netinet/in.h>
 #include <net/if.h>
@@ -569,6 +570,31 @@ int main(int argc, char* argv[])
 
 	cout << "IMPORTANT: This tool requires to run on the Performance Module #1" << endl;
     cout << endl;
+
+    // MCOL-3675
+    struct stat dir_info;
+    if (stat(tmpDir.c_str(), &dir_info) != 0)
+    {
+        cerr<<endl<<tmpDir<<" directory not found."<<endl;
+        cerr<<"Make sure columnstore-post-install is run before you run this tool. Exiting."<<endl<<endl;
+        exit(1);
+    }
+
+    string ProfileFile;
+    try
+    {
+        ProfileFile = sysConfig->getConfig(InstallSection, "ProfileFile");
+    }
+    catch (...)
+    {}
+
+    // MCOL-3676
+    if (ProfileFile.empty())
+    {
+        cerr<<endl<<"ProfileFile variable not set in the Config file."<<endl;
+        cerr<<"Make sure columnstore-post-install is run before you run this tool. Exiting."<<endl<<endl;
+        exit(1);
+    }
 
 	if (!single_server_quick_install || !multi_server_quick_install || !amazon_quick_install)
 	{
@@ -4141,14 +4167,6 @@ int main(int argc, char* argv[])
 
     cout << endl << "MariaDB ColumnStore Database Platform Starting, please wait .";
     cout.flush();
-
-    string ProfileFile;
-	try
-	{
-		ProfileFile = sysConfig->getConfig(InstallSection, "ProfileFile");
-	}
-	catch (...)
-	{}
 
     if ( waitForActive() )
     {

--- a/oamapps/postConfigure/quick_installer_single_server.sh
+++ b/oamapps/postConfigure/quick_installer_single_server.sh
@@ -6,13 +6,13 @@
 
 for arg in "$@"; do
 	if [ `expr -- "$arg" : '--help'` -eq 6 ]; then
-		echo "Usage ./quick_installer_multi_server.sh"
+		echo "Usage ./quick_installer_single_server.sh"
 		echo ""
 		echo "Quick Installer for a Single Server MariaDB ColumnStore Install"
 		echo ""
 		exit 1
 	else
-		echo "quick_installer_multi_server.sh: ignoring unknown argument: $arg" 1>&2
+		echo "quick_installer_single_server.sh: ignoring unknown argument: $arg" 1>&2
 	fi
 done
 

--- a/primitives/linux-port/dictionary.cpp
+++ b/primitives/linux-port/dictionary.cpp
@@ -683,7 +683,7 @@ inline bool PrimitiveProcessor::isEscapedChar(char c)
 int PrimitiveProcessor::convertToRegexp(idb_regex_t* regex, const p_DataValue* str)
 {
     //In the worst case, every char is quadrupled, plus some leading/trailing cruft...
-    char* cBuf = (char*)alloca(((4 * str->len) + 3) * sizeof(char));
+    char* cBuf = new char[(4 * str->len) + 3];
     char c;
     int i, cBufIdx = 0;
     // translate to regexp symbols
@@ -764,6 +764,7 @@ int PrimitiveProcessor::convertToRegexp(idb_regex_t* regex, const p_DataValue* s
     regex->regex = cBuf;
 #endif
     regex->used = true;
+    delete [] cBuf;
     return 0;
 }
 

--- a/tools/dbloadxml/colxml.cpp
+++ b/tools/dbloadxml/colxml.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
     // set effective ID to root
     if( setuid( 0 ) < 0 )
     {
-        std::cerr << " colxml: setuid failed " << std::endl;
+        std::cerr << " colxml: couldn't set uid " << std::endl;
     }
     setlocale(LC_ALL, "");
     WriteEngine::Config::initConfigCache(); // load Columnstore.xml config settings

--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -2429,7 +2429,7 @@ int64_t DataConvert::intToDate(int64_t data)
 
     // this snprintf call causes a compiler warning b/c we're potentially copying a 20-digit #
     // into 15 bytes, however, that appears to be intentional.
-#if defined(__GNUC__) && __GNUC__ >= 6
+#if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation="
     snprintf( buf, 15, "%llu", (long long unsigned int)data);
@@ -2565,7 +2565,7 @@ int64_t DataConvert::intToDatetime(int64_t data, bool* date)
 
     // this snprintf call causes a compiler warning b/c we're potentially copying a 20-digit #
     // into 15 bytes, however, that appears to be intentional.
-#if defined(__GNUC__) && __GNUC__ >= 6
+#if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation="
     snprintf( buf, 15, "%llu", (long long unsigned int)data);
@@ -2703,7 +2703,7 @@ int64_t DataConvert::intToTime(int64_t data, bool fromString)
 
     // this snprintf call causes a compiler warning b/c we're potentially copying a 20-digit #
     // into 15 bytes, however, that appears to be intentional.
-#if defined(__GNUC__) && __GNUC__ >= 6
+#if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation="
     snprintf( buf, 15, "%llu", (long long unsigned int)data);

--- a/utils/dataconvert/dataconvert.h
+++ b/utils/dataconvert/dataconvert.h
@@ -683,7 +683,7 @@ inline void DataConvert::timeToString1( long long timevalue, char* buf, unsigned
     }
     // this snprintf call causes a compiler warning b/c buffer size is less
     // then maximum string size.
-#if defined(__GNUC__) && __GNUC__ >= 6
+#if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation="
     snprintf( buf, buflen, "%02d%02d%02d",

--- a/utils/dataconvert/dataconvert.h
+++ b/utils/dataconvert/dataconvert.h
@@ -125,7 +125,6 @@ enum CalpontDateTimeFormat
     CALPONTTIME_ENUM     = 3
 };
 
-
 /** @brief a structure to hold a date
  */
 struct Date
@@ -298,7 +297,7 @@ bool isDateValid ( int day, int month, int year)
 {
     bool valid = true;
 
-    if ( year == 0 && month == 0 && year == 0 )
+    if ( day == 0 && month == 0 && year == 0 )
     {
         return true;
     }
@@ -809,7 +808,7 @@ inline void DataConvert::trimWhitespace(int64_t& charData)
 inline std::string DataConvert::constructRegexp(const std::string& str)
 {
     //In the worst case, every char is quadrupled, plus some leading/trailing cruft...
-    char* cBuf = (char*)alloca(((4 * str.length()) + 3) * sizeof(char));
+    char* cBuf = new char[(4 * str.length()) + 3];
     char c;
     uint32_t i, cBufIdx = 0;
     // translate to regexp symbols
@@ -882,7 +881,9 @@ inline std::string DataConvert::constructRegexp(const std::string& str)
 #ifdef VERBOSE
     cerr << "regexified string is " << cBuf << endl;
 #endif
-    return cBuf;
+    std::string ret(cBuf);
+    delete [] cBuf;
+    return ret;
 }
 
 } // namespace dataconvert

--- a/utils/funcexp/func_char_length.cpp
+++ b/utils/funcexp/func_char_length.cpp
@@ -83,9 +83,9 @@ int64_t Func_char_length::getIntVal(rowgroup::Row& row,
                 return 0;
 
             size_t strwclen = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
-            wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+            wchar_t* wcbuf = new wchar_t[strwclen];
             strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen);
-
+            delete [] wcbuf;
             return (int64_t)strwclen;
         }
 

--- a/utils/funcexp/func_concat_ws.cpp
+++ b/utils/funcexp/func_concat_ws.cpp
@@ -57,7 +57,7 @@ string Func_concat_ws::getStrVal(Row& row,
 #ifdef STRCOLL_ENH__
     wstring wstr;
     size_t strwclen = utf8::idb_mbstowcs(0, delim.c_str(), 0) + 1;
-    wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+    wchar_t* wcbuf = new wchar_t[strwclen];
     strwclen = utf8::idb_mbstowcs(wcbuf, delim.c_str(), strwclen);
     wstring wdelim(wcbuf, strwclen);
 
@@ -75,14 +75,15 @@ string Func_concat_ws::getStrVal(Row& row,
             wstr += wdelim;
 
         size_t strwclen1 = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
-        wchar_t* wcbuf1 = (wchar_t*)alloca(strwclen1 * sizeof(wchar_t));
+        wchar_t* wcbuf1 = new wchar_t[strwclen1];
         strwclen1 = utf8::idb_mbstowcs(wcbuf1, tstr.c_str(), strwclen1);
         wstring str1(wcbuf1, strwclen1);
         wstr += str1;
+        delete [] wcbuf1;
     }
 
     size_t strmblen = utf8::idb_wcstombs(0, wstr.c_str(), 0) + 1;
-    char* outbuf = (char*)alloca(strmblen * sizeof(char));
+    char* outbuf = new char[strmblen];
     strmblen = utf8::idb_wcstombs(outbuf, wstr.c_str(), strmblen);
 
     if (strmblen == 0)
@@ -90,7 +91,10 @@ string Func_concat_ws::getStrVal(Row& row,
     else
         isNull = false;
 
-    return string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+    delete [] outbuf;
+    delete [] wcbuf;
+    return ret;
 
 #else
     string str;

--- a/utils/funcexp/func_lcase.cpp
+++ b/utils/funcexp/func_lcase.cpp
@@ -68,7 +68,7 @@ std::string Func_lcase::getStrVal(rowgroup::Row& row,
         return "";
 
     size_t strwclen = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
-    wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+    wchar_t* wcbuf = new wchar_t[strwclen];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen);
     wstring wstr(wcbuf, strwclen);
 
@@ -76,9 +76,12 @@ std::string Func_lcase::getStrVal(rowgroup::Row& row,
         wstr[i] = std::towlower(wstr[i]);
 
     size_t strmblen = utf8::idb_wcstombs(0, wstr.c_str(), 0) + 1;
-    char* outbuf = (char*)alloca(strmblen * sizeof(char));
+    char* outbuf = new char[strmblen];
     strmblen = utf8::idb_wcstombs(outbuf, wstr.c_str(), strmblen);
-    return string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+    delete [] outbuf;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_left.cpp
+++ b/utils/funcexp/func_left.cpp
@@ -56,7 +56,7 @@ std::string Func_left::getStrVal(rowgroup::Row& row,
         return "";
 
     size_t strwclen = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
-    wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+    wchar_t* wcbuf = new wchar_t[strwclen];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen);
     wstring str(wcbuf, strwclen);
 
@@ -70,9 +70,12 @@ std::string Func_left::getStrVal(rowgroup::Row& row,
 
     wstring out = str.substr(0, pos + 1);
     size_t strmblen = utf8::idb_wcstombs(0, out.c_str(), 0) + 1;
-    char* outbuf = (char*)alloca(strmblen * sizeof(char));
+    char* outbuf = new char[strmblen];
     strmblen = utf8::idb_wcstombs(outbuf, out.c_str(), strmblen);
-    return string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+    delete [] outbuf;
+    delete [] wcbuf;
+    return ret;
 
 //	return str.substr(0, pos+1);
 }

--- a/utils/funcexp/func_lpad.cpp
+++ b/utils/funcexp/func_lpad.cpp
@@ -155,10 +155,10 @@ std::string Func_lpad::getStrVal(rowgroup::Row& row,
     if (strwclen > len)
         alen = strwclen;
 
-    size_t bufsize = (alen + 1) * sizeof(wchar_t);
+    size_t bufsize = alen + 1;
 
     // Convert to wide characters. Do all further work in wide characters
-    wchar_t* wcbuf = (wchar_t*)alloca(bufsize);
+    wchar_t* wcbuf = new wchar_t[bufsize];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen + 1);
 
     size_t strSize = strwclen;    // The number of significant characters
@@ -190,8 +190,8 @@ std::string Func_lpad::getStrVal(rowgroup::Row& row,
 
     // Convert the pad string to wide
     padwclen = pad->length();  // A guess to start.
-    size_t padbufsize = (padwclen + 1) * sizeof(wchar_t);
-    wchar_t* wcpad = (wchar_t*)alloca(padbufsize);
+    size_t padbufsize = padwclen + 1;
+    wchar_t* wcpad = new wchar_t[padbufsize];
     // padwclen+1 is for giving count for the terminating null
     size_t padlen = utf8::idb_mbstowcs(wcpad, pad->c_str(), padwclen + 1);
 
@@ -234,7 +234,10 @@ std::string Func_lpad::getStrVal(rowgroup::Row& row,
 
     wstring padded = wstring(wcbuf, len);
     // Turn back to a string
-    return utf8::wstring_to_utf8(padded.c_str());
+    std::string ret(utf8::wstring_to_utf8(padded.c_str()));
+    delete [] wcpad;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_ltrim.cpp
+++ b/utils/funcexp/func_ltrim.cpp
@@ -74,10 +74,10 @@ std::string Func_ltrim::getStrVal(rowgroup::Row& row,
     // determine the size of buffer to allocate, we can be sure the wide
     // char string won't be longer than:
     strwclen = tstr.length(); // a guess to start with. This will be >= to the real count.
-    int bufsize = (strwclen + 1) * sizeof(wchar_t);
+    int bufsize = strwclen + 1;
 
     // Convert the string to wide characters. Do all further work in wide characters
-    wchar_t* wcbuf = (wchar_t*)alloca(bufsize);
+    wchar_t* wcbuf = new wchar_t[bufsize];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen + 1);
 
     // idb_mbstowcs can return -1 if there is bad mbs char in tstr
@@ -86,8 +86,8 @@ std::string Func_ltrim::getStrVal(rowgroup::Row& row,
 
     // Convert the trim string to wide
     trimwclen = trim.length();  // A guess to start.
-    int trimbufsize = (trimwclen + 1) * sizeof(wchar_t);
-    wchar_t* wctrim = (wchar_t*)alloca(trimbufsize);
+    int trimbufsize = trimwclen + 1;
+    wchar_t* wctrim = new wchar_t[trimbufsize];
     size_t trimlen = utf8::idb_mbstowcs(wctrim, trim.c_str(), trimwclen + 1);
 
     // idb_mbstowcs can return -1 if there is bad mbs char in tstr
@@ -123,7 +123,10 @@ std::string Func_ltrim::getStrVal(rowgroup::Row& row,
     size_t aLen = strwclen - (aPtr - oPtr);
     wstring trimmed = wstring(aPtr, aLen);
     // Turn back to a string
-    return utf8::wstring_to_utf8(trimmed.c_str());
+    std::string ret(utf8::wstring_to_utf8(trimmed.c_str()));
+    delete [] wctrim;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_repeat.cpp
+++ b/utils/funcexp/func_repeat.cpp
@@ -81,8 +81,7 @@ std::string Func_repeat::getStrVal(rowgroup::Row& row,
     int size = str.length() * count;
 
     //allocate memory
-    char* result = NULL;
-    result = (char*) alloca(size * sizeof(char) + 1);
+    char* result = new char[size + 1];
 
     if (result == NULL)
     {
@@ -97,7 +96,9 @@ std::string Func_repeat::getStrVal(rowgroup::Row& row,
             return "";
     }
 
-    return result;
+    std::string res(result);
+    delete [] result;
+    return res;
 }
 
 

--- a/utils/funcexp/func_right.cpp
+++ b/utils/funcexp/func_right.cpp
@@ -65,7 +65,7 @@ std::string Func_right::getStrVal(rowgroup::Row& row,
 
     size_t strwclen = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
     //wchar_t wcbuf[strwclen];
-    wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+    wchar_t* wcbuf = new wchar_t[strwclen];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen);
     wstring str(wcbuf, strwclen);
 
@@ -75,9 +75,12 @@ std::string Func_right::getStrVal(rowgroup::Row& row,
     wstring out = str.substr(strwclen - pos, strwclen);
     size_t strmblen = utf8::idb_wcstombs(0, out.c_str(), 0) + 1;
     //char outbuf[strmblen];
-    char* outbuf = (char*)alloca(strmblen * sizeof(char));
+    char* outbuf = new char[strmblen];
     strmblen = utf8::idb_wcstombs(outbuf, out.c_str(), strmblen);
-    return string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+    delete [] outbuf;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_round.cpp
+++ b/utils/funcexp/func_round.cpp
@@ -623,5 +623,14 @@ string Func_round::getStrVal(Row& row,
 }
 
 
+int64_t Func_round::getDatetimeIntVal(Row& row,
+                                      FunctionParm& parm,
+                                      bool& isNull,
+                                      CalpontSystemCatalog::ColType& op_ct)
+{
+    return parm[0]->data()->getIntVal(row, isNull);
+}
+
+
 } // namespace funcexp
 // vim:ts=4 sw=4:

--- a/utils/funcexp/func_rpad.cpp
+++ b/utils/funcexp/func_rpad.cpp
@@ -155,10 +155,10 @@ std::string Func_rpad::getStrVal(rowgroup::Row& row,
     if (strwclen > len)
         alen = strwclen;
 
-    int bufsize = (alen + 1) * sizeof(wchar_t);
+    int bufsize = alen + 1;
 
     // Convert to wide characters. Do all further work in wide characters
-    wchar_t* wcbuf = (wchar_t*)alloca(bufsize);
+    wchar_t* wcbuf = new wchar_t[bufsize];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen + 1);
 
     unsigned int strSize = strwclen;    // The number of significant characters
@@ -190,8 +190,8 @@ std::string Func_rpad::getStrVal(rowgroup::Row& row,
 
     // Convert the pad string to wide
     padwclen = pad->length();  // A guess to start.
-    int padbufsize = (padwclen + 1) * sizeof(wchar_t);
-    wchar_t* wcpad = (wchar_t*)alloca(padbufsize);
+    int padbufsize = padwclen + 1;
+    wchar_t* wcpad = new wchar_t[padbufsize];
     size_t padlen = utf8::idb_mbstowcs(wcpad, pad->c_str(), padwclen + 1);
 
     // How many chars do we need?
@@ -221,7 +221,10 @@ std::string Func_rpad::getStrVal(rowgroup::Row& row,
     wstring padded = wstring(wcbuf, len);
 
     // Bug 5110 : strings were getting truncated since enough bytes not allocated.
-    return utf8::wstring_to_utf8(padded.c_str());
+    std::string ret(utf8::wstring_to_utf8(padded.c_str()));
+    delete [] wcpad;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_rtrim.cpp
+++ b/utils/funcexp/func_rtrim.cpp
@@ -73,10 +73,10 @@ std::string Func_rtrim::getStrVal(rowgroup::Row& row,
     // determine the size of buffer to allocate, we can be sure the wide
     // char string won't be longer than:
     strwclen = tstr.length(); // a guess to start with. This will be >= to the real count.
-    int bufsize = (strwclen + 1) * sizeof(wchar_t);
+    int bufsize = strwclen + 1;
 
     // Convert the string to wide characters. Do all further work in wide characters
-    wchar_t* wcbuf = (wchar_t*)alloca(bufsize);
+    wchar_t* wcbuf = new wchar_t[bufsize];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen + 1);
 
     // utf8::idb_mbstowcs could return -1 if there is bad chars
@@ -85,8 +85,8 @@ std::string Func_rtrim::getStrVal(rowgroup::Row& row,
 
     // Convert the trim string to wide
     trimwclen = trim.length();  // A guess to start.
-    int trimbufsize = (trimwclen + 1) * sizeof(wchar_t);
-    wchar_t* wctrim = (wchar_t*)alloca(trimbufsize);
+    int trimbufsize = trimwclen + 1;
+    wchar_t* wctrim = new wchar_t[trimbufsize];
     size_t trimlen = utf8::idb_mbstowcs(wctrim, trim.c_str(), trimwclen + 1);
 
     // idb_mbstowcs could return -1 if there is bad chars
@@ -128,7 +128,10 @@ std::string Func_rtrim::getStrVal(rowgroup::Row& row,
     size_t aLen = strwclen - trimCnt;
     wstring trimmed = wstring(aPtr, aLen);
     // Turn back to a string
-    return utf8::wstring_to_utf8(trimmed.c_str());
+    std::string ret(utf8::wstring_to_utf8(trimmed.c_str()));
+    delete [] wctrim;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_substr.cpp
+++ b/utils/funcexp/func_substr.cpp
@@ -59,7 +59,7 @@ std::string Func_substr::getStrVal(rowgroup::Row& row,
         return "";
 
     size_t strwclen = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
-    wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+    wchar_t* wcbuf = new wchar_t[strwclen];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen);
     wstring str(wcbuf, strwclen);
 
@@ -98,9 +98,12 @@ std::string Func_substr::getStrVal(rowgroup::Row& row,
 
     wstring out = str.substr(start, n);
     size_t strmblen = utf8::idb_wcstombs(0, out.c_str(), 0) + 1;
-    char* outbuf = (char*)alloca(strmblen * sizeof(char));
+    char* outbuf = new char[strmblen];
     strmblen = utf8::idb_wcstombs(outbuf, out.c_str(), strmblen);
-    return string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+    delete [] outbuf;
+    delete [] wcbuf;
+    return ret;
 #else
     const string& str = fp[0]->data()->getStrVal(row, isNull);
 

--- a/utils/funcexp/func_trim.cpp
+++ b/utils/funcexp/func_trim.cpp
@@ -72,10 +72,10 @@ std::string Func_trim::getStrVal(rowgroup::Row& row,
     // determine the size of buffer to allocate, we can be sure the wide
     // char string won't be longer than:
     strwclen = tstr.length(); // a guess to start with. This will be >= to the real count.
-    int bufsize = (strwclen + 1) * sizeof(wchar_t);
+    int bufsize = strwclen + 1;
 
     // Convert the string to wide characters. Do all further work in wide characters
-    wchar_t* wcbuf = (wchar_t*)alloca(bufsize);
+    wchar_t* wcbuf = new wchar_t[bufsize];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen + 1);
 
     // Bad char in mbc can return -1
@@ -84,8 +84,8 @@ std::string Func_trim::getStrVal(rowgroup::Row& row,
 
     // Convert the trim string to wide
     trimwclen = trim.length();  // A guess to start.
-    int trimbufsize = (trimwclen + 1) * sizeof(wchar_t);
-    wchar_t* wctrim = (wchar_t*)alloca(trimbufsize);
+    int trimbufsize = trimwclen + 1;
+    wchar_t* wctrim = new wchar_t[trimbufsize];
     size_t trimlen = utf8::idb_mbstowcs(wctrim, trim.c_str(), trimwclen + 1);
 
     // Bad char in mbc can return -1
@@ -144,7 +144,10 @@ std::string Func_trim::getStrVal(rowgroup::Row& row,
     size_t aLen = strwclen - trimCnt;
     wstring trimmed = wstring(aPtr, aLen);
     // Turn back to a string
-    return utf8::wstring_to_utf8(trimmed.c_str());
+    std::string ret(utf8::wstring_to_utf8(trimmed.c_str()));
+    delete [] wctrim;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/func_ucase.cpp
+++ b/utils/funcexp/func_ucase.cpp
@@ -67,7 +67,7 @@ std::string Func_ucase::getStrVal(rowgroup::Row& row,
         return "";
 
     size_t strwclen = utf8::idb_mbstowcs(0, tstr.c_str(), 0) + 1;
-    wchar_t* wcbuf = (wchar_t*)alloca(strwclen * sizeof(wchar_t));
+    wchar_t* wcbuf = new wchar_t[strwclen];
     strwclen = utf8::idb_mbstowcs(wcbuf, tstr.c_str(), strwclen);
     wstring wstr(wcbuf, strwclen);
 
@@ -75,9 +75,12 @@ std::string Func_ucase::getStrVal(rowgroup::Row& row,
         wstr[i] = std::towupper(wstr[i]);
 
     size_t strmblen = utf8::idb_wcstombs(0, wstr.c_str(), 0) + 1;
-    char* outbuf = (char*)alloca(strmblen * sizeof(char));
+    char* outbuf = new char[strmblen];
     strmblen = utf8::idb_wcstombs(outbuf, wstr.c_str(), strmblen);
-    return string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+    delete [] outbuf;
+    delete [] wcbuf;
+    return ret;
 }
 
 

--- a/utils/funcexp/functor_real.h
+++ b/utils/funcexp/functor_real.h
@@ -197,6 +197,11 @@ public:
                           FunctionParm& fp,
                           bool& isNull,
                           execplan::CalpontSystemCatalog::ColType& op_ct);
+
+    int64_t getDatetimeIntVal(rowgroup::Row& row,
+                              FunctionParm& fp,
+                              bool& isNull,
+                              execplan::CalpontSystemCatalog::ColType& op_ct);
 };
 
 

--- a/utils/funcexp/utils_utf8.h
+++ b/utils/funcexp/utils_utf8.h
@@ -222,10 +222,10 @@ size_t idb_wcstombs(char* dest, const wchar_t* src, size_t max)
 inline
 std::wstring utf8_to_wstring (const std::string& str)
 {
-    int bufsize = (int)((str.length() + 1) * sizeof(wchar_t));
+    size_t bufsize = str.length() + 1;
 
     // Convert to wide characters. Do all further work in wide characters
-    wchar_t* wcbuf = (wchar_t*)alloca(bufsize);
+    wchar_t* wcbuf = new wchar_t[bufsize];
     // Passing +1 so that windows is happy to see extra position to place NULL
     size_t strwclen = idb_mbstowcs(wcbuf, str.c_str(), str.length() + 1);
 
@@ -234,7 +234,10 @@ std::wstring utf8_to_wstring (const std::string& str)
     if ( strwclen == static_cast<size_t>(-1) )
         strwclen = 0;
 
-    return std::wstring(wcbuf, strwclen);
+    std::wstring ret(wcbuf, strwclen);
+
+    delete [] wcbuf;
+    return ret;
 }
 
 
@@ -242,7 +245,7 @@ std::wstring utf8_to_wstring (const std::string& str)
 inline
 std::string wstring_to_utf8 (const std::wstring& str)
 {
-    char* outbuf = (char*)alloca((str.length() * MAX_UTF8_BYTES_PER_CHAR) + 1);
+    char* outbuf = new char[(str.length() * MAX_UTF8_BYTES_PER_CHAR) + 1];
     // Passing +1 so that windows is happy to see extra position to place NULL
     size_t strmblen = idb_wcstombs(outbuf, str.c_str(), str.length() * MAX_UTF8_BYTES_PER_CHAR + 1);
 
@@ -251,7 +254,10 @@ std::string wstring_to_utf8 (const std::wstring& str)
     if ( strmblen == static_cast<size_t>(-1) )
         strmblen = 0;
 
-    return std::string(outbuf, strmblen);
+    std::string ret(outbuf, strmblen);
+
+    delete [] outbuf;
+    return ret;
 }
 
 inline

--- a/utils/rowgroup/rowaggregation.h
+++ b/utils/rowgroup/rowaggregation.h
@@ -42,6 +42,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/shared_array.hpp>
 #include <boost/scoped_array.hpp>
+#include <boost/scoped_ptr.hpp>
 
 #include "serializeable.h"
 #include "bytestream.h"

--- a/utils/threadpool/threadpool.h
+++ b/utils/threadpool/threadpool.h
@@ -77,7 +77,7 @@ public:
     boost::thread* create_thread(F threadfunc)
     {
         boost::lock_guard<boost::shared_mutex> guard(m);
-#if defined(__GNUC__) && __GNUC__ >= 7
+#if __cplusplus >= 201103L
         std::unique_ptr<boost::thread> new_thread(new boost::thread(threadfunc));
 #else
         std::auto_ptr<boost::thread> new_thread(new boost::thread(threadfunc));

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -455,33 +455,6 @@ int TimeCompare::operator()(IdbCompare* l, Row::Pointer r1, Row::Pointer r2)
     l->row1().setData(r1);
     l->row2().setData(r2);
 
-    int ret = 0;
-    uint64_t v1 = l->row1().getUintField(fSpec.fIndex);
-    uint64_t v2 = l->row2().getUintField(fSpec.fIndex);
-
-    if (v1 == joblist::TIMENULL || v2 == joblist::TIMENULL)
-    {
-        if (v1 != joblist::TIMENULL && v2 == joblist::TIMENULL)
-            ret = fSpec.fNf;
-        else if (v1 == joblist::TIMENULL && v2 != joblist::TIMENULL)
-            ret = -fSpec.fNf;
-    }
-    else
-    {
-        if (v1 > v2)
-            ret = fSpec.fAsc;
-        else if (v1 < v2)
-            ret = -fSpec.fAsc;
-    }
-
-    return ret;
-}
-
-int TimeCompare::operator()(IdbCompare* l, Row::Pointer r1, Row::Pointer r2)
-{
-    l->row1().setData(r1);
-    l->row2().setData(r2);
-
     bool b1 = l->row1().isNullValue(fSpec.fIndex);
     bool b2 = l->row2().isNullValue(fSpec.fIndex);
 
@@ -524,7 +497,6 @@ int TimeCompare::operator()(IdbCompare* l, Row::Pointer r1, Row::Pointer r2)
 
     return ret;
 }
-
 
 bool CompareRule::less(Row::Pointer r1, Row::Pointer r2)
 {
@@ -676,13 +648,6 @@ void CompareRule::compileRules(const std::vector<IdbSortSpec>& spec, const rowgr
                 fCompares.push_back(c);
                 break;
             }
-            case CalpontSystemCatalog::TIME:
-            {
-                Compare* c = new TimeCompare(*i);
-                fCompares.push_back(c);
-                break;
-            }
-
             case CalpontSystemCatalog::TIME:
             {
                 Compare* c = new TimeCompare(*i);

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -455,8 +455,11 @@ int TimeCompare::operator()(IdbCompare* l, Row::Pointer r1, Row::Pointer r2)
     l->row1().setData(r1);
     l->row2().setData(r2);
 
-    bool b1 = l->row1().isNullValue(fSpec.fIndex);
-    bool b2 = l->row2().isNullValue(fSpec.fIndex);
+    int64_t v1 = l->row1().getIntField(fSpec.fIndex);
+    int64_t v2 = l->row2().getIntField(fSpec.fIndex);
+
+    bool b1 = (joblist::TIMENULL == (uint64_t) v1);
+    bool b2 = (joblist::TIMENULL == (uint64_t) v2);
 
     int ret = 0;
 

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -814,8 +814,8 @@ uint64_t IdbOrderBy::Hasher::operator()(const Row::Pointer& p) const
 {
     Row& row = ts->row1;
     row.setPointer(p);
-    // MCOL-1829 Row::h uses colcount as an array idx down a callstack.
-    uint64_t ret = row.hash();
+    // MCOL-1829 Row::hash uses colcount - 1 as an array idx down a callstack.
+    uint64_t ret = row.hash(colCount - 1);
     return ret;
 }
 
@@ -825,7 +825,7 @@ bool IdbOrderBy::Eq::operator()(const Row::Pointer& d1, const Row::Pointer& d2) 
     r1.setPointer(d1);
     r2.setPointer(d2);
     // MCOL-1829 Row::equals uses 2nd argument as key columns container size boundary
-    bool ret = r1.equals(r2, colCount);
+    bool ret = r1.equals(r2, colCount - 1);
 
     return ret;
 }

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -477,6 +477,55 @@ int TimeCompare::operator()(IdbCompare* l, Row::Pointer r1, Row::Pointer r2)
     return ret;
 }
 
+int TimeCompare::operator()(IdbCompare* l, Row::Pointer r1, Row::Pointer r2)
+{
+    l->row1().setData(r1);
+    l->row2().setData(r2);
+
+    bool b1 = l->row1().isNullValue(fSpec.fIndex);
+    bool b2 = l->row2().isNullValue(fSpec.fIndex);
+
+    int ret = 0;
+
+    if (b1 == true || b2 == true)
+    {
+        if (b1 == false && b2 == true)
+            ret = fSpec.fNf;
+        else if (b1 == true && b2 == false)
+            ret = -fSpec.fNf;
+    }
+    else
+    {
+        int64_t v1 = l->row1().getIntField(fSpec.fIndex);
+        int64_t v2 = l->row2().getIntField(fSpec.fIndex);
+
+        // ((int64_t) -00:00:26) > ((int64_t) -00:00:25)
+        // i.e. For 2 negative TIME values, we invert the order of
+        // comparison operations to force "-00:00:26" to appear before
+        // "-00:00:25" in ascending order.
+        if (v1 < 0 && v2 < 0)
+        {
+            // Unset the MSB.
+            v1 &= ~(1ULL << 63);
+            v2 &= ~(1ULL << 63);
+            if (v1 < v2)
+                ret = fSpec.fAsc;
+            else if (v1 > v2)
+                ret = -fSpec.fAsc;
+        }
+        else
+        {
+            if (v1 > v2)
+                ret = fSpec.fAsc;
+            else if (v1 < v2)
+                ret = -fSpec.fAsc;
+        }
+    }
+
+    return ret;
+}
+
+
 bool CompareRule::less(Row::Pointer r1, Row::Pointer r2)
 {
     for (vector<Compare*>::iterator i = fCompares.begin(); i != fCompares.end(); i++)
@@ -627,6 +676,13 @@ void CompareRule::compileRules(const std::vector<IdbSortSpec>& spec, const rowgr
                 fCompares.push_back(c);
                 break;
             }
+            case CalpontSystemCatalog::TIME:
+            {
+                Compare* c = new TimeCompare(*i);
+                fCompares.push_back(c);
+                break;
+            }
+
             case CalpontSystemCatalog::TIME:
             {
                 Compare* c = new TimeCompare(*i);

--- a/utils/windowfunction/idborderby.h
+++ b/utils/windowfunction/idborderby.h
@@ -290,15 +290,6 @@ public:
 
 // End of comparators for variable sized types
 
-class TimeCompare : public Compare
-{
-public:
-    TimeCompare(const IdbSortSpec& spec) : Compare(spec) {}
-
-    int operator()(IdbCompare*, rowgroup::Row::Pointer, rowgroup::Row::Pointer);
-};
-
-
 class CompareRule
 {
 public:

--- a/utils/windowfunction/idborderby.h
+++ b/utils/windowfunction/idborderby.h
@@ -290,6 +290,15 @@ public:
 
 // End of comparators for variable sized types
 
+class TimeCompare : public Compare
+{
+public:
+    TimeCompare(const IdbSortSpec& spec) : Compare(spec) {}
+
+    int operator()(IdbCompare*, rowgroup::Row::Pointer, rowgroup::Row::Pointer);
+};
+
+
 class CompareRule
 {
 public:

--- a/writeengine/bulk/cpimport.cpp
+++ b/writeengine/bulk/cpimport.cpp
@@ -1025,7 +1025,7 @@ int main(int argc, char** argv)
     // set effective ID to root
     if( setuid( 0 ) < 0 )
     {
-        std::cerr << " cpimport: setuid failed " << std::endl;
+        std::cerr << " cpimport: couldn't set uid " << std::endl;
     } 
 #endif
     setupSignalHandlers();

--- a/writeengine/bulk/we_bulkloadbuffer.cpp
+++ b/writeengine/bulk/we_bulkloadbuffer.cpp
@@ -718,7 +718,7 @@ void BulkLoadBuffer::convert(char* field, int fieldLength,
                     errno   = 0;
 
                     origVal = strtoll(field, 0, 10);
-                    
+
                     if (errno == ERANGE)
                         bSatVal = true;
                 }
@@ -803,7 +803,7 @@ void BulkLoadBuffer::convert(char* field, int fieldLength,
                         strcpy(field, "1");
                         fieldLength = 1;
                     }
-                    
+
                     if ( (column.dataType == CalpontSystemCatalog::DECIMAL ) ||
                             (column.dataType == CalpontSystemCatalog::UDECIMAL))
                     {
@@ -977,7 +977,7 @@ void BulkLoadBuffer::convert(char* field, int fieldLength,
                             strcpy(field, "1");
                             fieldLength = 1;
                         }
-                        
+
                         if ( (column.dataType == CalpontSystemCatalog::DECIMAL) ||
                                 (column.dataType == CalpontSystemCatalog::UDECIMAL))
                         {
@@ -1354,7 +1354,7 @@ void BulkLoadBuffer::convert(char* field, int fieldLength,
                             strcpy(field, "1");
                             fieldLength = 1;
                         }
-                    
+
                         if ( (column.dataType == CalpontSystemCatalog::DECIMAL) ||
                                 (column.dataType == CalpontSystemCatalog::UDECIMAL))
                         {
@@ -1585,7 +1585,7 @@ int  BulkLoadBuffer::parseCol(ColumnInfo& columnInfo)
                 tokenNullFlag = true;
             }
 
-            // convert the data into appropriate format.
+            // convert the data into appropriate format and update CP values
             convert(field, tokenLength, tokenNullFlag,
                     buf + i * columnInfo.column.width,
                     columnInfo.column, bufStats);
@@ -1616,7 +1616,7 @@ int  BulkLoadBuffer::parseCol(ColumnInfo& columnInfo)
 
                 lastInputRowInExtent += columnInfo.rowsPerExtent();
 
-                if (isUnsigned(columnInfo.column.dataType))
+                if (isUnsigned(columnInfo.column.dataType) || isCharType(columnInfo.column.dataType))
                 {
                     bufStats.minBufferVal = static_cast<int64_t>(MAX_UBIGINT);
                     bufStats.maxBufferVal = static_cast<int64_t>(MIN_UBIGINT);

--- a/writeengine/bulk/we_bulkloadbuffer.h
+++ b/writeengine/bulk/we_bulkloadbuffer.h
@@ -44,7 +44,7 @@ public:
     int64_t satCount;
     BLBufferStats(ColDataType colDataType) : satCount(0)
     {
-        if (isUnsigned(colDataType))
+        if (isUnsigned(colDataType) || isCharType(colDataType))
         {
             minBufferVal = static_cast<int64_t>(MAX_UBIGINT);
             maxBufferVal = static_cast<int64_t>(MIN_UBIGINT);

--- a/writeengine/bulk/we_columninfocompressed.cpp
+++ b/writeengine/bulk/we_columninfocompressed.cpp
@@ -411,6 +411,7 @@ int ColumnInfoCompressed::truncateDctnryStore(
             fLog->logMsg( oss.str(), rc, MSGLVL_ERROR );
             fTruncateDctnryFileOp.closeFile( dFile );
 
+            delete [] pointerHdr;
             return rc;
         }
 

--- a/writeengine/shared/we_chunkmanager.cpp
+++ b/writeengine/shared/we_chunkmanager.cpp
@@ -1928,7 +1928,7 @@ int ChunkManager::reallocateChunks(CompFileData* fileData)
         char tmText[24];
     // this snprintf call causes a compiler warning b/c buffer size is less
     // then maximum string size.
-#if defined(__GNUC__) && __GNUC__ >= 6
+#if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation="
         snprintf(tmText, sizeof(tmText), ".%04d%02d%02d%02d%02d%02d%06ld",
@@ -2123,7 +2123,7 @@ int ChunkManager::reallocateChunks(CompFileData* fileData)
             char tmText[24];
     // this snprintf call causes a compiler warning b/c buffer size is less
     // then maximum string size.
-#if defined(__GNUC__) && __GNUC__ >= 6
+#if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation="
             snprintf(tmText, sizeof(tmText), ".%04d%02d%02d%02d%02d%02d%06ld",

--- a/writeengine/splitter/we_splitterapp.cpp
+++ b/writeengine/splitter/we_splitterapp.cpp
@@ -609,7 +609,7 @@ int main(int argc, char** argv)
     // @BUG4343
     if( setuid( 0 ) < 0 )
     {
-        std::cerr << " we_splitterapp: setuid failed " << std::endl;
+        std::cerr << " we_splitterapp: couldn't set uid " << std::endl;
     }
 
     std::cin.sync_with_stdio(false);


### PR DESCRIPTION
Includes the following fixes from dev-1.4

MCOL-1598    (new ticket is MCOL-3802)
MCOL-2224    (new ticket MCOL-3803)
MCOL-2159    (new ticket MCOL-3804)
MCOL-2146    (possible dup of 2159.  new ticket MCOL-3805)
MCOL-3621    (new ticket MCOL-3816)
MCOL-3598    (new ticket MCOL-3817)
MCOL-3702    (partial import of this; replication is fine in 1.2 AFAIK, only brought in the jemalloc searching part.  MCOL-3818)
MCOL-3173    (new ticket MCOL-3819)
MCOL-3675    (new ticket MCOL-3820)
MCOL-3632    (new ticket MCOL-3821)
MCOL-3662    (new ticket MCOL-3822)
MCOL-3716    (new ticket MCOL-3823)
MCOL-537      (new ticket MCOL-3824)

also a couple fixes that did not have a ticket AFAICT
Gagan's "fix-round-datetime" and "fix-negative-time-orderby" feature branches
