### PR TITLE
MCOL-4282 Follow up version 2.

### DIFF
--- a/dbcon/mysql/ha_mcs.h
+++ b/dbcon/mysql/ha_mcs.h
@@ -138,6 +138,20 @@ public:
     */
     int open(const char* name, int mode, uint32_t test_if_locked);    // required
 
+    // MCOL-4282 This function is called by open_tables in sql_base.cc.
+    // We mutate the optimizer flags here for prepared statements as this
+    // handler function is called before JOIN::prepare, and we need to
+    // disable the default optimizer flags before JOIN::prepare (which is
+    // called during "PREPARE stmt FROM ..." SQL) is called.
+    // Sequence of SQL statements that will lead to this execution path
+    // for prepared statements:
+    //   CREATE TABLE t1 (a int, b int) engine=columnstore;
+    //   INSERT INTO t1 VALUES (1, 2), (2, 4), (3, 1);
+    //   PREPARE stmt1 FROM "SELECT * FROM t1";
+    //   EXECUTE stmt1;
+
+    int discover_check_version() override;
+
     /** @brief
       We implement this in ha_example.cc; it's a required method.
     */

--- a/dbcon/mysql/ha_mcs_pushdown.cpp
+++ b/dbcon/mysql/ha_mcs_pushdown.cpp
@@ -47,10 +47,16 @@ void mutate_optimizer_flags(THD *thd_)
     // MCOL-2178 Disable all optimizer flags as it was in the fork.
     // CS restores it later in SH::scan_end() and in case of an error
     // in SH::scan_init()
-    set_original_optimizer_flags(thd_->variables.optimizer_switch, thd_);
-    thd_->variables.optimizer_switch = OPTIMIZER_SWITCH_IN_TO_EXISTS |
+
+    ulonglong flags_to_set = OPTIMIZER_SWITCH_IN_TO_EXISTS |
         OPTIMIZER_SWITCH_COND_PUSHDOWN_FOR_DERIVED |
         OPTIMIZER_SWITCH_COND_PUSHDOWN_FROM_HAVING;
+
+    if (thd_->variables.optimizer_switch == flags_to_set)
+        return;
+
+    set_original_optimizer_flags(thd_->variables.optimizer_switch, thd_);
+    thd_->variables.optimizer_switch = flags_to_set;
 }
 
 void restore_optimizer_flags(THD *thd_)


### PR DESCRIPTION
Mutate the optimizer flags for prepared statements in:
  1. ha_mcs::open
  2. ha_mcs::discover_check_version

This is done to ensure the optimizer flags are disabled before
JOIN::prepare() is called during "PREPARE stmt FROM ...".