### PR TITLE
MCOL-3830 post-mysql-install fix on systems not running systemd

### DIFF
--- a/oam/install_scripts/columnstore-pre-uninstall.in
+++ b/oam/install_scripts/columnstore-pre-uninstall.in
@@ -4,6 +4,15 @@
 #
 # pre-uninstall steps for columnstore install
 
+running_systemd() {
+    if  [ ps --no-headers -o comm 1 == "systemd" ]; then
+        echo 0
+    else
+        echo 1
+    fi
+
+}
+
 rpmmode=install
 user=`whoami 2>/dev/null`
 
@@ -28,7 +37,7 @@ columnstore stop > /dev/null 2>&1
 
 # Test we are using systemd
 systemctl cat mariadb.service > /dev/null 2>&1
-if [ $? -eq 0 ]; then
+if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
     systemctl stop mariadb.service > /dev/null 2>&1
 else
     pkill mysqld

--- a/oam/install_scripts/columnstore.in
+++ b/oam/install_scripts/columnstore.in
@@ -17,6 +17,14 @@
 # Short-Description: Start/stop MariaDB Columnstore DW DBMS
 ### END INIT INFO
 
+running_systemd() {
+    if  [ ps --no-headers -o comm 1 == "systemd" ]; then
+        echo 0
+    else
+        echo 1
+    fi
+}
+
 USER=`whoami 2>/dev/null`
 
 # Source function library.
@@ -95,7 +103,7 @@ stop() {
 	fuser -k 8604/tcp > /dev/null 2>&1
     # Test we are using systemd
     systemctl cat mariadb.service > /dev/null 2>&1
-    if [ $? -eq 0 ]; then
+    if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
         systemctl stop mariadb.service > /dev/null 2>&1
     else
         pkill mysqld

--- a/oam/install_scripts/post-mysql-install
+++ b/oam/install_scripts/post-mysql-install
@@ -4,6 +4,15 @@
 #
 # Post-install steps for calpont-mysql install
 
+# check if running systemd
+running_systemd() {
+   if  [ ps --no-headers -o comm 1 == "systemd" ]; then
+       echo 0
+   else
+       echo 1
+   fi
+}
+
 # check log for error
 checkForError() {
 	# check for password error
@@ -13,7 +22,7 @@ checkForError() {
 		  rm -f ${tmpdir}/error.check
           # Test we are using systemd
           systemctl cat mariadb.service > /dev/null 2>&1
-          if [ $? -eq 0 ]; then
+          if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
               systemctl stop mariadb.service > /dev/null 2>&1
           else
               pkill mysqld
@@ -62,7 +71,7 @@ done
 # Restart in the same way that mysqld will be started normally.
 # Test we are using systemd
 systemctl cat mariadb.service > /dev/null 2>&1
-if [ $? -eq 0 ]; then
+if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
     systemctl stop mariadb.service > /dev/null 2>&1
 else
     pkill mysqld
@@ -71,7 +80,7 @@ sleep 2
 export MYSQL_OPTS="--skip-grant-tables"
 # Test we are using systemd
 systemctl cat mariadb.service > /dev/null 2>&1
-if [ $? -eq 0 ]; then
+if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
     systemctl start mariadb.service
 else
     /usr/bin/mysqld_safe --skip-grant-tables &
@@ -87,7 +96,7 @@ if [ $? -ne 0 ]; then
     echo "ERROR: Invalid password in .my.cnf, or Columnstore plugin install missing"
     # Test we are using systemd
     systemctl cat mariadb.service > /dev/null 2>&1
-    if [ $? -eq 0 ]; then
+    if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
         systemctl stop mariadb.service > /dev/null 2>&1
     else
         pkill mysqld
@@ -98,7 +107,7 @@ fi
 
 # Test we are using systemd
 systemctl cat mariadb.service > /dev/null 2>&1
-if [ $? -eq 0 ]; then
+if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
     systemctl stop mariadb.service > /dev/null 2>&1
 else
     pkill mysqld


### PR DESCRIPTION
Updated post-mysql-install, columnstore-pre-uninstall, and columnstore scripts to work on systems not running systemd.

Tested shutdown, postConfigure, start, restart, stop on both my develop branch and in Todd's docker container https://github.com/mariadb-corporation/mariadb-enterprise-columnstore-docker to make sure it's working on systems with and without systemd