### PR TITLE
Mcol 2022:  nvme device names not supported

### DIFF
--- a/oam/etc/ConsoleCmds.xml
+++ b/oam/etc/ConsoleCmds.xml
@@ -274,13 +274,13 @@
 	</Cmd42>
 	<Cmd43>
 		<Name>assignElasticIPAddress</Name>
-		<Desc1>Assign Amazon Elastic IP Address to a module</Desc1>
+		<Desc1>Assign Amazon Elastic IP Address to a module (deprecated)</Desc1>
 		<Arg1>Required: Amazon Elastic IP Address</Arg1>
 		<Arg2>Required: Module Name</Arg2>
 	</Cmd43>
 	<Cmd44>
 		<Name>unassignElasticIPAddress</Name>
-		<Desc1>Unassign Amazon Elastic IP Address</Desc1>
+		<Desc1>Unassign Amazon Elastic IP Address (deprecated)</Desc1>
 		<Arg1>Required: Amazon Elastic IP Address</Arg1>
 	</Cmd44>
 	<Cmd45>

--- a/oamapps/postConfigure/CMakeLists.txt
+++ b/oamapps/postConfigure/CMakeLists.txt
@@ -65,5 +65,5 @@ install(TARGETS mycnfUpgrade DESTINATION ${ENGINE_BINDIR} COMPONENT columnstore-
 
 ########### next target ###############
 
-install(PROGRAMS quick_installer_single_server.sh quick_installer_multi_server.sh quick_installer_amazon.sh
+install(PROGRAMS quick_installer_single_server.sh quick_installer_multi_server.sh 
         DESTINATION ${ENGINE_BINDIR} COMPONENT columnstore-platform)               

--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -1399,15 +1399,6 @@ int main(int argc, char* argv[])
     {
         cloud  = oam::UnassignedName;
     }
-    
-    #if XXXPAT
-    if (cloud.find("amazon") != string::npos)
-    {
-        cout << "AWS-specific functionality has been deprecated for this version." << endl
-            << "Please re-run postConfigure without the upgrade option." << endl;
-        exit(1);
-    }
-    #endif
 
     if ( cloud == "disable" )
         amazonInstall = false;

--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -316,11 +316,6 @@ int main(int argc, char* argv[])
 			multi_server_quick_install = true;
 			noPrompting = true;
 		}
-		else if( string("-qa") == argv[i] )
-		{
-			amazon_quick_install = true;
-			noPrompting = true;
-		}
         else if ( string("-f") == argv[i] )
             nodeps = "--nodeps";
         else if ( string("-o") == argv[i] )
@@ -460,7 +455,7 @@ int main(int argc, char* argv[])
         else
         {
             cout << "   ERROR: Invalid Argument = " << argv[i] << endl;
-   			cout << "   Usage: postConfigure [-h][-c][-u][-p][-qs][-qm][-qa][-port][-i][-sn][-pm-ip-addrs][-um-ip-addrs][-pm-count][-um-count][-x][-xr][-numBlocksPct][-totalUmMemory]" << endl;
+   			cout << "   Usage: postConfigure [-h][-c][-u][-p][-qs][-qm][-port][-i][-sn][-pm-ip-addrs][-um-ip-addrs][-pm-count][-um-count][-x][-xr][-numBlocksPct][-totalUmMemory]" << endl;
 			exit (1);
 		}
 	}
@@ -1354,6 +1349,7 @@ int main(int argc, char* argv[])
     bool amazonInstall = false;
     string cloud = oam::UnassignedName;
 
+    #if 0
 	if (!multi_server_quick_install)
 	{
 		string amazonLog = tmpDir + "/amazon.log";
@@ -1393,6 +1389,7 @@ int main(int argc, char* argv[])
 				amazonInstall = true;
 		}
 	}
+    #endif
 
     try
     {
@@ -1402,6 +1399,15 @@ int main(int argc, char* argv[])
     {
         cloud  = oam::UnassignedName;
     }
+    
+    #if XXXPAT
+    if (cloud.find("amazon") != string::npos)
+    {
+        cout << "AWS-specific functionality has been deprecated for this version." << endl
+            << "Please re-run postConfigure without the upgrade option." << endl;
+        exit(1);
+    }
+    #endif
 
     if ( cloud == "disable" )
         amazonInstall = false;


### PR DESCRIPTION
It turns out this bug is only possible when you enable the aws-specific features.

When enabled, oam will be able to create, attach, & detach EBS volumes for dbroots automatically.  The problem is that it makes a bad assumption about the device name when the node type is one of the (LOL) 'Nitro' types.  For nitro types, they are connected as an nvme device, for non-nitro, they connect as a more generic Xen virtual storage device.  OAM assumes the xen device names, which was valid until last year or so.

See this for the list of node types that are 'nitro': https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances

We decided to remove the aws-specific stuff for multiple reasons.  1) political, 2) we'd rather be platform-agnostic anyway, 3) it doesn't do anything the user can't do, 4) easier to support fewer possible configurations, 5) OAM in its current form is going away soon, 6) etc.

Also, apparently the automatic EBS stuff is broken in 1.4.  There is a typo in a grep cmd that makes it hang forever.  Awesome.

What I did here is disable the ability to enable the option for new installations in postconfigure in 1.4 and 1.5.  I did not remove all of the aws-specific code because that would substantially raise the risk, dev effort, testing effort, and it's going away soon anyway.

For 1.2, it is still possible to get a non-nitro node configured this way.  For the 1.2 fix, upgrades from successful installations will be allowed.

I tested upgrades from 1.4.3-4 to 1.5, and new 1.5 installations, specifying 'external' storage, which is how users will configure their systems to get the same functionality.  For 1.2, I tested an upgrade from 1.2.5 to my patched version, and new installations of my patched version.  I did not test the patched version of 1.4 explicitly, because the relevant code in 1.5 is the same in all branches.  I did all this on both nitro and non-nitro instance types.