### PR TITLE
Stalled. Mcol 3771 benchmark re2 to replace boost regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,8 @@ ENDIF()
 check_cxx_source_compiles("#include <filesystem>\n void main(){}" HAS_STD_FILESYSTEM)
 check_cxx_source_compiles("#include <experimental/filesystem>\n void main(){}" HAS_STD_EXPERIMENTAL_FILESYSTEM)
 
+INCLUDE(libre2)
+
 SET (PACKAGE columnstore)
 SET (PACKAGE_NAME columnstore)
 SET (PACKAGE_TARNAME columnstore)
@@ -201,7 +203,11 @@ ENDIF()
 
 SET (ENGINE_LDFLAGS    "-Wl,--no-as-needed -Wl,--add-needed")
 SET (ENGINE_DT_LIB datatypes)
-SET (ENGINE_COMMON_LIBS     messageqcpp loggingcpp configcpp idbboot ${Boost_LIBRARIES} xml2 pthread rt libmysql_client ${ENGINE_DT_LIB})
+IF(USE_LIBRE2)
+	SET (ENGINE_COMMON_LIBS     messageqcpp loggingcpp configcpp idbboot ${Boost_LIBRARIES} xml2 pthread rt libmysql_client ${LIBRE2_LIB} ${ENGINE_DT_LIB})
+ELSE()
+	SET (ENGINE_COMMON_LIBS     messageqcpp loggingcpp configcpp idbboot ${Boost_LIBRARIES} xml2 pthread rt libmysql_client ${ENGINE_DT_LIB})
+ENDIF()
 SET (ENGINE_OAM_LIBS        oamcpp alarmmanager)
 SET (ENGINE_BRM_LIBS        brm idbdatafile cacheutils rwlock ${ENGINE_OAM_LIBS} ${ENGINE_COMMON_LIBS})
 SET (ENGINE_EXEC_LIBS       joblist execplan windowfunction joiner rowgroup funcexp udfsdk regr dataconvert common compress querystats querytele thrift threadpool ${ENGINE_BRM_LIBS})
@@ -369,6 +375,13 @@ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/gitversionEngine DESTINATION ${ENGINE_
 IF (RPM)
     INSTALL(FILES utils/jemalloc/libjemalloc.so.2 DESTINATION ${ENGINE_DATADIR} COMPONENT columnstore-engine)
 ENDIF ()
+
+IF (USE_LIBRE2)
+    # XXX hacky XXX
+    INSTALL(FILES lib/libre2-mcs.so
+	    PERMISSIONS OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE OWNER_READ GROUP_READ WORLD_READ
+	    DESTINATION ${ENGINE_LIBDIR} COMPONENT columnstore-engine)
+ENDIF()
 
 IF (INSTALL_LAYOUT)
     # Do this or when MariaDB builds us we don't have GenError which is required for these

--- a/cmake/libre2.cmake
+++ b/cmake/libre2.cmake
@@ -1,0 +1,20 @@
+# cmake module to enable use of libre2.
+
+OPTION(USE_LIBRE2 "Enable re2 as an external project" ON)
+
+IF(USE_LIBRE2)
+
+  EXTERNALPROJECT_ADD(libre2
+                       PREFIX "libre2"
+                       GIT_REPOSITORY "https://github.com/google/re2.git"
+                       CMAKE_ARGS "-DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/.."
+                       INSTALL_COMMAND cp libre2.so ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libre2-mcs.so
+                      )
+  ADD_DEFINITIONS("-DWITH_LIBRE2")
+  EXTERNALPROJECT_GET_PROPERTY(libre2 SOURCE_DIR)
+  MESSAGE(STATUS "libre2 source dir: ${SOURCE_DIR}")
+  INCLUDE_DIRECTORIES(libre2 "${SOURCE_DIR}")
+  SET(LIBRE2_LIB "-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}" "libre2-mcs.so")
+
+ENDIF()
+

--- a/dbcon/execplan/constantcolumn.cpp
+++ b/dbcon/execplan/constantcolumn.cpp
@@ -206,12 +206,13 @@ ConstantColumn::ConstantColumn( const ConstantColumn& rhs):
     if (fRegex.get() != NULL)
     {
         fRegex.reset(new CNX_Regex());
-#ifdef POSIX_REGEX
         string str = dataconvert::DataConvert::constructRegexp(fResult.strVal);
-        regcomp(fRegex.get(), str.c_str(), REG_NOSUB | REG_EXTENDED);
-#else
-        *fRegex = dataconvert::DataConvert::constructRegexp(fResult.strVal);
-#endif
+        fRegex->compile(str.c_str());
+    }
+    if (fDirectRegex.get() != NULL)
+    {
+        fDirectRegex.reset(new CNX_Regex());
+        fDirectRegex->compile(fResult.strVal.c_str());
     }
 }
 
