### PR TITLE
MCOL-641 Ternary operation with different datatype of the two

### DIFF
--- a/datatypes/mcs_decimal.h
+++ b/datatypes/mcs_decimal.h
@@ -155,16 +155,6 @@ inline void getScaleDivisor(T& divisor, const int8_t scale)
     }
 }
 
-/**
-    @brief The template to generalise common math operation
-    execution path using struct from <functional>.
-*/
-template<typename BinaryOperation, typename OverflowCheck>
-void execute(const execplan::IDB_Decimal& l,
-    const execplan::IDB_Decimal& r,
-    execplan::IDB_Decimal& result,
-    BinaryOperation op,
-    OverflowCheck overflowCheck);
 
 /**
     @brief Contains subset of decimal related operations.

--- a/versioning/BRM/extentmap.cpp
+++ b/versioning/BRM/extentmap.cpp
@@ -829,9 +829,8 @@ void ExtentMap::mergeExtentsMaxMin(CPMaxMinMergeMap_t& cpMap, bool useLock)
                     // Merge input min/max with current min/max
                     case CP_VALID:
                     {
-                        if (!isValidCPRange( !isBinaryColumn ? it->second.max : it->second.bigMax,
-                                             !isBinaryColumn ? it->second.min : it->second.bigMin,
-                                             it->second.type ))
+                        if ((!isBinaryColumn && !isValidCPRange(it->second.max, it->second.min, it->second.type)) ||
+                            (isBinaryColumn && !isValidCPRange(it->second.bigMax, it->second.bigMin, it->second.type)))
                         {
                             break;
                         }
@@ -843,10 +842,8 @@ void ExtentMap::mergeExtentsMaxMin(CPMaxMinMergeMap_t& cpMap, bool useLock)
                         // having all NULL values, in which case the current
                         // min/max needs to be set instead of merged.
 
-                        if (isValidCPRange(
-                                    !isBinaryColumn ? fExtentMap[i].partition.cprange.hiVal : fExtentMap[i].partition.cprange.bigHiVal,
-                                    !isBinaryColumn ? fExtentMap[i].partition.cprange.loVal : fExtentMap[i].partition.cprange.bigLoVal,
-                                    it->second.type))
+                        if ((!isBinaryColumn && isValidCPRange(fExtentMap[i].partition.cprange.hiVal, fExtentMap[i].partition.cprange.loVal, it->second.type)) ||
+                            (isBinaryColumn && isValidCPRange(fExtentMap[i].partition.cprange.bigHiVal, fExtentMap[i].partition.cprange.bigLoVal, it->second.type)))
                         {
                             // Swap byte order to do binary string comparison
                             if (isCharType(it->second.type))
@@ -981,9 +978,8 @@ void ExtentMap::mergeExtentsMaxMin(CPMaxMinMergeMap_t& cpMap, bool useLock)
 
                         if (it->second.newExtent)
                         {
-                            if (isValidCPRange( !isBinaryColumn ? it->second.max : it->second.bigMax,
-                                                !isBinaryColumn ? it->second.min : it->second.bigMin,
-                                                it->second.type ))
+                            if ((!isBinaryColumn && isValidCPRange(it->second.max, it->second.min, it->second.type)) ||
+                                (isBinaryColumn && isValidCPRange(it->second.bigMax, it->second.bigMin, it->second.type)))
                             {
                                 if (!isBinaryColumn)
                                 {


### PR DESCRIPTION
resulting expressions cannot be used as a template argument.
This is because the template instantiation happens at compile time
and cannot depend on the runtime value of the evaluating expression.