### PR TITLE
MCOL-3760 Fix rand func in columnstore not matching mdb

### DIFF
--- a/utils/funcexp/functor_export.h
+++ b/utils/funcexp/functor_export.h
@@ -46,6 +46,8 @@ public:
     {
         fSeedSet = seedSet;
         fMultipleSeedsSet = seedSet;
+        fFirstRow = nullptr;
+        fSeeds = {};
     }
     execplan::CalpontSystemCatalog::ColType operationType(FunctionParm& fp, execplan::CalpontSystemCatalog::ColType& resultType);
 


### PR DESCRIPTION
Construction of Func_rand only happens once so we need to initialize fFirstRow and fSeeds just like fSeedSet, inside seedSet(), otherwise fSeeds and fFirstRow never get reinitialized.

