### PR TITLE
MCOL-3914 Systemd service updates

### DIFF
--- a/oam/install_scripts/mcs-controllernode.service.in
+++ b/oam/install_scripts/mcs-controllernode.service.in
@@ -8,8 +8,7 @@ Type=forking
 Environment="SKIP_OAM_INIT=1"
 ExecStart=@ENGINE_BINDIR@/controllernode
 Restart=on-failure
-ExecStop=@ENGINE_BINDIR@/mcs-stop-controllernode.sh
-TimeoutStopSec=15
+ExecStop=@ENGINE_BINDIR@/mcs-stop-controllernode.sh $MAINPID
 
 [Install]
 WantedBy=mariadb-columnstore.service

--- a/oam/install_scripts/mcs-controllernode.service.in
+++ b/oam/install_scripts/mcs-controllernode.service.in
@@ -9,7 +9,7 @@ Environment="SKIP_OAM_INIT=1"
 ExecStart=@ENGINE_BINDIR@/controllernode
 Restart=on-failure
 ExecStop=@ENGINE_BINDIR@/mcs-stop-controllernode.sh
-TimeoutStopSec=$(mcsGetConfig SystemConfig DBRMTimeout)
+TimeoutStopSec=15
 
 [Install]
 WantedBy=mariadb-columnstore.service

--- a/oam/install_scripts/mcs-ddlproc.service.in
+++ b/oam/install_scripts/mcs-ddlproc.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=mcs-ddlproc
-PartOf=mcs-writeengineserver.service
+PartOf=mcs-exemgr.service
 After=mcs-dmlproc.service
 
 [Service]

--- a/oam/install_scripts/mcs-dmlproc.service.in
+++ b/oam/install_scripts/mcs-dmlproc.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=mcs-dmlproc
-PartOf=mcs-writeengineserver.service
-After=mcs-writeengineserver.service
+PartOf=mcs-exemgr.service
+After=mcs-exemgr.service
 
 [Service]
 Type=simple

--- a/oam/install_scripts/mcs-primproc.service.in
+++ b/oam/install_scripts/mcs-primproc.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=mcs-primproc
 PartOf=mcs-workernode.service
+PartOf=mcs-controllernode.service
 After=mcs-controllernode.service
 
 [Service]

--- a/oam/install_scripts/mcs-stop-controllernode.sh.in
+++ b/oam/install_scripts/mcs-stop-controllernode.sh.in
@@ -1,3 +1,2 @@
 #!/bin/bash
-kill -15 $(pidof workernode)
-kill -15 $(pidof controllernode)
+systemctl stop mcs-workernode --ignore-dependencies

--- a/oam/install_scripts/mcs-stop-controllernode.sh.in
+++ b/oam/install_scripts/mcs-stop-controllernode.sh.in
@@ -1,2 +1,15 @@
 #!/bin/bash
+
+/bin/kill -15 "$1"
 systemctl stop mcs-workernode --ignore-dependencies
+timeout=$(mcsGetConfig SystemConfig DBRMTimeout)
+
+while [ -n $(pgrep -x controllernode) ] && [ $timeout -gt 0 ]
+do
+    sleep 1
+    ((--timeout))
+done
+
+if [ -n $(pgrep -x controllernode) ]; then
+    /bin/kill -9 "$1"
+fi


### PR DESCRIPTION
Fixed a race condition between exemgr and dml/ddlproc caused by reordering startup of exemgr and writeengineserver without updating ddlrpoc/dmlproc systemd units.

Proper stop call to workernode when stopping controllernode.
