### PR TITLE
MCOL-3769 This commit divides create_SH() in two parts.

### DIFF
--- a/dbcon/mysql/ha_mcs_opt_rewrites.cpp
+++ b/dbcon/mysql/ha_mcs_opt_rewrites.cpp
@@ -18,7 +18,7 @@
 
 // Search simplify_joins() function in the server's code for detail
 COND *
-simplify_joins_(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top,
+simplify_joins_mcs(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top,
                bool in_sj)
 {
   TABLE_LIST *table;
@@ -26,7 +26,7 @@ simplify_joins_(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top,
   TABLE_LIST *prev_table= 0;
   List_iterator<TABLE_LIST> li(*join_list);
   bool straight_join= MY_TEST(join->select_options & SELECT_STRAIGHT_JOIN);
-  DBUG_ENTER("simplify_joins");
+  DBUG_ENTER("simplify_joins_mcs");
 
   /* 
     Try to simplify join operations from join_list.
@@ -54,7 +54,7 @@ simplify_joins_(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top,
            the outer join is converted to an inner join and
            the corresponding on expression is added to E. 
 	*/ 
-        expr= simplify_joins_(join, &nested_join->join_list,
+        expr= simplify_joins_mcs(join, &nested_join->join_list,
                              expr, FALSE, in_sj || table->sj_on_expr);
 
         if (!table->prep_on_expr || expr != table->on_expr)
@@ -67,7 +67,7 @@ simplify_joins_(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top,
       }
       nested_join->used_tables= (table_map) 0;
       nested_join->not_null_tables=(table_map) 0;
-      conds= simplify_joins_(join, &nested_join->join_list, conds, top, 
+      conds= simplify_joins_mcs(join, &nested_join->join_list, conds, top, 
                             in_sj || table->sj_on_expr);
       used_tables= nested_join->used_tables;
       not_null_tables= nested_join->not_null_tables;  
@@ -241,5 +241,5 @@ simplify_joins_(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top,
       li.replace(repl_list);
     }
   }
-  DBUG_RETURN(conds); 
+  DBUG_RETURN(conds);
 }

--- a/dbcon/mysql/ha_mcs_opt_rewrites.h
+++ b/dbcon/mysql/ha_mcs_opt_rewrites.h
@@ -20,7 +20,7 @@
 
 #include "idb_mysql.h"
 
-COND *simplify_joins_(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top, bool in_sj);
+COND *simplify_joins_mcs(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top, bool in_sj);
 
 #endif
 

--- a/dbcon/mysql/ha_mcs_pushdown.cpp
+++ b/dbcon/mysql/ha_mcs_pushdown.cpp
@@ -27,7 +27,7 @@ void disable_indices_for_CEJ(THD *thd_)
     TABLE_LIST* global_list;
     for (global_list = thd_->lex->query_tables; global_list; global_list = global_list->next_global)
     {
-    // MCOL-652 - doing this with derived tables can cause bad things to happen
+        // MCOL-652 - doing this with derived tables can cause bad things to happen
         if (!global_list->derived)
         {
             global_list->index_hints= new (thd_->mem_root) List<Index_hint>();
@@ -42,7 +42,7 @@ void disable_indices_for_CEJ(THD *thd_)
     }
 }
 
-bool optimize_unflattened_subqueries_(SELECT_LEX *select_lex)
+bool optimize_unflattened_subqueries_mcs(SELECT_LEX *select_lex)
 {
     bool result = false;
     TABLE_LIST *tbl;
@@ -52,7 +52,7 @@ bool optimize_unflattened_subqueries_(SELECT_LEX *select_lex)
         if (tbl->is_view_or_derived())
         {
             SELECT_LEX *dsl = tbl->derived->first_select();
-            result = optimize_unflattened_subqueries_(dsl);
+            result = optimize_unflattened_subqueries_mcs(dsl);
         }
     }
 
@@ -516,7 +516,7 @@ create_columnstore_derived_handler(THD* thd, TABLE_LIST *derived)
     //To search for CROSS JOIN-s we use tree invariant
     //G(V,E) where [V] = [E]+1
     List<Item> join_preds_list;
-    TABLE_LIST *tl;   
+    TABLE_LIST *tl;
     for (tl = sl->get_table_list(); !unsupported_feature && tl; tl = tl->next_local)
     {
         Item_cond* where_icp= 0;
@@ -766,9 +766,6 @@ create_columnstore_select_handler(THD* thd, SELECT_LEX* select_lex)
     // Disable SP support in the select_handler for now.
     if ((thd->lex)->sphead)
     {
-        //std::string warnMsg("Select Handler doesn't support SP.");
-        //push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
-        //    CS_WARNING_ID, warnMsg.c_str());
         return handler;
     }
 
@@ -778,9 +775,6 @@ create_columnstore_select_handler(THD* thd, SELECT_LEX* select_lex)
     if (((thd->lex)->result &&
          !((select_dumpvar *)(thd->lex)->result)->var_list.is_empty()))
     {
-        //std::string warnMsg("Select Handler doesn't assign variables values.");
-        //push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
-        //    CS_WARNING_ID, warnMsg.c_str());
         return handler;
     }
 
@@ -791,14 +785,10 @@ create_columnstore_select_handler(THD* thd, SELECT_LEX* select_lex)
         || (thd->lex)->exchange)
         
     {
-        //std::string warnMsg("Query inserts its result. Select Handler doesn't work.");
-        //push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
-        //    CS_WARNING_ID, warnMsg.c_str());
         return handler;
     }
 
     bool unsupported_feature = false;
-    logging::Message::Args args;
     // Iterate and traverse through the item list and do not create SH
     // if the unsupported (set/get_user_var) functions are present.
     TABLE_LIST* table_ptr = select_lex->get_table_list();
@@ -811,74 +801,57 @@ create_columnstore_select_handler(THD* thd, SELECT_LEX* select_lex)
             item_check(item, &unsupported_feature);
             if (unsupported_feature)
             {
-                //std::string warnMsg("Select Handler doesn't work b/c of the unsupported item found in item_check()");
-                //push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
-                //    CS_WARNING_ID, warnMsg.c_str());
                 return handler;
             }
         }
     }
 
-    // We apply dedicated rewrites from MDB here so the data structures
-    // becomes dirty and CS has to raise an error in case of any problem.
+    // We apply dedicated rewrites from MDB here so MDB's data structures
+    // becomes dirty and CS has to raise an error in case of any problem
+    // or unsupported feature.
+    handler= new ha_columnstore_select_handler(thd, select_lex);
     JOIN *join= select_lex->join;
-    // Next block tries to execute the query using SH very early to fallback
-    // if execution fails.
-    if (!unsupported_feature)
     {
         disable_indices_for_CEJ(thd);
 
         if (select_lex->handle_derived(thd->lex, DT_MERGE))
         {
-            // early quit b/c of the error in handle_derived
-            return handler;
+            unsupported_feature = true;
+            handler->err_msg.assign("create_columnstore_select_handler(): \
+                Internal error occured in SL::handle_derived()");
         }
 
-        COND *conds = NULL;
-        conds = simplify_joins_(join, select_lex->join_list, join->conds, TRUE, FALSE);
+        COND *conds = nullptr;
+        if (!unsupported_feature)
+        {
+            conds = simplify_joins_mcs(join, select_lex->join_list,
+                join->conds, TRUE, FALSE);
+        }
         // MCOL-3747 IN-TO-EXISTS rewrite inside MDB didn't add
         // an equi-JOIN condition.
-        optimize_unflattened_subqueries_(select_lex);
-    
-        if (conds)
+        if (!unsupported_feature
+            && optimize_unflattened_subqueries_mcs(select_lex))
+        {
+            unsupported_feature = true;
+            handler->err_msg.assign("create_columnstore_select_handler(): \
+                Internal error occured in optimize_unflattened_subqueries_mcs()");
+        }
+
+        if (!unsupported_feature && conds)
         {
 #ifdef DEBUG_WALK_COND
             conds->traverse_cond(cal_impl_if::debug_walk, NULL, Item::POSTFIX);
 #endif
             join->conds = conds;
         }
-
-        // Impossible HAVING or WHERE
-        // TODO replace with function call
-        if (unsupported_feature
-           || select_lex->having_value == Item::COND_FALSE
-            || select_lex->cond_value == Item::COND_FALSE )
-        {
-            unsupported_feature = true;
-            restore_optimizer_flags(thd);
-        }
     }
 
-    if (!unsupported_feature)
-    {
-        handler= new ha_columnstore_select_handler(thd, select_lex);
-        mcs_handler_info mhi= mcs_handler_info(reinterpret_cast<void*>(handler), SELECT);
-        // handler::table is the place for the result set
-        int rc= 0;
-        // Skip execution for EXPLAIN queries
-        if (!thd->lex->describe)
-        {
-            rc= ha_cs_impl_pushdown_init(&mhi, handler->table);
-        }
+    // We can't raise error now so set an error to raise it later in init_SH.
+    handler->rewrite_error= unsupported_feature;
 
-        // Return SH even if init fails b/c CS changed SELECT_LEX structures
-        // with simplify_joins_()
-        if (rc)
-            unsupported_feature = true;
-        return handler;
-    }
-
-    return NULL;
+    // Return SH even if init fails b/c CS changed SELECT_LEX structures
+    // with simplify_joins_mcs()
+    return handler;
 }
 
 /***********************************************************
@@ -892,7 +865,8 @@ ha_columnstore_select_handler::ha_columnstore_select_handler(THD *thd,
                                                              SELECT_LEX* select_lex)
   : select_handler(thd, mcs_hton)
 {
-  select = select_lex;
+  select= select_lex;
+  rewrite_error= false;
 }
 
 /***********************************************************
@@ -916,9 +890,25 @@ int ha_columnstore_select_handler::init_scan()
 {
     DBUG_ENTER("ha_columnstore_select_handler::init_scan");
 
-    // Dummy init for SH. Actual init happens in create_SH
-    // to allow fallback to other handlers if SH fails.
     int rc = 0;
+
+    if (!rewrite_error)
+    {
+        // handler::table is the place for the result set
+        // Skip execution for EXPLAIN queries
+        if (!thd->lex->describe)
+        {
+            mcs_handler_info mhi= mcs_handler_info(
+                reinterpret_cast<void*>(this), SELECT);
+            rc= ha_cs_impl_pushdown_init(&mhi, this->table);
+        }
+    }
+    else
+    {
+        my_printf_error(ER_INTERNAL_ERROR, "%s", MYF(0), err_msg.c_str());
+        sql_print_error("%s", err_msg.c_str());
+        rc= ER_INTERNAL_ERROR;
+    }
 
     DBUG_RETURN(rc);
 }
@@ -960,6 +950,3 @@ int ha_columnstore_select_handler::end_scan()
 
     DBUG_RETURN(rc);
 }
-
-void ha_columnstore_select_handler::print_error(int, unsigned long)
-{}

--- a/dbcon/mysql/ha_mcs_pushdown.h
+++ b/dbcon/mysql/ha_mcs_pushdown.h
@@ -80,9 +80,9 @@ class ha_mcs_group_by_handler: public group_by_handler
 public:
     ha_mcs_group_by_handler(THD* thd_arg, Query* query);
     ~ha_mcs_group_by_handler();
-    int init_scan();
-    int next_row();
-    int end_scan();
+    int init_scan() override;
+    int next_row() override;
+    int end_scan() override;
 
     List<Item>* select;
     TABLE_LIST* table_list;
@@ -114,9 +114,9 @@ private:
 public:
   ha_columnstore_derived_handler(THD* thd_arg, TABLE_LIST *tbl);
   ~ha_columnstore_derived_handler();
-  int init_scan();
-  int next_row();
-  int end_scan();
+  int init_scan() override;
+  int next_row() override;
+  int end_scan() override;
   void print_error(int, unsigned long);
 };
 
@@ -139,12 +139,13 @@ private:
   COLUMNSTORE_SHARE *share;
 
 public:
+  bool rewrite_error;
+  std::string err_msg;
   ha_columnstore_select_handler(THD* thd_arg, SELECT_LEX* sel);
   ~ha_columnstore_select_handler();
-  int init_scan();
-  int next_row();
-  int end_scan();
-  void print_error(int, unsigned long);
+  int init_scan() override;
+  int next_row() override;
+  int end_scan() override;
 };
 
 #endif


### PR DESCRIPTION
This commit divides create_SH in two parts : before rewrites and 
after rewrites. We can safely fallback from SH to DH and table mode from
'before rewrites' part. We also returns meaningful warning.