### PR TITLE
MCOL-2096 Fix evaluation for derived table inside ConstantFilter

### DIFF
--- a/dbcon/execplan/constantfilter.cpp
+++ b/dbcon/execplan/constantfilter.cpp
@@ -272,8 +272,19 @@ void ConstantFilter::setDerivedTable()
         fDerivedTable = "";
         return;
     }
+    for (unsigned i = 0; i < fFilterList.size(); i++)
+    {
+        fFilterList[i]->setDerivedTable();
+    }
 
-    fDerivedTable = fCol->derivedTable();
+    if (!fFilterList.empty())
+    {
+        fDerivedTable = fFilterList[0]->derivedTable();
+    }
+    else
+    {
+        fDerivedTable = "";
+    }
 }
 
 void ConstantFilter::replaceRealCol(std::vector<SRCP>& derivedColList)


### PR DESCRIPTION
fDerivedTable inside ConstantFilter was not being set correctly. ConstantFilter::setDerivedTable should call setDerivedTable on each SimpleFilter and retrieve derivedTable for one of them (they will all be the same derived table so retrieving the first will suffice).

See https://github.com/mariadb-corporation/mariadb-columnstore-regression-test/pull/193 for regression test updates.