### PR TITLE
MCOL-4023 Enable condition pushdown for UPDATE/DELETE.

### DIFF
--- a/dbcon/mysql/ha_mcs.cpp
+++ b/dbcon/mysql/ha_mcs.cpp
@@ -448,7 +448,7 @@ int ha_mcs::direct_update_rows(ha_rows *update_rows)
     int rc;
     try
     {
-        rc = ha_mcs_impl_direct_update_delete_rows(false, update_rows);
+        rc = ha_mcs_impl_direct_update_delete_rows(false, update_rows, table);
     }
     catch (std::runtime_error& e)
     {
@@ -464,7 +464,7 @@ int ha_mcs::direct_update_rows(ha_rows *update_rows, ha_rows *found_rows)
     int rc;
     try
     {
-        rc = ha_mcs_impl_direct_update_delete_rows(false, update_rows);
+        rc = ha_mcs_impl_direct_update_delete_rows(false, update_rows, table);
         *found_rows = *update_rows;
     }
     catch (std::runtime_error& e)
@@ -487,7 +487,7 @@ int ha_mcs::direct_delete_rows(ha_rows *deleted_rows)
     int rc;
     try
     {
-        rc = ha_mcs_impl_direct_update_delete_rows(true, deleted_rows);
+        rc = ha_mcs_impl_direct_update_delete_rows(true, deleted_rows, table);
     }
     catch (std::runtime_error& e)
     {

--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -1194,7 +1194,7 @@ vector<string> getOnUpdateTimestampColumns(string& schema, string& tableName, in
     return returnVal;
 }
 
-uint32_t doUpdateDelete(THD* thd, gp_walk_info& gwi)
+uint32_t doUpdateDelete(THD* thd, gp_walk_info& gwi, TABLE *table)
 {
     if (get_fe_conn_info_ptr() == nullptr)
         set_fe_conn_info_ptr((void*)new cal_connection_info());
@@ -1780,7 +1780,7 @@ uint32_t doUpdateDelete(THD* thd, gp_walk_info& gwi)
 
         gwi.clauseType = WHERE;
 
-        if (getSelectPlan(gwi, select_lex, updateCP, false) != 0) //@Bug 3030 Modify the error message for unsupported functions
+        if (getSelectPlan(gwi, select_lex, updateCP, false, false, table) != 0) //@Bug 3030 Modify the error message for unsupported functions
         {
             if (gwi.cs_vtable_is_update_with_derive)
             {
@@ -2284,7 +2284,7 @@ int ha_mcs_impl_discover_existence(const char* schema, const char* name)
     return 0;
 }
 
-int ha_mcs_impl_direct_update_delete_rows(bool execute, ha_rows *affected_rows)
+int ha_mcs_impl_direct_update_delete_rows(bool execute, ha_rows *affected_rows, TABLE *table)
 {
     THD* thd = current_thd;
     int rc = 0;
@@ -2308,7 +2308,7 @@ int ha_mcs_impl_direct_update_delete_rows(bool execute, ha_rows *affected_rows)
 
     if (execute)
     {
-        rc = doUpdateDelete(thd, gwi);
+        rc = doUpdateDelete(thd, gwi, table);
     }
 
     cal_connection_info* ci = reinterpret_cast<cal_connection_info*>(get_fe_conn_info_ptr());
@@ -2384,7 +2384,7 @@ int ha_mcs_impl_rnd_init(TABLE* table)
 
     //Update and delete code
     if ( ((thd->lex)->sql_command == SQLCOM_UPDATE)  || ((thd->lex)->sql_command == SQLCOM_DELETE) || ((thd->lex)->sql_command == SQLCOM_DELETE_MULTI) || ((thd->lex)->sql_command == SQLCOM_UPDATE_MULTI))
-        return doUpdateDelete(thd, gwi);
+        return doUpdateDelete(thd, gwi, table);
 
     uint32_t sessionID = tid2sid(thd->thread_id);
     boost::shared_ptr<CalpontSystemCatalog> csc = CalpontSystemCatalog::makeCalpontSystemCatalog(sessionID);
@@ -3991,12 +3991,6 @@ COND* ha_mcs_impl_cond_push(COND* cond, TABLE* table)
 {
     THD* thd = current_thd;
 
-    if (((thd->lex)->sql_command == SQLCOM_UPDATE) ||
-            ((thd->lex)->sql_command == SQLCOM_UPDATE_MULTI) ||
-            ((thd->lex)->sql_command == SQLCOM_DELETE) ||
-            ((thd->lex)->sql_command == SQLCOM_DELETE_MULTI))
-        return cond;
-
     string alias;
     alias.assign(table->alias.ptr(), table->alias.length());
     IDEBUG( cout << "ha_mcs_impl_cond_push: " << alias << endl );
@@ -4025,7 +4019,6 @@ COND* ha_mcs_impl_cond_push(COND* cond, TABLE* table)
             ti.condInfo = new gp_walk_info();
 
         gp_walk_info* gwi = ti.condInfo;
-        gwi->dropCond = false;
         gwi->fatalParseError = false;
         gwi->condPush = true;
         gwi->thd = thd;
@@ -4047,14 +4040,7 @@ COND* ha_mcs_impl_cond_push(COND* cond, TABLE* table)
             return cond;
         }
 
-        if (gwi->dropCond)
-        {
-            return cond;
-        }
-        else
-        {
-            return nullptr;
-        }
+        return nullptr;
     }
 
     return cond;
@@ -4963,7 +4949,7 @@ int ha_cs_impl_pushdown_init(mcs_handler_info* handler_info, TABLE* table)
 
     //Update and delete code
     if ( ((thd->lex)->sql_command == SQLCOM_UPDATE)  || ((thd->lex)->sql_command == SQLCOM_DELETE) || ((thd->lex)->sql_command == SQLCOM_DELETE_MULTI) || ((thd->lex)->sql_command == SQLCOM_UPDATE_MULTI))
-        return doUpdateDelete(thd, gwi);
+        return doUpdateDelete(thd, gwi, table);
 
     uint32_t sessionID = tid2sid(thd->thread_id);
     boost::shared_ptr<CalpontSystemCatalog> csc = CalpontSystemCatalog::makeCalpontSystemCatalog(sessionID);

--- a/dbcon/mysql/ha_mcs_impl.h
+++ b/dbcon/mysql/ha_mcs_impl.h
@@ -42,7 +42,7 @@ extern int ha_mcs_impl_close_connection (handlerton* hton, THD* thd);
 extern COND* ha_mcs_impl_cond_push(COND* cond, TABLE* table);
 extern int ha_mcs_impl_external_lock(THD* thd, TABLE* table, int lock_type);
 extern int ha_mcs_impl_update_row();
-extern int ha_mcs_impl_direct_update_delete_rows(bool execute, ha_rows *affected_rows);
+extern int ha_mcs_impl_direct_update_delete_rows(bool execute, ha_rows *affected_rows, TABLE *table);
 extern int ha_mcs_impl_delete_row();
 extern int ha_mcs_impl_rnd_pos(uchar* buf, uchar* pos);
 extern int ha_cs_impl_pushdown_init(mcs_handler_info* handler_info, TABLE* table);

--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -118,7 +118,6 @@ struct gp_walk_info
     std::set<execplan::CalpontSystemCatalog::TableAliasName> innerTables;
     // the followinig members are used for table mode
     bool condPush;
-    bool dropCond;
     std::string funcName;
     std::vector<execplan::AggregateColumn*> count_asterisk_list;
     std::vector<execplan::FunctionColumn*> no_parm_func_list;
@@ -161,7 +160,6 @@ struct gp_walk_info
     gp_walk_info() : sessionid(0),
         fatalParseError(false),
         condPush(false),
-        dropCond(false),
         internalDecimalScale(4),
         thd(0),
         subSelectType(uint64_t(-1)),
@@ -342,7 +340,7 @@ int cp_get_table_plan(THD* thd, execplan::SCSEP& csep, cal_impl_if::cal_table_in
 int cp_get_group_plan(THD* thd, execplan::SCSEP& csep, cal_impl_if::cal_group_info& gi);
 int cs_get_derived_plan(derived_handler* handler, THD* thd, execplan::SCSEP& csep, gp_walk_info& gwi);
 int cs_get_select_plan(select_handler* handler, THD* thd, execplan::SCSEP& csep, gp_walk_info& gwi);
-int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, execplan::SCSEP& csep, bool isUnion = false, bool isSelectHandlerTop = false);
+int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, execplan::SCSEP& csep, bool isUnion = false, bool isSelectHandlerTop = false, TABLE *table = 0);
 int getGroupPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, execplan::SCSEP& csep, cal_group_info& gi, bool isUnion = false);
 void setError(THD* thd, uint32_t errcode, const std::string errmsg, gp_walk_info* gwi);
 void setError(THD* thd, uint32_t errcode, const std::string errmsg);


### PR DESCRIPTION
In case SELECT_LEX.where has empty where conditions,
get the where conditions from the condition pushdown.
This can happen when there are impossible conditions in
the where clause like:
  update cs1 set i = 41 where i = 42 or (i is null and 42 is null);