### PR TITLE
MCOL-4043 Fix memory leaks - 1

### DIFF
--- a/dbcon/execplan/simplefilter.cpp
+++ b/dbcon/execplan/simplefilter.cpp
@@ -150,8 +150,14 @@ SimpleFilter::SimpleFilter(const SimpleFilter& rhs) :
 SimpleFilter::~SimpleFilter()
 {
     //delete fOp;
-    delete fLhs;
-    delete fRhs;
+    if (fLhs != NULL)
+        delete fLhs;
+
+    if (fRhs != NULL)
+        delete fRhs;
+
+    fLhs = NULL;
+    fRhs = NULL;
 }
 
 /**

--- a/dbcon/joblist/jlf_common.h
+++ b/dbcon/joblist/jlf_common.h
@@ -363,6 +363,11 @@ struct JobInfo
     bool isDML;
     std::string timeZone;
 
+    // This is for tracking any dynamically allocated ParseTree objects
+    // in simpleScalarFilterToParseTree() for later deletion in
+    // JobList::~JobList()
+    std::vector<std::pair<execplan::ParseTree*, execplan::ParseTree*>> dynamicParseTreeVec;
+
 private:
     //defaults okay
     //JobInfo(const JobInfo& rhs);

--- a/dbcon/joblist/jlf_execplantojoblist.cpp
+++ b/dbcon/joblist/jlf_execplantojoblist.cpp
@@ -3251,6 +3251,12 @@ void doOR(ParseTree* n, JobInfo& jobInfo, bool tryCombine)
                             ccp->left(parseTree->left());
                             ccp->right(parseTree->right());
                             ccp->data(parseTree->data());
+                            jobInfo.dynamicParseTreeVec.push_back(make_pair(parseTree, ccp));
+                        }
+                        else if (parseTree)
+                        {
+                            delete parseTree;
+                            parseTree = NULL;
                         }
                     }
 

--- a/dbcon/joblist/jlf_subquery.cpp
+++ b/dbcon/joblist/jlf_subquery.cpp
@@ -192,7 +192,10 @@ void ssfInHaving(ParseTree* pt, void* obj)
             pt->right(parseTree->right());
             pt->data(parseTree->data());
 
+            jobInfo->dynamicParseTreeVec.push_back(make_pair(parseTree, pt));
             // don't delete the parseTree, it has been placed in the plan.
+            // Instead, we use the dynamicParseTreeVec above for deletion
+            // in the JobList dtor after the query executes.
             // delete parseTree;
         }
         else
@@ -627,7 +630,10 @@ void doSimpleScalarFilter(ParseTree* p, JobInfo& jobInfo)
         // create job steps for each simple filter
         JLF_ExecPlanToJobList::walkTree(parseTree, jobInfo);
 
+        jobInfo.dynamicParseTreeVec.push_back(make_pair(parseTree, ccp));
         // don't delete the parseTree, it has been placed in the plan.
+        // Instead, we use the dynamicParseTreeVec above for deletion
+        // in the JobList dtor after the query executes.
         // delete parseTree;
     }
     else

--- a/dbcon/joblist/joblist.cpp
+++ b/dbcon/joblist/joblist.cpp
@@ -142,6 +142,26 @@ JobList::~JobList()
                 (*iter)->join();
             }
         }
+
+        for (auto& parseTree : fDynamicParseTreeVec)
+        {
+            if (parseTree.first)
+            {
+                delete parseTree.first;
+                parseTree.first = NULL;
+                // Note that we don't delete parseTree.second here,
+                // that is handled by CalpontSelectExecutionPlan::unserialize().
+                // parseTree.first already deleted the objects pointed to by
+                // parseTree.second->left()/right()/data(), so we set the
+                // pointers to NULL here.
+                if (parseTree.second)
+                {
+                    parseTree.second->left((ParseTree*) (NULL));
+                    parseTree.second->right((ParseTree*) (NULL));
+                    parseTree.second->data((TreeNode*) (NULL));
+                }
+            }
+        }
     }
     catch (exception& ex)
     {

--- a/dbcon/joblist/joblist.h
+++ b/dbcon/joblist/joblist.h
@@ -34,6 +34,7 @@
 
 #include "jobstep.h"
 #include "bytestream.h"
+#include "parsetree.h"
 
 #ifndef __GNUC__
 #  ifndef __attribute__
@@ -190,6 +191,12 @@ public:
         fPmsConfigured = pms;
     }
 
+    virtual void setDynamicParseTreeVec(
+        const std::vector<std::pair<execplan::ParseTree*, execplan::ParseTree*>>& dynamicParseTreeVec)
+    {
+        fDynamicParseTreeVec = dynamicParseTreeVec;
+    }
+
 protected:
     //defaults okay
     //JobList(const JobList& rhs);
@@ -217,6 +224,7 @@ protected:
     volatile uint32_t fAborted;
 
     uint32_t fPriority;   //higher #s = higher priority
+    std::vector<std::pair<execplan::ParseTree*, execplan::ParseTree*>> fDynamicParseTreeVec;
 };
 
 class TupleJobList : public JobList

--- a/dbcon/joblist/joblistfactory.cpp
+++ b/dbcon/joblist/joblistfactory.cpp
@@ -1990,6 +1990,7 @@ SJLP makeJobList_(
         jl->addQuery(querySteps);
         jl->addProject(projectSteps);
         jl->addDelivery(deliverySteps);
+        jl->setDynamicParseTreeVec(jobInfo.dynamicParseTreeVec);
 
         dynamic_cast<TupleJobList*>(jl)->setDeliveryFlag(true);
     }


### PR DESCRIPTION
simpleScalarFilterToParseTree() performs a dynamic allocation
of a ParseTree object, but this memory is never freed later.
We now keep track of this allocation and perform the delete
in the JobList dtor after the query finishes.