### PR TITLE
MCOL-4314 shared storage manager cluster initialization fix.

### DIFF
--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -301,25 +301,26 @@ if [ ! -z "$MCS_USE_S3_STORAGE" ] && [ $MCS_USE_S3_STORAGE -eq 1 ]; then
 fi
 
 #change ownership/permissions to be able to run columnstore as non-root
-chown -R mysql:mysql /var/log/mariadb/columnstore
-chown -R mysql:mysql /etc/columnstore
-chown -R mysql:mysql /var/lib/columnstore
-chown -R mysql:mysql /tmp/columnstore_tmp_files
-chmod 777 /tmp/columnstore_tmp_files
-chmod 777 /dev/shm
+# TODO: Remove conditional once container dispatcher uses non-root by default
+if [ $(running_systemd) -eq 0 ]; then
+    chown -R mysql:mysql /var/log/mariadb/columnstore
+    chown -R mysql:mysql /etc/columnstore
+    chown -R mysql:mysql /var/lib/columnstore
+    chown -R mysql:mysql /tmp/columnstore_tmp_files
+    chmod 777 /tmp/columnstore_tmp_files
+    chmod 777 /dev/shm
+fi
 
 systemctl cat mariadb-columnstore.service > /dev/null 2>&1
 if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
-    # prevent clusters using shared storage from initializing columnstore more than once
-    IFLAG=/var/lib/columnstore/storagemanager/cs-initialized
     mkdir -p /var/lib/columnstore/storagemanager
     chown -R mysql:mysql /var/lib/columnstore/storagemanager
 
-    if [ ! -e $IFLAG ]; then
-       touch $IFLAG
-       echo "Populating the engine initial system catalog."
-       systemctl start mariadb-columnstore
-    fi
+    echo "Populating the engine initial system catalog."
+
+    # prevent nodes using shared storage manager from stepping on each other when initializing
+    flock /var/lib/columnstore/storagemanager -c "systemctl start mariadb-columnstore"
+    systemctl stop mariadb-columnstore # shutdown after initialization
 fi
  
 if [ $stop_mysqld -eq 1 ];then

--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -317,10 +317,8 @@ if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
     chown -R mysql:mysql /var/lib/columnstore/storagemanager
 
     echo "Populating the engine initial system catalog."
-
-    # prevent nodes using shared storage manager from stepping on each other when initializing
-    flock /var/lib/columnstore/storagemanager -c "systemctl start mariadb-columnstore"
-    systemctl stop mariadb-columnstore # shutdown after initialization
+    systemctl start mariadb-columnstore
+    systemctl stop mariadb-columnstore
 fi
  
 if [ $stop_mysqld -eq 1 ];then

--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -318,7 +318,6 @@ if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
 
     echo "Populating the engine initial system catalog."
     systemctl start mariadb-columnstore
-    systemctl stop mariadb-columnstore
 fi
  
 if [ $stop_mysqld -eq 1 ];then

--- a/oam/install_scripts/mariadb-columnstore-start.sh
+++ b/oam/install_scripts/mariadb-columnstore-start.sh
@@ -9,6 +9,7 @@
 /bin/systemctl start mcs-exemgr
 /bin/systemctl start mcs-dmlproc
 /bin/systemctl start mcs-ddlproc
+sleep 2
 
 su -s /bin/sh -c 'dbbuilder 7' mysql 2> /tmp/columnstore_tmp_files/dbbuilder.log
 

--- a/oam/install_scripts/mariadb-columnstore-start.sh
+++ b/oam/install_scripts/mariadb-columnstore-start.sh
@@ -3,9 +3,10 @@
 # This script allows to gracefully start MCS
 
 # prevent nodes using shared storage manager from stepping on each other when initializing
-# flock -x 200 will open up an exclusive file lock to run atomic operations
-(
-flock -x 200
+# flock will open up an exclusive file lock to run atomic operations
+exec {fd_lock}>/var/lib/columnstore/storagemanager/storagemanager-lock
+flock -x "$fd_lock"
+
 /bin/systemctl start mcs-workernode
 /bin/systemctl start mcs-controllernode
 /bin/systemctl start mcs-primproc
@@ -14,8 +15,8 @@ flock -x 200
 /bin/systemctl start mcs-dmlproc
 /bin/systemctl start mcs-ddlproc
 sleep 2
-
 su -s /bin/sh -c 'dbbuilder 7' mysql 1> /tmp/columnstore_tmp_files/dbbuilder.log
-) 200>/var/lib/columnstore/storagemanager/cs-initialized
+
+flock -u "$fd_lock"
 
 exit 0

