### PR TITLE
MCOL-3839 Count as window function doesn't work with NULLs

### DIFF
--- a/utils/windowfunction/wf_count.cpp
+++ b/utils/windowfunction/wf_count.cpp
@@ -120,11 +120,12 @@ void WF_count<T>::operator()(int64_t b, int64_t e, int64_t c)
             if (cc)
             {
                 bool isNull = false;
-                int val = cc->getIntVal(fRow, isNull);
+                cc->getIntVal(fRow, isNull);
 
                 if (!isNull)
                 {
-                    fCount = val;
+                    // constant, set fCount to row count
+                    fCount = e - b + 1;
                 } 
             }
         }

--- a/utils/windowfunction/wf_count.cpp
+++ b/utils/windowfunction/wf_count.cpp
@@ -125,23 +125,21 @@ void WF_count<T>::operator()(int64_t b, int64_t e, int64_t c)
                 if (!isNull)
                 {
                     // constant, set fCount to row count
-                    fCount = e - b + 1;
+                    fCount += e - b + 1;
                 } 
             }
         }
+        else if (fFunctionId == WF__COUNT_ASTERISK)
+        {
+            // count(*), set fCount to row count
+            fCount += e - b + 1;
+        }
         else
         {
-
             for (int64_t i = b; i <= e; i++)
             {
                 if (i % 1000 == 0 && fStep->cancelled())
                     break;
-
-                if (fFunctionId == WF__COUNT_ASTERISK)
-                {
-                    fCount++;
-                    continue;
-                }
 
                 fRow.setData(getPointer(fRowData->at(i)));
 

--- a/utils/windowfunction/wf_count.cpp
+++ b/utils/windowfunction/wf_count.cpp
@@ -112,37 +112,57 @@ void WF_count<T>::operator()(int64_t b, int64_t e, int64_t c)
         // for count(*), the column is optimized out, index[1] does not exist.
         int64_t colIn = (fFunctionId == WF__COUNT_ASTERISK) ? 0 : fFieldIndex[1];
 
-        for (int64_t i = b; i <= e; i++)
+        // constant param will have fFieldIndex[1] of -1. Get value of constant param
+        if (colIn == -1)
         {
-            if (i % 1000 == 0 && fStep->cancelled())
-                break;
+            ConstantColumn* cc = static_cast<ConstantColumn*>(fConstantParms[0].get());
 
-            if (fFunctionId == WF__COUNT_ASTERISK)
+            if (cc)
             {
-                fCount++;
-                continue;
+                bool isNull = false;
+                int val = cc->getIntVal(fRow, isNull);
+
+                if (!isNull)
+                {
+                    fCount = val;
+                } 
             }
+        }
+        else
+        {
 
-            fRow.setData(getPointer(fRowData->at(i)));
-
-            if (colIn == -1 || fRow.isNullValue(colIn) == true)
-                continue;
-
-            if (fFunctionId != WF__COUNT_DISTINCT)
+            for (int64_t i = b; i <= e; i++)
             {
-                fCount++;
-            }
-            else
-            {
-                T valIn;
-                getValue(colIn, valIn);
+                if (i % 1000 == 0 && fStep->cancelled())
+                    break;
 
-                if (fSet.find(valIn) == fSet.end())
+                if (fFunctionId == WF__COUNT_ASTERISK)
                 {
                     fCount++;
+                    continue;
+                }
 
-                    if (fFunctionId == WF__COUNT_DISTINCT)
-                        fSet.insert(valIn);
+                fRow.setData(getPointer(fRowData->at(i)));
+
+                if (fRow.isNullValue(colIn) == true)
+                    continue;
+
+                if (fFunctionId != WF__COUNT_DISTINCT)
+                {
+                    fCount++;
+                }
+                else
+                {
+                    T valIn;
+                    getValue(colIn, valIn);
+
+                    if (fSet.find(valIn) == fSet.end())
+                    {
+                        fCount++;
+
+                        if (fFunctionId == WF__COUNT_DISTINCT)
+                            fSet.insert(valIn);
+                    }
                 }
             }
         }

--- a/utils/windowfunction/wf_count.cpp
+++ b/utils/windowfunction/wf_count.cpp
@@ -110,7 +110,7 @@ void WF_count<T>::operator()(int64_t b, int64_t e, int64_t c)
             e = c;
 
         // for count(*), the column is optimized out, index[1] does not exist.
-        uint64_t colIn = (fFunctionId == WF__COUNT_ASTERISK) ? 0 : fFieldIndex[1];
+        int64_t colIn = (fFunctionId == WF__COUNT_ASTERISK) ? 0 : fFieldIndex[1];
 
         for (int64_t i = b; i <= e; i++)
         {
@@ -125,7 +125,7 @@ void WF_count<T>::operator()(int64_t b, int64_t e, int64_t c)
 
             fRow.setData(getPointer(fRowData->at(i)));
 
-            if (fRow.isNullValue(colIn) == true)
+            if (colIn == -1 || fRow.isNullValue(colIn) == true)
                 continue;
 
             if (fFunctionId != WF__COUNT_DISTINCT)


### PR DESCRIPTION
We were incorrectly handling NULL as an argument for wf_count. fFieldIndex was returning -1 but we were storing as unsigned int causing unexpected results and a ExeMgr crash