### PR TITLE
MCOL-4303 UPDATE..SET using another table is not updating

### DIFF
--- a/dbcon/mysql/ha_mcs.cpp
+++ b/dbcon/mysql/ha_mcs.cpp
@@ -167,7 +167,8 @@ ha_mcs::ha_mcs(handlerton* hton, TABLE_SHARE* table_arg) :
     int_table_flags(HA_BINLOG_STMT_CAPABLE | HA_BINLOG_ROW_CAPABLE |
                     HA_TABLE_SCAN_ON_INDEX |
                     HA_CAN_TABLE_CONDITION_PUSHDOWN |
-                    HA_CAN_DIRECT_UPDATE_AND_DELETE)
+                    HA_CAN_DIRECT_UPDATE_AND_DELETE),
+    m_lock_type(F_UNLCK)
 { }
 
 
@@ -578,7 +579,7 @@ int ha_mcs::rnd_init(bool scan)
     {
         try
         {
-            rc = ha_mcs_impl_rnd_init(table, condStack);
+            rc = impl_rnd_init(table, condStack);
         }
         catch (std::runtime_error& e)
         {
@@ -861,7 +862,7 @@ int ha_mcs::external_lock(THD* thd, int lock_type)
         if ((thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN)))
             trans_register_ha( thd, true, mcs_hton, 0);
 
-        rc = ha_mcs_impl_external_lock(thd, table, lock_type);
+        rc = impl_external_lock(thd, table, lock_type);
     }
     catch (std::runtime_error& e)
     {

--- a/dbcon/mysql/ha_mcs.h
+++ b/dbcon/mysql/ha_mcs.h
@@ -51,6 +51,10 @@ class ha_mcs: public handler
     // as apparently there is a linker error on the std::stack<COND*>::pop()
     // call on Ubuntu18.
     std::vector<COND*> condStack;
+    int m_lock_type;
+
+    int impl_external_lock(THD* thd, TABLE* table, int lock_type);
+    int impl_rnd_init(TABLE* table, const std::vector<COND*>& condStack);
 
 public:
     ha_mcs(handlerton* hton, TABLE_SHARE* table_arg);
@@ -239,6 +243,11 @@ public:
 
     int repair(THD* thd, HA_CHECK_OPT* check_opt);
     bool is_crashed() const;
+
+    bool isReadOnly() const
+    {
+      return m_lock_type == F_RDLCK;
+    }
 };
 
 

--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -2286,7 +2286,7 @@ int ha_mcs_impl_direct_update_delete_rows(bool execute, ha_rows *affected_rows, 
     return rc;
 }
 
-int ha_mcs_impl_rnd_init(TABLE* table, const std::vector<COND*>& condStack)
+int ha_mcs::impl_rnd_init(TABLE* table, const std::vector<COND*>& condStack)
 {
     IDEBUG( cout << "rnd_init for table " << table->s->table_name.str << endl );
     THD* thd = current_thd;
@@ -2356,7 +2356,7 @@ int ha_mcs_impl_rnd_init(TABLE* table, const std::vector<COND*>& condStack)
 
       UPDATE innotab1 SET a=100 WHERE a NOT IN (SELECT a FROM cstab1 WHERE a=1);
     */
-    if (!ci->isReadOnly() && // make sure the current table is being modified
+    if (!isReadOnly() && // make sure the current table is being modified
         (thd->lex->sql_command == SQLCOM_UPDATE ||
          thd->lex->sql_command == SQLCOM_DELETE ||
          thd->lex->sql_command == SQLCOM_DELETE_MULTI ||
@@ -4061,7 +4061,7 @@ COND* ha_mcs_impl_cond_push(COND* cond, TABLE* table, std::vector<COND*>& condSt
     return cond;
 }
 
-int ha_mcs_impl_external_lock(THD* thd, TABLE* table, int lock_type)
+int ha_mcs::impl_external_lock(THD* thd, TABLE* table, int lock_type)
 {
     // @bug 3014. Error out locking table command. IDB does not support it now.
     if (thd->lex->sql_command == SQLCOM_LOCK_TABLES)
@@ -4090,7 +4090,7 @@ int ha_mcs_impl_external_lock(THD* thd, TABLE* table, int lock_type)
         return 0;
     }
 
-    ci->lock_type= lock_type;
+    m_lock_type= lock_type;
 
     CalTableMap::iterator mapiter = ci->tableMap.find(table);
     // make sure this is a release lock (2nd) call called in

--- a/dbcon/mysql/ha_mcs_impl.h
+++ b/dbcon/mysql/ha_mcs_impl.h
@@ -29,7 +29,6 @@ extern int ha_mcs_impl_create(const char* name, TABLE* table_arg, HA_CREATE_INFO
 extern int ha_mcs_impl_delete_table(const char* name);
 extern int ha_mcs_impl_open(const char* name, int mode, uint32_t test_if_locked);
 extern int ha_mcs_impl_close(void);
-extern int ha_mcs_impl_rnd_init(TABLE* table, const std::vector<COND*>& condStack);
 extern int ha_mcs_impl_rnd_next(uchar* buf, TABLE* table);
 extern int ha_mcs_impl_rnd_end(TABLE* table, bool is_derived_hand = false);
 extern int ha_mcs_impl_write_row(const uchar* buf, TABLE* table, uint64_t rows_changed);
@@ -40,7 +39,6 @@ extern int ha_mcs_impl_commit (handlerton* hton, THD* thd, bool all);
 extern int ha_mcs_impl_rollback (handlerton* hton, THD* thd, bool all);
 extern int ha_mcs_impl_close_connection (handlerton* hton, THD* thd);
 extern COND* ha_mcs_impl_cond_push(COND* cond, TABLE* table, std::vector<COND*>&);
-extern int ha_mcs_impl_external_lock(THD* thd, TABLE* table, int lock_type);
 extern int ha_mcs_impl_update_row();
 extern int ha_mcs_impl_direct_update_delete_rows(bool execute, ha_rows *affected_rows, const std::vector<COND*>& condStack);
 extern int ha_mcs_impl_delete_row();

--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -262,8 +262,7 @@ struct cal_connection_info
         utf8(false),
         useCpimport(1),
         delimiter('\7'),
-        affectedRows(0),
-        lock_type(F_UNLCK)
+        affectedRows(0)
     {
         // check if this is a slave mysql daemon
         isSlaveNode = checkSlave();
@@ -284,11 +283,6 @@ struct cal_connection_info
             return false;
 
         return true;
-    }
-
-    bool isReadOnly() const
-    {
-        return lock_type == F_RDLCK;
     }
 
     sm::cpsm_conhdl_t* cal_conn_hndl;
@@ -341,7 +335,6 @@ struct cal_connection_info
     // MCOL-1101 remove compilation unit variable rmParms
     std::vector <execplan::RMParam> rmParms;
     long long affectedRows;
-    int lock_type;
 };
 
 const std::string infinidb_err_msg = "\nThe query includes syntax that is not supported by MariaDB Columnstore. Use 'show warnings;' to get more information. Review the MariaDB Columnstore Syntax guide for additional information on supported distributed syntax or consider changing the MariaDB Columnstore Operating Mode (infinidb_vtable_mode).";


### PR DESCRIPTION
The change for MCOL-4264 erroneously added the "lock_type" member
to cal_connection_info, which is shared between multiple tables.
So some tables that were opened for write erroneously identified
themselves as read only.

Moving the member to ha_mcs instead.