### PR TITLE
MCOL-4330 dev Refresh shared memory

### DIFF
--- a/dbcon/mysql/is_columnstore_extents.cpp
+++ b/dbcon/mysql/is_columnstore_extents.cpp
@@ -59,7 +59,6 @@ static int generate_result(BRM::OID_t oid, BRM::DBRM* emp, TABLE* table, THD* th
     std::vector<struct BRM::EMEntry>::iterator iter;
     std::vector<struct BRM::EMEntry>::iterator end;
 
-
     emp->getExtents(oid, entries, false, false, true);
 
     if (entries.size() == 0)
@@ -188,6 +187,7 @@ static int is_columnstore_extents_fill(THD* thd, TABLE_LIST* tables, COND* cond)
     BRM::OID_t cond_oid = 0;
     TABLE* table = tables->table;
 
+    BRM::DBRM::refreshShm();
     BRM::DBRM* emp = new BRM::DBRM();
 
     if (!emp || !emp->isDBRMReady())

--- a/dbcon/mysql/is_columnstore_files.cpp
+++ b/dbcon/mysql/is_columnstore_files.cpp
@@ -207,6 +207,7 @@ static int generate_result(BRM::OID_t oid, BRM::DBRM* emp, TABLE* table, THD* th
 
 static int is_columnstore_files_fill(THD* thd, TABLE_LIST* tables, COND* cond)
 {
+    BRM::DBRM::refreshShm();
     BRM::DBRM* emp = new BRM::DBRM();
     BRM::OID_t cond_oid = 0;
     TABLE* table = tables->table;

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -70,7 +70,7 @@ using namespace oam;
 namespace BRM
 {
 
-DBRM::DBRM(bool noBRMinit) throw() : fDebug(false)
+DBRM::DBRM(bool noBRMinit) : fDebug(false)
 {
     if (!noBRMinit)
     {
@@ -1751,7 +1751,7 @@ unsigned DBRM::getExtentRows() throw()
 }
 
 int DBRM::getExtents(int OID, std::vector<struct EMEntry>& entries,
-                     bool sorted, bool notFoundErr, bool incOutOfService) throw()
+                     bool sorted, bool notFoundErr, bool incOutOfService)
 {
 #ifdef BRM_INFO
 

--- a/versioning/BRM/dbrm.h
+++ b/versioning/BRM/dbrm.h
@@ -104,9 +104,16 @@ class DBRM
 public:
     // The param noBRMFcns suppresses init of the ExtentMap, VSS, VBBM, and CopyLocks.
     // It can speed up init if the caller only needs the other structures.
-    EXPORT DBRM(bool noBRMFcns = false) throw();
-    EXPORT ~DBRM() throw();
+    EXPORT DBRM(bool noBRMFcns = false);
+    EXPORT ~DBRM();
 
+    EXPORT static void refreshShm()
+    {
+        MasterSegmentTableImpl::refreshShm();
+        ExtentMapImpl::refreshShm();
+        FreeListImpl::refreshShm();
+    }
+    
     // @bug 1055+ - Added functions below for multiple files per OID enhancement.
 
     /** @brief Get the OID, offset, db root, partition, and segment of a logical block ID.
@@ -495,7 +502,7 @@ public:
      */
     EXPORT int getExtents(int OID, std::vector<struct EMEntry>& entries,
                           bool sorted = true, bool notFoundErr = true,
-                          bool incOutOfService = false) throw();
+                          bool incOutOfService = false);
 
     /** @brief Gets the extents of a given OID under specified dbroot
      *
@@ -1015,6 +1022,7 @@ public:
     */
     EXPORT void invalidateUncommittedExtentLBIDs(execplan::CalpontSystemCatalog::SCN txnid,
             std::vector<LBID_t>* plbidList = NULL);
+    
 private:
     DBRM(const DBRM& brm);
     DBRM& operator=(const DBRM& brm);

--- a/versioning/BRM/extentmap.h
+++ b/versioning/BRM/extentmap.h
@@ -161,7 +161,17 @@ struct ExtentSorter
 class ExtentMapImpl
 {
 public:
+    ~ExtentMapImpl(){};
+
     static ExtentMapImpl* makeExtentMapImpl(unsigned key, off_t size, bool readOnly = false);
+    static void refreshShm()
+    {
+        if (fInstance)
+        {
+            delete fInstance;
+            fInstance = NULL;
+        }
+    }
 
     inline void grow(unsigned key, off_t size)
 #ifdef NDEBUG
@@ -199,7 +209,6 @@ public:
 
 private:
     ExtentMapImpl(unsigned key, off_t size, bool readOnly = false);
-    ~ExtentMapImpl();
     ExtentMapImpl(const ExtentMapImpl& rhs);
     ExtentMapImpl& operator=(const ExtentMapImpl& rhs);
 
@@ -212,7 +221,17 @@ private:
 class FreeListImpl
 {
 public:
+    ~FreeListImpl(){};
+
     static FreeListImpl* makeFreeListImpl(unsigned key, off_t size, bool readOnly = false);
+    static void refreshShm()
+    {
+        if (fInstance)
+        {
+            delete fInstance;
+            fInstance = NULL;
+        }
+    }
 
     inline void grow(unsigned key, off_t size)
 #ifdef NDEBUG
@@ -250,7 +269,6 @@ public:
 
 private:
     FreeListImpl(unsigned key, off_t size, bool readOnly = false);
-    ~FreeListImpl();
     FreeListImpl(const FreeListImpl& rhs);
     FreeListImpl& operator=(const FreeListImpl& rhs);
 

--- a/versioning/BRM/mastersegmenttable.h
+++ b/versioning/BRM/mastersegmenttable.h
@@ -64,14 +64,23 @@ struct MSTEntry
 class MasterSegmentTableImpl
 {
 public:
+    ~MasterSegmentTableImpl(){};
     static MasterSegmentTableImpl* makeMasterSegmentTableImpl(int key, int size);
 
+    static void refreshShm()
+    {
+        if (fInstance)
+        {
+            delete fInstance;
+            fInstance = NULL;
+        }
+    }
+    
     boost::interprocess::shared_memory_object fShmobj;
     boost::interprocess::mapped_region fMapreg;
-
+    
 private:
     MasterSegmentTableImpl(int key, int size);
-    ~MasterSegmentTableImpl();
     MasterSegmentTableImpl(const MasterSegmentTableImpl& rhs);
     MasterSegmentTableImpl& operator=(const MasterSegmentTableImpl& rhs);
 
@@ -90,7 +99,6 @@ public:
      * @note Throws runtime_error on a semaphore-related error.
      */
     EXPORT MasterSegmentTable();
-    //MasterSegmentTable(const MasterSegmentTable& mst);
     EXPORT ~MasterSegmentTable();
 
     /// specifies the Extent Map table


### PR DESCRIPTION
If the plugin is restarted after the system is running, it's possible to have stale references to shared memory. This patch deletes those references so the next time they're used, just-in-time initialization will get the latest.