### PR TITLE
MCOL-3914 Add proper termination of systemd units.

### DIFF
--- a/oam/etc/Columnstore.xml
+++ b/oam/etc/Columnstore.xml
@@ -247,7 +247,7 @@
         <DBRoot1>/var/lib/columnstore/data1</DBRoot1>
         <DBRMRoot>/var/lib/columnstore/data1/systemFiles/dbrm/BRM_saves</DBRMRoot>
         <TableLockSaveFile>/var/lib/columnstore/data1/systemFiles/dbrm/tablelocks</TableLockSaveFile>
-		<DBRMTimeOut>20</DBRMTimeOut> <!-- in seconds -->
+		<DBRMTimeOut>15</DBRMTimeOut> <!-- in seconds -->
 		<DBRMSnapshotInterval>100000</DBRMSnapshotInterval>
 		<ExternalCriticalThreshold>90</ExternalCriticalThreshold>
 		<ExternalMajorThreshold>80</ExternalMajorThreshold>

--- a/oam/install_scripts/CMakeLists.txt
+++ b/oam/install_scripts/CMakeLists.txt
@@ -20,6 +20,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-writeengineserver.service.in" "$
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-dmlproc.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-dmlproc.service" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-ddlproc.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-ddlproc.service" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-loadbrm.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-loadbrm.service" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-stop-controllernode.sh.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-stop-controllernode.sh" @ONLY)
 
 install(PROGRAMS columnstore-post-install 
                 columnstore-pre-uninstall 
@@ -42,6 +43,7 @@ install(PROGRAMS columnstore-post-install
                 disable-rep-columnstore.sh  
                 mariadb-command-line.sh 
                 mcs_module_installer.sh
+                mcs-stop-controllernode.sh
                 DESTINATION ${ENGINE_BINDIR} COMPONENT columnstore-engine)
 
 install(FILES mariadb-columnstore.service

--- a/oam/install_scripts/mcs-controllernode.service.in
+++ b/oam/install_scripts/mcs-controllernode.service.in
@@ -8,7 +8,8 @@ Type=forking
 Environment="SKIP_OAM_INIT=1"
 ExecStart=@ENGINE_BINDIR@/controllernode
 Restart=on-failure
-ExecStop=/usr/bin/env bash -c "/bin/kill -15 $MAINPID && sleep 2 && /bin/kill -9 $(pidof controllernode) || /bin/true"
+ExecStop=@ENGINE_BINDIR@/mcs-stop-controllernode.sh
+TimeoutStopSec=$(mcsGetConfig SystemConfig DBRMTimeout)
 
 [Install]
 WantedBy=mariadb-columnstore.service

--- a/oam/install_scripts/mcs-ddlproc.service.in
+++ b/oam/install_scripts/mcs-ddlproc.service.in
@@ -8,7 +8,7 @@ Type=simple
 Environment="SKIP_OAM_INIT=1"
 ExecStart=@ENGINE_BINDIR@/DDLProc
 Restart=on-failure
-ExecStop=/usr/bin/env bash -c "/bin/kill -15 $(pidof DDLProc) && sleep 2 && /bin/kill -9 $(pidof DDLProc) || /bin/true"
+TimeoutStopSec=2
 
 [Install]
 WantedBy=mariadb-columnstore.service

--- a/oam/install_scripts/mcs-dmlproc.service.in
+++ b/oam/install_scripts/mcs-dmlproc.service.in
@@ -8,7 +8,7 @@ Type=simple
 Environment="SKIP_OAM_INIT=1"
 ExecStart=@ENGINE_BINDIR@/DMLProc
 Restart=on-failure
-ExecStop=/usr/bin/env bash -c "/bin/kill -15 $(pidof DMLProc) && sleep 2 && /bin/kill -9 $(pidof DMLProc) || /bin/true"
+TimeoutStopSec=2
 
 [Install]
 WantedBy=mariadb-columnstore.service

--- a/oam/install_scripts/mcs-exemgr.service.in
+++ b/oam/install_scripts/mcs-exemgr.service.in
@@ -8,7 +8,7 @@ Type=simple
 Environment="SKIP_OAM_INIT=1"
 ExecStart=@ENGINE_BINDIR@/ExeMgr
 Restart=on-failure
-ExecStop=/usr/bin/env bash -c "/bin/kill -15 $(pidof ExeMgr) && sleep 2 && /bin/kill -9 $(pidof ExeMgr) || /bin/true"
+TimeoutStopSec=2
 
 [Install]
 WantedBy=mariadb-columnstore.service

--- a/oam/install_scripts/mcs-primproc.service.in
+++ b/oam/install_scripts/mcs-primproc.service.in
@@ -1,14 +1,14 @@
 [Unit]
 Description=mcs-primproc
 PartOf=mcs-workernode.service
-After=mcs-workernode.service
+After=mcs-controllernode.service
 
 [Service]
 Type=simple
 Environment="SKIP_OAM_INIT=1"
 ExecStart=@ENGINE_BINDIR@/PrimProc
 Restart=on-failure
-ExecStop=/usr/bin/env bash -c "/bin/kill -15 $(pidof PrimProc) && sleep 2 && /bin/kill -9 $(pidof PrimProc) || /bin/true"
+TimeoutStopSec=2
 
 [Install]
 WantedBy=mariadb-columnstore.service

--- a/oam/install_scripts/mcs-stop-controllernode.sh.in
+++ b/oam/install_scripts/mcs-stop-controllernode.sh.in
@@ -1,0 +1,3 @@
+#!/bin/bash
+kill -15 $(pidof workernode)
+kill -15 $(pidof controllernode)

--- a/oam/install_scripts/mcs-workernode.service.in
+++ b/oam/install_scripts/mcs-workernode.service.in
@@ -9,8 +9,8 @@ Environment="SKIP_OAM_INIT=1"
 ExecStart=@ENGINE_BINDIR@/workernode DBRM_Worker1
 Restart=on-failure
 ExecStop=-@ENGINE_BINDIR@/save_brm
-ExecStop=/usr/bin/env bash -c "/bin/kill -15 $MAINPID && sleep 2 && /bin/kill -9 $(pidof workernode) || /bin/true"
 ExecStopPost=/usr/bin/env bash -c "clearShm > /dev/null 2>&1"
+TimeoutStopSec=2
 
 [Install]
 WantedBy=mariadb-columnstore.service

--- a/oam/install_scripts/mcs-writeengineserver.service.in
+++ b/oam/install_scripts/mcs-writeengineserver.service.in
@@ -8,7 +8,7 @@ Type=simple
 Environment="SKIP_OAM_INIT=1"
 ExecStart=@ENGINE_BINDIR@/WriteEngineServer
 Restart=on-failure
-ExecStop=/usr/bin/env bash -c "/bin/kill -15 $(pidof WriteEngineServer) && sleep 2 && /bin/kill -9 $(pidof WriteEngineServer) || /bin/true"
+TimeoutStopSec=2
 
 [Install]
 WantedBy=mariadb-columnstore.service


### PR DESCRIPTION
Includes script for terminating controllernode. 

Turns out systemd by default calls SIGTERM on the process first, followed by SIGKILL, so all that is needed to do a clean TERM/WAIT/KILL, with the exception of controllernode, is to set TimeoutStopSec in the systemd units. ExecStop no longer needed for all but mcs-controllernode