### PR TITLE
Don't merge yet. Columnstore syslog file creation should be with mysql as owner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ oam/etc/ProcessConfig.xml
 oam/install_scripts/columnstore-post-install
 oam/install_scripts/columnstore-pre-uninstall
 oam/install_scripts/columnstore.service
+oam/install_scripts/columnstoreSyslog
 oam/install_scripts/columnstoreSyslogSetup.sh
 oam/install_scripts/columnstore_module_installer.sh
 oam/install_scripts/disable-rep-columnstore.sh

--- a/oam/install_scripts/CMakeLists.txt
+++ b/oam/install_scripts/CMakeLists.txt
@@ -1,3 +1,6 @@
+SET (DEFAULT_USER "mysql")
+SET (DEFAULT_GROUP "mysql")
+
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/columnstoreSyslogSetup.sh.in" "${CMAKE_CURRENT_SOURCE_DIR}/columnstoreSyslogSetup.sh" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/columnstore-post-install.in" "${CMAKE_CURRENT_SOURCE_DIR}/columnstore-post-install" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/columnstore.in" "${CMAKE_CURRENT_SOURCE_DIR}/columnstore" @ONLY)
@@ -25,6 +28,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-storagemanager.service.in" "${CM
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-stop-controllernode.sh.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-stop-controllernode.sh" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-loadbrm.py.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-loadbrm.py" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcs-savebrm.py.in" "${CMAKE_CURRENT_SOURCE_DIR}/mcs-savebrm.py" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/columnstoreSyslog.in" "${CMAKE_CURRENT_SOURCE_DIR}/columnstoreSyslog" @ONLY)
 
 install(PROGRAMS columnstore-post-install 
                 columnstore-pre-uninstall 
@@ -74,4 +78,3 @@ install(FILES mariadb-columnstore.service
               DESTINATION ${ENGINE_SUPPORTDIR} COMPONENT columnstore-engine)
 
 install(FILES  module DESTINATION ${ENGINE_DATADIR}/local COMPONENT columnstore-engine)
-

--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -320,10 +320,10 @@ fi
 #change ownership/permissions to be able to run columnstore as non-root
 # TODO: Remove conditional once container dispatcher uses non-root by default
 if [ $(running_systemd) -eq 0 ]; then
-    chown -R mysql:mysql /var/log/mariadb/columnstore
-    chown -R mysql:mysql /etc/columnstore
-    chown -R mysql:mysql /var/lib/columnstore
-    chown -R mysql:mysql /tmp/columnstore_tmp_files
+    chown -R @DEFAULT_USER@:@DEFAULT_GROUP@ /var/log/mariadb/columnstore
+    chown -R @DEFAULT_USER@:@DEFAULT_GROUP@ /etc/columnstore
+    chown -R @DEFAULT_USER@:@DEFAULT_GROUP@ /var/lib/columnstore
+    chown -R @DEFAULT_USER@:@DEFAULT_GROUP@ /tmp/columnstore_tmp_files
     chmod 777 /tmp/columnstore_tmp_files
     chmod 777 /dev/shm
 fi

--- a/oam/install_scripts/columnstoreSyslog
+++ b/oam/install_scripts/columnstoreSyslog
@@ -1,8 +1,0 @@
-# MariaDB Columnstore Database Platform Logging
-$FileOwner mysql
-$FileGroup mysql
-local1.=crit -/var/log/mariadb/columnstore/crit.log
-local1.=err -/var/log/mariadb/columnstore/err.log
-local1.=warning -/var/log/mariadb/columnstore/warning.log
-local1.=info -/var/log/mariadb/columnstore/info.log
-local1.=debug -/var/log/mariadb/columnstore/debug.log

--- a/oam/install_scripts/columnstoreSyslog
+++ b/oam/install_scripts/columnstoreSyslog
@@ -1,4 +1,6 @@
 # MariaDB Columnstore Database Platform Logging
+$FileOwner mysql
+$FileGroup mysql
 local1.=crit -/var/log/mariadb/columnstore/crit.log
 local1.=err -/var/log/mariadb/columnstore/err.log
 local1.=warning -/var/log/mariadb/columnstore/warning.log

--- a/oam/install_scripts/columnstoreSyslog.in
+++ b/oam/install_scripts/columnstoreSyslog.in
@@ -1,0 +1,8 @@
+# MariaDB Columnstore Database Platform Logging
+$FileOwner @DEFAULT_USER@
+$FileGroup @DEFAULT_GROUP@
+local1.=crit -/var/log/mariadb/columnstore/crit.log
+local1.=err -/var/log/mariadb/columnstore/err.log
+local1.=warning -/var/log/mariadb/columnstore/warning.log
+local1.=info -/var/log/mariadb/columnstore/info.log
+local1.=debug -/var/log/mariadb/columnstore/debug.log

--- a/oam/install_scripts/mariadb-columnstore-start.sh.in
+++ b/oam/install_scripts/mariadb-columnstore-start.sh.in
@@ -16,7 +16,7 @@ flock -n "$fd_lock" || exit 0
 /bin/systemctl start mcs-dmlproc
 /bin/systemctl start mcs-ddlproc
 sleep 2
-su -s /bin/sh -c '@ENGINE_BINDIR@/dbbuilder 7' mysql 1> /tmp/columnstore_tmp_files/dbbuilder.log
+su -s /bin/sh -c '@ENGINE_BINDIR@/dbbuilder 7' @DEFAULT_USER@ 1> /tmp/columnstore_tmp_files/dbbuilder.log
 
 flock -u "$fd_lock"
 

--- a/oam/install_scripts/mcs-controllernode.service.in
+++ b/oam/install_scripts/mcs-controllernode.service.in
@@ -8,8 +8,8 @@ After=network.target mcs-workernode@1.service
 [Service]
 Type=simple
 
-User=mysql
-Group=mysql
+User=@DEFAULT_USER@
+Group=@DEFAULT_GROUP@
 LimitNOFILE=65536
 LimitNPROC=65536
 

--- a/oam/install_scripts/mcs-ddlproc.service.in
+++ b/oam/install_scripts/mcs-ddlproc.service.in
@@ -8,8 +8,8 @@ After=network.target mcs-dmlproc.service
 [Service]
 Type=simple
 
-User=mysql
-Group=mysql
+User=@DEFAULT_USER@
+Group=@DEFAULT_GROUP@
 LimitNOFILE=65536
 LimitNPROC=65536
 

--- a/oam/install_scripts/mcs-dmlproc.service.in
+++ b/oam/install_scripts/mcs-dmlproc.service.in
@@ -8,8 +8,8 @@ After=network.target mcs-writeengineserver.service
 [Service]
 Type=simple
 
-User=mysql
-Group=mysql
+User=@DEFAULT_USER@
+Group=@DEFAULT_GROUP@
 LimitNOFILE=65536
 LimitNPROC=65536
 

--- a/oam/install_scripts/mcs-exemgr.service.in
+++ b/oam/install_scripts/mcs-exemgr.service.in
@@ -8,8 +8,8 @@ After=network.target mcs-primproc.service
 [Service]
 Type=simple
 
-User=mysql
-Group=mysql
+User=@DEFAULT_USER@
+Group=@DEFAULT_GROUP@
 LimitNOFILE=65536
 LimitNPROC=65536
 

--- a/oam/install_scripts/mcs-loadbrm.py.in
+++ b/oam/install_scripts/mcs-loadbrm.py.in
@@ -11,8 +11,8 @@ import shutil
 
 API_CONFIG_PATH = '/etc/columnstore/cmapi_server.conf'
 BYPASS_SM_PATH = '/tmp/columnstore_tmp_files/rdwrscratch/BRM_saves'
-USER = 'mysql'
-GROUP = 'mysql'
+USER = '@DEFAULT_USER@'
+GROUP = '@DEFAULT_GROUP@'
 
 
 def get_key():
@@ -83,7 +83,7 @@ if __name__ == '__main__':
     if storage.lower() == 's3' and not bucket.lower() == 'some_bucket' and pmCount == 1:
         try:
             if use_systemd:
-                args = ['su', '-s', '/bin/sh', '-c', 'smcat {}'.format(brm), 'mysql']
+                args = ['su', '-s', '/bin/sh', '-c', 'smcat {}'.format(brm), USER]
             else:
                 args = ['smcat', brm]
 
@@ -154,8 +154,8 @@ node {}.'.format(primary_address), file=sys.stderr)
 
     if brm_saves_current:
         if use_systemd:
-            cmd = 'su -s /bin/sh -c "{} {}{}" mysql'.format(loadbrm, dbrmroot, \
-brm_saves_current.decode("utf-8").replace("BRM_saves", ""))
+            cmd = 'su -s /bin/sh -c "{} {}{}" {}'.format(loadbrm, dbrmroot, \
+brm_saves_current.decode("utf-8").replace("BRM_saves", ""), USER)
         else:
             cmd = '{} {}{}'.format(loadbrm, dbrmroot, \
 brm_saves_current.decode("utf-8").replace("BRM_saves", ""))

--- a/oam/install_scripts/mcs-primproc.service.in
+++ b/oam/install_scripts/mcs-primproc.service.in
@@ -9,8 +9,8 @@ After=network.target mcs-workernode@1.service mcs-workernode@2.service mcs-contr
 [Service]
 Type=simple
 
-User=mysql
-Group=mysql
+User=@DEFAULT_USER@
+Group=@DEFAULT_GROUP@
 LimitNOFILE=65536
 LimitNPROC=65536
 

--- a/oam/install_scripts/mcs-storagemanager.service.in
+++ b/oam/install_scripts/mcs-storagemanager.service.in
@@ -4,8 +4,8 @@ Description=storagemanager
 [Service]
 Type=simple
 
-User=mysql
-Group=mysql
+User=@DEFAULT_USER@
+Group=@DEFAULT_GROUP@
 LimitNOFILE=65536
 LimitNPROC=65536
 

--- a/oam/install_scripts/mcs-workernode.service.in
+++ b/oam/install_scripts/mcs-workernode.service.in
@@ -5,8 +5,8 @@ After=network.target mcs-loadbrm.service
 [Service]
 Type=simple
 
-User=mysql
-Group=mysql
+User=@DEFAULT_USER@
+Group=@DEFAULT_GROUP@
 LimitNOFILE=65536
 LimitNPROC=65536
 

--- a/oam/install_scripts/mcs-writeengineserver.service.in
+++ b/oam/install_scripts/mcs-writeengineserver.service.in
@@ -8,8 +8,8 @@ After=network.target mcs-exemgr.service
 [Service]
 Type=simple
 
-User=mysql
-Group=mysql
+User=@DEFAULT_USER@
+Group=@DEFAULT_GROUP@
 LimitNOFILE=65536
 LimitNPROC=65536
 


### PR DESCRIPTION
Columnstore syslog file creation should be with mysql as owner

Along with this I have created cmake variables for default user/group to increase maintainability of user/group. Allows us to stop hardcoding "mysql" as user and will allow us in the future to simplistically change default.