### PR TITLE
MCOL-3915 Update columnstore install and uninstall procedure

### DIFF
--- a/cmake/cpackEngineRPM.cmake
+++ b/cmake/cpackEngineRPM.cmake
@@ -86,7 +86,7 @@ else ()
     SETA(CPACK_RPM_columnstore-engine_PACKAGE_REQUIRES "boost >= 1.53.0" "snappy" "jemalloc" "net-tools")
 endif()
 
-SET(CPACK_RPM_columnstore-engine_PRE_INSTALL_SCRIPT_FILE ${CMAKE_SOURCE_DIR}/build/preInstall_storeage_engine.sh)
+SET(CPACK_RPM_columnstore-engine_PRE_INSTALL_SCRIPT_FILE ${CMAKE_SOURCE_DIR}/build/preInstall_storage_engine.sh)
 SET(CPACK_RPM_columnstore-engine_POST_INSTALL_SCRIPT_FILE ${CMAKE_SOURCE_DIR}/build/postInstall_storage_engine.sh)
 SET(CPACK_RPM_columnstore-engine_PRE_UNINSTALL_SCRIPT_FILE ${CMAKE_SOURCE_DIR}/build/preUn_storage_engine.sh)
 

--- a/dbcon/mysql/install_mcs_mysql.sh.in
+++ b/dbcon/mysql/install_mcs_mysql.sh.in
@@ -17,7 +17,7 @@ for arg in "$@"; do
 done
 
 # DELETE libcalmysql.so entries first as they are in ha_columnstore.so in 1.4.2 onwards
-su -s /bin/sh -c 'mysql < /tmp/123.sql'  mysql 2> ${tmpdir}/mysql_install.log <<EOD
+su -s /bin/sh -c 'mysql'  mysql 2> ${tmpdir}/mysql_install.log <<EOD
 DELETE FROM mysql.func WHERE dl='libcalmysql.so';
 INSERT INTO mysql.func VALUES ('calgetstats',0,'ha_columnstore.so','function');
 INSERT INTO mysql.func VALUES ('calsettrace',2,'ha_columnstore.so','function');
@@ -110,9 +110,10 @@ CREATE TABLE IF NOT EXISTS infinidb_querystats.priority
 insert ignore into infinidb_querystats.priority values ('High', 100),('Medium', 66), ('Low', 33);
 EOD
 
-su -s /bin/sh -c 'mysql < /tmp/123.sql'  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/syscatalog_mysql.sql
-su -s /bin/sh -c 'mysql < /tmp/123.sql'  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/calsetuserpriority.sql
-su -s /bin/sh -c 'mysql < /tmp/123.sql'  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/calremoveuserpriority.sql
-su -s /bin/sh -c 'mysql < /tmp/123.sql'  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/calshowprocesslist.sql
-su -s /bin/sh -c 'mysql < /tmp/123.sql'  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/columnstore_info.sql
+su -s /bin/sh -c 'mysql <@ENGINE_SUPPORTDIR@/syscatalog_mysql.sql' mysql 2>/dev/null
+su -s /bin/sh -c 'mysql <@ENGINE_SUPPORTDIR@/calsetuserpriority.sql' mysql 2>/dev/null
+su -s /bin/sh -c 'mysql <@ENGINE_SUPPORTDIR@/calremoveuserpriority.sql' mysql 2>/dev/null
+su -s /bin/sh -c 'mysql <@ENGINE_SUPPORTDIR@/calshowprocesslist.sql' mysql 2>/dev/null
+su -s /bin/sh -c 'mysql <@ENGINE_SUPPORTDIR@/columnstore_info.sql' mysql 2>/dev/null
+
 

--- a/dbcon/mysql/install_mcs_mysql.sh.in
+++ b/dbcon/mysql/install_mcs_mysql.sh.in
@@ -17,7 +17,7 @@ for arg in "$@"; do
 done
 
 # DELETE libcalmysql.so entries first as they are in ha_columnstore.so in 1.4.2 onwards
-mysql --force --user=root mysql 2> ${tmpdir}/mysql_install.log <<EOD
+su -s /bin/sh -c 'mysql < /tmp/123.sql'  mysql 2> ${tmpdir}/mysql_install.log <<EOD
 DELETE FROM mysql.func WHERE dl='libcalmysql.so';
 INSERT INTO mysql.func VALUES ('calgetstats',0,'ha_columnstore.so','function');
 INSERT INTO mysql.func VALUES ('calsettrace',2,'ha_columnstore.so','function');
