### PR TITLE
Revert "MCOL-4126 reset ci->tableOid after INSERT|DELETE"

### DIFF
--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -2248,9 +2248,6 @@ uint32_t doUpdateDelete(THD* thd, gp_walk_info& gwi, const std::vector<COND*>& c
 
     delete ci->dmlProc;
     ci->dmlProc = nullptr;
-
-    ci->tableOid = 0;
-    
     return rc;
 }
 


### PR DESCRIPTION
Reverts mariadb-corporation/mariadb-columnstore-engine#1318

Dave & I spotted problems after I merged it.