### PR TITLE
MCOL-3420 Don't break on bad systemlang

### DIFF
--- a/procmon/main.cpp
+++ b/procmon/main.cpp
@@ -2101,7 +2101,7 @@ static void statusControlThread()
             }
         }
 
-        log.writeLog(__LINE__, "System/Module Status shared Memory allociated and Initialized", LOG_TYPE_DEBUG);
+        log.writeLog(__LINE__, "System/Module Status shared Memory allocated and Initialized", LOG_TYPE_DEBUG);
     }
 
     //
@@ -2134,7 +2134,7 @@ static void statusControlThread()
             memcpy(fShmNICStatus[i].Name, hostNameList[i].c_str(), NAMESIZE);
         }
 
-        log.writeLog(__LINE__, "NIC Status shared Memory allociated and Initialized", LOG_TYPE_DEBUG);
+        log.writeLog(__LINE__, "NIC Status shared Memory allocated and Initialized", LOG_TYPE_DEBUG);
     }
 
     //
@@ -2191,7 +2191,7 @@ static void statusControlThread()
             memcpy(fShmExtDeviceStatus[i].Name, extDeviceNameList[i].c_str(), NAMESIZE);
         }
 
-        log.writeLog(__LINE__, "Ext Device Status shared Memory allociated and Initialized", LOG_TYPE_DEBUG);
+        log.writeLog(__LINE__, "Ext Device Status shared Memory allocated and Initialized", LOG_TYPE_DEBUG);
     }
 
     //
@@ -2258,7 +2258,7 @@ static void statusControlThread()
             memcpy(fShmDbrootStatus[i].Name, dbrootList[i].c_str(), NAMESIZE);
         }
 
-        log.writeLog(__LINE__, "Dbroot Status shared Memory allociated and Initialized", LOG_TYPE_DEBUG);
+        log.writeLog(__LINE__, "Dbroot Status shared Memory allocated and Initialized", LOG_TYPE_DEBUG);
     }
 
     //Set mainResumeFlag, to start up main thread

--- a/utils/funcexp/utils_utf8.h
+++ b/utils/funcexp/utils_utf8.h
@@ -62,6 +62,7 @@ std::string idb_setlocale()
     // get and set locale language
     std::string systemLang("C");
     oam::Oam oam;
+    static bool loggedMsg = false;
 
     try
     {
@@ -78,11 +79,27 @@ std::string idb_setlocale()
     {
         try
         {
-            //send alarm
-            alarmmanager::ALARMManager alarmMgr;
-            std::string alarmItem = "system";
-            alarmMgr.sendAlarmReport(alarmItem.c_str(), oam::INVALID_LOCALE, alarmmanager::SET);
-            printf("Failed to set locale : %s, Critical alarm generated\n", systemLang.c_str());
+            if (!loggedMsg)
+            {
+                //send alarm
+                alarmmanager::ALARMManager alarmMgr;
+                std::string alarmItem = "system";
+                alarmMgr.sendAlarmReport(alarmItem.c_str(), oam::INVALID_LOCALE, alarmmanager::SET);
+                
+                // Log one line
+                logging::LoggingID lid(17);  // ProcessManager -- probably the only one to find this for now
+                logging::MessageLog ml(lid);
+                logging::Message msg(1);
+                logging::Message::Args args;
+                args.add("Failed to set locale ");
+                args.add(systemLang.c_str());
+                args.add(": Setting to 'C'. Critical alarm generated");
+                msg.format( args );
+                ml.logErrorMessage(msg);
+                
+                loggedMsg = true;
+            }
+            systemLang = "C";
         }
         catch (...)
         {


### PR DESCRIPTION
If systemlang in the XML is not valid, fall back to "C" and log an error