### PR TITLE
MCOL-4328 There is a new option in both cpimport and cpimport.bin to …

### DIFF
--- a/writeengine/bulk/cpimport.cpp
+++ b/writeengine/bulk/cpimport.cpp
@@ -105,7 +105,8 @@ void printUsage()
          "    [-c readBufSize] [-e maxErrs] [-B libBufSize] [-n NullOption] " << endl <<
          "    [-E encloseChar] [-C escapeChar] [-I binaryOpt] [-S] "
          "[-d debugLevel] [-i] " << endl <<
-         "     [-D] [-N] [-L rejectDir] [-T timeZone]" << endl;
+         "     [-D] [-N] [-L rejectDir] [-T timeZone]" << endl <<
+         "    [-U username]" << endl << endl;
 
     cout << endl << "Traditional usage without positional parameters "
          "(XML job file required):" << endl <<
@@ -115,7 +116,8 @@ void printUsage()
          "    [-E encloseChar] [-C escapeChar] [-I binaryOpt] [-S] "
          "[-d debugLevel] [-i] " << endl <<
          "    [-p path] [-l loadFile]" << endl <<
-         "     [-D] [-N] [-L rejectDir] [-T timeZone]" << endl << endl;
+         "     [-D] [-N] [-L rejectDir] [-T timeZone]" << endl <<
+         "    [-U username]" << endl << endl;
 
     cout << "    Positional parameters:" << endl <<
          "        dbName    Name of database to load" << endl <<
@@ -171,7 +173,8 @@ void printUsage()
          "        -K S3 Authentication Secret (for S3 imports)" << endl <<
          "        -t S3 Bucket (for S3 imports)" << endl <<
          "        -H S3 Hostname (for S3 imports, Amazon's S3 default)" << endl <<
-         "        -g S3 Regions (for S3 imports)" << endl;
+         "        -g S3 Regions (for S3 imports)" << endl <<
+         "        -U username of new data files owner. Default is mysql" << endl;
 
     cout << "    Example1:" << endl <<
          "        cpimport.bin -j 1234" << endl <<
