### PR TITLE
MCOL-3769 This commit divides create_SH in two parts: before rewrites…

### DIFF
--- a/dbcon/mysql/ha_mcs_opt_rewrites.cpp
+++ b/dbcon/mysql/ha_mcs_opt_rewrites.cpp
@@ -18,7 +18,7 @@
 
 // Search simplify_joins() function in the server's code for detail
 COND *
-simplify_joins_(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top,
+simplify_joins_mcs(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top,
                bool in_sj)
 {
   TABLE_LIST *table;
@@ -26,7 +26,7 @@ simplify_joins_(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top,
   TABLE_LIST *prev_table= 0;
   List_iterator<TABLE_LIST> li(*join_list);
   bool straight_join= MY_TEST(join->select_options & SELECT_STRAIGHT_JOIN);
-  DBUG_ENTER("simplify_joins");
+  DBUG_ENTER("simplify_joins_mcs");
 
   /* 
     Try to simplify join operations from join_list.
@@ -54,7 +54,7 @@ simplify_joins_(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top,
            the outer join is converted to an inner join and
            the corresponding on expression is added to E. 
 	*/ 
-        expr= simplify_joins_(join, &nested_join->join_list,
+        expr= simplify_joins_mcs(join, &nested_join->join_list,
                              expr, FALSE, in_sj || table->sj_on_expr);
 
         if (!table->prep_on_expr || expr != table->on_expr)
@@ -67,7 +67,7 @@ simplify_joins_(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top,
       }
       nested_join->used_tables= (table_map) 0;
       nested_join->not_null_tables=(table_map) 0;
-      conds= simplify_joins_(join, &nested_join->join_list, conds, top, 
+      conds= simplify_joins_mcs(join, &nested_join->join_list, conds, top, 
                             in_sj || table->sj_on_expr);
       used_tables= nested_join->used_tables;
       not_null_tables= nested_join->not_null_tables;  
@@ -241,5 +241,5 @@ simplify_joins_(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top,
       li.replace(repl_list);
     }
   }
-  DBUG_RETURN(conds); 
+  DBUG_RETURN(conds);
 }

--- a/dbcon/mysql/ha_mcs_opt_rewrites.h
+++ b/dbcon/mysql/ha_mcs_opt_rewrites.h
@@ -20,7 +20,7 @@
 
 #include "idb_mysql.h"
 
-COND *simplify_joins_(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top, bool in_sj);
+COND *simplify_joins_mcs(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top, bool in_sj);
 
 #endif
 

--- a/dbcon/mysql/ha_mcs_pushdown.h
+++ b/dbcon/mysql/ha_mcs_pushdown.h
@@ -80,9 +80,9 @@ class ha_mcs_group_by_handler: public group_by_handler
 public:
     ha_mcs_group_by_handler(THD* thd_arg, Query* query);
     ~ha_mcs_group_by_handler();
-    int init_scan();
-    int next_row();
-    int end_scan();
+    int init_scan() override;
+    int next_row() override;
+    int end_scan() override;
 
     List<Item>* select;
     TABLE_LIST* table_list;
@@ -114,9 +114,9 @@ private:
 public:
   ha_columnstore_derived_handler(THD* thd_arg, TABLE_LIST *tbl);
   ~ha_columnstore_derived_handler();
-  int init_scan();
-  int next_row();
-  int end_scan();
+  int init_scan() override;
+  int next_row() override;
+  int end_scan() override;
   void print_error(int, unsigned long);
 };
 
@@ -139,12 +139,13 @@ private:
   COLUMNSTORE_SHARE *share;
 
 public:
+  bool rewrite_error;
+  std::string err_msg;
   ha_columnstore_select_handler(THD* thd_arg, SELECT_LEX* sel);
   ~ha_columnstore_select_handler();
-  int init_scan();
-  int next_row();
-  int end_scan();
-  void print_error(int, unsigned long);
+  int init_scan() override;
+  int next_row() override;
+  int end_scan() override;
 };
 
 #endif


### PR DESCRIPTION
This commit divides create_SH in two parts : before rewrites and 
after rewrites. We can safely fallback from SH to DH and table mode from
'before rewrites' part. We also returns meaningful warning.