### PR TITLE
1.5: MCOL-3829: CS not starting correctly if rebooted at specific point

### DIFF
--- a/versioning/BRM/slavecomm.cpp
+++ b/versioning/BRM/slavecomm.cpp
@@ -2266,7 +2266,7 @@ void SlaveComm::saveDelta()
     {
         uint32_t len = delta.length();
 
-        
+        journalh->seek(0, SEEK_END);
         journalh->write((const char*) &len, sizeof(len));
         journalh->write((const char*) delta.buf(), delta.length());
         journalh->flush();


### PR DESCRIPTION
Found that the IDBDataFile path in BRM journal writing code needs to seek
to the end of the file before writing.

If save_brm is run (as it is during init), it truncates the journal file,
but the workernode retained its original offset, resulting in the front
of the file being 0-filled on the next journal write.  Load_brm can't
load that.