@@ -110,9 +110,9 @@ CREATE TABLE IF NOT EXISTS infinidb_querystats.priority
 insert ignore into infinidb_querystats.priority values ('High', 100),('Medium', 66), ('Low', 33);
 EOD
 
-mysql --user=root  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/syscatalog_mysql.sql
-mysql --user=root  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/calsetuserpriority.sql
-mysql --user=root  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/calremoveuserpriority.sql
-mysql --user=root  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/calshowprocesslist.sql
-mysql --user=root  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/columnstore_info.sql
+su -s /bin/sh -c 'mysql < /tmp/123.sql'  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/syscatalog_mysql.sql
+su -s /bin/sh -c 'mysql < /tmp/123.sql'  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/calsetuserpriority.sql
+su -s /bin/sh -c 'mysql < /tmp/123.sql'  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/calremoveuserpriority.sql
+su -s /bin/sh -c 'mysql < /tmp/123.sql'  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/calshowprocesslist.sql
+su -s /bin/sh -c 'mysql < /tmp/123.sql'  mysql 2>/dev/null <@ENGINE_SUPPORTDIR@/columnstore_info.sql
 

--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -4,10 +4,32 @@
 #
 # Post-install steps for columnstore install
 
+running_systemd() {
+   if  [ "$(ps --no-headers -o comm 1)" == "systemd" ]; then
+       echo 0
+   else
+       echo 1
+   fi
+}
+
 rpmmode=install
 user=`whoami 2>/dev/null`
 
 quiet=0
+
+stop_mysqld=0
+if [ -z "$(pgrep -x mysqld)" ];then
+
+    # Startup mysqld 
+    systemctl cat mariadb.service > /dev/null 2>&1
+    if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
+        systemctl start mariadb.service
+    else
+        /usr/bin/mysqld_safe &
+    fi
+    stop_mysqld=1
+fi
+sleep 2
 
 if [ -f @ENGINE_SYSCONFDIR@/columnstore/storagemanager.cnf.rpmsave ]; then
     /bin/cp -f @ENGINE_SYSCONFDIR@/columnstore/storagemanager.cnf @ENGINE_SYSCONFDIR@/columnstore/storagemanager.cnf.new
@@ -60,70 +82,70 @@ mkdir /mnt/tmp > /dev/null 2>&1
 
 if [ $user = "root" ]; then
 	#setup the columnstore service script
-	rm -f /etc/init.d/columnstore >/dev/null 2>&1
-	rm -f /etc/default/columnstore
+    rm -f /etc/init.d/columnstore >/dev/null 2>&1
+    rm -f /etc/default/columnstore
 
-	systemctl=`which systemctl 2>/dev/null`
-	if [ -n "$systemctl" ]; then
-		cp @ENGINE_SUPPORTDIR@/mariadb-columnstore.service /usr/lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mariadb-columnstore.service /lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-controllernode.service /usr/lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-controllernode.service /lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-ddlproc.service /usr/lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-ddlproc.service /lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-dmlproc.service /usr/lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-dmlproc.service /lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-exemgr.service /usr/lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-exemgr.service /lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-primproc.service /usr/lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-primproc.service /lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-workernode.service /usr/lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-workernode.service /lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-writeengineserver.service /usr/lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-writeengineserver.service /lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-loadbrm.service /usr/lib/systemd/system/. >/dev/null 2>&1
-		cp @ENGINE_SUPPORTDIR@/mcs-loadbrm.service /lib/systemd/system/. >/dev/null 2>&1
+    systemctl=`which systemctl 2>/dev/null`
+    if [ -n "$systemctl" ]; then
+        cp @ENGINE_SUPPORTDIR@/mariadb-columnstore.service /usr/lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mariadb-columnstore.service /lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-controllernode.service /usr/lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-controllernode.service /lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-ddlproc.service /usr/lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-ddlproc.service /lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-dmlproc.service /usr/lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-dmlproc.service /lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-exemgr.service /usr/lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-exemgr.service /lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-primproc.service /usr/lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-primproc.service /lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-workernode.service /usr/lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-workernode.service /lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-writeengineserver.service /usr/lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-writeengineserver.service /lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-loadbrm.service /usr/lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-loadbrm.service /lib/systemd/system/. >/dev/null 2>&1
 