@@ -322,7 +325,7 @@ void parseCmdLineArgs(
     std::string jobUUID;
 
     while ( (option = getopt(
-                          argc, argv, "b:c:d:e:f:hij:kl:m:n:p:r:s:u:w:B:C:DE:I:P:R:ST:X:NL:y:K:t:H:g:")) != EOF )
+                          argc, argv, "b:c:d:e:f:hij:kl:m:n:p:r:s:u:w:B:C:DE:I:P:R:ST:X:NL:y:K:t:H:g:U:")) != EOF )
     {
         switch (option)
         {
@@ -743,6 +746,11 @@ void parseCmdLineArgs(
                 break;
             }
 
+            case 'U':
+            {
+                curJob.setUsername(optarg);
+                break;
+            }
 
             default :
             {

--- a/writeengine/bulk/we_bulkload.cpp
+++ b/writeengine/bulk/we_bulkload.cpp
@@ -38,6 +38,7 @@
 #include <boost/filesystem/convenience.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
+#include <pwd.h>
 
 #include "we_bulkstatus.h"
 #include "we_rbmetawriter.h"
@@ -157,7 +158,8 @@ BulkLoad::BulkLoad() :
     fbContinue(false),
     fDisableTimeOut(false),
     fUUID(boost::uuids::nil_generator()()),
-    fTimeZone("SYSTEM")
+    fTimeZone("SYSTEM"),
+    fUsername("mysql") // MCOL-4328 default file owner
 {
     fTableInfo.clear();
     setDebugLevel( DEBUG_0 );
@@ -484,6 +486,22 @@ int BulkLoad::preProcess( Job& job, int tableNo,
     tableInfo->setTimeZone(fTimeZone);
     tableInfo->setJobUUID(fUUID);
 
+    // MCOL-4328 Get username gid and uid if they are set
+    // We inject uid and gid into TableInfo and All ColumnInfo-s later.
+    struct passwd* pwd = nullptr;
+    errno = 0;
+    if (fUsername.length() && (pwd = getpwnam(fUsername.c_str())) == nullptr)
+    {
+        std::ostringstream oss;
+        oss << "Error getting pwd for " << fUsername
+            << " with errno "
+            << errno;
+        fLog.logMsg( oss.str(), MSGLVL_ERROR );
+        return ERR_FILE_CHOWN;
+    }
+
+    tableInfo->setUIDGID(pwd->pw_uid, pwd->pw_gid);
+
     if (fMaxErrors != -1)
         tableInfo->setMaxErrorRows(fMaxErrors);
     else
@@ -684,6 +702,9 @@ int BulkLoad::preProcess( Job& job, int tableNo,
                                   job.jobTableList[tableNo].colList[i],
                                   pDBRootExtentTracker,
                                   tableInfo);
+
+        if (pwd)
+            info->setUIDGID(pwd->pw_uid, pwd->pw_gid);
 
         // For auto increment column, we need to get the starting value
         if (info->column.autoIncFlag)
@@ -921,7 +942,7 @@ int BulkLoad::preProcessHwmLbid(
 
     return rc;
 }
-
+
 //------------------------------------------------------------------------------
 // DESCRIPTION:
 //    NO_ERROR if success

--- a/writeengine/bulk/we_bulkload.h
+++ b/writeengine/bulk/we_bulkload.h
@@ -160,6 +160,7 @@ public:
     void                setS3Bucket          ( const std::string& bucket );
     void                setS3Host            ( const std::string& host );
     void                setS3Region          ( const std::string& region );
+    void                setUsername          ( const std::string& username );
     // Timer functions
     void                startTimer           ( );
     void                stopTimer            ( );
@@ -244,6 +245,7 @@ private:
     std::string fS3Host;                   // S3 Host
     std::string fS3Bucket;                 // S3 Bucket
     std::string fS3Region;                 // S3 Region
+    std::string fUsername;                 // data files owner name mysql by default 
 
     //--------------------------------------------------------------------------
     // Private Functions
@@ -534,6 +536,11 @@ inline void BulkLoad::setS3Host( const std::string& host )
 inline void BulkLoad::setS3Region( const std::string& region )
 {
     fS3Region = region;
+}
+
+inline void BulkLoad::setUsername( const std::string& username )
+{
+    fUsername = username;
 }
 
 inline void BulkLoad::startTimer( )

--- a/writeengine/bulk/we_columninfo.cpp
+++ b/writeengine/bulk/we_columninfo.cpp
@@ -160,7 +160,9 @@ ColumnInfo::ColumnInfo(Log*             logger,
     fDbRootExtTrk(pDBRootExtTrk),
     fColWidthFactor(1),
     fDelayedFileCreation(INITIAL_DBFILE_STAT_FILE_EXISTS),
-    fRowsPerExtent(0)
+    fRowsPerExtent(0),
+    uID((uid_t)-1),
+    gID((gid_t)-1)
 {
     column = columnIn;
 
@@ -458,6 +460,10 @@ int ColumnInfo::createDelayedFileIfNeeded( const std::string& tableName )
         }
 
         boost::scoped_ptr<Dctnry> refDctnry(tempD);
+        // MCOL-4328 Define a file owner uid and gid
+        if (uID != (uid_t)-1)
+            refDctnry->setUIDGID(uID, gID);
+
         rc = tempD->createDctnry(
                  column.dctnry.dctnryOid,
                  column.dctnryWidth,
@@ -1681,6 +1687,7 @@ int ColumnInfo::openDctnryStore( bool bMustExist )
 
     fStore->setLogger(fLog);
     fStore->setColWidth( column.dctnryWidth );
+    fStore->setUIDGID(uID, gID);
 
     if (column.fWithDefault)
         fStore->setDefault( column.fDefaultChr );

--- a/writeengine/bulk/we_columninfo.h
+++ b/writeengine/bulk/we_columninfo.h
@@ -38,6 +38,7 @@
 #include <boost/scoped_ptr.hpp>
 #include <sys/time.h>
 #include <vector>
+#include <pwd.h>
 
 #include "atomicops.h"
 
@@ -397,6 +398,8 @@ struct ColumnInfo
      */
     unsigned rowsPerExtent( );
 
+    void setUIDGID(uid_t uid, gid_t gid);
+
 protected:
 
     //--------------------------------------------------------------------------
@@ -502,11 +505,23 @@ protected:
     // to be created after preprocessing
 
     unsigned     fRowsPerExtent;            // Number of rows per column extent
+    /** @brief uid of the owner of segment and dict files */
+    uid_t uID;
+
+    /** @brief gid of the owner of segment and dict files */
+    gid_t gID;
 };
 
 //------------------------------------------------------------------------------
 // Inline functions
 //------------------------------------------------------------------------------
+inline void ColumnInfo::setUIDGID(uid_t uid, gid_t gid)
+{
+    uID = uid; gID = gid;
+    if (colOp)
+        colOp->setUIDGID(uid, gid);
+}
+
 inline boost::mutex& ColumnInfo::colMutex()
 {
     return fColMutex;

--- a/writeengine/bulk/we_tableinfo.cpp
+++ b/writeengine/bulk/we_tableinfo.cpp
@@ -2428,6 +2428,8 @@ int TableInfo::saveBulkRollbackMetaData( Job& job,
 
     }   // end of loop through columns
 
+    if (fUid != (uid_t)-1)
+        fRBMetaWriter.setUIDGID(fUid, fGid);
     try
     {
         fRBMetaWriter.saveBulkRollbackMetaData(

--- a/writeengine/bulk/we_tableinfo.h
+++ b/writeengine/bulk/we_tableinfo.h
@@ -26,6 +26,7 @@
 #include <fstream>
 #include <utility>
 #include <vector>
+#include <pwd.h>
 
 #include <boost/thread/mutex.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
@@ -171,6 +172,9 @@ private:
     oam::OamCache* fOamCachePtr;	// OamCache: ptr is copyable
     boost::uuids::uuid fJobUUID;        // Job UUID
     std::vector<BRM::LBID_t> fDictFlushBlks;//dict blks to be flushed from cache
+    uid_t         fUid;                 // UID of the files owner
+    gid_t         fGid;                 // GID of the files owner
+
 
     //--------------------------------------------------------------------------
     // Private Functions
@@ -478,6 +482,8 @@ public:
 
     void setJobUUID(const boost::uuids::uuid& jobUUID);
 
+    void setUIDGID(const uid_t uid, const gid_t gid);
+
 public:
     friend class BulkLoad;
     friend struct ColumnInfo;
@@ -488,6 +494,11 @@ public:
 //------------------------------------------------------------------------------
 // Inline functions
 //------------------------------------------------------------------------------
+inline void TableInfo::setUIDGID(const uid_t uid, const gid_t gid)
+{
+    fUid = uid;
+    fGid = gid;
+}
 inline int TableInfo::getCurrentParseBuffer() const
 {
     return fCurrentParseBuffer;

--- a/writeengine/dictionary/we_dctnry.h
+++ b/writeengine/dictionary/we_dctnry.h
@@ -31,6 +31,7 @@
 #include <cstddef>
 #include <iostream>
 #include <string>
+#include <pwd.h>
 
 #include "we_dbfileop.h"
 #include "we_type.h"
@@ -248,6 +249,11 @@ public:
         return createDctnryFile(name, width, mode, ioBuffSize);
     }
 
+    inline void setUIDGID(const uid_t uid, const gid_t gid)
+    {
+        m_uid = uid;
+        m_gid = gid;
+    }
 
 //------------------------------------------------------------------------------
 // Protected members
@@ -342,6 +348,8 @@ protected:
     int          m_colWidth;         // width of this dictionary column
     std::string  m_defVal;           // optional default string value
     ImportDataMode m_importDataMode; // Import data in text or binary mode
+    uid_t        m_uid;              // new dict files belongs to this uid
+    gid_t        m_gid;              // new dict files belongs to this gid
 
 };//end of class
 

--- a/writeengine/shared/we_define.h
+++ b/writeengine/shared/we_define.h
@@ -153,6 +153,7 @@ const int   ERR_VB_FILE_NOT_EXIST   = ERR_FILEBASE + 17;// Version buffer file n
 const int   ERR_FILE_FLUSH          = ERR_FILEBASE + 18;// Error flushing file
 const int   ERR_FILE_GLOBBING       = ERR_FILEBASE + 19;// Error globbing a file name
 const int   ERR_FILE_EOF            = ERR_FILEBASE + 20;// EOF
+const int   ERR_FILE_CHOWN          = ERR_FILEBASE + 21;// EOF
 
 //--------------------------------------------------------------------------
 // XML level error

--- a/writeengine/shared/we_fileop.h
+++ b/writeengine/shared/we_fileop.h
@@ -27,6 +27,7 @@
 #include <vector>
 #include <map>
 #include <boost/thread.hpp>
+#include <pwd.h>
 
 #ifdef _MSC_VER
 #include <direct.h>
@@ -501,6 +502,7 @@ public:
                                           bool     bExpandExtent,
                                           bool     bAbbrevExtent,
                                           bool     bOptExtension=false );
+    void                setUIDGID(const uid_t uid, const gid_t gid);
 
 protected:
     EXPORT virtual int         updateColumnExtent(IDBDataFile* pFile, int nBlocks);
@@ -549,11 +551,19 @@ private:
     static boost::mutex               m_mkdirMutex;
 
     char*       m_buffer;             // buffer used with setvbuf()
+    uid_t       m_uid;                // owner uid
+    gid_t       m_gid;                // owner gid
 };
 
 //------------------------------------------------------------------------------
 // Inline functions
 //------------------------------------------------------------------------------
+inline void FileOp::setUIDGID(const uid_t uid, const gid_t gid)
+{
+    m_uid = uid;
+    m_gid = gid;
+}
+
 inline void FileOp::compressionType(int t)
 {
     m_compressionType = t;

--- a/writeengine/shared/we_rbmetawriter.h
+++ b/writeengine/shared/we_rbmetawriter.h
@@ -229,6 +229,8 @@ public:
 
     /** @brief Verify that specified record type is a DStore2 record */
     static bool verifyDStore2Rec(const char* recType);
+    
+    void setUIDGID(const uid_t uid, const gid_t);
 
 private:
     // disable copy constructor and assignment operator
@@ -372,7 +374,15 @@ private:
     boost::mutex           fRBChunkDctnryMutex;//Mutex lock for RBChunkSet
     OID                    fTableOID;         // OID of relevant table
     std::string            fTableName;        // Name of relevant table
+    uid_t                  fUid;              // files owner
+    gid_t                  fGid;              // files owner
 };
+
+inline void RBMetaWriter::setUIDGID(const uid_t uid, const gid_t gid)
+{
+    fUid = uid;
+    fGid = gid;
+}
 
 } //end of namespace
 

--- a/writeengine/splitter/we_cmdargs.cpp
+++ b/writeengine/splitter/we_cmdargs.cpp
@@ -144,6 +144,9 @@ std::string WECmdArgs::getCpImportCmdLine()
         else if (0 == fLocFile.length()) //No filename given, from job file
             aSS << " -f " << fPmFilePath;
     }
+    
+    if (fUsername.length() > 0)
+        aSS << " -U " << fUsername;
 
     if (fJobId.length() > 0)
         aSS << " -j " << fJobId;
@@ -502,7 +505,7 @@ void WECmdArgs::usage()
     cout << "\t\t [-r readers] [-j JobID] [-e maxErrs] [-B libBufSize] [-w parsers]\n";
     cout << "\t\t [-s c] [-E enclosedChar] [-C escapeChar] [-n NullOption]\n";
     cout << "\t\t [-q batchQty] [-p jobPath] [-P list of PMs] [-S] [-i] [-v verbose]\n";
-    cout << "\t\t [-I binaryOpt] [-T timeZone]\n";
+    cout << "\t\t [-I binaryOpt] [-T timeZone] [-U username]\n";
 
 
     cout << "Traditional usage without positional parameters (XML job file required):\n";
@@ -511,7 +514,7 @@ void WECmdArgs::usage()
     cout << "\t\t [-b readBufs] [-p path] [-c readBufSize] [-e maxErrs] [-B libBufSize]\n";
     cout << "\t\t [-n NullOption] [-E encloseChar] [-C escapeChar] [-i] [-v verbose]\n";
     cout << "\t\t [-d debugLevel] [-q batchQty] [-l loadFile] [-P list of PMs] [-S]\n";
-    cout << "\t\t [-I binaryOpt] [-T timeZone]\n";
+    cout << "\t\t [-I binaryOpt] [-T timeZone] [-U username]\n";
 
     cout << "\n\nPositional parameters:\n";
     cout << "\tdbName     Name of the database to load\n";
@@ -563,7 +566,8 @@ void WECmdArgs::usage()
          << "\t-K\tS3 Authentication Secret (for S3 imports)\n"
          << "\t-t\tS3 Bucket (for S3 imports)\n"
          << "\t-H\tS3 Hostname (for S3 imports, Amazon's S3 default)\n"
-         << "\t-g\tS3 Region (for S3 imports)\n";
+         << "\t-g\tS3 Region (for S3 imports)\n"
+         << "\t-U\tusername of the data files owner. Default is mysql\n";
 
     cout << "\nExample1: Traditional usage\n"
          << "\tcpimport -j 1234";
@@ -597,19 +601,14 @@ void WECmdArgs::parseCmdLineArgs(int argc, char** argv)
     if (argc > 0)
         fPrgmName = "cpimport.bin"; //argv[0] is splitter but we need cpimport
 
-    //Just for testing cpimport invoking in UM
-    //if(argc>0)
-    //	fPrgmName = "/home/bpaul/genii/export/bin/cpimport";
-
     while ((aCh = getopt(argc, argv,
-                         "d:j:w:s:v:l:r:b:e:B:f:q:ihm:E:C:P:I:n:p:c:ST:Ny:K:t:H:g:"))
+                         "d:j:w:s:v:l:r:b:e:B:f:q:ihm:E:C:P:I:n:p:c:ST:Ny:K:t:H:g:U:"))
             != EOF)
     {
         switch (aCh)
         {
             case 'm':
             {
-                //fMode = atoi(optarg);
                 fArgMode = atoi(optarg);
 
                 //cout << "Mode level set to " << fMode << endl;
@@ -934,6 +933,12 @@ void WECmdArgs::parseCmdLineArgs(int argc, char** argv)
             case 'g': //-g S3 Region
             {
                 fS3Region = optarg;
+                break;
+            }
+
+            case 'U': //-U username of the files owner
+            {
+                fUsername = optarg;
                 break;
             }
 

--- a/writeengine/splitter/we_cmdargs.h
+++ b/writeengine/splitter/we_cmdargs.h
@@ -180,6 +180,8 @@ public:
     {
         fbTruncationAsError = bTruncationAsError;
     }
+    void setUsername(const std::string& username);
+    
     bool isJobLogOnly() const
     {
         return fJobLogOnly;
@@ -262,11 +264,11 @@ public:
     {
         return fS3Secret;
     }
-    std::string getS3Region() const 
+    std::string getS3Region() const
     {
         return fS3Region;
     }
-
+    std::string& getUsername();
     std::string PrepMode2ListOfFiles(std::string& FileName); // Bug 4342
     void getColumnList( std::set<std::string>& columnList ) const;
 
@@ -325,9 +327,19 @@ private:	// variables for SplitterApp
     bool fbTruncationAsError; // Treat string truncation as error
     boost::uuids::uuid fUUID;
     bool fConsoleOutput;    // If false, no output to console.
-    std::string fTimeZone;      // Timezone to use for TIMESTAMP datatype
+    std::string fTimeZone;  // Timezone to use for TIMESTAMP datatype
+    std::string fUsername;  // Username of the data files owner
 };
 //----------------------------------------------------------------------
+
+inline void WECmdArgs::setUsername(const std::string& username)
+{
+    fUsername = username;
+}
+inline std::string& WECmdArgs::getUsername()
+{
+    return fUsername;
+}
 
 
 }


### PR DESCRIPTION
…asign

an owner for all data files created by cpimport

The patch consists of three parts: cpimport.bin changes, cpimport splitter
changes and plugin changes

cpimport.bin gets uid_t and gid_t early and propagates it down the stack
where MCS creates data files