### PR TITLE
MCOL-4169 Prevent mcs-loadbrm from starting up twice

### DIFF
--- a/oam/install_scripts/mariadb-columnstore-start.sh
+++ b/oam/install_scripts/mariadb-columnstore-start.sh
@@ -2,7 +2,6 @@
 
 # This script allows to gracefully start MCS
 
-/bin/systemctl start mcs-loadbrm
 /bin/systemctl start mcs-workernode
 /bin/systemctl start mcs-controllernode
 /bin/systemctl start mcs-primproc


### PR DESCRIPTION
No need to explicitly call start mcs-loadbrm in areas where we start mcs-workernode. This will unintentionally call mcs-loadbrm twice.