### PR TITLE
MCOL-4188 Fix regressions in CEIL()/CHAR() for narrow decimals.

### DIFF
--- a/dbcon/execplan/simplecolumn.h
+++ b/dbcon/execplan/simplecolumn.h
@@ -335,20 +335,18 @@ public:
         //      the original decimal scale is stored in scale field, which is no use for double.
         if (fResultType.precision == -1)
         {
-            IDB_Decimal rv;
             if (fResultType.colDataType == CalpontSystemCatalog::DOUBLE)
             {
-                rv.scale = fResultType.scale;
-                rv.precision = 15;
-                rv.value = (int64_t)(TreeNode::getDoubleVal() * IDB_pow[rv.scale]);
+                IDB_Decimal rv(
+                    (int64_t)(TreeNode::getDoubleVal() * IDB_pow[fResultType.scale]),
+                    fResultType.scale, 15);
                 return rv;
             }
             else if (fResultType.colDataType == CalpontSystemCatalog::LONGDOUBLE)
             {
-                IDB_Decimal rv;
-                rv.scale = fResultType.scale;
-                rv.precision = 19;
-                rv.value = (int64_t)(TreeNode::getLongDoubleVal() * IDB_pow[rv.scale]);
+                IDB_Decimal rv (
+                    (int64_t)(TreeNode::getLongDoubleVal() * IDB_pow[fResultType.scale]),
+                    fResultType.scale, fResultType.precision);
                 return rv;
             }
         }

--- a/dbcon/execplan/treenode.h
+++ b/dbcon/execplan/treenode.h
@@ -62,6 +62,9 @@ class IDB_Decimal: public datatypes::VDecimal
 public:
   using datatypes::VDecimal::VDecimal;
 