-		systemctl enable mariadb-columnstore >/dev/null 2>&1
-		systemctl enable mcs-controllernode > /dev/null 2>&1
-		systemctl enable mcs-ddlproc > /dev/null 2>&1
-		systemctl enable mcs-dmlproc > /dev/null 2>&1
-		systemctl enable mcs-exemgr > /dev/null 2>&1
-		systemctl enable mcs-primproc > /dev/null 2>&1
-		systemctl enable mcs-workernode > /dev/null 2>&1
-		systemctl enable mcs-writeengineserver > /dev/null 2>&1
-		systemctl enable mcs-loadbrm > /dev/null 2>&1
-	else
-		chkconfig=`which chkconfig 2>/dev/null`
-		if [ -n "$chkconfig" ]; then
+        systemctl enable mariadb-columnstore >/dev/null 2>&1
+        systemctl enable mcs-controllernode > /dev/null 2>&1
+        systemctl enable mcs-ddlproc > /dev/null 2>&1
+        systemctl enable mcs-dmlproc > /dev/null 2>&1
+        systemctl enable mcs-exemgr > /dev/null 2>&1
+        systemctl enable mcs-primproc > /dev/null 2>&1
+        systemctl enable mcs-workernode > /dev/null 2>&1
+        systemctl enable mcs-writeengineserver > /dev/null 2>&1
+        systemctl enable mcs-loadbrm > /dev/null 2>&1
+    else
+        chkconfig=`which chkconfig 2>/dev/null`
+        if [ -n "$chkconfig" ]; then
 
-			cp @ENGINE_SBINDIR@/columnstore /etc/init.d/. >/dev/null 2>&1
-			chkconfig --add columnstore > /dev/null 2>&1
-			chkconfig columnstore on > /dev/null 2>&1
-		else
-			cp @ENGINE_SBINDIR@/columnstore /etc/init.d/. >/dev/null 2>&1
-			updaterc=`which update-rc.d 2>/dev/null`
-			if [ -n "$updaterc" ]; then
+            cp @ENGINE_SBINDIR@/columnstore /etc/init.d/. >/dev/null 2>&1
+            chkconfig --add columnstore > /dev/null 2>&1
+            chkconfig columnstore on > /dev/null 2>&1
+        else
+            cp @ENGINE_SBINDIR@/columnstore /etc/init.d/. >/dev/null 2>&1
+            updaterc=`which update-rc.d 2>/dev/null`
+            if [ -n "$updaterc" ]; then
 
-				update-rc.d columnstore defaults 99 > /dev/null 2>&1
-			else
-				echo ""
-				echo "Package 'systemctl', 'chkconfig' or 'update-rc.d' not installed, contact your sysadmin if you want to setup to autostart for columnstore"	
-			fi
-		fi
-	fi
+                update-rc.d columnstore defaults 99 > /dev/null 2>&1
+            else
+                echo ""
+                echo "Package 'systemctl', 'chkconfig' or 'update-rc.d' not installed, contact your sysadmin if you want to setup to autostart for columnstore"	
+            fi
+        fi
+    fi
 fi
 
 if [ $user = "root" ]; then
-	columnstoreSyslogSetup.sh install > $tmpDir/syslog_install.log 2>&1
+    columnstoreSyslogSetup.sh install > $tmpDir/syslog_install.log 2>&1
 
-	#check if MariaDB Columnstore system logging was setup
-	cat $tmpDir/syslog_install.log | grep 'No System Logging' >/dev/null 2>&1
-	if [ $? -eq 0 ]; then
-	    cat $tmpDir/syslog_install.log
-	fi
+    #check if MariaDB Columnstore system logging was setup
+    cat $tmpDir/syslog_install.log | grep 'No System Logging' >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        cat $tmpDir/syslog_install.log
+    fi
 else
-	chown $user:$user @ENGINE_SYSCONFDIR@/columnstore/Columnstore.xml
+    chown $user:$user @ENGINE_SYSCONFDIR@/columnstore/Columnstore.xml
 	
 cat <<EOD
 
@@ -151,17 +173,28 @@ rm -f $lockdir/columnstore
 #check and get amazon env variables
 aws=`which aws 2>/dev/null`
 if [ -z "aws" ]; then
-	MCSgetCredentials.sh >/dev/null 2>&1
+    MCSgetCredentials.sh >/dev/null 2>&1
 fi
 
 postConfigure
 systemctl start mariadb-columnstore
 
