### PR TITLE
MCOL-3887 - postconfig problem processing an upgrade

### DIFF
--- a/oamapps/postConfigure/mycnfUpgrade.cpp
+++ b/oamapps/postConfigure/mycnfUpgrade.cpp
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
     }
 
     //my.cnf.rpmsave file
-    string mycnfsaveFile = "/etc/my.cnf/columnstore.cnf.rpmsave";
+    string mycnfsaveFile = std::string(MCSMYCNFDIR) + "/columnstore.cnf.rpmsave";
     ifstream mycnfsavefile (mycnfsaveFile.c_str());
 
     if (!mycnfsavefile)


### PR DESCRIPTION
mycnfUpgrade has been looking for our mysql config mods
in the /etc/my.cnf/ directory, which is wrong obviously.  Looks like
an oversight; all of the code around it is looking in the right place.
Changed it to look in the right place.