@@ -261,12 +262,6 @@ ConstantColumn::ConstantColumn(const uint64_t val, TYPE type,
 
 ConstantColumn::~ConstantColumn()
 {
-#ifdef POSIX_REGEX
-
-    if (fRegex.get() != NULL)
-        regfree(fRegex.get());
-
-#endif
 }
 
 const string ConstantColumn::toString() const
@@ -404,14 +399,11 @@ bool ConstantColumn::operator!=(const TreeNode* t) const
 
 void ConstantColumn::constructRegex()
 {
-    //fRegex = new regex_t();
     fRegex.reset(new CNX_Regex());
-#ifdef POSIX_REGEX
     string str = dataconvert::DataConvert::constructRegexp(fResult.strVal);
-    regcomp(fRegex.get(), str.c_str(), REG_NOSUB | REG_EXTENDED);
-#else
-    *fRegex = dataconvert::DataConvert::constructRegexp(fResult.strVal);
-#endif
+    fRegex->compile(str.c_str());
+    fDirectRegex.reset(new CNX_Regex());
+    fDirectRegex->compile(fResult.strVal.c_str());
 }
 
 }

--- a/dbcon/execplan/constantcolumn.h
+++ b/dbcon/execplan/constantcolumn.h
@@ -152,6 +152,12 @@ public:
         return new ConstantColumn (*this);
     }
 
+
+    virtual bool isConstant() const
+    {
+        return true;
+    }
+
     /*
      * The serialization interface
      */

--- a/dbcon/execplan/predicateoperator.cpp
+++ b/dbcon/execplan/predicateoperator.cpp
@@ -395,25 +395,15 @@ bool PredicateOperator::getBoolVal(rowgroup::Row& row, bool& isNull, ReturnedCol
 
         if (regex)
         {
-#ifdef POSIX_REGEX
-            bool ret = regexec(regex.get(), v.c_str(), 0, NULL, 0) == 0;
-#else
-            bool ret = boost::regex_match(v.c_str(), *regex);
-#endif
+            bool ret = regex->isLike(v.c_str());
             return (((fOp == OP_LIKE) ? ret : !ret) && !isNull);
         }
         else
         {
-#ifdef POSIX_REGEX
-            regex_t regex;
             std::string str = dataconvert::DataConvert::constructRegexp(rop->getStrVal(row, isNull));
-            regcomp(&regex, str.c_str(), REG_NOSUB | REG_EXTENDED);
-            bool ret = regexec(&regex, v.c_str(), 0, NULL, 0) == 0;
-            regfree(&regex);
-#else
-            boost::regex regex(dataconvert::DataConvert::constructRegexp(rop->getStrVal(row, isNull)));
-            bool ret = boost::regex_match(v.c_str(), regex);
-#endif
+	    IDB_Regex regex;
+	    regex.compile(str.c_str());
+	    bool ret = regex.isLike(v.c_str());
             return (((fOp == OP_LIKE) ? ret : !ret) && !isNull);
         }
     }

--- a/dbcon/execplan/treenode.cpp
+++ b/dbcon/execplan/treenode.cpp
@@ -51,6 +51,7 @@ TreeNode::TreeNode(const TreeNode& rhs):
     fResultType(rhs.resultType()),
     fOperationType(rhs.operationType()),
     fRegex (rhs.regex()),
+    fDirectRegex (rhs.regex()),
     fDerivedTable (rhs.derivedTable()),
     fRefCount(rhs.refCount()),
     fDerivedRefCol(rhs.derivedRefCol())

