### PR TITLE
MCOL-4188 Regression fixes for MCOL-641.

### DIFF
--- a/dbcon/execplan/predicateoperator.cpp
+++ b/dbcon/execplan/predicateoperator.cpp
@@ -215,7 +215,9 @@ void PredicateOperator::setOpType(Type& l, Type& r)
             {
                 // should following the result type that MySQL gives
                 fOperationType = l;
-                fOperationType.scale = (l.scale > r.scale ? l.scale : r.scale);
+                fOperationType.scale = std::max(l.scale, r.scale);
+                fOperationType.precision = std::max(l.precision, r.precision);
+                fOperationType.colWidth = std::max(l.colWidth, r.colWidth);
                 break;
             }
 
@@ -229,7 +231,9 @@ void PredicateOperator::setOpType(Type& l, Type& r)
             case execplan::CalpontSystemCatalog::UBIGINT:
                 fOperationType.colDataType = execplan::CalpontSystemCatalog::DECIMAL;
                 fOperationType.scale = l.scale;
-                fOperationType.colWidth = 8;
+                fOperationType.precision = l.precision;
+                fOperationType.colWidth = (l.colWidth == datatypes::MAXDECIMALWIDTH) ?
+                    l.colWidth : 8;
                 break;
 
             default:
@@ -261,7 +265,9 @@ void PredicateOperator::setOpType(Type& l, Type& r)
             case execplan::CalpontSystemCatalog::UBIGINT:
                 fOperationType.colDataType = execplan::CalpontSystemCatalog::DECIMAL;
                 fOperationType.scale = r.scale;
-                fOperationType.colWidth = 8;
+                fOperationType.precision = r.precision;
+                fOperationType.colWidth = (r.colWidth == datatypes::MAXDECIMALWIDTH) ?
+                    r.colWidth : 8;
                 break;
 
             case execplan::CalpontSystemCatalog::LONGDOUBLE:

--- a/dbcon/joblist/jlf_subquery.cpp
+++ b/dbcon/joblist/jlf_subquery.cpp
@@ -90,19 +90,23 @@ void getColumnValue(ConstantColumn** cc, uint64_t i, const Row& row, const strin
 
         case CalpontSystemCatalog::DECIMAL:
         case CalpontSystemCatalog::UDECIMAL:
-            data = row.getIntField(i);
-            oss << (data / IDB_pow[row.getScale(i)]);
-
-            if (row.getScale(i) > 0)
+            if (row.getColumnWidth(i) == datatypes::MAXDECIMALWIDTH)
             {
-                if (data > 0)
-                    oss << "." << (data % IDB_pow[row.getScale(i)]);
-                else if (data < 0)
-                    oss << "." << (-data % IDB_pow[row.getScale(i)]);
-            }
+                int128_t val;
+                row.getInt128Field(i, val);
 
-            *cc = new ConstantColumn(oss.str(),
-                                     IDB_Decimal(data, row.getScale(i), row.getPrecision(i)));
+                IDB_Decimal dec(0, row.getScale(i), row.getPrecision(i), val);
+
+                *cc = new ConstantColumn(dec.toString(true), dec);
+            }
+            else
+            {
+                data = row.getIntField(i);
+
+                IDB_Decimal dec(data, row.getScale(i), row.getPrecision(i));
+
+                *cc = new ConstantColumn(dec.toString(), dec);
+            }
             break;
 
         case CalpontSystemCatalog::UTINYINT:
@@ -118,7 +122,6 @@ void getColumnValue(ConstantColumn** cc, uint64_t i, const Row& row, const strin
         case CalpontSystemCatalog::UFLOAT:
             oss << fixed << row.getFloatField(i);
             *cc = new ConstantColumn(oss.str(), (double) row.getFloatField(i));
-            break;
             break;
 
         case CalpontSystemCatalog::DOUBLE:

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -172,8 +172,11 @@ int WideDecimalCompare::operator()(IdbCompare* l, Row::Pointer r1, Row::Pointer 
     l->row2().setData(r2);
 
     int ret = 0;
-    int128_t v1 = *(l->row1().getBinaryField_offset<int128_t>(keyColumnOffset));
-    int128_t v2 = *(l->row2().getBinaryField_offset<int128_t>(keyColumnOffset));
+
+    int128_t v1, v2;
+    l->row1().getInt128Field(fSpec.fIndex, v1);
+    l->row2().getInt128Field(fSpec.fIndex, v2);
+
     bool v1IsNull = v1 == datatypes::Decimal128Null;
     bool v2IsNull = v2 == datatypes::Decimal128Null;
 


### PR DESCRIPTION
  1. Make PredicateOperator::setOpType() function wide decimal aware.
  2. Added support for wide decimal in jlf_subquery.cpp::getColumnValue()
     used in scalar subqueries.
  3. Fixed the column index used for fetching wide decimal values from a Row
     when a wide decimal field is used in the order by clause.