+  IDB_Decimal(int64_t val, int8_t s, uint8_t p, const int128_t &val128 = 0) :
+    VDecimal(val, s, p, val128) {}
+
   inline void operator=(const datatypes::TSInt128& rhs)
   {
     value = 0; scale = 0; precision = 0;

--- a/dbcon/execplan/windowfunctioncolumn.cpp
+++ b/dbcon/execplan/windowfunctioncolumn.cpp
@@ -640,8 +640,10 @@ void WindowFunctionColumn::evaluate(Row& row, bool& isNull)
                         isNull = true;
                     else
                     {
-                        fResult.decimalVal.value = row.getIntField<1>(fInputIndex);
-                        fResult.decimalVal.scale = (unsigned)fResultType.scale;
+                        fResult.decimalVal = IDB_Decimal(
+                                                 row.getIntField<1>(fInputIndex),
+                                                 fResultType.scale,
+                                                 fResultType.precision);
                     }
 
                     break;
@@ -653,8 +655,10 @@ void WindowFunctionColumn::evaluate(Row& row, bool& isNull)
                         isNull = true;
                     else
                     {
-                        fResult.decimalVal.value = row.getIntField<2>(fInputIndex);
-                        fResult.decimalVal.scale = (unsigned)fResultType.scale;
+                        fResult.decimalVal = IDB_Decimal(
+                                                 row.getIntField<2>(fInputIndex),
+                                                 fResultType.scale,
+                                                 fResultType.precision);
                     }
 
                     break;
@@ -666,8 +670,10 @@ void WindowFunctionColumn::evaluate(Row& row, bool& isNull)
                         isNull = true;
                     else
                     {
-                        fResult.decimalVal.value = row.getIntField<4>(fInputIndex);
-                        fResult.decimalVal.scale = (unsigned)fResultType.scale;
+                        fResult.decimalVal = IDB_Decimal(
+                                                 row.getIntField<4>(fInputIndex),
+                                                 fResultType.scale,
+                                                 fResultType.precision);
                     }
 
                     break;
@@ -679,8 +685,10 @@ void WindowFunctionColumn::evaluate(Row& row, bool& isNull)
                         isNull = true;
                     else
                     {
-                        fResult.decimalVal.value = row.getIntField<8>(fInputIndex);
-                        fResult.decimalVal.scale = (unsigned)fResultType.scale;
+                        fResult.decimalVal = IDB_Decimal(
+                                                 row.getIntField<8>(fInputIndex),
+                                                 fResultType.scale,
+                                                 fResultType.precision);
                     }
 
                     break;
@@ -688,13 +696,14 @@ void WindowFunctionColumn::evaluate(Row& row, bool& isNull)
 
                 case 16:
                 {
-                    datatypes::TSInt128 dec(row.getBinaryField<int128_t>(fInputIndex));
-                    if (dec == datatypes::Decimal128Null)
+                    int128_t val;
+                    row.getInt128Field(fInputIndex, val);
+
+                    if (val == datatypes::Decimal128Null)
                         isNull = true;
                     else
                     {
-                        fResult.decimalVal = dec;
-                        fResult.decimalVal.scale = (unsigned)fResultType.scale;
+                        fResult.decimalVal = IDB_Decimal(0, fResultType.scale, fResultType.precision, val);
                     }
 
                     break;

--- a/utils/funcexp/func_ceil.cpp
+++ b/utils/funcexp/func_ceil.cpp
@@ -75,6 +75,12 @@ int64_t Func_ceil::getIntVal(Row& row,
         case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
         {
+            if (op_ct.scale == 0)
+            {
+                ret = parm[0]->data()->getIntVal(row, isNull);
+                break;
+            }
+
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
 
             if (isNull)
@@ -222,6 +228,12 @@ uint64_t Func_ceil::getUintVal(Row& row,
         case execplan::CalpontSystemCatalog::DECIMAL:
         case execplan::CalpontSystemCatalog::UDECIMAL:
         {
+            if (op_ct.scale == 0)
+            {
+                ret = parm[0]->data()->getIntVal(row, isNull);
+                break;
+            }
+
             IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
 
             if (isNull)

--- a/utils/funcexp/func_char.cpp
+++ b/utils/funcexp/func_char.cpp
@@ -132,7 +132,7 @@ string Func_char::getStrVal(Row& row,
             case execplan::CalpontSystemCatalog::DECIMAL:
             case execplan::CalpontSystemCatalog::UDECIMAL:
             {
-                IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
+                IDB_Decimal d = rc->getDecimalVal(row, isNull);
 
                 if (ct.colWidth == datatypes::MAXDECIMALWIDTH)
                 {
@@ -152,30 +152,16 @@ string Func_char::getStrVal(Row& row,
                         tmpval++;
 
                     value = datatypes::Decimal::getInt32FromWideDecimal(tmpval);
-
-                    // WIP MCOL-641
-                    /*if ( !getChar((int64_t)tmpval, buf) )
-                    {
-                        isNull = true;
-                        return "";
-                    }*/
                 }
                 else
                 {
                     double dscale = d.scale;
                     // get decimal and round up
-                    int value = d.value / pow(10.0, dscale);
+                    value = d.value / pow(10.0, dscale);
                     int lefto = (d.value - value * pow(10.0, dscale)) / pow(10.0, dscale - 1);
 
                     if ( lefto > 4 )
                         value++;
-
-                    // WIP MCOL-641
-                    /*if ( !getChar((int64_t)value, buf) )
-                    {
-                        isNull = true;
-                        return "";
-                    }*/
                 }
             }
             break;


### PR DESCRIPTION
In addition, a regression in a WHERE clause with a WF field
as the LHS and an addition operation on two WF fields on the RHS
is also fixed. The issue was SimpleColumn::getDecimalVal() was
setting precision = 19, with the value of one of the operands of the
addition operation being set in VDecimal::value instead of
VDecimal::s128Value. addSubtractExecute() in mcs_decimal.cpp makes the
assumption that if precision > 18 and precision <= 38, we need to
fetch the wide s128Value, not the narrow value field. So we are
fixing the precision set in SimpleColumn::getDecimalVal().