### PR TITLE
MCOL-4264 [Cross-Engine] UPDATE to INNODB table with WHERE clause usi…

### DIFF
--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -262,7 +262,8 @@ struct cal_connection_info
         utf8(false),
         useCpimport(1),
         delimiter('\7'),
-        affectedRows(0)
+        affectedRows(0),
+        lock_type(F_UNLCK)
     {
         // check if this is a slave mysql daemon
         isSlaveNode = checkSlave();
@@ -283,6 +284,11 @@ struct cal_connection_info
             return false;
 
         return true;
+    }
+
+    bool isReadOnly() const
+    {
+        return lock_type == F_RDLCK;
     }
 
     sm::cpsm_conhdl_t* cal_conn_hndl;
@@ -335,6 +341,7 @@ struct cal_connection_info
     // MCOL-1101 remove compilation unit variable rmParms
     std::vector <execplan::RMParam> rmParms;
     long long affectedRows;
+    int lock_type;
 };
 
 const std::string infinidb_err_msg = "\nThe query includes syntax that is not supported by MariaDB Columnstore. Use 'show warnings;' to get more information. Review the MariaDB Columnstore Syntax guide for additional information on supported distributed syntax or consider changing the MariaDB Columnstore Operating Mode (infinidb_vtable_mode).";


### PR DESCRIPTION
Please review my patch for:

MCOL-4264 [Cross-Engine] UPDATE to INNODB table with WHERE clause using Columnstore as sub query failing

Thanks.
