### PR TITLE
::writeRow now treats WR_BINARY as int128 for 16 bytes DT only

### DIFF
--- a/dbcon/ddlpackage/ddl.l
+++ b/dbcon/ddlpackage/ddl.l
@@ -189,7 +189,6 @@ LONGTEXT {return LONGTEXT;}
 BOOL {return BOOL;}
 BOOLEAN {return BOOLEAN;}
 MEDIUMINT {return MEDIUMINT;}
-BINARY {return BINARY;}
 ZEROFILL {return ZEROFILL;}
 
 \n { lineno++;}

--- a/dbcon/ddlpackage/ddl.y
+++ b/dbcon/ddlpackage/ddl.y
@@ -104,7 +104,7 @@ char* copy_string(const char *str);
 
 %token ACTION ADD ALTER AUTO_INCREMENT BIGINT BIT BLOB IDB_BLOB CASCADE IDB_CHAR
 CHARACTER CHECK CLOB COLUMN
-BOOL BOOLEAN BINARY
+BOOL BOOLEAN
 COLUMNS COMMENT CONSTRAINT CONSTRAINTS CREATE CURRENT_USER DATETIME DEC
 DECIMAL DEFAULT DEFERRABLE DEFERRED IDB_DELETE DROP ENGINE
 FOREIGN FULL IMMEDIATE INDEX INITIALLY IDB_INT INTEGER KEY LONGBLOB LONGTEXT
@@ -133,7 +133,6 @@ ZEROFILL
 %type <ata>                  ata_rename_table
 %type <columnType>           character_string_type
 %type <columnType>           binary_string_type
-%type <columnType>           fixed_binary_string_type
 %type <columnType>           blob_type
 %type <columnType>           text_type
 %type <str>                  check_constraint_def
@@ -752,7 +751,6 @@ opt_column_collate:
 data_type:
 	character_string_type opt_column_charset opt_column_collate
 	| binary_string_type
-	| fixed_binary_string_type
 	| numeric_type
 	| datetime_type
 	| blob_type
@@ -920,14 +918,6 @@ binary_string_type:
 	VARBINARY '(' ICONST ')'
 	{
 		$$ = new ColumnType(DDL_VARBINARY);
-		$$->fLength = atoi($3);
-	}
-	;
-
-fixed_binary_string_type:
-	BINARY '(' ICONST ')'
-	{
-		$$ = new ColumnType(DDL_BINARY);
 		$$->fLength = atoi($3);
 	}
 	;

