### PR TITLE
MCOL-4330 1.5 Refresh shared memory if needed

### DIFF
--- a/dbcon/mysql/is_columnstore_extents.cpp
+++ b/dbcon/mysql/is_columnstore_extents.cpp
@@ -59,7 +59,6 @@ static int generate_result(BRM::OID_t oid, BRM::DBRM* emp, TABLE* table, THD* th
     std::vector<struct BRM::EMEntry>::iterator iter;
     std::vector<struct BRM::EMEntry>::iterator end;
 
-
     emp->getExtents(oid, entries, false, false, true);
 
     if (entries.size() == 0)
@@ -283,5 +282,7 @@ int is_columnstore_extents_plugin_init(void* p)
     ST_SCHEMA_TABLE* schema = (ST_SCHEMA_TABLE*) p;
     schema->fields_info = is_columnstore_extents_fields;
     schema->fill_table = is_columnstore_extents_fill;
+    BRM::DBRM* dbrm = new BRM::DBRM();
+    dbrm->refreshShm();
     return 0;
 }

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -70,7 +70,7 @@ using namespace oam;
 namespace BRM
 {
 
-DBRM::DBRM(bool noBRMinit) throw() : fDebug(false)
+DBRM::DBRM(bool noBRMinit) : fDebug(false)
 {
     if (!noBRMinit)
     {
@@ -102,6 +102,18 @@ DBRM::~DBRM() throw()
 {
     if (msgClient != NULL)
         MessageQueueClientPool::releaseInstance(msgClient);
+}
+
+void DBRM::refreshShm()
+{
+    if (mst.get())
+    {
+        mst->refreshShm();
+    }
+    if (em.get())
+    {
+        em->refreshShm();
+    }
 }
 
 DBRM& DBRM::operator=(const DBRM& brm)
@@ -1751,7 +1763,7 @@ unsigned DBRM::getExtentRows() throw()
 }
 
 int DBRM::getExtents(int OID, std::vector<struct EMEntry>& entries,
-                     bool sorted, bool notFoundErr, bool incOutOfService) throw()
+                     bool sorted, bool notFoundErr, bool incOutOfService)
 {
 #ifdef BRM_INFO
 

--- a/versioning/BRM/dbrm.h
+++ b/versioning/BRM/dbrm.h
@@ -104,9 +104,11 @@ class DBRM
 public:
     // The param noBRMFcns suppresses init of the ExtentMap, VSS, VBBM, and CopyLocks.
     // It can speed up init if the caller only needs the other structures.
-    EXPORT DBRM(bool noBRMFcns = false) throw();
+    EXPORT DBRM(bool noBRMFcns = false);
     EXPORT ~DBRM() throw();
 
+    EXPORT void refreshShm();
+    
     // @bug 1055+ - Added functions below for multiple files per OID enhancement.
 
     /** @brief Get the OID, offset, db root, partition, and segment of a logical block ID.
@@ -495,7 +497,7 @@ public:
      */
     EXPORT int getExtents(int OID, std::vector<struct EMEntry>& entries,
                           bool sorted = true, bool notFoundErr = true,
-                          bool incOutOfService = false) throw();
+                          bool incOutOfService = false);
 
     /** @brief Gets the extents of a given OID under specified dbroot
      *
@@ -1015,6 +1017,7 @@ public:
     */
     EXPORT void invalidateUncommittedExtentLBIDs(execplan::CalpontSystemCatalog::SCN txnid,
             std::vector<LBID_t>* plbidList = NULL);
+    
 private:
     DBRM(const DBRM& brm);
     DBRM& operator=(const DBRM& brm);

--- a/versioning/BRM/extentmap.h
+++ b/versioning/BRM/extentmap.h
@@ -161,6 +161,8 @@ struct ExtentSorter
 class ExtentMapImpl
 {
 public:
+    ~ExtentMapImpl(){};
+
     static ExtentMapImpl* makeExtentMapImpl(unsigned key, off_t size, bool readOnly = false);
 
     inline void grow(unsigned key, off_t size)
@@ -174,6 +176,14 @@ public:
         idbassert(rc == 0);
     }
 #endif
+    inline void refreshShm()
+    {
+        if (fInstance)
+        {
+            delete fInstance;
+            fInstance = NULL;
+        }
+    }
     inline void makeReadOnly()
     {
         fExtMap.setReadOnly();
@@ -199,7 +209,6 @@ public:
 
 private:
     ExtentMapImpl(unsigned key, off_t size, bool readOnly = false);
-    ~ExtentMapImpl();
     ExtentMapImpl(const ExtentMapImpl& rhs);
     ExtentMapImpl& operator=(const ExtentMapImpl& rhs);
 
@@ -212,6 +221,8 @@ private:
 class FreeListImpl
 {
 public:
+    ~FreeListImpl(){};
+
     static FreeListImpl* makeFreeListImpl(unsigned key, off_t size, bool readOnly = false);
 
     inline void grow(unsigned key, off_t size)
@@ -225,6 +236,14 @@ public:
         idbassert(rc == 0);
     }
 #endif
+    inline void refreshShm()
+    {
+        if (fInstance)
+        {
+            delete fInstance;
+            fInstance = NULL;
+        }
+    }
     inline void makeReadOnly()
     {
         fFreeList.setReadOnly();
@@ -250,7 +269,6 @@ public:
 
 private:
     FreeListImpl(unsigned key, off_t size, bool readOnly = false);
-    ~FreeListImpl();
     FreeListImpl(const FreeListImpl& rhs);
     FreeListImpl& operator=(const FreeListImpl& rhs);
 
@@ -273,6 +291,14 @@ class ExtentMap : public Undoable
 public:
     EXPORT ExtentMap();
     EXPORT ~ExtentMap();
+
+    EXPORT void refreshShm()
+    {
+        if (fPExtMapImpl)
+            fPExtMapImpl->refreshShm();
+        if (fPFreeListImpl)
+            fPFreeListImpl->refreshShm();
+    }
 
     /** @brief Loads the ExtentMap entries from a file
      *

--- a/versioning/BRM/mastersegmenttable.h
+++ b/versioning/BRM/mastersegmenttable.h
@@ -69,9 +69,17 @@ public:
     boost::interprocess::shared_memory_object fShmobj;
     boost::interprocess::mapped_region fMapreg;
 
+    inline void refreshShm()
+    {
+        if (fInstance)
+        {
+            delete fInstance;
+            fInstance = NULL;
+        }
+    }
+    
 private:
     MasterSegmentTableImpl(int key, int size);
-    ~MasterSegmentTableImpl();
     MasterSegmentTableImpl(const MasterSegmentTableImpl& rhs);
     MasterSegmentTableImpl& operator=(const MasterSegmentTableImpl& rhs);
 
@@ -90,7 +98,6 @@ public:
      * @note Throws runtime_error on a semaphore-related error.
      */
     EXPORT MasterSegmentTable();
-    //MasterSegmentTable(const MasterSegmentTable& mst);
     EXPORT ~MasterSegmentTable();
 
     /// specifies the Extent Map table
@@ -106,6 +113,11 @@ public:
     /// the number of tables currently defined
     static const int nTables = 5;
 
+    EXPORT void refreshShm()
+    {
+        if (fPImpl)
+            fPImpl->refreshShm();
+    }
     /** @brief This function gets the specified table.
      *
      * This function gets the specified table and grabs the


### PR DESCRIPTION
If the plugin is restarted after the system is running, it's possible to have stale references to shared memory. This patch deletes those references so the next time they're used, just-in-time initialization will get the latest.