### PR TITLE
MCOL-641 Fixes for arithmetic operations.

### DIFF
--- a/datatypes/mcs_decimal.h
+++ b/datatypes/mcs_decimal.h
@@ -461,6 +461,21 @@ class Decimal
             scale += (scaleAvailable >= MAXSCALEINC4AVG) ? MAXSCALEINC4AVG : scaleAvailable;
             precision += (precisionAvailable >= MAXSCALEINC4AVG) ? MAXSCALEINC4AVG : precisionAvailable;
         }
+
+        /**
+            @brief Returns true if all arguments have a DECIMAL/UDECIMAL type
+        */
+        static inline bool isDecimalOperands(const ColDataTypeAlias resultDataType,
+            const ColDataTypeAlias leftColDataType,
+            const ColDataTypeAlias rightColDataType)
+        {
+            return ((resultDataType == execplan::CalpontSystemCatalog::DECIMAL ||
+                     resultDataType == execplan::CalpontSystemCatalog::UDECIMAL) &&
+                    (leftColDataType == execplan::CalpontSystemCatalog::DECIMAL ||
+                     leftColDataType == execplan::CalpontSystemCatalog::UDECIMAL) &&
+                    (rightColDataType == execplan::CalpontSystemCatalog::DECIMAL ||
+                     rightColDataType == execplan::CalpontSystemCatalog::UDECIMAL));
+        }
 };
 
 /**

--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -346,12 +346,8 @@ namespace joblist
 void wideDecimalOrLongDouble(const uint64_t colProj,
     const CalpontSystemCatalog::ColDataType type,
     const vector<uint32_t>& precisionProj,
-    const vector<uint32_t>& oidsProj,
-    const uint32_t aggKey,
     const vector<uint32_t>& scaleProj,
     const vector<uint32_t>& width,
-    vector<uint32_t>& oidsAgg,
-    vector<uint32_t>& keysAgg,
     vector<CalpontSystemCatalog::ColDataType>& typeAgg,
     vector<uint32_t>& scaleAgg,
     vector<uint32_t>& precisionAgg,
@@ -361,8 +357,6 @@ void wideDecimalOrLongDouble(const uint64_t colProj,
         || type == CalpontSystemCatalog::UDECIMAL)
         && datatypes::Decimal::isWideDecimalType(precisionProj[colProj]))
     {
-        oidsAgg.push_back(oidsProj[colProj]);
-        keysAgg.push_back(aggKey);
         typeAgg.push_back(type);
         scaleAgg.push_back(scaleProj[colProj]);
         precisionAgg.push_back(precisionProj[colProj]);
@@ -370,8 +364,6 @@ void wideDecimalOrLongDouble(const uint64_t colProj,
     }
     else
     {
-        oidsAgg.push_back(oidsProj[colProj]);
-        keysAgg.push_back(aggKey);
         typeAgg.push_back(CalpontSystemCatalog::LONGDOUBLE);
         scaleAgg.push_back(0);
         precisionAgg.push_back(-1);
@@ -785,29 +777,38 @@ void TupleAggregateStep::configDeliveredRowGroup(const JobInfo& jobInfo)
     if (jobInfo.havingStep)
     {
         retColCount = jobInfo.returnedColVec.size();
+
         idbassert(jobInfo.returnedColVec.size() == jobInfo.nonConstCols.size());
-        for (auto& rc : jobInfo.nonConstCols)
+
+        for (size_t i = 0; i < jobInfo.nonConstCols.size() &&
+             scaleIter != scale.end(); i++)
         {
-            auto& colType = rc->resultType();
+            const auto& colType = jobInfo.nonConstCols[i]->resultType();
+
             if (datatypes::Decimal::isWideDecimalType(colType))
             {
                 *scaleIter = colType.scale;
                 *precisionIter = colType.precision;
             }
+
             scaleIter++; precisionIter++;
         }
     }
     else
     {
         retColCount = jobInfo.nonConstDelCols.size();
-        for (auto& rc : jobInfo.nonConstDelCols)
+
+        for (size_t i = 0; i < jobInfo.nonConstDelCols.size() &&
+             scaleIter != scale.end(); i++)
         {
-            auto& colType = rc->resultType();
+            const auto& colType = jobInfo.nonConstDelCols[i]->resultType();
+
             if (datatypes::Decimal::isWideDecimalType(colType))
             {
                 *scaleIter = colType.scale;
                 *precisionIter = colType.precision;
             }
+
             scaleIter++; precisionIter++;
         }
     }
@@ -1383,10 +1384,13 @@ void TupleAggregateStep::prep1PhaseAggregate(
                     cerr << "prep1PhaseAggregate: " << emsg << endl;
                     throw IDBExcept(emsg, ERR_AGGREGATE_TYPE_NOT_SUPPORT);
                 }
+
                 wideDecimalOrLongDouble(colProj, typeProj[colProj],
-                    precisionProj, oidsProj, key, scaleProj, width,
-                    oidsAgg, keysAgg, typeAgg, scaleAgg,
-                    precisionAgg, widthAgg);
+                    precisionProj, scaleProj, width,
+                    typeAgg, scaleAgg, precisionAgg, widthAgg);
+
+                oidsAgg.push_back(oidsProj[colProj]);
+                keysAgg.push_back(key);
                 csNumAgg.push_back(csNumProj[colProj]);
             }
             break;
@@ -3200,10 +3204,13 @@ void TupleAggregateStep::prep2PhasesAggregate(
                         cerr << "prep2PhasesAggregate: " << emsg << endl;
                         throw IDBExcept(emsg, ERR_AGGREGATE_TYPE_NOT_SUPPORT);
                     }
+
                     wideDecimalOrLongDouble(colProj, typeProj[colProj],
-                        precisionProj, oidsProj, aggKey, scaleProj, width,
-                        oidsAggPm, keysAggPm, typeAggPm, scaleAggPm,
-                        precisionAggPm, widthAggPm);
+                        precisionProj, scaleProj, width,
+                        typeAggPm, scaleAggPm, precisionAggPm, widthAggPm);
+
+                    oidsAggPm.push_back(oidsProj[colProj]);
+                    keysAggPm.push_back(aggKey);
                     csNumAggPm.push_back(8);
                     colAggPm++;
                 }
@@ -3488,9 +3495,11 @@ void TupleAggregateStep::prep2PhasesAggregate(
                         if (aggOp == ROWAGG_SUM)
                         {
                             wideDecimalOrLongDouble(colPm, typeProj[colPm],
-                                precisionProj, oidsProj, retKey, scaleProj, widthAggPm,
-                                oidsAggUm, keysAggUm, typeAggUm, scaleAggUm,
-                                precisionAggUm, widthAggUm);
+                                precisionProj, scaleProj, widthAggPm,
+                                typeAggUm, scaleAggUm, precisionAggUm, widthAggUm);
+
+                            oidsAggUm.push_back(oidsProj[colPm]);
+                            keysAggUm.push_back(retKey);
                             csNumAggUm.push_back(8);
                         }
                         else

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -3601,68 +3601,51 @@ ArithmeticColumn* buildArithmeticColumn(
 
     // @bug5715. Use InfiniDB adjusted coltype for result type.
     // decimal arithmetic operation gives double result when the session variable is set.
-    CalpontSystemCatalog::ColType mysql_type = colType_MysqlToIDB(item);
+    CalpontSystemCatalog::ColType mysqlType = colType_MysqlToIDB(item);
 
-    if (mysql_type.colDataType == CalpontSystemCatalog::DECIMAL ||
-        mysql_type.colDataType == CalpontSystemCatalog::UDECIMAL)
+    const CalpontSystemCatalog::ColType& leftColType = pt->left()->data()->resultType();
+    const CalpontSystemCatalog::ColType& rightColType = pt->right()->data()->resultType();
+
+    // Only tinker with the type if all columns involved are decimal
+    if (datatypes::Decimal::isDecimalOperands(mysqlType.colDataType,
+            leftColType.colDataType, rightColType.colDataType))
     {
-        int32_t leftColWidth = pt->left()->data()->resultType().colWidth;
-        int32_t rightColWidth = pt->right()->data()->resultType().colWidth;
+        int32_t leftColWidth = leftColType.colWidth;
+        int32_t rightColWidth = rightColType.colWidth;
 
-        // Revert back to legacy values of scale and precision
-        // if the 2 columns involved in the expression are not wide
-        if (leftColWidth <= utils::MAXLEGACYWIDTH &&
-            rightColWidth <= utils::MAXLEGACYWIDTH)
+        if (leftColWidth == datatypes::MAXDECIMALWIDTH ||
+            rightColWidth == datatypes::MAXDECIMALWIDTH)
         {
-            Item_decimal* idp = (Item_decimal*)item;
+            mysqlType.colWidth = datatypes::MAXDECIMALWIDTH;
 
-            mysql_type.colWidth = 8;
+            string funcName = item->func_name();
 
-            unsigned int precision = idp->max_length;
-            unsigned int scale = idp->decimals;
+            int32_t scale1 = leftColType.scale;
+            int32_t scale2 = rightColType.scale;
 
-            datatypes::Decimal::setDecimalScalePrecisionLegacy(mysql_type,
-                precision, scale);
-        }
-        else
-        {
-
-            if (leftColWidth == datatypes::MAXDECIMALWIDTH ||
-                rightColWidth == datatypes::MAXDECIMALWIDTH)
-                mysql_type.colWidth = datatypes::MAXDECIMALWIDTH;
-
-            if (mysql_type.colWidth == datatypes::MAXDECIMALWIDTH)
+            if (funcName == "/" &&
+                (mysqlType.scale - (scale1 - scale2)) > datatypes::INT128MAXPRECISION)
             {
-                string funcName = item->func_name();
+                Item_decimal* idp = (Item_decimal*)item;
 
-                int32_t scale1 = pt->left()->data()->resultType().scale;
-                int32_t scale2 = pt->right()->data()->resultType().scale;
+                unsigned int precision = idp->decimal_precision();
+                unsigned int scale = idp->decimal_scale();
 
-                if (funcName == "/" &&
-                    (mysql_type.scale - (scale1 - scale2)) >
-                        datatypes::INT128MAXPRECISION)
-                {
-                    Item_decimal* idp = (Item_decimal*)item;
+                datatypes::Decimal::setDecimalScalePrecisionHeuristic(mysqlType, precision, scale);
 
-                    unsigned int precision = idp->decimal_precision();
-                    unsigned int scale = idp->decimal_scale();
+                if (mysqlType.scale < scale1)
+                    mysqlType.scale = scale1;
 
-                    datatypes::Decimal::setDecimalScalePrecisionHeuristic(mysql_type, precision, scale);
-
-                    if (mysql_type.scale < scale1)
-                        mysql_type.scale = scale1;
-
-                    if (mysql_type.precision < mysql_type.scale)
-                        mysql_type.precision = mysql_type.scale;
-                }
+                if (mysqlType.precision < mysqlType.scale)
+                    mysqlType.precision = mysqlType.scale;
             }
         }
     }
 
     if (get_double_for_decimal_math(current_thd) == true)
-        aop->adjustResultType(mysql_type);
+        aop->adjustResultType(mysqlType);
     else
-        aop->resultType(mysql_type);
+        aop->resultType(mysqlType);
 
     // adjust decimal result type according to internalDecimalScale
     if (gwi.internalDecimalScale >= 0 && aop->resultType().colDataType == CalpontSystemCatalog::DECIMAL)


### PR DESCRIPTION
1. Perform type promotion to wide decimal if the result
   of an arithmetic operation has a precision > 18.
2. Only set the decimal width of an arithmetic operation to wide
   if both the LHS and RHS of the operation are decimal types.