### PR TITLE
MCOL-4043 Fix memory leaks - 2

### DIFF
--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -691,6 +691,24 @@ OrderByData::OrderByData(const std::vector<IdbSortSpec>& spec, const rowgroup::R
 }
 
 
+// OrderByData class dtor
+OrderByData::~OrderByData()
+{
+    // delete compare objects
+    vector<Compare*>::iterator i = fRule.fCompares.begin();
+
+    while (i != fRule.fCompares.end())
+    {
+        if (*i)
+        {
+            delete *i;
+            *i = NULL;
+        }
+        i++;
+    }
+}
+
+
 // IdbOrderBy class implementation
 IdbOrderBy::IdbOrderBy() :
     fDistinct(false), fMemSize(0), fRowsPerRG(rowgroup::rgCommonSize),

--- a/utils/windowfunction/idborderby.h
+++ b/utils/windowfunction/idborderby.h
@@ -368,7 +368,7 @@ class OrderByData : public IdbCompare
 {
 public:
     OrderByData(const std::vector<IdbSortSpec>&, const rowgroup::RowGroup&);
-    virtual ~OrderByData() {};
+    virtual ~OrderByData();
 
     bool operator() (rowgroup::Row::Pointer p1, rowgroup::Row::Pointer p2)
     {


### PR DESCRIPTION
Perform deletes of Compare objects in the OrderByData dtor,
which were allocated by CompareRule::compileRules().