### PR TITLE
Mcol 3251 1.5

### DIFF
--- a/primitives/blockcache/iomanager.cpp
+++ b/primitives/blockcache/iomanager.cpp
@@ -1356,30 +1356,7 @@ ioManager::ioManager(FileBufferMgr& fbm,
     }
 
     fThreadCount = thrCount;
-    lastConfigMTime = 0;
-    loadDBRootCache();
     go();
-}
-
-void ioManager::loadDBRootCache()
-{
-    if (fConfig->getLastMTime() == lastConfigMTime)
-        return;
-    
-    char buf[100];
-    dbRootCache.clear();
-    
-    // this will grab all of the dbroots on the cluster, not just the ones on this node
-    // for simplicity.
-    oam::Oam OAM;
-    oam::DBRootConfigList dbRoots;
-    OAM.getSystemDbrootConfig(dbRoots);
-    for (auto _dbroot : dbRoots)
-    {
-        sprintf(buf, "DBRoot%d", _dbroot);
-        string location = fConfig->getConfig("SystemConfig", buf);
-        dbRootCache[_dbroot] = location;
-    }
 }
 
 void ioManager::buildOidFileName(const BRM::OID_t oid, uint16_t dbRoot, const uint16_t partNum, const uint32_t segNum, char* file_name)
@@ -1387,38 +1364,8 @@ void ioManager::buildOidFileName(const BRM::OID_t oid, uint16_t dbRoot, const ui
     // when it's a request for the version buffer, the dbroot comes in as 0 for legacy reasons
     if (dbRoot == 0 && oid < 1000)
         dbRoot = fdbrm.getDBRootOfVBOID(oid);
-        
-    boost::unique_lock<boost::mutex> lock(dbRootCacheLock);
-    loadDBRootCache();
-    string dbRootPath;
-    auto it = dbRootCache.find(dbRoot);
-    if (it == dbRootCache.end())
-    {
-        ostringstream oss;
-        oss << "(dbroot " << dbRoot << " offline)";
-        dbRootPath = oss.str();
-    }
-    else 
-        dbRootPath = it->second;
-    lock.unlock();
     
-    // different filenames for the version buffer files
-    if (oid < 1000)
-        snprintf(file_name, WriteEngine::FILE_NAME_SIZE, "%s/versionbuffer.cdf", dbRootPath.c_str());
-    else
-        snprintf(file_name, WriteEngine::FILE_NAME_SIZE, "%s/%03u.dir/%03u.dir/%03u.dir/%03u.dir/%03u.dir/FILE%03d.cdf",
-            dbRootPath.c_str(), oid >> 24, (oid & 0x00ff0000) >> 16, (oid & 0x0000ff00) >> 8, 
-            oid & 0x000000ff, partNum, segNum);
-    
-    
-    /*  old version
-    if (fFileOp.getFileName(oid, file_name, dbRoot, partNum, segNum) != WriteEngine::NO_ERROR)
-    {
-        file_name[0] = 0;
-        throw std::runtime_error("fileOp.getFileName failed");
-    }
-    //cout << "Oid2Filename o: " << oid << " n: " << file_name << endl;
-    */
+    fFileOp.getFileNameForPrimProc(oid, file_name, dbRoot, partNum, segNum);
 }
 
 const int ioManager::localLbidLookup(BRM::LBID_t lbid,

--- a/primitives/blockcache/iomanager.cpp
+++ b/primitives/blockcache/iomanager.cpp
@@ -1359,7 +1359,7 @@ ioManager::ioManager(FileBufferMgr& fbm,
     go();
 }
 
-void ioManager::buildOidFileName(const BRM::OID_t oid, uint16_t dbRoot, const uint16_t partNum, const uint32_t segNum, char* file_name)
+void ioManager::buildOidFileName(const BRM::OID_t oid, uint16_t dbRoot, const uint32_t partNum, const uint16_t segNum, char* file_name)
 {
     // when it's a request for the version buffer, the dbroot comes in as 0 for legacy reasons
     if (dbRoot == 0 && oid < 1000)

--- a/primitives/blockcache/iomanager.h
+++ b/primitives/blockcache/iomanager.h
@@ -83,7 +83,7 @@ public:
                               uint32_t& fileBlockOffset);
 
     void buildOidFileName(const BRM::OID_t oid,
-                          const uint16_t dbRoot,
+                          uint16_t dbRoot,
                           const uint16_t partNum,
                           const uint32_t segNum,
                           char* file_name);
@@ -153,6 +153,11 @@ private:
     uint32_t fDecreaseOpenFilesCount;
     bool fFDCacheTrace;
     std::ofstream fFDTraceFile;
+    
+    std::map<int, std::string> dbRootCache;
+    boost::mutex dbRootCacheLock;
+    void loadDBRootCache();
+    time_t lastConfigMTime;
 
 };
 

