### PR TITLE
MCOL-4347: Better handling of getConnection() returning NULL

### DIFF
--- a/storage-manager/src/S3Storage.cpp
+++ b/storage-manager/src/S3Storage.cpp
@@ -231,6 +231,12 @@ int S3Storage::getObject(const string &_sourceKey, boost::shared_array<uint8_t> 
     string sourceKey = prefix + _sourceKey;
     
     ms3_st *creds = getConnection();
+    if (!creds)
+    {
+        logger->log(LOG_ERR, "S3Storage::getObject(): failed to GET, S3Storage::getConnection() returned NULL on init");
+        errno = EINVAL;
+        return -1;
+    }
     ScopedConnection sc(this, creds);
     
     do {
@@ -325,6 +331,12 @@ int S3Storage::putObject(const boost::shared_array<uint8_t> data, size_t len, co
     string destKey = prefix + _destKey;
     uint8_t s3err;
     ms3_st *creds = getConnection();
+    if (!creds)
+    {
+        logger->log(LOG_ERR, "S3Storage::putObject(): failed to PUT, S3Storage::getConnection() returned NULL on init");
+        errno = EINVAL;
+        return -1;
+    }
     ScopedConnection sc(this, creds);
     
     do {
@@ -363,6 +375,12 @@ int S3Storage::deleteObject(const string &_key)
     uint8_t s3err;
     string key = prefix + _key;
     ms3_st *creds = getConnection();
+    if (!creds)
+    {
+        logger->log(LOG_ERR, "S3Storage::deleteObject(): failed to DELETE, S3Storage::getConnection() returned NULL on init");
+        errno = EINVAL;
+        return -1;
+    }
     ScopedConnection sc(this, creds);
 
     do {
@@ -401,6 +419,12 @@ int S3Storage::copyObject(const string &_sourceKey, const string &_destKey)
     string sourceKey = prefix + _sourceKey, destKey = prefix + _destKey;
     uint8_t s3err;
     ms3_st *creds = getConnection();
+    if (!creds)
+    {
+        logger->log(LOG_ERR, "S3Storage::copyObject(): failed to copy, S3Storage::getConnection() returned NULL on init");
+        errno = EINVAL;
+        return -1;
+    }
     ScopedConnection sc(this, creds);
     
     do 
@@ -455,6 +479,12 @@ int S3Storage::exists(const string &_key, bool *out)
     uint8_t s3err;
     ms3_status_st status;
     ms3_st *creds = getConnection();
+    if (!creds)
+    {
+        logger->log(LOG_ERR, "S3Storage::exists(): failed to HEAD, S3Storage::getConnection() returned NULL on init");
+        errno = EINVAL;
+        return -1;
+    }
     ScopedConnection sc(this, creds);
     
     do {

--- a/storage-manager/src/main.cpp
+++ b/storage-manager/src/main.cpp
@@ -77,11 +77,25 @@ void coreSM(int sig)
 int main(int argc, char** argv)
 {
 
+    SMLogging* logger = SMLogging::get();
+    IOCoordinator* ioc = NULL;
+    Cache* cache = NULL;
+    Synchronizer* sync = NULL;
+    Replicator* rep = NULL;
+
     /* Instantiate objects to have them verify config settings before continuing */
-    IOCoordinator* ioc = IOCoordinator::get();
-    Cache* cache = Cache::get();
-    Synchronizer* sync = Synchronizer::get();
-    Replicator* rep = Replicator::get();
+    try
+    {
+        ioc = IOCoordinator::get();
+        cache = Cache::get();
+        sync = Synchronizer::get();
+        rep = Replicator::get();
+    }
+    catch (exception &e)
+    {
+        logger->log(LOG_INFO, "StorageManager init FAIL: %s", e.what());
+        return -1;
+    }
 
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
@@ -111,8 +125,6 @@ int main(int argc, char** argv)
     sigaction(SIGUSR2, &sa, NULL);
     
     int ret = 0;
-
-    SMLogging* logger = SMLogging::get();
 
     logger->log(LOG_NOTICE,"StorageManager started.");
 

--- a/storage-manager/src/smcat.cpp
+++ b/storage-manager/src/smcat.cpp
@@ -55,30 +55,37 @@ void catFileOffline(const char *filename, int prefixlen)
     uint8_t data[8192];
     off_t offset = 0;
     int read_err, write_err, count;
-    boost::scoped_ptr<IOCoordinator> ioc(IOCoordinator::get());
-    
-    do {
-        count = 0;
-        read_err = ioc->read(filename, data, offset, 8192);
-        if (read_err < 0)
-        {
-            int l_errno = errno;
-            cerr << "Error reading " << &filename[prefixlen] << ": " << strerror_r(l_errno, (char *) data, 8192) << endl;
-        }
+    try
+    {
+        boost::scoped_ptr<IOCoordinator> ioc(IOCoordinator::get());
 
-        while (count < read_err)
-        {
-            write_err = write(STDOUT_FILENO, &data[count], read_err - count);
-            if (write_err < 0)
+        do {
+            count = 0;
+            read_err = ioc->read(filename, data, offset, 8192);
+            if (read_err < 0)
             {
                 int l_errno = errno;
-                cerr << "Error writing to stdout: " << strerror_r(l_errno, (char *) data, 8192) << endl;
-                exit(1);
+                cerr << "Error reading " << &filename[prefixlen] << ": " << strerror_r(l_errno, (char *) data, 8192) << endl;
             }
-            count += write_err;
-        }
-        offset += read_err;
-    } while (read_err > 0);
+
+            while (count < read_err)
+            {
+                write_err = write(STDOUT_FILENO, &data[count], read_err - count);
+                if (write_err < 0)
+                {
+                    int l_errno = errno;
+                    cerr << "Error writing to stdout: " << strerror_r(l_errno, (char *) data, 8192) << endl;
+                    exit(1);
+                }
+                count += write_err;
+            }
+            offset += read_err;
+        } while (read_err > 0);
+    }
+    catch (exception &e)
+    {
+        cerr << "smcat catFileOffline FAIL: " << e.what() << endl;
+    }
 }
 
 void catFileOnline(const char *filename, int prefixlen)

--- a/storage-manager/src/smls.cpp
+++ b/storage-manager/src/smls.cpp
@@ -58,41 +58,48 @@ bool SMOnline()
 
 void lsOffline(const char *path)
 {
-    boost::scoped_ptr<IOCoordinator> ioc(IOCoordinator::get());
-    vector<string> listing;
-    
-    int err = ioc->listDirectory(path, &listing);
-    if (err)
-        exit(1);
-    
-    struct stat _stat;
-    boost::filesystem::path base(path);
-    boost::filesystem::path p;
-    cout.fill(' ');
-    for (auto &entry : listing)
+    try
     {
-        p = base / entry;
-        err = ioc->stat(p.string().c_str(), &_stat);
-        if (!err)
+        boost::scoped_ptr<IOCoordinator> ioc(IOCoordinator::get());
+        vector<string> listing;
+
+        int err = ioc->listDirectory(path, &listing);
+        if (err)
+            exit(1);
+
+        struct stat _stat;
+        boost::filesystem::path base(path);
+        boost::filesystem::path p;
+        cout.fill(' ');
+        for (auto &entry : listing)
         {
-            if (_stat.st_mode & S_IFDIR)
+            p = base / entry;
+            err = ioc->stat(p.string().c_str(), &_stat);
+            if (!err)
             {
-                cout << "d";
-                cout.width(14);
+                if (_stat.st_mode & S_IFDIR)
+                {
+                    cout << "d";
+                    cout.width(14);
+                }
+                else
+                    cout.width(15);
+
+                struct tm *my_tm = localtime(&_stat.st_mtim.tv_sec);
+                char date[100];
+                strftime(date, 100, "%b %e %H:%M", my_tm);
+                cout << right << _stat.st_size << left << " " << date << left << " " << entry << endl;
             }
             else
+            {
                 cout.width(15);
-
-            struct tm *my_tm = localtime(&_stat.st_mtim.tv_sec);
-            char date[100];
-            strftime(date, 100, "%b %e %H:%M", my_tm);
-            cout << right << _stat.st_size << left << " " << date << left << " " << entry << endl;
+                cout << right << "error" << left <<  " " << entry << endl;
+            }
         }
-        else
-        {
-            cout.width(15);
-            cout << right << "error" << left <<  " " << entry << endl;
-        }
+    }
+    catch (exception &e)
+    {
+        cerr << "smls lsOffline FAIL: " << e.what() << endl;
     }
 }
 

--- a/storage-manager/src/smrm.cpp
+++ b/storage-manager/src/smrm.cpp
@@ -54,14 +54,21 @@ bool SMOnline()
 
 void rmOffline(int argCount, const char **args, const char *prefix, uint prefixlen)
 {
-    boost::scoped_ptr<IOCoordinator> ioc(IOCoordinator::get());
-    char buf[16384];
-    strncpy(buf, prefix, prefixlen);
-    
-    for (int i = 1; i < argCount; i++)
+    try
     {
-        memcpy(&buf[prefixlen], args[i], min(16383 - prefixlen, strlen(args[i])) + 1);
-        ioc->unlink(buf);
+        boost::scoped_ptr<IOCoordinator> ioc(IOCoordinator::get());
+        char buf[16384];
+        strncpy(buf, prefix, prefixlen);
+
+        for (int i = 1; i < argCount; i++)
+        {
+            memcpy(&buf[prefixlen], args[i], min(16383 - prefixlen, strlen(args[i])) + 1);
+            ioc->unlink(buf);
+        }
+    }
+    catch (exception &e)
+    {
+        cerr << "smrm rmOffline FAIL: " << e.what() << endl;
     }
 }
 


### PR DESCRIPTION
getConnection() returns NULL if  libmarias3 ms3_init() or ms3_init_assume_role() fail
ms3_init() is highly unlikely to fail as we do adequately check in constructor for at least some value for s3 key/secret is set in config.
ms3_init_assume_role() is more likely to fail as it attempts to assume a role during init meaning IAM and STS requests are performed. This can fail for many reasons related to both user input in config (role name wrong), role permission errors, or network issues resulting in the request not reaching the desired endpoint.
This fix provides better error handling ensuring that it does not rely on assert in ScopedConnection or failing the request because ms3_st is NULL.