### PR TITLE
MCOL-4314 Fix newly initialized nodes corrupting shared storagemanager data a previous node created.

### DIFF
--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -316,9 +316,14 @@ systemctl cat mariadb-columnstore.service > /dev/null 2>&1
 if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
     mkdir -p /var/lib/columnstore/storagemanager
     chown -R mysql:mysql /var/lib/columnstore/storagemanager
+    IFLAG=/var/lib/columnstore/storagemanager/storagemanager-lock
 
-    echo "Populating the engine initial system catalog."
-    systemctl start mariadb-columnstore
+    # prevent nodes using shared storage manager from stepping on each other when initializing
+    # if storagemanager-lock already exists, we have already initialized
+    if [ ! -e $IFLAG ]; then
+        echo "Populating the engine initial system catalog."
+        systemctl start mariadb-columnstore
+    fi
 fi
  
 if [ $stop_mysqld -eq 1 ];then

--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -318,12 +318,21 @@ if [ $? -eq 0 ] && [ $(running_systemd) -eq 0 ]; then
     chown -R mysql:mysql /var/lib/columnstore/storagemanager
     IFLAG=/var/lib/columnstore/storagemanager/storagemanager-lock
 
-    # prevent nodes using shared storage manager from stepping on each other when initializing
+    # shared dbroot1 synchronization
+    # prevents dbbuilder from processing simultaneously on two or more nodes
+    exec {fd_lock}>/var/lib/columnstore/data1/dbroot1-lock
+    flock -x "$fd_lock"
+
+    # shared storagemanager data corruption prevention
+    # intially, a node is in a single node setting and takes ownership of storagemanager
+    # prevent nodes using shared storage manager from stepping on each other
     # if storagemanager-lock already exists, we have already initialized
     if [ ! -e $IFLAG ]; then
         echo "Populating the engine initial system catalog."
         systemctl start mariadb-columnstore
     fi
+
+    flock -u "$fd_lock"
 fi
  
 if [ $stop_mysqld -eq 1 ];then

--- a/oam/install_scripts/columnstore-pre-uninstall.in
+++ b/oam/install_scripts/columnstore-pre-uninstall.in
@@ -110,7 +110,7 @@ if [ -n "$systemctl" ] && [ $(running_systemd) -eq 0 ]; then
 
     systemctl daemon-reload
     # remove flag to prevent clusters using shared storage from initializing columnstore more than once
-    IFLAG=/var/lib/columnstore/storagemanager/cs-initialized
+    IFLAG=/var/lib/columnstore/storagemanager/storagemanager-lock
     if [ -e $IFLAG ]; then
         rm $IFLAG
     fi


### PR DESCRIPTION
The problem this addresses is only an issue in scenarios with shared storagemanager.
Issue: when columnstore is installed on new nodes after columnstore is installed on a previous node, the new nodes corrupt data in storagemanager folder when they initialize as single nodes.