### PR TITLE
MCOL-4282 Enable Select Handler for Prepared Statements

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -6369,8 +6369,13 @@ int processWhere(SELECT_LEX &select_lex,
     Item_cond* icp = 0;
     bool isUpdateDelete = false;
 
-    if (join != 0)
+    // Flag to indicate if this is a prepared statement
+    bool isPS = gwi.thd->stmt_arena && gwi.thd->stmt_arena->is_stmt_execute();
+
+    if (join != 0 && !isPS)
         icp = reinterpret_cast<Item_cond*>(join->conds);
+    else if (isPS && select_lex.prep_where)
+        icp = (Item_cond*)(select_lex.prep_where);
 
     // if icp is null, try to find the where clause other where
     if (!join && gwi.thd->lex->derived_tables)

--- a/dbcon/mysql/ha_mcs_opt_rewrites.h
+++ b/dbcon/mysql/ha_mcs_opt_rewrites.h
@@ -20,8 +20,11 @@
 
 #include "idb_mysql.h"
 
-COND *simplify_joins_mcs(JOIN *join, List<TABLE_LIST> *join_list, COND *conds, bool top, bool in_sj);
 bool in_subselect_rewrite(SELECT_LEX *select_lex);
+void opt_flag_unset_PS(SELECT_LEX *select_lex);
+COND *simplify_joins_mcs(JOIN *join, List<TABLE_LIST> *join_list,
+                         COND *conds, bool top, bool in_sj);
+uint build_bitmap_for_nested_joins_mcs(List<TABLE_LIST> *join_list,
+                                       uint first_unused);
 
 #endif
-


### PR DESCRIPTION
This patch enables select handler for executing prepared
statements. Most importantly, we are now activating a
persistent arena which will allocate any new items in a
permanent MEMROOT for prepared statements and stored procedures.
Refer to JOIN::optimize_inner() for details.

In processWhere(), we now use SELECT_LEX::prep_where in case
we are executing a prepared statement, as this is where the saved
WHERE clause is stored for prepared statement processing.

In addition, we also disable derived handler for prepared
statements.