### PR TITLE
MCOL-2096 Fix IN clause combined with a subquery and window function

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -3729,7 +3729,7 @@ ReturnedColumn* buildFunctionColumn(
                 return NULL;
             }
 
-            if (!selectBetweenIn && (ifp->arguments()[0]->type() == Item::FIELD_ITEM ||
+            if (funcName == "between" && !selectBetweenIn && (ifp->arguments()[0]->type() == Item::FIELD_ITEM ||
                     (ifp->arguments()[0]->type() == Item::REF_ITEM &&
                      (*(((Item_ref*)ifp->arguments()[0])->ref))->type() == Item::FIELD_ITEM)))
             {


### PR DESCRIPTION
filter was never being applied with this combination. after a large amount of investigation the culprit was the IN clause was never being built as a function.

regression tests; https://github.com/mariadb-corporation/mariadb-columnstore-regression-test/pull/193 