### PR TITLE
MCOL-3999: Must restart WES on failover.

### DIFF
--- a/procmgr/processmanager.cpp
+++ b/procmgr/processmanager.cpp
@@ -3839,7 +3839,7 @@ void ProcessManager::reinitProcesses(std::string skipModule)
     log.writeLog(__LINE__, "reinitProcesses... ", LOG_TYPE_DEBUG);
 
     reinitProcessType("DBRMWorkerNode");
-    reinitProcessType("WriteEngineServer");
+    restartProcessType("WriteEngineServer");
     restartProcessType("ExeMgr",skipModule);
     sleep(1);
     restartProcessType("DDLProc",skipModule);


### PR DESCRIPTION
On failover cannot just reinit WES must restart. This is because of mutex allocation on create table cannot handle added dbroots after an initial table is created. To test: 
1. create multinode cluster with gluster. 
2. create a table. (if no table is created before the failover there is no error)
3. failover non primary PM.
4. create another table.