### PR TITLE
MCOL-4181: Possible setting of ci->stats.fUser to NULL causing crash.

### DIFF
--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -5022,7 +5022,14 @@ int ha_cs_impl_pushdown_init(mcs_handler_info* handler_info, TABLE* table)
     {
         ci->stats.reset(); // reset query stats
         ci->stats.setStartTime();
-        ci->stats.fUser = thd->main_security_ctx.user;
+        if (thd->main_security_ctx.user)
+        {
+            ci->stats.fUser = thd->main_security_ctx.user;
+        }
+        else
+        {
+            ci->stats.fUser = "";
+        }
 
         if (thd->main_security_ctx.host)
             ci->stats.fHost = thd->main_security_ctx.host;


### PR DESCRIPTION
This was fixed everywhere else in code the same way as part of MCOL-593. This appears to have been overlooked possibly. 
