### PR TITLE
MCOL-4264 [Cross-Engine] UPDATE to INNODB table with WHERE clause usi…

### DIFF
--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -262,7 +262,8 @@ struct cal_connection_info
         utf8(false),
         useCpimport(1),
         delimiter('\7'),
-        affectedRows(0)
+        affectedRows(0),
+        lock_type(F_UNLCK)
     {
         // check if this is a slave mysql daemon
         isSlaveNode = checkSlave();
@@ -283,6 +284,11 @@ struct cal_connection_info
             return false;
 
         return true;
+    }
+
+    bool isReadOnly() const
+    {
+        return lock_type == F_RDLCK;
     }
 
     sm::cpsm_conhdl_t* cal_conn_hndl;
@@ -335,6 +341,7 @@ struct cal_connection_info
     // MCOL-1101 remove compilation unit variable rmParms
     std::vector <execplan::RMParam> rmParms;
     long long affectedRows;
+    int lock_type;
 };
 
 const std::string infinidb_err_msg = "\nThe query includes syntax that is not supported by MariaDB Columnstore. Use 'show warnings;' to get more information. Review the MariaDB Columnstore Syntax guide for additional information on supported distributed syntax or consider changing the MariaDB Columnstore Operating Mode (infinidb_vtable_mode).";


### PR DESCRIPTION
…ng Columnstore as sub query failing

Problem:

When processing cross-engine queries like:

update cstab1 set a=100 where a not in (select a from innotab1 where a=11);
delete from innotab1  where a not in (select a from cstab1 where a=1);

the ColumnStore plugin erroneously executed the whole query inside
ColumnStore.

Fix:

- Adding a new member cal_connection_info::lock_type and setting it
  inside ha_mcs_impl_external_lock() to the value passed in the parameter
  "lock_type".

- Adding a method cal_connection_info::isReadOnly() to test
  if the last table lock made in ha_mcs_impl_external_lock()
  for done for reading.

- Adding a new condition checking cal_connection_info::isReadOnly() inside
  ha_mcs_impl_rnd_init(). If the current table was locked last time for reading,
  then doUpdateDelete() should not be executed.