### PR TITLE
MCOL-3485 

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -4941,7 +4941,8 @@ ReturnedColumn* buildAggregateColumn(Item* item, gp_walk_info& gwi)
         {
             for (uint32_t i = 0; i < gwi.returnedCols.size(); i++)
             {
-                if (*ac == gwi.returnedCols[i].get())
+                if (*ac == gwi.returnedCols[i].get() 
+                        && ac->alias() == gwi.returnedCols[i].get()->alias())
                     ac->expressionId(gwi.returnedCols[i]->expressionId());
             }
         }


### PR DESCRIPTION
Fix ORDER BY not working with multiple aggregates of same type in SELECT clause

Issue turned out to be the sum aggregates in the test case were sharing the same expression id (second aggregates expression id was overriding the first), which was causing the order by to sort by the second aggregate (see example). 

Altered code to correctly check for same aggregate on the select list