### PR TITLE
Fixing a problem in MCOL-4335 Add absolute path into columnstore-post…

### DIFF
--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -226,7 +226,7 @@ rm -f $lockdir/columnstore
 
 # This was the last place of postConfigure. RIP
 
-@ENGINE_BINDIR@/install_mcs_mysql.sh --tmpdir=$tmpDir
+@ENGINE_SBINDIR@/install_mcs_mysql.sh --tmpdir=$tmpDir
 
 # Restart MDB to enable plugin
 systemctl cat mariadb.service > /dev/null 2>&1


### PR DESCRIPTION
…-install and mariadb-columnstore-start.sh

install_mcs_mysql.sh resides in ENGINE_SBINDIR, not in ENGINE_BINDIR