--- a/utils/windowfunction/wf_sum_avg.cpp
+++ b/utils/windowfunction/wf_sum_avg.cpp
@@ -54,50 +54,60 @@ namespace windowfunction
 {
 
 template<typename T_IN, typename T_OUT>
-inline void WF_sum_avg<T_IN,T_OUT>::checkSumLimit(T_IN& val, T_OUT& sum)
+inline void WF_sum_avg<T_IN,T_OUT>::checkSumLimit(const T_IN& val,
+    const T_OUT& sum)
 { }
 
 template<>
-inline void WF_sum_avg<int128_t,int128_t>::checkSumLimit(int128_t& val, int128_t& sum)
+inline void WF_sum_avg<int128_t,int128_t>::checkSumLimit(const int128_t& val, 
+    const int128_t& sum)
 {
     datatypes::AdditionOverflowCheck ofCheckOp;
     ofCheckOp(sum, val);
 }
 
 template<>
-inline void WF_sum_avg<long double,long double>::checkSumLimit(long double& val, long double& sum)
+inline void WF_sum_avg<long double,long double>::checkSumLimit(const long double& val, 
+    const long double& sum)
 { }
 
 template<>
-inline void WF_sum_avg<float, long double>::checkSumLimit(float&, long double&)
+inline void WF_sum_avg<float, long double>::checkSumLimit(const float&,
+    const long double&)
 { }
 
 template<>
-inline void WF_sum_avg<long, long double>::checkSumLimit(long&, long double&)
+inline void WF_sum_avg<long, long double>::checkSumLimit(const long&,
+    const long double&)
 { }
 
 template<>
-inline void WF_sum_avg<unsigned long, long double>::checkSumLimit(unsigned long&, long double&)
+inline void WF_sum_avg<unsigned long, long double>::checkSumLimit(const unsigned long&,
+    const long double&)
 { }
 template<>
-inline void WF_sum_avg<double, long double>::checkSumLimit(double&, long double&)
+inline void WF_sum_avg<double, long double>::checkSumLimit(const double&,
+    const long double&)
 { }
 
 template<>
-void WF_sum_avg<int128_t,int128_t>::checkSumLimit(int128_t& val, int128_t& sum);
+void WF_sum_avg<int128_t,int128_t>::checkSumLimit(const int128_t&, const int128_t&);
 template<>
-void WF_sum_avg<long double,long double>::checkSumLimit(long double& val, long double& sum);
+void WF_sum_avg<long double,long double>::checkSumLimit(const long double& val, const long double&);
 template<>
-void WF_sum_avg<float, long double>::checkSumLimit(float&, long double&);
+void WF_sum_avg<float, long double>::checkSumLimit(const float&, const long double&);
 template<>
-void WF_sum_avg<long, long double>::checkSumLimit(long&, long double&);
+void WF_sum_avg<long, long double>::checkSumLimit(const long&, const long double&);
 template<>
-void WF_sum_avg<unsigned long, long double>::checkSumLimit(unsigned long&, long double&);
+void WF_sum_avg<unsigned long, long double>::checkSumLimit(const unsigned long&,
+    const long double&);
 template<>
-void WF_sum_avg<double, long double>::checkSumLimit(double&, long double&);
+void WF_sum_avg<double, long double>::checkSumLimit(const double&, const long double&);
 
 template<typename T_IN, typename T_OUT>
-int128_t WF_sum_avg<T_IN, T_OUT>::calculateAvg(int128_t sum, uint64_t count, int scale)
+int128_t WF_sum_avg<T_IN, T_OUT>::calculateAvg(const int128_t& sum,
+    const uint64_t count,
+    const int scale)
 {
     int128_t avg = 0;
     int128_t factor;
@@ -133,7 +143,9 @@ int128_t WF_sum_avg<T_IN, T_OUT>::calculateAvg(int128_t sum, uint64_t count, int
 }
 
 template<typename T_IN, typename T_OUT>
-inline long double WF_sum_avg<T_IN, T_OUT>::calculateAvg(long double sum, uint64_t count, int scale)
+inline long double WF_sum_avg<T_IN, T_OUT>::calculateAvg(const long double& sum, 
+    const uint64_t count, 
+    const int scale)
 {
     return sum / count;
 }

--- a/utils/windowfunction/wf_sum_avg.h
+++ b/utils/windowfunction/wf_sum_avg.h
@@ -56,15 +56,11 @@ protected:
     bool        fDistinct;
     std::set<T_IN> fSet;
 
-    void checkSumLimit(T_IN& val, T_OUT& sum);
+    void checkSumLimit(const T_IN& val, const T_OUT& sum);
 
-    int128_t calculateAvg(int128_t sum, uint64_t count, int scale);
-    long double calculateAvg(long double sum, uint64_t count, int scale);
+    int128_t calculateAvg(const int128_t& sum, const uint64_t count, const int scale);
+    long double calculateAvg(const long double& sum, const uint64_t count, const int scale);
 };
-
-template<>
-void WF_sum_avg<long double,long double>::checkSumLimit(long double& val, long double& sum);
-
 
 } // namespace
 

