### PR TITLE
MCOL-3760 Fix issue with random seed list not being initilized to empty

### DIFF
--- a/utils/funcexp/func_rand.cpp
+++ b/utils/funcexp/func_rand.cpp
@@ -77,7 +77,7 @@ double Func_rand::getDoubleVal(rowgroup::Row& row,
         fSeedSet = false;
         fSeedIndex += 1;
     }
-    else if (fFirstRow == 0)
+    else if (fFirstRow == nullptr)
     {
         // Store first row
         fFirstRow = row.getData();

--- a/utils/funcexp/functor_export.h
+++ b/utils/funcexp/functor_export.h
@@ -38,7 +38,7 @@ namespace funcexp
 class Func_rand : public Func
 {
 public:
-    Func_rand() : Func("rand"), fSeed1(0), fSeed2(0), fSeedSet(false), fMultipleSeedsSet(false), fFirstRow(nullptr){}
+    Func_rand() : Func("rand"), fSeed1(0), fSeed2(0), fSeedSet(false), fMultipleSeedsSet(false), fFirstRow(nullptr), fSeeds(){}
     virtual ~Func_rand() {}
 
     double getRand();
@@ -46,7 +46,6 @@ public:
     {
         fSeedSet = seedSet;
         fMultipleSeedsSet = seedSet;
-        fFirstRow = nullptr;
     }
     execplan::CalpontSystemCatalog::ColType operationType(FunctionParm& fp, execplan::CalpontSystemCatalog::ColType& resultType);
 


### PR DESCRIPTION
fSeeds needs to be initialized to empty otherwise size keeps growing and condition to reset back to seed 0 (line 98) of func_rand.cpp is never met.