-while  [ -z  $(pgrep -x controllernode) ];
+while  [ -z  "$(pgrep -x controllernode)" ];
 do
-    sleep 2
+    sleep 1
 done
  
 dbbuilder 7 > $tmpDir/dbbuilder.log
-exit 0
 
+if [ $stop_mysqld -eq 1 ];then
+    # Make sure we stop mariadb since it wasn't running prior to columnstore installation
+    systemctl cat mariadb.service > /dev/null 2>&1
+    if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
+        systemctl stop mariadb.service > /dev/null 2>&1
+    else
+        pkill mysqld
+    fi
+
+fi
+sleep 2
+exit 0

--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -179,7 +179,8 @@ fi
 postConfigure
 systemctl start mariadb-columnstore
 
-while  [ -z  "$(pgrep -x controllernode)" ];
+# Wait for all columnstore to be ready, DDLProc is final process in startup order
+while  [ -z  "$(pgrep -x DDLProc)" ];
 do
     sleep 1
 done

--- a/oam/install_scripts/columnstore-pre-uninstall.in
+++ b/oam/install_scripts/columnstore-pre-uninstall.in
@@ -10,7 +10,6 @@ running_systemd() {
     else
         echo 1
     fi
-
 }
 
 # Test we are using systemd
@@ -22,15 +21,18 @@ else
     kill $(pidof $PROGS) > /dev/null
     sleep 3
     kill -9 $(pidof $PROGS) > /dev/null
+    clearShm  > /dev/null 2>&1
+fi
+
+if [ -n "$(pgrep -x ProcMon)" ] || [ -n "$(pgrep -x ProcMgr)" ];then
+   # Old system must be running, kill ProcMon/ProcMgr 
+    pkill ProcMon
+    pkill ProcMgr
 fi
 
 rm -f /etc/profile.d/columnstoreAlias.sh
