### PR TITLE
MCOL-4109 Error out instead of sending a warning

### DIFF
--- a/dbcon/ddlpackageproc/ddlpackageprocessor.h
+++ b/dbcon/ddlpackageproc/ddlpackageprocessor.h
@@ -88,7 +88,7 @@ public:
      */
     enum ResultCode { NO_ERROR, CREATE_ERROR,  ALTER_ERROR, DROP_ERROR, TRUNC_ERROR,
                       TOKENIZATION_ERROR, NOT_ACCEPTING_PACKAGES, PK_NOTNULL_ERROR, WARNING, USER_ERROR, NETWORK_ERROR, PARTITION_WARNING,
-                      WARN_NO_PARTITION
+                      WARN_NO_PARTITION, DROP_TABLE_NOT_IN_CATALOG_ERROR
                     };
 
     enum DebugLevel                            /** @brief Debug level type enumeration */

--- a/dbcon/ddlpackageproc/droptableprocessor.cpp
+++ b/dbcon/ddlpackageproc/droptableprocessor.cpp
@@ -151,12 +151,9 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackage(ddlpackage::Dro
             {
                 Message::Args args;
                 Message message(1);
-                args.add("Table dropped with warning ");
-                args.add("Table does not exist in columnstore engine.");
-                args.add("");
-                args.add("");
+                args.add("Table does not exist in ColumnStore.");
                 message.format(args);
-                result.result = WARNING;
+                result.result = DROP_TABLE_NOT_IN_CATALOG_ERROR;
                 result.message = message;
                 fSessionManager.rolledback(txnID);
                 return result;

--- a/dbcon/mysql/ha_mcs_ddl.cpp
+++ b/dbcon/mysql/ha_mcs_ddl.cpp
@@ -2128,6 +2128,11 @@ int ProcessDDLStatement(string& ddlStatement, string& schema, const string& tabl
             ci->isAlter = false;
         }
 
+        if (b == ddlpackageprocessor::DDLPackageProcessor::DROP_TABLE_NOT_IN_CATALOG_ERROR)
+        {
+            return ER_NO_SUCH_TABLE_IN_ENGINE;
+        }
+
         if ((b != 0) && (b != ddlpackageprocessor::DDLPackageProcessor::WARNING))
         {
             thd->get_stmt_da()->set_overwrite_status(true);
@@ -2583,7 +2588,7 @@ int ha_mcs_impl_delete_table_(const char* db, const char* name, cal_connection_i
     stmt += ";";
     int rc = ProcessDDLStatement(stmt, schema, tbl, tid2sid(thd->thread_id), emsg);
 
-    if (rc != 0)
+    if (rc != 0 && rc != ER_NO_SUCH_TABLE_IN_ENGINE)
     {
         push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 9999, emsg.c_str());
     }


### PR DESCRIPTION
when a non-existing table is dropped.

This patch accomodates the changes made to server 10.5 as part
of MDEV-11412, where the server now tries to drop the table from
all storage engines when a .frm table does not exist.

We were earlier retuning a warning to the client and setting the
return code to 0. We now instead return ER_NO_SUCH_TABLE_IN_ENGINE
error code to the server if the table does not exist in
ColumnStore.