### PR TITLE
MCOL-2181 MessageQueueClient :: setup (): unknown name or service

### DIFF
--- a/utils/messageqcpp/messagequeue.cpp
+++ b/utils/messageqcpp/messagequeue.cpp
@@ -163,6 +163,11 @@ void MessageQueueClient::setup(bool syncProto)
     otherEndIPStr = fConfig->getConfig(fOtherEnd, "IPAddr");
     otherEndPortStr = fConfig->getConfig(fOtherEnd, "Port");
 
+    if (otherEndIPStr == "unassigned") 
+    {
+        otherEndIPStr = "0.0.0.0";
+    }
+
     if (otherEndIPStr.length() == 0) otherEndIPStr = "127.0.0.1";
 
     if (otherEndPortStr.length() == 0 || static_cast<uint16_t>(strtol(otherEndPortStr.c_str(), 0, 0)) == 0)


### PR DESCRIPTION
Browsing through Columnstore.xml, I observed that whenever an entity has module as unassigned we are treating the IP address as 0.0.0.0. This seems like the appropriate way to handle an IP of unassigned.