### PR TITLE
mcs-loadbrm.py now works with python 3.5 that is used by certain

### DIFF
--- a/oam/install_scripts/mcs-loadbrm.py.in
+++ b/oam/install_scripts/mcs-loadbrm.py.in
@@ -76,13 +76,14 @@ if __name__ == '__main__':
         config_root.find('./SystemConfig/DataFilePlugin').text = "libcloudio.so"
         
         cs_config.write('/etc/columnstore/Columnstore.xml.loadbrm')
-        os.replace('/etc/columnstore/Columnstore.xml.loadbrm', '/etc/columnstore/Columnstore.xml')    # atomic replacement
+        os.replace('/etc/columnstore/Columnstore.xml.loadbrm',
+                   '/etc/columnstore/Columnstore.xml')    # atomic replacement
 
     # Single-node on S3
     if storage.lower() == 's3' and not bucket.lower() == 'some_bucket' and pmCount == 1:
         try:
             if use_systemd:
-                args = ['su', '-s', '/bin/sh', '-c', f'smcat {brm}', 'mysql']
+                args = ['su', '-s', '/bin/sh', '-c', 'smcat {}'.format(brm), 'mysql']
             else:
                 args = ['smcat', brm]
 


### PR DESCRIPTION
deb-based distributions