### PR TITLE
MCOL-4285 For Insert...Select, pass the is_cache_insert=true

### DIFF
--- a/dbcon/mysql/ha_mcs.cpp
+++ b/dbcon/mysql/ha_mcs.cpp
@@ -1219,6 +1219,8 @@ my_bool get_status_and_flush_cache(void *param,
   int error;
   enum_sql_command sql_command= cache->table->in_use->lex->sql_command;
 
+  cache->sql_command= sql_command;
+
   cache->insert_command= (sql_command == SQLCOM_INSERT ||
                           sql_command == SQLCOM_LOAD);
   /*
@@ -1781,7 +1783,16 @@ void ha_mcs_cache::start_bulk_insert(ha_rows rows, uint flags)
       bzero(&cache_handler->copy_info, sizeof(cache_handler->copy_info));
       return cache_handler->start_bulk_insert(rows, flags);
     }
-    return parent::start_bulk_insert(rows, flags);
+    else if (sql_command == SQLCOM_INSERT_SELECT)
+    {
+      return parent::start_bulk_insert_from_cache(rows, flags);
+    }
+    // sql_command == SQLCOM_END:
+    // See the comment in get_status_and_flush_cache
+    else
+    {
+      return parent::start_bulk_insert(rows, flags);
+    }
   }
   else
   {

--- a/dbcon/mysql/ha_mcs.h
+++ b/dbcon/mysql/ha_mcs.h
@@ -285,6 +285,7 @@ class ha_mcs_cache :public ha_mcs
   typedef ha_mcs parent;
   int original_lock_type;
   bool insert_command, cache_locked;
+  enum_sql_command sql_command;
 
   // True if this handler belongs to either calpontsys.systable or
   // calpontsys.syscolumn system catalog tables


### PR DESCRIPTION
flag to ha_mcs_impl_start_bulk_insert.

An earlier commit to fix LDI under replication changed the call in
ha_mcs_cache::start_bulk_insert for a non-insert command from
parent::start_bulk_insert_from_cache to parent::start_bulk_insert.
This commit reverts that change for INSERT...SELECT operation.