### PR TITLE
DO NOT MERGE: MCOL-3917 DDLProc/DMLProc re-establish connections on Primproc restart.

### DIFF
--- a/dbcon/joblist/distributedenginecomm.cpp
+++ b/dbcon/joblist/distributedenginecomm.cpp
@@ -1054,7 +1054,10 @@ int DistributedEngineComm::writeToClient(size_t index, const ByteStream& bs, uin
         alarmItem.append(" PrimProc");
         alarmMgr.sendAlarmReport(alarmItem.c_str(), oam::CONN_FAILURE, SET);
         */
-        throw runtime_error("DistributedEngineComm::write: Broken Pipe error");
+
+        // Re-establish connection before throwing error 
+        Setup();
+        throw runtime_error("DistributedEngineComm::write: Broken Pipe error. Attempting to re-establish connection.");
     }
 }
 

--- a/dmlproc/dmlprocessor.cpp
+++ b/dmlproc/dmlprocessor.cpp
@@ -1097,8 +1097,6 @@ void PackageHandler::run()
     }
     catch (std::exception& e)
     {
-
-
         cout << "dmlprocessor.cpp PackageHandler::run() package type("
              << fPackageType << ") exception: " << e.what() << endl;
         logging::LoggingID lid(21);
@@ -1112,6 +1110,9 @@ void PackageHandler::run()
         ml.logErrorMessage(message);
         result.result = DMLPackageProcessor::COMMAND_ERROR;
         result.message = message;
+
+        DistributedEngineComm* dec = DistributedEngineComm::instance(frm);
+        dec->Setup();
     }
     catch (...)
     {

--- a/oam/install_scripts/mariadb-columnstore-start.sh.in
+++ b/oam/install_scripts/mariadb-columnstore-start.sh.in
@@ -15,7 +15,7 @@ flock -n "$fd_lock" || exit 0
 /bin/systemctl start mcs-exemgr
 /bin/systemctl start mcs-dmlproc
 /bin/systemctl start mcs-ddlproc
-sleep 2
+
 su -s /bin/sh -c '@ENGINE_BINDIR@/dbbuilder 7' @DEFAULT_USER@ 1> /tmp/columnstore_tmp_files/dbbuilder.log
 
 flock -u "$fd_lock"

--- a/oam/install_scripts/mcs-controllernode.service.in
+++ b/oam/install_scripts/mcs-controllernode.service.in
@@ -1,9 +1,6 @@
 [Unit]
 Description=mcs-controllernode
-
-# restart/stop mcs-controllernode on restart/stop of mcs-workernode
-PartOf=mcs-workernode@1.service
-After=network.target mcs-workernode@1.service
+After=network.target
 
 [Service]
 Type=forking

--- a/oam/install_scripts/mcs-ddlproc.service.in
+++ b/oam/install_scripts/mcs-ddlproc.service.in
@@ -1,9 +1,6 @@
 [Unit]
 Description=mcs-ddlproc
-
-# restart/start mcs-ddlproc on restart/start of mcs-writeengineserver
-PartOf=mcs-writeengineserver.service
-After=network.target mcs-dmlproc.service
+After=network.target
 
 [Service]
 Type=forking
@@ -13,7 +10,7 @@ Group=@DEFAULT_GROUP@
 LimitNOFILE=65536
 LimitNPROC=65536
 
-ExecStart=/usr/bin/env bash -c "/bin/sleep 2 && @ENGINE_BINDIR@/DDLProc"
+ExecStart=@ENGINE_BINDIR@/DDLProc
 
 Restart=on-failure
 TimeoutStopSec=2

--- a/oam/install_scripts/mcs-dmlproc.service.in
+++ b/oam/install_scripts/mcs-dmlproc.service.in
@@ -1,9 +1,9 @@
 [Unit]
 Description=mcs-dmlproc
 
-# restart/stop mcs-dmlproc on restart/stop of mcs-writeengineserver
-PartOf=mcs-writeengineserver.service
-After=network.target mcs-writeengineserver.service
+#restart/start mcs-dmlproc on mcs-controllernode restart/start
+PartOf=mcs-controllernode.service 
+After=network.target mcs-controllernode.service
 
 [Service]
 Type=forking
@@ -13,7 +13,7 @@ Group=@DEFAULT_GROUP@
 LimitNOFILE=65536
 LimitNPROC=65536
 
-ExecStart=/usr/bin/env bash -c "/bin/sleep 2 && @ENGINE_BINDIR@/DMLProc"
+ExecStart=@ENGINE_BINDIR@/DMLProc
 
 Restart=on-failure
 TimeoutStopSec=2

--- a/oam/install_scripts/mcs-exemgr.service.in
+++ b/oam/install_scripts/mcs-exemgr.service.in
@@ -1,9 +1,9 @@
 [Unit]
 Description=mcs-exemgr
 
-# restart/start mcs-exemgr on restart/start of mcs-primproc
-PartOf=mcs-primproc.service
-After=network.target mcs-primproc.service
+# restart/start mcs-exemgr on mcs-controllernode restart/start
+PartOf=mcs-controllernode.service
+After=network.target mcs-controllernode.service
 
 [Service]
 Type=forking

--- a/oam/install_scripts/mcs-loadbrm.service.in
+++ b/oam/install_scripts/mcs-loadbrm.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=loadbrm
 PartOf=mcs-workernode@1.service mcs-workernode@2.service
-After=network.target mcs-storagemanager.service
+After=network.target
 
 [Service]
 Type=oneshot

--- a/oam/install_scripts/mcs-primproc.service.in
+++ b/oam/install_scripts/mcs-primproc.service.in
@@ -1,10 +1,6 @@
 [Unit]
 Description=mcs-primproc
-
-# restart/stop mcs-primproc on restart/stop of mcs-workernode or mcs-controllernode
-PartOf=mcs-workernode@1.service mcs-workernode@2.service
-PartOf=mcs-controllernode.service
-After=network.target mcs-workernode@1.service mcs-workernode@2.service mcs-controllernode.service
+After=network.target
 
 [Service]
 Type=forking
@@ -16,7 +12,6 @@ LimitNPROC=65536
 
 ExecStartPre=/usr/bin/env bash -c "[ -f '@ENGINE_DATADIR@/libjemalloc.so.2' ] || ldconfig -p | grep -m1 libjemalloc > /dev/null || echo 'Please install jemalloc to avoid ColumnStore performance degradation and unexpected service interruptions.'"
 ExecStart=/usr/bin/env bash -c "ldconfig -p | grep -m1 libjemalloc > /dev/null && LD_PRELOAD=$(ldconfig -p | grep -m1 libjemalloc | awk '{print $1}') exec @ENGINE_BINDIR@/PrimProc || [ -f '@ENGINE_DATADIR@/libjemalloc.so.2' ] && LD_PRELOAD=@ENGINE_DATADIR@/libjemalloc.so.2 exec @ENGINE_BINDIR@/PrimProc || exec @ENGINE_BINDIR@/PrimProc"
-ExecStartPost=/bin/sleep 2
 
 Restart=on-failure
 TimeoutStopSec=2

--- a/oam/install_scripts/mcs-writeengineserver.service.in
+++ b/oam/install_scripts/mcs-writeengineserver.service.in
@@ -1,9 +1,6 @@
 [Unit]
 Description=WriteEngineServer
-
-# restart/stop mcs-writeengineserver on restart/stop of mcs-exemgr
-PartOf=mcs-exemgr.service
-After=network.target mcs-exemgr.service
+After=network.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
Whenever Primproc is restarted, or crashes and recovers, both DMLProc and DDLProc are unusable. This patch allows DMLProc/DDLProc to Primproc reconnection to happen when the error inside DistributedEngineComm is hit.

This patch also removes all systemd service dependencies from systemd units except the following:

mcs-exemgr restarts when mcs-controllernode restarts so "system is ready to accept ready" flag is set to true on controllernode restarts.
mcs-dmlproc restarts when mcs-controllernode restarts so "systemready" flag  is set to true during controllernode restart

mcs-loadbrm is started when mcs-workernode@1 or mcs-workernode@2 is restarted/started.

The latter will likely stay as-is, but the other two will be addressed in a future PR.