--- a/dbcon/execplan/treenode.h
+++ b/dbcon/execplan/treenode.h
@@ -78,11 +78,8 @@ typedef IDB_Decimal CNX_Decimal;
  * @brief IDB_Regex struct
  *
  */
-#ifdef POSIX_REGEX
-typedef regex_t IDB_Regex;
-#else
-typedef boost::regex IDB_Regex;
-#endif
+#include <regex-port.h>
+typedef utils::mcs_regex_t IDB_Regex;
 
 typedef IDB_Regex CNX_Regex;
 
@@ -183,6 +180,15 @@ public:
     virtual void data(const std::string data) = 0;
     virtual const std::string toString() const = 0;
     virtual TreeNode* clone() const = 0;
+
+    /** @brief Tell the world we are constant.
+     *
+     * Right now it allows to detect ConstantColumn to use with Func_regexp. But might be used more widely.
+     */
+    virtual bool isConstant() const
+    {
+        return false;
+    }
 
     /**
      * Interface for serialization
@@ -370,6 +376,16 @@ public:
         return fRegex;
     }
 
+    // direct regex mutator and accessor
+    virtual void directRegex(SP_IDB_Regex regex)
+    {
+        fDirectRegex = regex;
+    }
+    virtual SP_IDB_Regex directRegex() const
+    {
+        return fDirectRegex;
+    }
+
     uint32_t charsetNumber() const
     {
         return fResultType.charsetNumber;
@@ -385,6 +401,7 @@ protected:
     execplan::CalpontSystemCatalog::ColType fResultType; // mapped from mysql data type
     execplan::CalpontSystemCatalog::ColType fOperationType; // operator type, could be different from the result type
     SP_IDB_Regex fRegex;
+    SP_IDB_Regex fDirectRegex;
 
     // double's range is +/-1.7E308 with at least 15 digits of precision
     char tmp[312]; // for conversion use

--- a/primitives/primproc/dictstep.h
+++ b/primitives/primproc/dictstep.h
@@ -146,7 +146,7 @@ private:
     
     bool hasEqFilter;
     boost::shared_ptr<primitives::DictEqualityFilter> eqFilter;
-    boost::shared_array<primitives::idb_regex_t> likeFilter;
+    boost::shared_array<utils::mcs_regex_t> likeFilter;
     uint8_t eqOp;   // COMPARE_EQ or COMPARE_NE
 
     friend class RTSCommand;

--- a/utils/common/CMakeLists.txt
+++ b/utils/common/CMakeLists.txt
@@ -17,5 +17,9 @@ add_library(common SHARED ${common_LIB_SRCS})
 
 add_dependencies(common loggingcpp)
 
+if(USE_LIBRE2)
+    add_dependencies(common libre2)
+endif()
+
 install(TARGETS common DESTINATION ${ENGINE_LIBDIR} COMPONENT columnstore-engine)
 

--- a/utils/common/regex-port.h
+++ b/utils/common/regex-port.h
@@ -1,0 +1,193 @@
+/* Copyright (C) 2014 InfiniDB, Inc.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+   MA 02110-1301, USA. */
+
+/* Implementing common regular expression pattern matching across platforms. */
+
+/** @file */
+
+#ifndef REGEX_PORT_H_
+#define REGEX_PORT_H_
+
+#if defined(WITH_LIBRE2)
+#   include <re2/re2.h>
+#else
+#   ifdef __linux__
+#       define WITH_POSIX_REGEX
+#   endif
+
+// these regex libraries for fallback if RE2 fails.
+#   ifdef WITH_POSIX_REGEX
+#       include <regex.h>
+#   else
+#       include <boost/regex.hpp>
+#   endif
+#endif
+
+
+namespace utils {
+
+
+// There are three versions of same interface for different variants
+// of underlying regex engines.
+//
+// This way they are clear to read, write and follow. Otherwise they were morphing
+// into unwieldy mess of code and conditional compilation.
+
+#if defined(WITH_LIBRE2)
+struct mcs_regex_t
+{
+private:
+
+    re2::RE2* regex; // we have no assignment operators and need to construct object dynamically.
+public:
+    mcs_regex_t() : regex(0) { }
+    ~mcs_regex_t()
+    {
+        if (regex)
+	{
+            delete regex;
+        }
+    }
+
+    bool isLike(const char* str) const
+    {
+	return re2::RE2::FullMatch(str, *regex);
+    }
+    bool isLikeWithLength(const unsigned char* str, size_t len) const
+    {
+        re2::StringPiece wrapped_str(reinterpret_cast<const char*>(str), len);
+	return re2::RE2::FullMatch(wrapped_str, *regex);
+    }
+    bool matchSubstring(const char* str) const
+    {
+	return re2::RE2::PartialMatch(str, *regex);
+    }
+
+    void compile(const char* str)
+    {
+        regex = new re2::RE2(str);
+    }
+
+    bool notInitialized() const
+    {
+        return !regex;
+    }
+
+    void reset()
+    {
+        if (regex) {
+            delete regex;
+	    regex = 0;
+	}
+    }
+};
+#elif defined(WITH_POSIX_REGEX)
+struct mcs_regex_t
+{
+private:
+
+    bool used; // this member is associated with POSIX regex field @regex@.
+    regex_t regex;
+public:
+    mcs_regex_t() : used(false) { }
+    ~mcs_regex_t()
+    {
+        if (used)
+            regfree(&regex);
+    }
+
+    bool isLike(const char* str) const
+    {
+        return (regexec(&regex, str, 0, NULL, 0) == 0);
+    }
+    bool isLikeWithLength(const unsigned char* str, size_t len) const
+    {
+        std::string strbuf(reinterpret_cast<const char*>(str), len);
+
+        return (regexec(&regex, strbuf.c_str(), 0, NULL, 0) == 0);
+    }
+    bool matchSubstring(const char* str) const
+    {
+	return regexec(&regex, str, 0, NULL, 0) == 0;
+    }
+
+    void compile(const char* str)
+    {
+	used = true;
+        regcomp(&regex, str, REG_NOSUB | REG_EXTENDED);
+    }
+
+    bool notInitialized() const
+    {
+        return !used;
+    }
+
+    void reset()
+    {
+        if (used) {
+            regfree(&regex);
+	}
+        used = false;
+    }
+};
+#else // Boost::regex.
+struct mcs_regex_t
+{
+private:
+
+    bool used; // this member is associated with POSIX regex field @regex@.
+    boost::regex regex;
+public:
+    mcs_regex_t() : used(false) { }
+    ~mcs_regex_t() { }
+
+    bool isLike(const char* str) const
+    {
+        return regex_match(str, regex);
+    }
+    bool isLikeWithLength(const unsigned char* str, size_t len) const
+    {
+        /* Note, the passed-in pointers are effectively begin() and end() iterators */
+        return regex_match(str, str + len, regex);
+    }
+    bool matchSubstring(const char* str) const
+    {
+	return regex_search(str, regex);
+    }
+
+    void compile(const char* str)
+    {
+	used = true;
+        regex = str;
+    }
+
+    bool notInitialized() const
+    {
+        return !used;
+    }
+
+    void reset()
+    {
+        used = false;
+    }
+};
+#endif
+
+} // namespace utils
+
+#endif /* REGEX_PORT_H_ */
+

--- a/utils/dataconvert/dataconvert.h
+++ b/utils/dataconvert/dataconvert.h
@@ -37,15 +37,7 @@
 #include <netinet/in.h>
 #endif
 
-#ifdef __linux__
-#define POSIX_REGEX
-#endif
-
-#ifdef POSIX_REGEX
-#include <regex.h>
-#else
-#include <boost/regex.hpp>
-#endif
+#include "regex-port.h"
 
 #include "mcs_datatype.h"
 #include "columnresult.h"


### PR DESCRIPTION
Relevant JIRA ticket: https://jira.mariadb.org/browse/MCOL-3771?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&focusedCommentId=169986

What I did here is to remove a bunch of "#ifdef __linux__" conditionals from different parts of code and moved them into single header file (utils/common/regexp-port.h). That file defines a regex containing structure and everyone creates that structures and uses unified interface.

To utilize re2 I had to link it somehow and I added it as an external CMake project. This is second relatively big change.

I also did a dozen or so fixes of warnings, most probably I will have to revert some of them if not all.