-
 rm -f /var/log/mariadb/columnstore/activeAlarms > /dev/null 2>&1
 rm -f /var/log/mariadb/columnstore/*.log1 > /dev/null 2>&1
-
-# delete Mariab Columnstore shared memory segments
-clearShm  > /dev/null 2>&1
 
 #get temp directory
 tmpDir=`mcsGetConfig SystemConfig SystemTempFileDir`
@@ -38,13 +40,13 @@ if [[ $tmpDir = *"tmp" ]]; then
 	# delete tmp files
 	rm -rf $tmpDir/*
 fi
+
 rm -f /var/lib/columnstore/local/*.columnstore
 rm -rf /var/lib/columnstore/local/etc/
 rm -f /var/lib/columnstore/data/bulk/tmp/job/* >/dev/null 2>&1
 rm -f /var/lib/columnstore/local/moveDbrootTransactionLog
 rm -rf /var/log/mariadb/columnstore/
 rm -rf /tmp/columnstore_tmp_files
-rm -rf /usr/share/columnstore
 
 lockdir=`mcsGetConfig Installation LockFileDirectory`
 rm -f $lockdir/columnstore
@@ -69,45 +71,44 @@ if [ -n "$systemctl" ] && [ $(running_systemd) -eq 0 ]; then
     systemctl disable mcs-writeengineserver > /dev/null 2>&1
     systemctl disable mcs-loadbrm > /dev/null 2>&1
 
-	rm -f /usr/lib/systemd/system/mariadb-columnstore.service
-	rm -f /lib/systemd/system/mariadb-columnstore.service
-        rm -f /usr/lib/systemd/system/mcs-controllernode.service
-	rm -f /lib/systemd/system/mcs-controllernode.service
-        rm -f /usr/lib/systemd/system/mcs-ddlproc.service
-	rm -f /lib/systemd/system/mcs-ddlproc.service
-        rm -f /usr/lib/systemd/system/mcs-dmlproc.service
- 	rm -f /lib/systemd/system/mcs-dmlproc.service
-        rm -f /usr/lib/systemd/system/mcs-exemgr.service
-	rm -f /lib/systemd/system/mcs-exemgr.service
-        rm -f /usr/lib/systemd/system/mcs-primproc.service
-	rm -f /lib/systemd/system/mcs-primproc.service
-        rm -f /usr/lib/systemd/system/mcs-workernode.service
-	rm -f /lib/systemd/system/mcs-workernode.service
-        rm -f /usr/lib/systemd/system/mcs-writeengineserver.service
-	rm -f /lib/systemd/system/mcs-writeengineserver.service
-        rm -f /usr/lib/systemd/system/mcs-loadbrm.service
-	rm -f /lib/systemd/system/mcs-loadbrm.service
+    rm -f /usr/lib/systemd/system/mariadb-columnstore.service
+    rm -f /lib/systemd/system/mariadb-columnstore.service
+    rm -f /usr/lib/systemd/system/mcs-controllernode.service
+    rm -f /lib/systemd/system/mcs-controllernode.service
+    rm -f /usr/lib/systemd/system/mcs-ddlproc.service
+    rm -f /lib/systemd/system/mcs-ddlproc.service
+    rm -f /usr/lib/systemd/system/mcs-dmlproc.service
+    rm -f /lib/systemd/system/mcs-dmlproc.service
+    rm -f /usr/lib/systemd/system/mcs-exemgr.service
+    rm -f /lib/systemd/system/mcs-exemgr.service
+    rm -f /usr/lib/systemd/system/mcs-primproc.service
+    rm -f /lib/systemd/system/mcs-primproc.service
+    rm -f /usr/lib/systemd/system/mcs-workernode.service
+    rm -f /lib/systemd/system/mcs-workernode.service
+    rm -f /usr/lib/systemd/system/mcs-writeengineserver.service
+    rm -f /lib/systemd/system/mcs-writeengineserver.service
+    rm -f /usr/lib/systemd/system/mcs-loadbrm.service
+    rm -f /lib/systemd/system/mcs-loadbrm.service
     systemctl daemon-reload
 else
-	chkconfig=`which chkconfig 2>/dev/null`
-	if [ -n "$chkconfig" ]; then
-		chkconfig columnstore off > /dev/null 2>&1
-		chkconfig --del columnstore > /dev/null 2>&1
-		rm -f /etc/init.d/columnstore > /dev/null 2>&1
-	else
-		updaterc=`which update-rc.d 2>/dev/null`
-		if [ -n "$updaterc" ]; then
-			update-rc.d -f columnstore remove > /dev/null 2>&1
-			rm -f /etc/init.d/columnstore > /dev/null 2>&1	
-		fi
-	fi
+    chkconfig=`which chkconfig 2>/dev/null`
+    if [ -n "$chkconfig" ]; then
+        chkconfig columnstore off > /dev/null 2>&1
+        chkconfig --del columnstore > /dev/null 2>&1
+        rm -f /etc/init.d/columnstore > /dev/null 2>&1
+    else
+        updaterc=`which update-rc.d 2>/dev/null`
+        if [ -n "$updaterc" ]; then
+            update-rc.d -f columnstore remove > /dev/null 2>&1
+            rm -f /etc/init.d/columnstore > /dev/null 2>&1	
+        fi
+    fi
 fi
 
 #make copy of Columnstore.xml
 /bin/cp -f @ENGINE_SYSCONFDIR@/columnstore/Columnstore.xml @ENGINE_SYSCONFDIR@/columnstore/Columnstore.xml.rpmsave > /dev/null 2>&1
 /bin/cp -f @ENGINE_SYSCONFDIR@/columnstore/storagemanager.cnf @ENGINE_SYSCONFDIR@/columnstore/storagemanager.cnf.rpmsave > /dev/null 2>&1
 /bin/cp -f @MARIADB_MYCNFDIR@/columnstore.cnf @MARIADB_MYCNFDIR@/columnstore.cnf.rpmsave > /dev/null 2>&1
-cp @ENGINE_SUPPORTDIR@/myCnf-include-args.text @ENGINE_SUPPORTDIR@/myCnf-include-args.text.rpmsave >& /dev/null
 rm -f @ENGINE_SYSCONFDIR@/columnstore/AlarmConfig.xml.installSave
 
 #remove OAMdbrootCheck file

--- a/oam/install_scripts/mcs-stop-controllernode.sh.in
+++ b/oam/install_scripts/mcs-stop-controllernode.sh.in
@@ -4,12 +4,12 @@
 systemctl stop mcs-workernode --ignore-dependencies
 timeout=$(mcsGetConfig SystemConfig DBRMTimeout)
 
-while [ -n $(pgrep -x controllernode) ] && [ $timeout -gt 0 ]
+while [ -n "$(pgrep -x controllernode)" ] && [ $timeout -gt 0 ]
 do
     sleep 1
     ((--timeout))
 done
 
-if [ -n $(pgrep -x controllernode) ]; then
+if [ -n "$(pgrep -x controllernode)" ]; then
     /bin/kill -9 "$1"
 fi

--- a/oam/install_scripts/post-mysql-install
+++ b/oam/install_scripts/post-mysql-install
@@ -5,13 +5,6 @@
 # Post-install steps for calpont-mysql install
 
 # check if running systemd
-running_systemd() {
-   if  [ "$(ps --no-headers -o comm 1)" == "systemd" ]; then
-       echo 0
-   else
-       echo 1
-   fi
-}
 
 # check log for error
 checkForError() {
@@ -62,20 +55,6 @@ done
 
 # Install various Calpont stuff...
 install_mcs_mysql.sh  --tmpdir=$tmpdir
-
-# Restart MariDB, otherwise engine does not show up.
-# Test we are using systemd
-systemctl cat mariadb.service > /dev/null 2>&1
-if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
-    systemctl restart mariadb.service > /dev/null 2>&1
-else
-    pkill mysqld
-    sleep 2
-    export MYSQL_OPTS="--skip-grant-tables"
-    /usr/bin/mysqld_safe --skip-grant-tables &
-    unset MYSQL_OPTS
-fi
-sleep 5
 
 checkForError
 if [ $? -ne 0 ]; then

--- a/oamapps/postConfigure/helpers.cpp
+++ b/oamapps/postConfigure/helpers.cpp
@@ -250,14 +250,12 @@ void mysqlSetup()
 {
     Oam oam;
     string cmd;
-
-	string tmpDir = startup::StartUp::tmpDir();
-
+    string tmpDir = startup::StartUp::tmpDir();
     string mysqlpw = oam.getMySQLPassword();
-
-	string passwordOption = "";
-	if ( mysqlpw != oam::UnassignedName )
-		passwordOption = " --password=" + mysqlpw;
+    string passwordOption = "";
+    
+    if ( mysqlpw != oam::UnassignedName )
+        passwordOption = " --password=" + mysqlpw;
 
     cmd = "post-mysqld-install " + passwordOption + " --tmpdir=" + tmpDir + " > " + tmpDir + "/post-mysqld-install.log 2>&1";
     int rtnCode = system(cmd.c_str());

--- a/oamapps/postConfigure/postConfigure.cpp
+++ b/oamapps/postConfigure/postConfigure.cpp
@@ -89,13 +89,8 @@ int main(int argc, char* argv[])
     string cmd;
     string numBlocksPctParam = "";
     string totalUmMemoryParam = "";
-    string reuseConfig = "n";
-    string mysqlPort = "";
     string homeDir = "/root";
     bool rootUser = true;
-    Config* sysConfig = Config::makeConfig();
-
-    mysqlPort = sysConfig->getConfig("Installation", "MySQLPort");
 
     //check if root-user
     int user;
@@ -122,14 +117,10 @@ int main(int argc, char* argv[])
 	char timestamp[200];
 	strftime (timestamp, 200, "%m:%d:%y-%H:%M:%S", &tm);
 	string currentDate = timestamp;
-
 	string postConfigureLog = "/var/log/columnstore-postconfigure-" + currentDate;
 
 	// perform single server install
 	cout << endl << "Performing the Single Server Install." << endl << endl;
-
-	//setup to Columnstore.xml file for single server
-    //singleServerConfigSetup(sysConfig);
 
 	if (!rootUser)
     {
@@ -147,7 +138,7 @@ int main(int argc, char* argv[])
         totalUmMemoryParam = "-";
     }
 
-	cmd = "columnstore_installer dummy.rpm dummy.rpm dummy.rpm dummy.rpm dummy.rpm initial dummy " + reuseConfig + " --nodeps ' ' 1 " + numBlocksPctParam + " " + totalUmMemoryParam;
+	cmd = "columnstore_installer dummy.rpm dummy.rpm dummy.rpm dummy.rpm dummy.rpm initial dummy n --nodeps ' ' 1 " + numBlocksPctParam + " " + totalUmMemoryParam;
 	system(cmd.c_str());
 	exit(0);
 }


### PR DESCRIPTION
Columnstore installation now leaves mariadb in the same state (active or inactive) as it was before installation. Columnstore properly cleans up log/tmp/share files during columnstore-pre-uninstall w/o the warnings from rpm.

Also did some cleanup.