### PR TITLE
Mcol 3743 - add cmdline options to postconfig for configuring storagemanager

### DIFF
--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -32,7 +32,6 @@ if [ ! -f @ENGINE_SYSCONFDIR@/columnstore/Columnstore.xml ]; then
 fi
 
 if [ -f @ENGINE_SYSCONFDIR@/columnstore/storagemanager.cnf.rpmsave ]; then
-    /bin/cp -f @ENGINE_SYSCONFDIR@/columnstore/storagemanager.cnf @ENGINE_SYSCONFDIR@/columnstore/storagemanager.cnf.new
     /bin/cp -f @ENGINE_SYSCONFDIR@/columnstore/storagemanager.cnf.rpmsave @ENGINE_SYSCONFDIR@/columnstore/storagemanager.cnf
 fi
 

--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -242,12 +242,8 @@ void modifySMConfigFile()
         tmp = s3Location + "/storagemanager/path";
         smConfig.put<string>("LocalStorage.path", tmp.normalize().string());
         tmp = s3Location + "/storagemanager/cache";
-        smConfig.put<string>("Cache.path", s3Location + tmp.normalize().string());
+        smConfig.put<string>("Cache.path", tmp.normalize().string());
     }
-    
-    // save a copy of the original to preserve the in-line documentation
-    if (!boost::filesystem::exists(smConfigFile + ".original"))
-        boost::filesystem::copy_file(smConfigFile, smConfigFile + ".original");
     boost::property_tree::ini_parser::write_ini(smConfigFile, smConfig);
 }
 
@@ -341,7 +337,7 @@ int main(int argc, char* argv[])
             cout << "    (percentages of the total memory need to be stated with suffix %, explcit values with suffixes M or G)" << endl;
             cout << endl;
             cout << "    S3-compat storage quick-configure options:" << endl;
-            cout << "    (See /etc/columnstore/storagemanager.cnf for more information on these)" << endl;
+            cout << "    (See /etc/columnstore/storagemanager.cnf.example for more information on these)" << endl;
             cout << "       -sm-bucket bucket  The bucket to use." << endl;
             cout << "       -sm-region region  The region to use." << endl;
             cout << "       -sm-id id          The ID to use; equivalent to AWS_ACCESS_KEY_ID in AWS" << endl;
