### PR TITLE
make columnstore to load in enterprise

### DIFF
--- a/dbcon/mysql/CMakeLists.txt
+++ b/dbcon/mysql/CMakeLists.txt
@@ -66,3 +66,5 @@ install(PROGRAMS install_mcs_mysql.sh
 
 install(FILES columnstore.cnf
     DESTINATION ${MARIADB_MYCNFDIR} COMPONENT columnstore-engine)
+install(FILES x-columnstore.cnf
+    DESTINATION ${MARIADB_MYCNFDIR} COMPONENT columnstore-engine)

--- a/dbcon/mysql/ha_mcs.cpp
+++ b/dbcon/mysql/ha_mcs.cpp
@@ -28,7 +28,7 @@
 #include "ha_mcs_version.h"
 
 #ifndef COLUMNSTORE_MATURITY
-#define COLUMNSTORE_MATURITY MariaDB_PLUGIN_MATURITY_STABLE
+#define COLUMNSTORE_MATURITY MariaDB_PLUGIN_MATURITY_BETA
 #endif
 
 #define CACHE_PREFIX "#cache#"

--- a/dbcon/mysql/x-columnstore.cnf
+++ b/dbcon/mysql/x-columnstore.cnf
@@ -1,0 +1,3 @@
+# make ha_columnstore.so to load
+[mariadb]
+plugin-maturity=beta


### PR DESCRIPTION
.cnf file overwriting plugin-maturity must be lexicographically
after mariadb-enterprise.cnf

also set the maturity correctly without relying on supermodule doing it