### PR TITLE
Improve batch inserts.

### DIFF
--- a/dbcon/dmlpackage/dmltable.cpp
+++ b/dbcon/dmlpackage/dmltable.cpp
@@ -72,6 +72,28 @@ int DMLTable::read(messageqcpp::ByteStream& bytestream)
     return retval;
 }
 
+void DMLTable::readMetaData(messageqcpp::ByteStream& bytestream)
+{
+    // read the table name
+    bytestream >> fName;
+
+    // read the schema name
+    bytestream >> fSchema;
+}
+
+void DMLTable::readRowData(messageqcpp::ByteStream& bytestream)
+{
+    messageqcpp::ByteStream::quadbyte rowNum;
+    bytestream >> rowNum;
+
+    for (unsigned int i = 0; i < rowNum; i++)
+    {
+        Row* aRow = new Row();
+        aRow->read(bytestream);
+        fRows.push_back(aRow);
+    }
+}
+
 int DMLTable::write(messageqcpp::ByteStream& bytestream)
 {
     int retval = 1;

--- a/dbcon/dmlpackage/dmltable.h
+++ b/dbcon/dmlpackage/dmltable.h
@@ -91,6 +91,20 @@ public:
     int read(messageqcpp::ByteStream& bytestream);
 
 
+    /** @brief read a DMLTable metadata from a ByteStream
+      *
+      * @param bytestream the ByteStream to read from
+      */
+    void readMetaData(messageqcpp::ByteStream& bytestream);
+
+
+    /** @brief read a DMLTable row data from a ByteStream
+      *
+      * @param bytestream the ByteStream to read from
+      */
+    void readRowData(messageqcpp::ByteStream& bytestream);
+
+
     /** @brief write a DMLTable to a ByteStream
       *
       * @param bytestream the ByteStream to write to

--- a/dbcon/dmlpackage/insertdmlpackage.h
+++ b/dbcon/dmlpackage/insertdmlpackage.h
@@ -73,6 +73,18 @@ public:
       */
     EXPORT int read(messageqcpp::ByteStream& bytestream);
 
+    /** @brief read InsertDMLPackage metadata from bytestream
+      *
+      * @param bytestream the ByteStream to read from
+      */
+    EXPORT void readMetaData(messageqcpp::ByteStream& bytestream);
+
+    /** @brief read InsertDMLPackage row data from bytestream
+      *
+      * @param bytestream the ByteStream to read from
+      */
+    EXPORT void readRowData(messageqcpp::ByteStream& bytestream);
+
     /** @brief build a InsertDMLPackage from a string buffer
       *
       * @param buffer

--- a/versioning/BRM/brmtypes.h
+++ b/versioning/BRM/brmtypes.h
@@ -507,6 +507,7 @@ const uint8_t RELEASE_LBID_RANGES = 91;
 /* More main BRM functions 100-110 */
 const uint8_t BULK_UPDATE_DBROOT = 100;
 const uint8_t GET_SYSTEM_CATALOG = 101;
+const uint8_t BULK_WRITE_VB_ENTRY = 102;
 
 
 /* Error codes returned by the DBRM functions. */

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -2226,6 +2226,42 @@ int DBRM::writeVBEntry(VER_t transID, LBID_t lbid, OID_t vbOID,
     return err;
 }
 
+int DBRM::bulkWriteVBEntry(VER_t transID,
+                           const std::vector<BRM::LBID_t>& lbids,
+                           OID_t vbOID,
+                           const std::vector<uint32_t>& vbFBOs) DBRM_THROW
+{
+
+#ifdef BRM_INFO
+
+    if (fDebug)
+    {
+        TRACER_WRITELATER("bulkWriteVBEntry");
+        TRACER_WRITE;
+    }
+
+#endif
+
+    ByteStream command, response;
+    uint8_t err;
+
+    command << BULK_WRITE_VB_ENTRY << (uint32_t) transID;
+    serializeInlineVector(command, lbids);
+    command << (uint32_t) vbOID;
+    serializeInlineVector(command, vbFBOs);
+    err = send_recv(command, response);
+
+    if (err != ERR_OK)
+        return err;
+
+    if (response.length() != 1)
+        return ERR_NETWORK;
+
+    response >> err;
+    CHECK_EMPTY(response);
+    return err;
+}
+
 struct _entry
 {
     _entry(LBID_t l) : lbid(l) { };

--- a/versioning/BRM/dbrm.h
+++ b/versioning/BRM/dbrm.h
@@ -608,6 +608,20 @@ public:
     EXPORT int writeVBEntry(VER_t transID, LBID_t lbid, OID_t vbOID,
                             uint32_t vbFBO) DBRM_THROW;
 
+    /** @brief Bulk registers a version buffer entry.
+     *
+     * Similar to writeVBEntry, but registers the version buffer
+     * entries in bulk for a list of lbids and vbFBOs, for a given
+     * transID and vbOID.
+     * @note The version buffer locations must hold the 'copy' lock
+     * first.
+     * @return 0 on success, non-0 on error (see brmtypes.h)
+     */
+    EXPORT int bulkWriteVBEntry(VER_t transID,
+                                const std::vector<BRM::LBID_t>& lbids,
+                                OID_t vbOID,
+                                const std::vector<uint32_t>& vbFBOs) DBRM_THROW;
+
     /** @brief Retrieves a list of uncommitted LBIDs.
      *
      * Retrieves a list of uncommitted LBIDs for the given transaction ID.

--- a/versioning/BRM/slavecomm.h
+++ b/versioning/BRM/slavecomm.h
@@ -91,6 +91,7 @@ private:
     void do_bulkSetHWM(messageqcpp::ByteStream& msg);
     void do_bulkSetHWMAndCP(messageqcpp::ByteStream& msg);
     void do_writeVBEntry(messageqcpp::ByteStream& msg);
+    void do_bulkWriteVBEntry(messageqcpp::ByteStream& msg);
     void do_beginVBCopy(messageqcpp::ByteStream& msg);
     void do_endVBCopy(messageqcpp::ByteStream& msg);
     void do_vbRollback1(messageqcpp::ByteStream& msg);

--- a/versioning/BRM/slavedbrmnode.h
+++ b/versioning/BRM/slavedbrmnode.h
@@ -364,6 +364,20 @@ public:
     EXPORT int writeVBEntry(VER_t transID, LBID_t lbid, OID_t vbOID,
                             uint32_t vbFBO) throw();
 
+    /** @brief Bulk registers a version buffer entry.
+     *
+     * Similar to writeVBEntry, but registers the version buffer
+     * entries in bulk for a list of lbids and vbFBOs, for a given
+     * transID and vbOID.
+     * @note The version buffer locations must hold the 'copy' lock
+     * first.
+     * @return 0 on success, -1 on error
+     */
+    EXPORT int bulkWriteVBEntry(VER_t transID,
+                                const std::vector<BRM::LBID_t>& lbids,
+                                OID_t vbOID,
+                                const std::vector<uint32_t>& vbFBOs) throw();
+
     /** @brief Atomically prepare to copy data to the version buffer
      *
      * Atomically sets the copy flag on the specified LBID ranges


### PR DESCRIPTION
  1) Instead of making dbrm calls to writeVBEntry() per block,
     we make these calls per batch. This can have non-trivial
     reductions in the overhead of these calls if the batch size
     is large.

  2) In dmlproc, do not deserialize the whole insertpackage, which
     consists of the complete record set per column, which would be
     wasteful as we only need some metadata fields from insertpackage
     here. This is only done for batch inserts at the moment, this
     should also be applied to single inserts.