@@ -355,7 +351,7 @@ int main(int argc, char* argv[])
         {
             if (++i == argc)
             {
-                cout << "   ERROR: S3 bucket not provided" << endl;
+                cout << "   ERROR: StorageManager bucket not provided" << endl;
                 exit(1);
             }
             s3Bucket = argv[i];
@@ -365,7 +361,7 @@ int main(int argc, char* argv[])
         {
             if (++i == argc)
             {
-                cout << "   ERROR: S3 region not provided" << endl;
+                cout << "   ERROR: StorageManager region not provided" << endl;
                 exit(1);
             }
             s3Region = argv[i];
@@ -375,7 +371,7 @@ int main(int argc, char* argv[])
         {
             if (++i == argc)
             {
-                cout << "   ERROR: S3 ID not provided" << endl;
+                cout << "   ERROR: StorageManager ID not provided" << endl;
                 exit(1);
             }
             s3Key = argv[i];
@@ -385,7 +381,7 @@ int main(int argc, char* argv[])
         {
             if (++i == argc)
             {
-                cout << "   ERROR: S3 secret not provided" << endl;
+                cout << "   ERROR: StorageManager secret not provided" << endl;
                 exit(1);
             }
             s3Secret = argv[i];
@@ -395,7 +391,7 @@ int main(int argc, char* argv[])
         {
             if (++i == argc)
             {
-                cout << "   ERROR: S3 endpoint not provided" << endl;
+                cout << "   ERROR: StorageManager endpoint not provided" << endl;
                 exit(1);
             }
             s3Endpoint = argv[i];
@@ -405,17 +401,17 @@ int main(int argc, char* argv[])
         {
             if (++i == argc)
             {
-                cout << "   ERROR: S3 cache size not provided" << endl;
+                cout << "   ERROR: StorageManager cache size not provided" << endl;
                 exit(1);
             }
             s3CacheSize = argv[i];
             configureS3 = true;
         }
-        else if (strcmp("-sm-location", argv[i]) == 0)
+        else if (strcmp("-sm-prefix", argv[i]) == 0)
         {
             if (++i == argc)
             {
-                cout << "   ERROR: S3 location not provided" << endl;
+                cout << "   ERROR: StorageManager prefix not provided" << endl;
                 exit(1);
             }
             s3Location = argv[i];
@@ -5013,8 +5009,19 @@ bool storageSetup(bool amazonInstall)
     storageManagerInstalled = boost::filesystem::exists(storageManagerLocation);
 
     if (configureS3)
-        modifySMConfigFile();
-
+    {
+        try
+        {
+            modifySMConfigFile();
+        }
+        catch (exception &e)
+        {
+            cerr << "There was an error processing the StorageManager command-line options." << endl;
+            cerr << "Got: " << e.what() << endl;
+            exit(1);
+        }
+    }
+        
     //
     // get Backend Data storage type
     //

--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -302,7 +302,7 @@ int main(int argc, char* argv[])
 
     for ( int i = 1; i < argc; i++ )
     {
-		if( string("-h") == argv[i] )
+		if( string("-h") == argv[i] || string("--help") == argv[i] )
 		{
             cout << endl;
             cout << "This is the MariaDB ColumnStore System Configuration and Installation tool." << endl;
@@ -317,11 +317,16 @@ int main(int argc, char* argv[])
             cout << "	Enter one of the options within [], if available, or" << endl;
             cout << "	Enter a new value" << endl << endl;
             cout << endl;
-   			cout << "Usage: postConfigure [-h][-c][-u][-p][-qs][-qm][-qa][-port][-i][-sn][-pm-ip-addrs][-um-ip-addrs][-pm-count][-um-count][-x][-xr][-numBlocksPct][-totalUmMemory]" << endl;
+   			cout << "Usage: postConfigure [-h][-c][-u][-p][-qs][-qm][-qa][-port][-i][-sn]" << endl;
+            cout << "       [-pm-ip-addrs][-um-ip-addrs][-pm-count][-um-count][-x][-xr]" << endl;
+            cout << "       [-numBlocksPct][-totalUmMemory][-sm-bucket][-sm-region][-sm-id]" << endl;
+            cout << "       [-sm-secret][-sm-endpoint][-sm-cache][-sm-prefix]" << endl;
             cout << "   -h  Help" << endl;
-            cout << "   -c  Config File to use to extract configuration data, default is Columnstore.xml.rpmsave" << endl;
-            cout << "   -u  Upgrade, Install using the Config File from -c, default to Columnstore.xml.rpmsave" << endl;
-            cout << "	    If ssh-keys aren't setup, you should provide passwords as command line arguments" << endl;
+            cout << "   -c  Config File to use to extract configuration data, default is " << endl;
+            cout << "       Columnstore.xml.rpmsave" << endl;
+            cout << "   -u  Upgrade, Install using the Config File from -c, default is " << endl;
+            cout << "       Columnstore.xml.rpmsave.  If ssh-keys aren't setup, you should provide " << endl;
+            cout << "       passwords as command line arguments" << endl;
             cout << "   -p  Unix Password, used with no-prompting option" << endl;
 			cout << "   -qs Quick Install - Single Server" << endl;
 			cout << "   -qm Quick Install - Multi Server" << endl;
@@ -330,14 +335,17 @@ int main(int argc, char* argv[])
 			cout << "   -pm-ip-addrs Performance Module IP Addresses xxx.xxx.xxx.xxx,xxx.xxx.xxx.xxx" << endl;
 			cout << "   -um-ip-addrs User Module IP Addresses xxx.xxx.xxx.xxx,xxx.xxx.xxx.xxx" << endl;
 			cout << "   -x  Do not resolve IP Addresses from host names" << endl;
-            cout << "   -xr Resolve host names into their reverse DNS host names. Only applied in combination with -x" << endl;
+            cout << "   -xr Resolve host names into their reverse DNS host names. Only applied in " << endl;
+            cout << "       combination with -x" << endl;
             cout << "   -numBlocksPct amount of physical memory to utilize for disk block caching" << endl;
-            cout << "    (percentages of the total memory need to be stated without suffix, explcit values with suffixes M or G)" << endl;
-            cout << "   -totalUmMemory amount of physical memory to utilize for joins, intermediate results and set operations on the UM" << endl;
-            cout << "    (percentages of the total memory need to be stated with suffix %, explcit values with suffixes M or G)" << endl;
+            cout << "       (percentages of the total memory need to be stated without suffix," << endl;
+            cout << "       explicit values with suffixes M or G)" << endl;
+            cout << "   -totalUmMemory amount of physical memory to utilize for joins, intermediate" << endl;
+            cout << "       results and set operations on the UM.  (percentages of the total memory" << endl;
+            cout << "       need to be stated with suffix %, explcit values with suffixes M or G)" << endl;
             cout << endl;
             cout << "    S3-compat storage quick-configure options:" << endl;
-            cout << "    (See /etc/columnstore/storagemanager.cnf.example for more information on these)" << endl;
+            cout << "    (See /etc/columnstore/storagemanager.cnf.example for more information)" << endl;
             cout << "       -sm-bucket bucket  The bucket to use." << endl;
             cout << "       -sm-region region  The region to use." << endl;
             cout << "       -sm-id id          The ID to use; equivalent to AWS_ACCESS_KEY_ID in AWS" << endl;
@@ -579,7 +587,10 @@ int main(int argc, char* argv[])
         else
         {
             cout << "   ERROR: Invalid Argument = " << argv[i] << endl;
-   			cout << "   Usage: postConfigure [-h][-c][-u][-p][-qs][-qm][-qa][-port][-i][-sn][-pm-ip-addrs][-um-ip-addrs][-pm-count][-um-count][-x][-xr][-numBlocksPct][-totalUmMemory]" << endl;
+            cout << "Usage: postConfigure [-h][-c][-u][-p][-qs][-qm][-qa][-port][-i][-sn]" << endl;
+            cout << "       [-pm-ip-addrs][-um-ip-addrs][-pm-count][-um-count][-x][-xr]" << endl;
+            cout << "       [-numBlocksPct][-totalUmMemory][-sm-bucket][-sm-region][-sm-id]" << endl;
+            cout << "       [-sm-secret][-sm-endpoint][-sm-cache][-sm-prefix]" << endl;
 			exit (1);
 		}
 	}

--- a/storage-manager/CMakeLists.txt
+++ b/storage-manager/CMakeLists.txt
@@ -134,8 +134,14 @@ install(TARGETS StorageManager smcat smput smls smrm
     COMPONENT columnstore-platform
 )
 
-
 install(FILES storagemanager.cnf 
     DESTINATION ${ENGINE_SYSCONFDIR}/columnstore
-    COMPONENT columnstore-platform)
+    COMPONENT columnstore-platform
+)
+
+install(FILES storagemanager.cnf 
+    RENAME storagemanager.cnf.example
+    DESTINATION ${ENGINE_SYSCONFDIR}/columnstore
+    COMPONENT columnstore-platform
+)
 


### PR DESCRIPTION
The ini writer clobbers commented lines, hence clobbers all of the inline documentation and commented-but-important options the user may want to use.  So, in addition to adding the options, I made the storagemanager cmake stuff save the documented copy of the config file as storagemanger.cnf.example.

Also removed some old code and reformatted the help / usage printouts to fix on 80-col displays.