### PR TITLE
Follow up on MCOL-4172 MultiDistinctRowAggregation didn't honor multiple UDAF in p…

### DIFF
--- a/utils/rowgroup/rowaggregation.h
+++ b/utils/rowgroup/rowaggregation.h
@@ -605,7 +605,8 @@ public:
         return fResultDataVec;
     }
 
-    virtual void aggregateRow(Row& row);
+    virtual void aggregateRow(Row& row,
+                              std::vector<mcsv1sdk::mcsv1Context>* rgContextColl = nullptr);
     inline uint32_t aggMapKeyLength()
     {
         return fAggMapKeyCount;
@@ -619,19 +620,29 @@ public:
     {
         return fTimeZone;
     }
+    inline std::vector<mcsv1sdk::mcsv1Context>* rgContextColl()
+    {
+        return &fRGContextColl;
+    }
 
 protected:
     virtual void initialize();
     virtual void initMapData(const Row& row);
     virtual void attachGroupConcatAg();
 
-    virtual void updateEntry(const Row& row);
+    virtual void updateEntry(const Row& row,
+                             std::vector<mcsv1sdk::mcsv1Context>* rgContextColl = nullptr);
     virtual void doMinMax(const Row&, int64_t, int64_t, int);
     virtual void doSum(const Row&, int64_t, int64_t, int);
     virtual void doAvg(const Row&, int64_t, int64_t, int64_t);
     virtual void doStatistics(const Row&, int64_t, int64_t, int64_t);
     virtual void doBitOp(const Row&, int64_t, int64_t, int);
-    virtual void doUDAF(const Row&, int64_t, int64_t, int64_t, uint64_t& funcColsIdx);
+    virtual void doUDAF(const Row&,
+                        int64_t,
+                        int64_t,
+                        int64_t,
+                        uint64_t& funcColsIdx,
+                        std::vector<mcsv1sdk::mcsv1Context>* rgContextColl = nullptr);
     virtual bool countSpecial(const RowGroup* pRG)
     {
         fRow.setUintField<8>(fRow.getUintField<8>(0) + pRG->getRowCount(), 0);
@@ -824,19 +835,21 @@ public:
         return fGroupConcat;
     }
 
-    void aggregateRow(Row&);
-    //void initialize();
+    void aggregateRow(Row&,
+                      std::vector<mcsv1sdk::mcsv1Context>* rgContextColl = nullptr) override;
     virtual void aggReset();
 
     void setInputOutput(const RowGroup& pRowGroupIn, RowGroup* pRowGroupOut);
 
 protected:
-    // virtual methods from base
-    void initialize();
-    void aggregateRowWithRemap(Row&);
+    void initialize() override;
+    void updateEntry(const Row& row,
+                     std::vector<mcsv1sdk::mcsv1Context>* rgContextColl = nullptr) override;
+
+    void aggregateRowWithRemap(Row&,
+                               std::vector<mcsv1sdk::mcsv1Context>* rgContextColl = nullptr);
 
     void attachGroupConcatAg();
-    void updateEntry(const Row& row);
     bool countSpecial(const RowGroup* pRG)
     {
         fRow.setIntField<8>(
@@ -949,12 +962,18 @@ public:
 
 protected:
     // virtual methods from base
-    void updateEntry(const Row& row);
+    void updateEntry(const Row& row,
+                     std::vector<mcsv1sdk::mcsv1Context>* rgContextColl = nullptr) override;
     void doAvg(const Row&, int64_t, int64_t, int64_t);
     void doStatistics(const Row&, int64_t, int64_t, int64_t);
     void doGroupConcat(const Row&, int64_t, int64_t);
     void doBitOp(const Row&, int64_t, int64_t, int);
-    void doUDAF(const Row&, int64_t, int64_t, int64_t, uint64_t& funcColsIdx);
+    void doUDAF(const Row&,
+                int64_t,
+                int64_t,
+                int64_t,
+                uint64_t& funcColsIdx,
+                std::vector<mcsv1sdk::mcsv1Context>* rgContextColl = nullptr) override;
     bool countSpecial(const RowGroup* pRG)
     {
         return false;
@@ -1022,8 +1041,8 @@ public:
     }
 
 protected:
-    // virtual methods from base
-    void updateEntry(const Row& row);
+    void updateEntry(const Row& row,
+                     std::vector<mcsv1sdk::mcsv1Context>* rgContextColl = nullptr) override;
 
     boost::shared_ptr<RowAggregation>   fAggregator;
     RowGroup                            fRowGroupDist;


### PR DESCRIPTION
…rojection

MultiDistinctRowAggregation::doAggregation() method mutates fFunctionCols that
describes aggregation functions and it didn't change fRGContextColl accordingly
so execution fails b/c of this desynchronization