### PR TITLE
MCOL-3760 Related. Fix bug3145 regression broken on rand()

### DIFF
--- a/utils/funcexp/func_rand.cpp
+++ b/utils/funcexp/func_rand.cpp
@@ -53,7 +53,15 @@ double Func_rand::getRand()
         fSeed1 += 23;
 
     fSeed2 = (fSeed1 + fSeed2 + 33) % maxValue;
-    fSeeds[fSeedIndex] = std::make_pair(fSeed1, fSeed2);
+    if (fSeeds.size() > fSeedIndex) 
+    {
+        fSeeds[fSeedIndex] = std::make_pair(fSeed1, fSeed2);
+    }
+    else
+    {
+        fSeeds.push_back(std::make_pair(fSeed1, fSeed2));
+    }
+
     return (((double) fSeed1) / (double)maxValue);
 }
 

--- a/utils/funcexp/functor_export.h
+++ b/utils/funcexp/functor_export.h
@@ -38,7 +38,7 @@ namespace funcexp
 class Func_rand : public Func
 {
 public:
-    Func_rand() : Func("rand"), fSeed1(0), fSeed2(0), fSeedSet(false), fMultipleSeedsSet(false), fFirstRow(nullptr), fSeeds(){}
+    Func_rand() : Func("rand"), fSeed1(0), fSeed2(0), fSeedSet(false), fMultipleSeedsSet(false), fFirstRow(NULL), fSeeds(){}
     virtual ~Func_rand() {}
 
     double getRand();
@@ -46,8 +46,8 @@ public:
     {
         fSeedSet = seedSet;
         fMultipleSeedsSet = seedSet;
-        fFirstRow = nullptr;
-        fSeeds = {};
+        fFirstRow = NULL;
+        fSeeds.clear();
     }
     execplan::CalpontSystemCatalog::ColType operationType(FunctionParm& fp, execplan::CalpontSystemCatalog::ColType& resultType);
 


### PR DESCRIPTION
Tested running regression suite test001, specifically looking at working_tpch1_calpontonly/misc/bug3145.sql. Now passing

fSeeds re-initialization was not thread-safe. Also added check before accessing invalid index of fSeeds.