### PR TITLE
Mcol 3356 1.5 - bit_{or,and,xor} problem in job creation

### DIFF
--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -1946,7 +1946,7 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(
                     keysAgg.push_back(aggKey);
                     scaleAgg.push_back(0);
                     precisionAgg.push_back(-16);  // for connector to skip null check
-                    typeAgg.push_back(CalpontSystemCatalog::BIGINT);
+                    //typeAgg.push_back(CalpontSystemCatalog::BIGINT);
 
                     if (isUnsigned(typeProj[colProj]))
                     {

--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -1946,7 +1946,6 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(
                     keysAgg.push_back(aggKey);
                     scaleAgg.push_back(0);
                     precisionAgg.push_back(-16);  // for connector to skip null check
-                    //typeAgg.push_back(CalpontSystemCatalog::BIGINT);
 
                     if (isUnsigned(typeProj[colProj]))
                     {

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -1047,6 +1047,15 @@ RowGroup::RowGroup(uint32_t colCount,
 
     useStringTable = (stringTable && hasLongStringField);
     offsets = (useStringTable ? &stOffsets[0] : &oldOffsets[0]);
+    
+    for (i = 0; i < columnCount; i++)
+    {
+        if (types[i] == CalpontSystemCatalog::BIGINT && colWidths[i] != 8)
+        {
+            cout << "WTF?" << endl;
+        }
+        
+    }
 }
 
 RowGroup::RowGroup(const RowGroup& r) :

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -1047,15 +1047,6 @@ RowGroup::RowGroup(uint32_t colCount,
 
     useStringTable = (stringTable && hasLongStringField);
     offsets = (useStringTable ? &stOffsets[0] : &oldOffsets[0]);
-    
-    for (i = 0; i < columnCount; i++)
-    {
-        if (types[i] == CalpontSystemCatalog::BIGINT && colWidths[i] != 8)
-        {
-            cout << "WTF?" << endl;
-        }
-        
-    }
 }
 
 RowGroup::RowGroup(const RowGroup& r) :


### PR DESCRIPTION
Was caused by a double-push to typeAgg.  The extra one in this case appears to be an old one that didn't get deleted during the unsigned int support was implenented, like 7-8 years ago.