--- a/primitives/blockcache/iomanager.h
+++ b/primitives/blockcache/iomanager.h
@@ -84,8 +84,8 @@ public:
 
     void buildOidFileName(const BRM::OID_t oid,
                           uint16_t dbRoot,
-                          const uint16_t partNum,
-                          const uint32_t segNum,
+                          const uint32_t partNum,
+                          const uint16_t segNum,
                           char* file_name);
 
     const uint32_t getExtentRows()

--- a/primitives/blockcache/iomanager.h
+++ b/primitives/blockcache/iomanager.h
@@ -153,12 +153,6 @@ private:
     uint32_t fDecreaseOpenFilesCount;
     bool fFDCacheTrace;
     std::ofstream fFDTraceFile;
-    
-    std::map<int, std::string> dbRootCache;
-    boost::mutex dbRootCacheLock;
-    void loadDBRootCache();
-    time_t lastConfigMTime;
-
 };
 
 // @bug2631, for remount filesystem by loadBlock() in primitiveserver

--- a/writeengine/shared/we_fileop.cpp
+++ b/writeengine/shared/we_fileop.cpp
@@ -2412,6 +2412,29 @@ int FileOp::oid2FileName( FID fid,
     return NO_ERROR;
 }
 
+void FileOp::getFileNameForPrimProc(FID fid,
+                          char* fullFileName,
+                          uint16_t dbRoot,
+                          uint32_t partition,
+                          uint16_t segment) const
+{        
+    string dbRootPath = Config::getDBRootByNum(dbRoot);
+    if (dbRootPath.empty())
+    {
+        ostringstream oss;
+        oss << "(dbroot " << dbRoot << " offline)";
+        dbRootPath = oss.str();        
+    }
+    
+    // different filenames for the version buffer files
+    if (fid < 1000)
+        snprintf(fullFileName, FILE_NAME_SIZE, "%s/versionbuffer.cdf", dbRootPath.c_str());
+    else
+        snprintf(fullFileName, FILE_NAME_SIZE, "%s/%03u.dir/%03u.dir/%03u.dir/%03u.dir/%03u.dir/FILE%03d.cdf",
+            dbRootPath.c_str(), fid >> 24, (fid & 0x00ff0000) >> 16, (fid & 0x0000ff00) >> 8, 
+            fid & 0x000000ff, partition, segment);
+}                          
+
 /***********************************************************
  * DESCRIPTION:
  *    Search for directory path associated with specified OID.

--- a/writeengine/shared/we_fileop.h
+++ b/writeengine/shared/we_fileop.h
@@ -310,6 +310,12 @@ public:
                                      uint32_t partition,
                                      uint16_t segment ) const;
 
+    /* Added for MCOL-3251 */
+    void                getFileNameForPrimProc(FID fid, char* fileName,
+                                     uint16_t dbRoot,
+                                     uint32_t partition,
+                                     uint16_t segment ) const;
+
     /**
      * @brief Construct directory path for the specified fid (OID), DBRoot, and
      * partition number.  Directory does not have to exist, nor is it created.


### PR DESCRIPTION
I could not reproduce the original problem, so I went to the code to generate the filenames.  It looks like the only way a filename with no leading dbroot path can be generated is if the dbroot went away in a narrow window between the jobs being issued to PrimProc, and when the job starts processing.

I decided to replace the method used by PrimProc.  The existing method does a Lot of Stuff, which primproc doesn't need, but which other callers might need.  The new method is much simpler than the old method, and will return a more useful file-not-found error if a dbroot suddenly goes offline, as what might be happening in the ticket.