### PR TITLE
Fixed a bug on init for non-systemd systems (MCOL-4083)

### DIFF
--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -226,7 +226,11 @@ if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
     systemctl restart mariadb.service > /dev/null 2>&1
 else
     pkill mysqld > /dev/null 2>&1
+    while [ -n "$(pgrep -x mysqld)" ] ; do
+        sleep 1
+    done
     /usr/bin/mysqld_safe &
+    sleep 2  
 fi
 
 checkForError


### PR DESCRIPTION
Fixed a bug where we would restart mysqld but not wait for the old one to go
away, or for the new one to start before connecting to it with the client.  Only
affects non-systemd systems.