--- a/writeengine/shared/we_define.h
+++ b/writeengine/shared/we_define.h
@@ -36,6 +36,8 @@
 /** Namespace WriteEngine */
 namespace WriteEngine
 {
+// Max column size is 16 bytes since MCOL-641. However left this value
+// for backward compatibility
 const short MAX_COLUMN_BOUNDARY     = 8;        // Max bytes for one column
 const int   MAX_SIGNATURE_SIZE      = 8000;     // Max len of dict sig val
 const int   MAX_FIELD_SIZE          = 1000;     // Max len non-dict fld val

--- a/writeengine/wrapper/we_colop.cpp
+++ b/writeengine/wrapper/we_colop.cpp
@@ -47,6 +47,7 @@ using namespace execplan;
 using namespace idbdatafile;
 
 #include "emptyvaluemanip.h"
+#include "mcs_decimal.h"
 
 namespace WriteEngine
 {
@@ -1670,8 +1671,6 @@ int ColumnOp::writeRow(Column& curCol, uint64_t totalRow, const RID* rowIdArray,
             bDataDirty = true;
         }
 
-        // This is a awkward way to convert void* and get its element, I just don't have a good solution for that
-        // How about pVal = valArray + i*curCol.colWidth?
         switch (curCol.colType)
         {
             case WriteEngine::WR_FLOAT :
@@ -1735,7 +1734,11 @@ int ColumnOp::writeRow(Column& curCol, uint64_t totalRow, const RID* rowIdArray,
                 break;
 
             case WriteEngine::WR_BINARY:
-                if (!bDelete) pVal = &((int128_t*) valArray)[i];
+                if (!bDelete)
+                {
+                    if (curCol.colWidth == datatypes::MAXDECIMALWIDTH)
+                        pVal = &((int128_t*) valArray)[i];
+                }
                 break;
                 
             default  :

--- a/writeengine/wrapper/writeengine.cpp
+++ b/writeengine/wrapper/writeengine.cpp
@@ -837,84 +837,22 @@ int WriteEngineWrapper::deleteRow(const TxnID& txnid, const vector<CSCTypesList>
 inline void allocateValArray(void*& valArray, ColTupleList::size_type totalRow,
                              ColType colType, int colWidth)
 {
+    // MCS allocates 8 bytes even for CHARs smaller then 8 bytes.
     switch (colType)
     {
         case WriteEngine::WR_VARBINARY : // treat same as char for now
         case WriteEngine::WR_CHAR:
         case WriteEngine::WR_BLOB:
         case WriteEngine::WR_TEXT:
-            valArray = (char*) calloc(sizeof(char), totalRow * MAX_COLUMN_BOUNDARY);
+            valArray = calloc(sizeof(char), totalRow * MAX_COLUMN_BOUNDARY);
             break;
         case WriteEngine::WR_TOKEN:
-            valArray = (Token*) calloc(sizeof(Token), totalRow);
+            valArray = calloc(sizeof(Token), totalRow);
             break;
         default:
             valArray = calloc(totalRow, colWidth);
             break;
     }
-    // TODO MCOL-641 is commenting out the switch statement below correct?
-#if 0
-    switch (colType)
-    {
-        case WriteEngine::WR_INT:
-        case WriteEngine::WR_MEDINT:
-            valArray = (int*) calloc(sizeof(int), totalRow);
-            break;
-
-        case WriteEngine::WR_UINT:
-        case WriteEngine::WR_UMEDINT:
-            valArray = (uint32_t*) calloc(sizeof(uint32_t), totalRow);
-            break;
-
-        case WriteEngine::WR_VARBINARY : // treat same as char for now
-        case WriteEngine::WR_CHAR:
-        case WriteEngine::WR_BLOB:
-        case WriteEngine::WR_TEXT:
-            valArray = (char*) calloc(sizeof(char), totalRow * MAX_COLUMN_BOUNDARY);
-            break;
-
-        case WriteEngine::WR_FLOAT:
-            valArray = (float*) calloc(sizeof(float), totalRow);
-            break;
-
-        case WriteEngine::WR_DOUBLE:
-            valArray = (double*) calloc(sizeof(double), totalRow);
-            break;
-
-        case WriteEngine::WR_BYTE:
-            valArray = (char*) calloc(sizeof(char), totalRow);
-            break;
-
-        case WriteEngine::WR_UBYTE:
-            valArray = (uint8_t*) calloc(sizeof(uint8_t), totalRow);
-            break;
-
-        case WriteEngine::WR_SHORT:
-            valArray = (short*) calloc(sizeof(short), totalRow);
-            break;
-
-        case WriteEngine::WR_USHORT:
-            valArray = (uint16_t*) calloc(sizeof(uint16_t), totalRow);
-            break;
-
-        case WriteEngine::WR_LONGLONG:
-            valArray = (long long*) calloc(sizeof(long long), totalRow);
-            break;
-
-        case WriteEngine::WR_ULONGLONG:
-            valArray = (uint64_t*) calloc(sizeof(uint64_t), totalRow);
-            break;
-
-        case WriteEngine::WR_TOKEN:
-            valArray = (Token*) calloc(sizeof(Token), totalRow);
-            break;
-
-        case WriteEngine::WR_BINARY:
-            valArray = calloc(totalRow, colWidth);
-            break;
-
-    }
-#endif
 }
 
 int WriteEngineWrapper::deleteBadRows(const TxnID& txnid, ColStructList& colStructs,


### PR DESCRIPTION
WF avg uses const & as arguments types

This should be merged only by the last reviewer. 