### PR TITLE
Fixed a storagemanager assertion crashing things

### DIFF
--- a/storage-manager/src/IOCoordinator.cpp
+++ b/storage-manager/src/IOCoordinator.cpp
@@ -1001,6 +1001,8 @@ int IOCoordinator::copyFile(const char *_filename1, const char *_filename2)
         for (const auto &object : objects)
         {
             bf::path journalFile = journalPath/firstDir1/(object.key + ".journal");
+            // XXXPAT: Need to follow up on this.  this is the wrong length to use here, but changing it
+            // to use the right length is causing an error somewhere else.  Not sure why yet.
             metadataObject newObj = meta2.addMetadataObject(filename2, object.length);
             assert(newObj.offset == object.offset);
             err = cs->copyObject(object.key, newObj.key);

--- a/storage-manager/src/Synchronizer.cpp
+++ b/storage-manager/src/Synchronizer.cpp
@@ -693,8 +693,8 @@ void Synchronizer::synchronizeWithJournal(const string &sourceFile, list<string>
             count += err;
         }
         numBytesWritten += size;
-        assert(bf::file_size(oldCachePath) == MetadataFile::getLengthFromKey(cloudKey));
-        cache->rename(prefix, cloudKey, newCloudKey, size - MetadataFile::getLengthFromKey(cloudKey));
+        //assert(bf::file_size(oldCachePath) == MetadataFile::getLengthFromKey(cloudKey));
+        cache->rename(prefix, cloudKey, newCloudKey, size - bf::file_size(oldCachePath));
         replicator->remove(oldCachePath);
     }
     


### PR DESCRIPTION
This is the minimal fix necessary to fix the problem we saw in Sky with a customer.  There are other bugs fixed in the sm-crash branch, but we're just committing the minimal fix for the 1.4.4 release.