### PR TITLE
MCOL-3760 Fix rand func in columnstore not matching mdb

### DIFF
--- a/utils/funcexp/func_rand.cpp
+++ b/utils/funcexp/func_rand.cpp
@@ -53,7 +53,15 @@ double Func_rand::getRand()
         fSeed1 += 23;
 
     fSeed2 = (fSeed1 + fSeed2 + 33) % maxValue;
-    fSeeds[fSeedIndex] = std::make_pair(fSeed1, fSeed2);
+    if (fSeeds.size() > fSeedIndex) 
+    {
+        fSeeds[fSeedIndex] = std::make_pair(fSeed1, fSeed2);
+    }
+    else
+    {
+        fSeeds.push_back(std::make_pair(fSeed1, fSeed2));
+    }
+
     return (((double) fSeed1) / (double)maxValue);
 }
 

--- a/utils/funcexp/functor_export.h
+++ b/utils/funcexp/functor_export.h
@@ -46,6 +46,8 @@ public:
     {
         fSeedSet = seedSet;
         fMultipleSeedsSet = seedSet;
+        fFirstRow = nullptr;
+        fSeeds = {};
     }
     execplan::CalpontSystemCatalog::ColType operationType(FunctionParm& fp, execplan::CalpontSystemCatalog::ColType& resultType);
 

--- a/utils/funcexp/functor_export.h
+++ b/utils/funcexp/functor_export.h
@@ -38,7 +38,7 @@ namespace funcexp
 class Func_rand : public Func
 {
 public:
-    Func_rand() : Func("rand"), fSeed1(0), fSeed2(0), fSeedSet(false), fMultipleSeedsSet(false), fFirstRow(nullptr), fSeeds(){}
+    Func_rand() : Func("rand"), fSeed1(0), fSeed2(0), fSeedSet(false), fMultipleSeedsSet(false), fFirstRow(NULL), fSeeds(){}
     virtual ~Func_rand() {}
 
     double getRand();
@@ -46,8 +46,8 @@ public:
     {
         fSeedSet = seedSet;
         fMultipleSeedsSet = seedSet;
-        fFirstRow = nullptr;
-        fSeeds = {};
+        fFirstRow = NULL;
+        fSeeds.clear();
     }
     execplan::CalpontSystemCatalog::ColType operationType(FunctionParm& fp, execplan::CalpontSystemCatalog::ColType& resultType);
 


### PR DESCRIPTION
Construction of Func_rand only happens once so we need to initialize fFirstRow and fSeeds just like fSeedSet, inside seedSet(), otherwise fSeeds and fFirstRow never get reinitialized.