### PR TITLE
Don't merge yet. MCOL-4320/4364/4370 Fix multibyte processing for LDI/Insert...Select

### DIFF
--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -3208,7 +3208,6 @@ void ha_mcs_impl_start_bulk_insert(ha_rows rows, TABLE* table, bool is_cache_ins
             tableName.schema = table->s->db.str;
             tableName.table = table->s->table_name.str;
             ci->useXbit = false;
-            ci->utf8 = false;
             CalpontSystemCatalog::RIDList colrids;
 
             try
@@ -3252,11 +3251,6 @@ void ha_mcs_impl_start_bulk_insert(ha_rows rows, TABLE* table, bool is_cache_ins
                 ci->headerLength = (1 + colrids.size() + 7 - 1 - numberNotNull) / 8; //xbit is used
             else
                 ci->headerLength = (1 + colrids.size() + 7 - numberNotNull) / 8;
-
-            if ((strncmp(table->s->table_charset->comment, "UTF-8", 5) == 0) || (strncmp(table->s->table_charset->comment, "utf-8", 5) == 0))
-            {
-                ci->utf8 = true;
-            }
 
             //Log the statement to debug.log
             {

--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -259,7 +259,6 @@ struct cal_connection_info
         filePtr(0),
         headerLength(0),
         useXbit(false),
-        utf8(false),
         useCpimport(1),
         delimiter('\7'),
         affectedRows(0)
@@ -327,7 +326,6 @@ struct cal_connection_info
     FILE* filePtr;
     uint8_t headerLength;
     bool useXbit;
-    bool utf8;
     uint8_t useCpimport;
     char delimiter;
     char enclosed_by;


### PR DESCRIPTION
For CHAR/VARCHAR/TEXT fields, the buffer size of a field represents
the field size in bytes, which can be bigger than the field size in
number of characters, for multi-byte character sets such as utf8,
utf8mb4 etc. The buffer also contains a byte length prefix which can be
up to 65532 bytes for a VARCHAR field, and much higher for a TEXT
field (we process a maximum byte length for a TEXT field which fits in
4 bytes, which is 2^32 - 1 = 4GB!).

There is also special processing for a TEXT field defined with a default
length like so:
  CREATE TABLE cs1 (a TEXT CHARACTER SET utf8)
Here, the byte length is a fixed 65535, irrespective of the character
set used. This is different from a case such as:
  CREATE TABLE cs1 (a TEXT(65535) CHARACTER SET utf8), where the byte length
for the field will be 65535*3.