### PR TITLE
MCOL-4314 Fix SM contention from workernode

### DIFF
--- a/oam/install_scripts/CMakeLists.txt
+++ b/oam/install_scripts/CMakeLists.txt
@@ -13,7 +13,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/disable-rep-columnstore.sh.in" "${CM
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mariadb-command-line.sh.in" "${CMAKE_CURRENT_SOURCE_DIR}/mariadb-command-line.sh" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/slave-rep-columnstore.sh.in" "${CMAKE_CURRENT_SOURCE_DIR}/slave-rep-columnstore.sh" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs_module_installer.sh.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs_module_installer.sh" @ONLY)
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-workernode.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-workernode@.service" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-workernode.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-workernode.service" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-controllernode.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-controllernode.service" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-primproc.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-primproc.service" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-exemgr.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-exemgr.service" @ONLY)
@@ -62,7 +62,7 @@ install(FILES mariadb-columnstore.service
               columnstoreLogRotate
               myCnf-include-args.text
               myCnf-exclude-args.text
-              mcs-workernode@.service
+              mcs-workernode.service
               mcs-controllernode.service
               mcs-primproc.service
               mcs-exemgr.service

--- a/oam/install_scripts/CMakeLists.txt
+++ b/oam/install_scripts/CMakeLists.txt
@@ -13,7 +13,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/disable-rep-columnstore.sh.in" "${CM
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mariadb-command-line.sh.in" "${CMAKE_CURRENT_SOURCE_DIR}/mariadb-command-line.sh" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/slave-rep-columnstore.sh.in" "${CMAKE_CURRENT_SOURCE_DIR}/slave-rep-columnstore.sh" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs_module_installer.sh.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs_module_installer.sh" @ONLY)
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-workernode.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-workernode.service" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-workernode.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-workernode@.service" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-controllernode.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-controllernode.service" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-primproc.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-primproc.service" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-exemgr.service.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-exemgr.service" @ONLY)
@@ -62,7 +62,7 @@ install(FILES mariadb-columnstore.service
               columnstoreLogRotate
               myCnf-include-args.text
               myCnf-exclude-args.text
-              mcs-workernode.service
+              mcs-workernode@.service
               mcs-controllernode.service
               mcs-primproc.service
               mcs-exemgr.service

--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -149,8 +149,8 @@ if [ $user = "root" ]; then
         cp @ENGINE_SUPPORTDIR@/mcs-exemgr.service /lib/systemd/system/. >/dev/null 2>&1
         cp @ENGINE_SUPPORTDIR@/mcs-primproc.service /usr/lib/systemd/system/. >/dev/null 2>&1
         cp @ENGINE_SUPPORTDIR@/mcs-primproc.service /lib/systemd/system/. >/dev/null 2>&1
-        cp @ENGINE_SUPPORTDIR@/mcs-workernode.service /usr/lib/systemd/system/. >/dev/null 2>&1
-        cp @ENGINE_SUPPORTDIR@/mcs-workernode.service /lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-workernode@.service /usr/lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-workernode@.service /lib/systemd/system/. >/dev/null 2>&1
         cp @ENGINE_SUPPORTDIR@/mcs-writeengineserver.service /usr/lib/systemd/system/. >/dev/null 2>&1
         cp @ENGINE_SUPPORTDIR@/mcs-writeengineserver.service /lib/systemd/system/. >/dev/null 2>&1
         cp @ENGINE_SUPPORTDIR@/mcs-loadbrm.service /usr/lib/systemd/system/. >/dev/null 2>&1
@@ -165,7 +165,7 @@ if [ $user = "root" ]; then
         systemctl enable mcs-dmlproc > /dev/null 2>&1
         systemctl enable mcs-exemgr > /dev/null 2>&1
         systemctl enable mcs-primproc > /dev/null 2>&1
-        systemctl enable mcs-workernode > /dev/null 2>&1
+        systemctl enable mcs-workernode@ > /dev/null 2>&1
         systemctl enable mcs-writeengineserver > /dev/null 2>&1
         systemctl enable mcs-loadbrm > /dev/null 2>&1
         systemctl enable mcs-storagemanager > /dev/null 2>&1

--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -158,14 +158,13 @@ if [ $user = "root" ]; then
         cp @ENGINE_SUPPORTDIR@/mcs-storagemanager.service /usr/lib/systemd/system/. >/dev/null 2>&1
         cp @ENGINE_SUPPORTDIR@/mcs-storagemanager.service /lib/systemd/system/. >/dev/null 2>&1
 
-
         systemctl enable mariadb-columnstore >/dev/null 2>&1
         systemctl enable mcs-controllernode > /dev/null 2>&1
         systemctl enable mcs-ddlproc > /dev/null 2>&1
         systemctl enable mcs-dmlproc > /dev/null 2>&1
         systemctl enable mcs-exemgr > /dev/null 2>&1
         systemctl enable mcs-primproc > /dev/null 2>&1
-        systemctl enable mcs-workernode@ > /dev/null 2>&1
+        systemctl enable mcs-workernode@1 > /dev/null 2>&1
         systemctl enable mcs-writeengineserver > /dev/null 2>&1
         systemctl enable mcs-loadbrm > /dev/null 2>&1
         systemctl enable mcs-storagemanager > /dev/null 2>&1

--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -149,8 +149,8 @@ if [ $user = "root" ]; then
         cp @ENGINE_SUPPORTDIR@/mcs-exemgr.service /lib/systemd/system/. >/dev/null 2>&1
         cp @ENGINE_SUPPORTDIR@/mcs-primproc.service /usr/lib/systemd/system/. >/dev/null 2>&1
         cp @ENGINE_SUPPORTDIR@/mcs-primproc.service /lib/systemd/system/. >/dev/null 2>&1
-        cp @ENGINE_SUPPORTDIR@/mcs-workernode@.service /usr/lib/systemd/system/. >/dev/null 2>&1
-        cp @ENGINE_SUPPORTDIR@/mcs-workernode@.service /lib/systemd/system/. >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-workernode.service /usr/lib/systemd/system/mcs-workernode@.service  >/dev/null 2>&1
+        cp @ENGINE_SUPPORTDIR@/mcs-workernode.service /lib/systemd/system/mcs-workernode@.service >/dev/null 2>&1
         cp @ENGINE_SUPPORTDIR@/mcs-writeengineserver.service /usr/lib/systemd/system/. >/dev/null 2>&1
         cp @ENGINE_SUPPORTDIR@/mcs-writeengineserver.service /lib/systemd/system/. >/dev/null 2>&1
         cp @ENGINE_SUPPORTDIR@/mcs-loadbrm.service /usr/lib/systemd/system/. >/dev/null 2>&1

--- a/oam/install_scripts/columnstore-pre-uninstall.in
+++ b/oam/install_scripts/columnstore-pre-uninstall.in
@@ -82,7 +82,7 @@ if [ -n "$systemctl" ] && [ $(running_systemd) -eq 0 ]; then
     systemctl disable mcs-dmlproc > /dev/null 2>&1
     systemctl disable mcs-exemgr > /dev/null 2>&1
     systemctl disable mcs-primproc > /dev/null 2>&1
-    systemctl disable mcs-workernode@.service > /dev/null 2>&1
+    systemctl disable mcs-workernode@1 > /dev/null 2>&1
     systemctl disable mcs-writeengineserver > /dev/null 2>&1
     systemctl disable mcs-loadbrm > /dev/null 2>&1
     systemctl disable mcs-storagemanager > /dev/null 2>&1

--- a/oam/install_scripts/columnstore-pre-uninstall.in
+++ b/oam/install_scripts/columnstore-pre-uninstall.in
@@ -82,7 +82,7 @@ if [ -n "$systemctl" ] && [ $(running_systemd) -eq 0 ]; then
     systemctl disable mcs-dmlproc > /dev/null 2>&1
     systemctl disable mcs-exemgr > /dev/null 2>&1
     systemctl disable mcs-primproc > /dev/null 2>&1
-    systemctl disable mcs-workernode > /dev/null 2>&1
+    systemctl disable mcs-workernode@.service > /dev/null 2>&1
     systemctl disable mcs-writeengineserver > /dev/null 2>&1
     systemctl disable mcs-loadbrm > /dev/null 2>&1
     systemctl disable mcs-storagemanager > /dev/null 2>&1
@@ -99,8 +99,8 @@ if [ -n "$systemctl" ] && [ $(running_systemd) -eq 0 ]; then
     rm -f /lib/systemd/system/mcs-exemgr.service
     rm -f /usr/lib/systemd/system/mcs-primproc.service
     rm -f /lib/systemd/system/mcs-primproc.service
-    rm -f /usr/lib/systemd/system/mcs-workernode.service
-    rm -f /lib/systemd/system/mcs-workernode.service
+    rm -f /usr/lib/systemd/system/mcs-workernode@.service
+    rm -f /lib/systemd/system/mcs-workernode@.service
     rm -f /usr/lib/systemd/system/mcs-writeengineserver.service
     rm -f /lib/systemd/system/mcs-writeengineserver.service
     rm -f /usr/lib/systemd/system/mcs-loadbrm.service

--- a/oam/install_scripts/columnstore-pre-uninstall.in
+++ b/oam/install_scripts/columnstore-pre-uninstall.in
@@ -83,6 +83,7 @@ if [ -n "$systemctl" ] && [ $(running_systemd) -eq 0 ]; then
     systemctl disable mcs-exemgr > /dev/null 2>&1
     systemctl disable mcs-primproc > /dev/null 2>&1
     systemctl disable mcs-workernode@1 > /dev/null 2>&1
+    systemctl disable mcs-workernode@2 > /dev/null 2>&1
     systemctl disable mcs-writeengineserver > /dev/null 2>&1
     systemctl disable mcs-loadbrm > /dev/null 2>&1
     systemctl disable mcs-storagemanager > /dev/null 2>&1

--- a/oam/install_scripts/mariadb-columnstore-start.sh.in
+++ b/oam/install_scripts/mariadb-columnstore-start.sh.in
@@ -7,7 +7,8 @@
 exec {fd_lock}>/var/lib/columnstore/storagemanager/storagemanager-lock
 flock -n "$fd_lock" || exit 0
 
-/bin/systemctl start mcs-workernode
+# pass in arg of 1 to start DBRM_Worker1
+/bin/systemctl start mcs-workernode@1.service
 /bin/systemctl start mcs-controllernode
 /bin/systemctl start mcs-primproc
 /bin/systemctl start mcs-writeengineserver

--- a/oam/install_scripts/mariadb-columnstore-stop.sh
+++ b/oam/install_scripts/mariadb-columnstore-stop.sh
@@ -8,7 +8,7 @@
 /bin/systemctl stop mcs-writeengineserver
 /bin/systemctl stop mcs-primproc
 /bin/systemctl stop mcs-controllernode
-/bin/systemctl stop mcs-workernode@1.service mcs-workenrode@2.service
+/bin/systemctl stop mcs-workernode@1.service
 /bin/systemctl stop mcs-storagemanager
 
 exit 0

--- a/oam/install_scripts/mariadb-columnstore-stop.sh
+++ b/oam/install_scripts/mariadb-columnstore-stop.sh
@@ -8,7 +8,7 @@
 /bin/systemctl stop mcs-writeengineserver
 /bin/systemctl stop mcs-primproc
 /bin/systemctl stop mcs-controllernode
-/bin/systemctl stop mcs-workernode
+/bin/systemctl stop mcs-workernode@.service
 /bin/systemctl stop mcs-storagemanager
 
 exit 0

--- a/oam/install_scripts/mariadb-columnstore-stop.sh
+++ b/oam/install_scripts/mariadb-columnstore-stop.sh
@@ -8,7 +8,7 @@
 /bin/systemctl stop mcs-writeengineserver
 /bin/systemctl stop mcs-primproc
 /bin/systemctl stop mcs-controllernode
-/bin/systemctl stop mcs-workernode@.service
+/bin/systemctl stop mcs-workernode@1.service mcs-workenrode@2.service
 /bin/systemctl stop mcs-storagemanager
 
 exit 0

--- a/oam/install_scripts/mcs-controllernode.service.in
+++ b/oam/install_scripts/mcs-controllernode.service.in
@@ -2,8 +2,8 @@
 Description=mcs-controllernode
 
 # restart/stop mcs-controllernode on restart/stop of mcs-workernode
-PartOf=mcs-workernode@.service
-After=network.target mcs-workernode@.service
+PartOf=mcs-workernode@1.service
+After=network.target mcs-workernode@1.service
 
 [Service]
 Type=simple

--- a/oam/install_scripts/mcs-controllernode.service.in
+++ b/oam/install_scripts/mcs-controllernode.service.in
@@ -2,8 +2,8 @@
 Description=mcs-controllernode
 
 # restart/stop mcs-controllernode on restart/stop of mcs-workernode
-PartOf=mcs-workernode.service
-After=network.target mcs-workernode.service
+PartOf=mcs-workernode@.service
+After=network.target mcs-workernode@.service
 
 [Service]
 Type=simple

--- a/oam/install_scripts/mcs-loadbrm.service.in
+++ b/oam/install_scripts/mcs-loadbrm.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=loadbrm
-PartOf=mcs-workernode.service
+PartOf=mcs-workernode@.service
 After=network.target mcs-storagemanager.service
 
 [Service]
@@ -8,4 +8,4 @@ Type=oneshot
 ExecStart=/usr/bin/env bash -c "@ENGINE_BINDIR@/mcs-loadbrm.py && sleep 2" 
 
 [Install]
-WantedBy=mcs-workernode.service
+WantedBy=mcs-workernode@.service

--- a/oam/install_scripts/mcs-loadbrm.service.in
+++ b/oam/install_scripts/mcs-loadbrm.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=loadbrm
-PartOf=mcs-workernode@.service
+PartOf=mcs-workernode@1.service mcs-workernode@2.service
 After=network.target mcs-storagemanager.service
 
 [Service]
@@ -8,4 +8,4 @@ Type=oneshot
 ExecStart=/usr/bin/env bash -c "@ENGINE_BINDIR@/mcs-loadbrm.py && sleep 2" 
 
 [Install]
-WantedBy=mcs-workernode@.service
+WantedBy=mcs-workernode@1.service mcs-workernode@2.service

--- a/oam/install_scripts/mcs-primproc.service.in
+++ b/oam/install_scripts/mcs-primproc.service.in
@@ -2,9 +2,9 @@
 Description=mcs-primproc
 
 # restart/stop mcs-primproc on restart/stop of mcs-workernode or mcs-controllernode
-PartOf=mcs-workernode.service
+PartOf=mcs-workernode@.service
 PartOf=mcs-controllernode.service
-After=network.target mcs-workernode.service mcs-controllernode.service
+After=network.target mcs-workernode@.service mcs-controllernode.service
 
 [Service]
 Type=simple

--- a/oam/install_scripts/mcs-primproc.service.in
+++ b/oam/install_scripts/mcs-primproc.service.in
@@ -2,9 +2,9 @@
 Description=mcs-primproc
 
 # restart/stop mcs-primproc on restart/stop of mcs-workernode or mcs-controllernode
-PartOf=mcs-workernode@.service
+PartOf=mcs-workernode@1.service mcs-workernode@2.service
 PartOf=mcs-controllernode.service
-After=network.target mcs-workernode@.service mcs-controllernode.service
+After=network.target mcs-workernode@1.service mcs-workernode@2.service mcs-controllernode.service
 
 [Service]
 Type=simple

--- a/oam/install_scripts/mcs-workernode.service.in
+++ b/oam/install_scripts/mcs-workernode.service.in
@@ -10,7 +10,7 @@ Group=mysql
 LimitNOFILE=65536
 LimitNPROC=65536
 
-ExecStart=@ENGINE_BINDIR@/workernode DBRM_Worker1 fg
+ExecStart=@ENGINE_BINDIR@/workernode DBRM_Worker%i fg
 ExecStopPost=@ENGINE_BINDIR@/mcs-savebrm.py
 ExecStopPost=/usr/bin/env bash -c "clearShm > /dev/null 2>&1"
 


### PR DESCRIPTION
Made mcs-workernode service a template service so it no longer has hardcoded DBRM_Worker1.
Fixes multinode issues where non-primary workernodes were running as DBRM_Worker1 and pulling ownership of dbroot1 from storagemanager.

CMAPI related changes: mariadb-corporation/mariadb-columnstore-cmapi#92