### PR TITLE
MCOL-3813 Count with view is incorrect

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -1303,7 +1303,7 @@ uint32_t buildOuterJoin(gp_walk_info& gwi, SELECT_LEX& select_lex)
         // View is already processed in view::transform
         // @bug5319. view is sometimes treated as derived table and
         // fromSub::transform does not build outer join filters.
-        if (!table_ptr->derived && table_ptr->view)
+        if (!table_ptr->derived && table_ptr->view && !gwi.subQuery)
             continue;
 
         CalpontSystemCatalog:: TableAliasName tan = make_aliasview(


### PR DESCRIPTION
This is not actually an issue with count, however, it is an issue that pertains to a view used in subquery.

Previously a fix for MCOL-1349 reinstated some code 0b32f95 where outer joins with views were being processed twice. There is a case where a view inside a subquery was not processing it's outer join at all. Added a fix here to allow view in subquery to process outerjoin.

This fixes regression test queries/working_tpch1_compareLogOnly/misc/bug5764.sql and i have added a separate regression test to test MCOL-1349 is in working state. mariadb-corporation/mariadb-columnstore-regression-test#219