--- a/oam/install_scripts/mariadb-columnstore-start.sh
+++ b/oam/install_scripts/mariadb-columnstore-start.sh
@@ -5,7 +5,7 @@
 # prevent nodes using shared storage manager from stepping on each other when initializing
 # flock will open up an exclusive file lock to run atomic operations
 exec {fd_lock}>/var/lib/columnstore/storagemanager/storagemanager-lock
-flock -x "$fd_lock"
+flock -n "$fd_lock" || exit 0
 
 /bin/systemctl start mcs-workernode
 /bin/systemctl start mcs-controllernode

--- a/oam/install_scripts/mariadb-columnstore-start.sh
+++ b/oam/install_scripts/mariadb-columnstore-start.sh
@@ -2,6 +2,10 @@
 
 # This script allows to gracefully start MCS
 
+# prevent nodes using shared storage manager from stepping on each other when initializing
+# flock -x 200 will open up an exclusive file lock to run atomic operations
+(
+flock -x 200
 /bin/systemctl start mcs-workernode
 /bin/systemctl start mcs-controllernode
 /bin/systemctl start mcs-primproc
@@ -11,6 +15,7 @@
 /bin/systemctl start mcs-ddlproc
 sleep 2
 
-su -s /bin/sh -c 'dbbuilder 7' mysql 2> /tmp/columnstore_tmp_files/dbbuilder.log
+su -s /bin/sh -c 'dbbuilder 7' mysql 1> /tmp/columnstore_tmp_files/dbbuilder.log
+) 200>/var/lib/columnstore/storagemanager/cs-initialized
 
 exit 0

--- a/oam/install_scripts/mcs-loadbrm.py.in
+++ b/oam/install_scripts/mcs-loadbrm.py.in
@@ -81,7 +81,12 @@ if __name__ == '__main__':
     # Single-node on S3
     if storage.lower() == 's3' and not bucket.lower() == 'some_bucket' and pmCount == 1:
         try:
-            brm_saves_current = subprocess.check_output(['smcat', brm])
+            if use_systemd:
+                args = ['su', '-s', '/bin/sh', '-c', f'smcat {brm}', 'mysql']
+            else:
+                args = ['smcat', brm]
+
+            brm_saves_current = subprocess.check_output(args)
         except subprocess.CalledProcessError as e:
             # will happen when brm file does not exist
             print('{} does not exist.'.format(brm), file=sys.stderr)
@@ -122,6 +127,8 @@ node.".format(e))
 
                         if not os.path.exists(dbrmroot):
                             os.makedirs(dbrmroot)
+                            if use_systemd:
+                                shutil.chown(dbrmroot, USER, GROUP)
 
                     current_name = '{}_{}'.format(dbrmroot, e)
 
@@ -145,7 +152,11 @@ node {}.'.format(primary_address), file=sys.stderr)
                 print('{} does not exist.'.format(brm), file=sys.stderr)
 
     if brm_saves_current:
-        cmd = '{} {}{}'.format(loadbrm, dbrmroot, \
+        if use_systemd:
+            cmd = 'su -s /bin/sh -c "{} {}{}" mysql'.format(loadbrm, dbrmroot, \
+brm_saves_current.decode("utf-8").replace("BRM_saves", ""))
+        else:
+            cmd = '{} {}{}'.format(loadbrm, dbrmroot, \
 brm_saves_current.decode("utf-8").replace("BRM_saves", ""))
         try:
             retcode = subprocess.call(cmd, shell=True)
@@ -153,6 +164,7 @@ brm_saves_current.decode("utf-8").replace("BRM_saves", ""))
                 print('{} exits with {}.'.format(cmd, retcode))
                 sys.exit(1)
             for shm_file in glob.glob('/dev/shm/*'):
-                shutil.chown(shm_file, USER, GROUP)
+                if use_systemd:
+                    shutil.chown(shm_file, USER, GROUP)
         except OSError as e:
             sys.exit(1)

--- a/oam/install_scripts/mcs-loadbrm.py.in
+++ b/oam/install_scripts/mcs-loadbrm.py.in
@@ -163,8 +163,8 @@ brm_saves_current.decode("utf-8").replace("BRM_saves", ""))
             if retcode < 0:
                 print('{} exits with {}.'.format(cmd, retcode))
                 sys.exit(1)
-            for shm_file in glob.glob('/dev/shm/*'):
-                if use_systemd:
+            if use_systemd:
+                for shm_file in glob.glob('/dev/shm/*'):                
                     shutil.chown(shm_file, USER, GROUP)
         except OSError as e:
             sys.exit(1)


### PR DESCRIPTION
The main purpose of this PR is to atomically run dbbuilder if on a  shared filesystem, specifically when sharing storagemanager folder.

This also contains some changes for MCOL-4012, in particular, to run smcat and loadbrm as user mysql.