### PR TITLE
Update the package scripts, remove arguments passed to columnstore-post-install

### DIFF
--- a/build/debian/storageEngine/postinst
+++ b/build/debian/storageEngine/postinst
@@ -1,8 +1,6 @@
 #!/bin/bash -e
 
-rpmmode=install
-
-columnstore-post-install --rpmmode=$rpmmode
+columnstore-post-install
 
 echo "MariaDB ColumnStore install completed"
 

--- a/build/postInstall_storage_engine.sh
+++ b/build/postInstall_storage_engine.sh
@@ -1,10 +1,5 @@
-rpmmode=install
-if  [ "$1" -eq "$1" 2> /dev/null ]; then
-	if [ $1 -ne 1 ]; then
-		rpmmode=upgrade
-	fi
-fi
 
 mkdir -p /var/lib/columnstore/local
-columnstore-post-install --rpmmode=$rpmmode
+columnstore-post-install 
 
+exit 0

--- a/build/preInstall_storage_engine.sh
+++ b/build/preInstall_storage_engine.sh
@@ -1,6 +1,6 @@
 
 if [ "$1" == "2" ]; then
-    /bin/cp -f /etc/columnstore/storagemanager.cnf /etc/columnstore/storagemanager.cnf.rpmsave > /dev/null 2>&1
     columnstore-pre-uninstall
 fi
+
 exit 0


### PR DESCRIPTION
This is not breaking any functionality but slowly cleaning up some scripts with unnecessary code.