### PR TITLE
MCOL-3494: make option for testing configuration to skip retry errors.

### DIFF
--- a/storage-manager/src/S3Storage.cpp
+++ b/storage-manager/src/S3Storage.cpp
@@ -86,7 +86,7 @@ S3Storage::ScopedConnection::~ScopedConnection()
     s3->returnConnection(conn);
 }
 
-S3Storage::S3Storage()
+S3Storage::S3Storage(bool skipRetry) : skipRetryableErrors(skipRetry)
 {
     /*  Check creds from envvars
         Get necessary vars from config
@@ -232,6 +232,10 @@ int S3Storage::getObject(const string &_sourceKey, boost::shared_array<uint8_t> 
             else 
                 logger->log(LOG_ERR, "S3Storage::getObject(): failed to GET, got '%s'.  bucket = %s, key = %s.  Retrying...",
                     s3err_msgs[err], bucket.c_str(), sourceKey.c_str());
+            if (skipRetryableErrors)
+            {
+                return -1;
+            }
             sleep(5);
         }
     } while (err && retryable_error(err));
@@ -322,6 +326,10 @@ int S3Storage::putObject(const boost::shared_array<uint8_t> data, size_t len, co
             else
                 logger->log(LOG_ERR, "S3Storage::putObject(): failed to PUT, got '%s'.  bucket = %s, key = %s."
                     "  Retrying...", s3err_msgs[s3err], bucket.c_str(), destKey.c_str());
+            if (skipRetryableErrors)
+            {
+                return -1;
+            }
             sleep(5);
         }
     } while (s3err && retryable_error(s3err));
@@ -356,6 +364,10 @@ int S3Storage::deleteObject(const string &_key)
             else
                 logger->log(LOG_ERR, "S3Storage::deleteObject(): failed to DELETE, got '%s'.  bucket = %s, key = %s.  Retrying...",
                     s3err_msgs[s3err], bucket.c_str(), key.c_str());
+            if (skipRetryableErrors)
+            {
+                return -1;
+            }
             sleep(5);
         }
     } while (s3err && s3err != MS3_ERR_NOT_FOUND && retryable_error(s3err));
@@ -391,6 +403,10 @@ int S3Storage::copyObject(const string &_sourceKey, const string &_destKey)
             else
                 logger->log(LOG_ERR, "S3Storage::copyObject(): failed to copy, got '%s'.  bucket = %s, srckey = %s, "
                     " destkey = %s.  Retrying...", s3err_msgs[s3err], bucket.c_str(), sourceKey.c_str(), destKey.c_str());
+            if (skipRetryableErrors)
+            {
+                return -1;
+            }
             sleep(5);
         }
     } while (s3err && retryable_error(s3err));
@@ -440,6 +456,10 @@ int S3Storage::exists(const string &_key, bool *out)
             else
                 logger->log(LOG_ERR, "S3Storage::exists(): failed to HEAD, got '%s'.  bucket = %s, key = %s.  Retrying...",
                     s3err_msgs[s3err], bucket.c_str(), key.c_str());
+            if (skipRetryableErrors)
+            {
+                return -1;
+            }
             sleep(5);
         }
     } while (s3err && s3err != MS3_ERR_NOT_FOUND && retryable_error(s3err));

--- a/storage-manager/src/S3Storage.cpp
+++ b/storage-manager/src/S3Storage.cpp
@@ -224,7 +224,7 @@ int S3Storage::getObject(const string &_sourceKey, boost::shared_array<uint8_t> 
     
     do {
         err = ms3_get(creds, bucket.c_str(), sourceKey.c_str(), &_data, &len);
-        if (err && retryable_error(err))
+        if (err && (!skipRetryableErrors && retryable_error(err)))
         { 
             if (ms3_server_error(creds))
                 logger->log(LOG_ERR, "S3Storage::getObject(): failed to GET, server says '%s'.  bucket = %s, key = %s."
@@ -232,14 +232,9 @@ int S3Storage::getObject(const string &_sourceKey, boost::shared_array<uint8_t> 
             else 
                 logger->log(LOG_ERR, "S3Storage::getObject(): failed to GET, got '%s'.  bucket = %s, key = %s.  Retrying...",
                     s3err_msgs[err], bucket.c_str(), sourceKey.c_str());
-            if (skipRetryableErrors)
-            {
-                errno = EAGAIN;
-                return -1;
-            }
             sleep(5);
         }
-    } while (err && retryable_error(err));
+    } while (err && (!skipRetryableErrors && retryable_error(err)));
     if (err)
     {
         if (ms3_server_error(creds))
@@ -319,7 +314,7 @@ int S3Storage::putObject(const boost::shared_array<uint8_t> data, size_t len, co
     
     do {
         s3err = ms3_put(creds, bucket.c_str(), destKey.c_str(), data.get(), len);
-        if (s3err && retryable_error(s3err))
+        if (s3err && (!skipRetryableErrors && retryable_error(s3err)))
         {
             if (ms3_server_error(creds))
                 logger->log(LOG_ERR, "S3Storage::putObject(): failed to PUT, server says '%s'.  bucket = %s, key = %s."
@@ -327,14 +322,9 @@ int S3Storage::putObject(const boost::shared_array<uint8_t> data, size_t len, co
             else
                 logger->log(LOG_ERR, "S3Storage::putObject(): failed to PUT, got '%s'.  bucket = %s, key = %s."
                     "  Retrying...", s3err_msgs[s3err], bucket.c_str(), destKey.c_str());
-            if (skipRetryableErrors)
-            {
-                errno = EAGAIN;
-                return -1;
-            }
             sleep(5);
         }
-    } while (s3err && retryable_error(s3err));
+    } while (s3err && (!skipRetryableErrors && retryable_error(s3err)));
     if (s3err)
     {
         if (ms3_server_error(creds))
@@ -358,7 +348,7 @@ int S3Storage::deleteObject(const string &_key)
         
     do {
         s3err = ms3_delete(creds, bucket.c_str(), key.c_str());
-        if (s3err && s3err != MS3_ERR_NOT_FOUND && retryable_error(s3err))
+        if (s3err && s3err != MS3_ERR_NOT_FOUND && (!skipRetryableErrors && retryable_error(s3err)))
         {
             if (ms3_server_error(creds))
                 logger->log(LOG_ERR, "S3Storage::deleteObject(): failed to DELETE, server says '%s'.  bucket = %s, key = %s."
@@ -366,14 +356,9 @@ int S3Storage::deleteObject(const string &_key)
             else
                 logger->log(LOG_ERR, "S3Storage::deleteObject(): failed to DELETE, got '%s'.  bucket = %s, key = %s.  Retrying...",
                     s3err_msgs[s3err], bucket.c_str(), key.c_str());
-            if (skipRetryableErrors)
-            {
-                errno = EAGAIN;
-                return -1;
-            }
             sleep(5);
         }
-    } while (s3err && s3err != MS3_ERR_NOT_FOUND && retryable_error(s3err));
+    } while (s3err && s3err != MS3_ERR_NOT_FOUND && (!skipRetryableErrors && retryable_error(s3err)));
     
     if (s3err != 0 && s3err != MS3_ERR_NOT_FOUND)
     {
@@ -398,7 +383,7 @@ int S3Storage::copyObject(const string &_sourceKey, const string &_destKey)
     do 
     {
         s3err = ms3_copy(creds, bucket.c_str(), sourceKey.c_str(), bucket.c_str(), destKey.c_str());
-        if (s3err && retryable_error(s3err))
+        if (s3err && (!skipRetryableErrors && retryable_error(s3err)))
         {
             if (ms3_server_error(creds))
                 logger->log(LOG_ERR, "S3Storage::copyObject(): failed to copy, server says '%s'.  bucket = %s, srckey = %s, "
@@ -406,14 +391,9 @@ int S3Storage::copyObject(const string &_sourceKey, const string &_destKey)
             else
                 logger->log(LOG_ERR, "S3Storage::copyObject(): failed to copy, got '%s'.  bucket = %s, srckey = %s, "
                     " destkey = %s.  Retrying...", s3err_msgs[s3err], bucket.c_str(), sourceKey.c_str(), destKey.c_str());
-            if (skipRetryableErrors)
-            {
-                errno = EAGAIN;
-                return -1;
-            }
             sleep(5);
         }
-    } while (s3err && retryable_error(s3err));
+    } while (s3err && (!skipRetryableErrors && retryable_error(s3err)));
     
     if (s3err) 
     {
@@ -452,7 +432,7 @@ int S3Storage::exists(const string &_key, bool *out)
     
     do {
         s3err = ms3_status(creds, bucket.c_str(), key.c_str(), &status);
-        if (s3err && s3err != MS3_ERR_NOT_FOUND && retryable_error(s3err))
+        if (s3err && s3err != MS3_ERR_NOT_FOUND && (!skipRetryableErrors && retryable_error(s3err)))
         {
             if (ms3_server_error(creds))
                 logger->log(LOG_ERR, "S3Storage::exists(): failed to HEAD, server says '%s'.  bucket = %s, key = %s."
@@ -460,14 +440,9 @@ int S3Storage::exists(const string &_key, bool *out)
             else
                 logger->log(LOG_ERR, "S3Storage::exists(): failed to HEAD, got '%s'.  bucket = %s, key = %s.  Retrying...",
                     s3err_msgs[s3err], bucket.c_str(), key.c_str());
-            if (skipRetryableErrors)
-            {
-                errno = EAGAIN;
-                return -1;
-            }
             sleep(5);
         }
-    } while (s3err && s3err != MS3_ERR_NOT_FOUND && retryable_error(s3err));
+    } while (s3err && s3err != MS3_ERR_NOT_FOUND && (!skipRetryableErrors && retryable_error(s3err)));
     
     if (s3err != 0 && s3err != MS3_ERR_NOT_FOUND)
     {

--- a/storage-manager/src/S3Storage.cpp
+++ b/storage-manager/src/S3Storage.cpp
@@ -234,6 +234,7 @@ int S3Storage::getObject(const string &_sourceKey, boost::shared_array<uint8_t> 
                     s3err_msgs[err], bucket.c_str(), sourceKey.c_str());
             if (skipRetryableErrors)
             {
+                errno = EAGAIN;
                 return -1;
             }
             sleep(5);
@@ -328,6 +329,7 @@ int S3Storage::putObject(const boost::shared_array<uint8_t> data, size_t len, co
                     "  Retrying...", s3err_msgs[s3err], bucket.c_str(), destKey.c_str());
             if (skipRetryableErrors)
             {
+                errno = EAGAIN;
                 return -1;
             }
             sleep(5);
@@ -366,6 +368,7 @@ int S3Storage::deleteObject(const string &_key)
                     s3err_msgs[s3err], bucket.c_str(), key.c_str());
             if (skipRetryableErrors)
             {
+                errno = EAGAIN;
                 return -1;
             }
             sleep(5);
@@ -405,6 +408,7 @@ int S3Storage::copyObject(const string &_sourceKey, const string &_destKey)
                     " destkey = %s.  Retrying...", s3err_msgs[s3err], bucket.c_str(), sourceKey.c_str(), destKey.c_str());
             if (skipRetryableErrors)
             {
+                errno = EAGAIN;
                 return -1;
             }
             sleep(5);
@@ -458,6 +462,7 @@ int S3Storage::exists(const string &_key, bool *out)
                     s3err_msgs[s3err], bucket.c_str(), key.c_str());
             if (skipRetryableErrors)
             {
+                errno = EAGAIN;
                 return -1;
             }
             sleep(5);

--- a/storage-manager/src/S3Storage.h
+++ b/storage-manager/src/S3Storage.h
@@ -30,7 +30,8 @@ namespace storagemanager
 class S3Storage : public CloudStorage
 {
     public:
-        S3Storage();
+        S3Storage(bool skipRetry = false);
+
         virtual ~S3Storage();
 
         int getObject(const std::string &sourceKey, const std::string &destFile, size_t *size = NULL);
@@ -46,6 +47,8 @@ class S3Storage : public CloudStorage
         ms3_st *getConnection();
         void returnConnection(ms3_st *);
     
+        bool skipRetryableErrors;
+
         std::string bucket;   // might store this as a char *, since it's only used that way
         std::string prefix;
         std::string region;

--- a/storage-manager/src/testS3Connection.cpp
+++ b/storage-manager/src/testS3Connection.cpp
@@ -35,7 +35,7 @@ int s3TestConnection()
     int ret = 0;
     try
     {
-        S3Storage* s3 = new S3Storage();
+        S3Storage* s3 = new S3Storage(true);
         cout << "S3 Storage Manager Configuration OK" << endl;
         delete s3;
     }


### PR DESCRIPTION
Some combinations of settings for storage manager at postConfigure were considered retry-able errors and would hang forever when testing. Add option to create S3Storage with flag set to return from these retry forever loops.