### PR TITLE
MCOL-4188 Regression fixes for MCOL-641.

### DIFF
--- a/dbcon/joblist/batchprimitiveprocessor-jl.cpp
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.cpp
@@ -703,6 +703,12 @@ bool BatchPrimitiveProcessorJL::countThisMsg(messageqcpp::ByteStream& in) const
     const uint8_t* data = in.buf();
     uint32_t offset = sizeof(ISMPacketHeader) + sizeof(PrimitiveHeader); // skip the headers
 
+    ISMPacketHeader* hdr = (ISMPacketHeader*)(data);
+
+    // Exit early if PrimProc has thrown an exception
+    if (hdr->Status > 0)
+        return true;
+
     if (_hasScan)
     {
         if (data[offset] != 0)

--- a/utils/windowfunction/wf_stats.cpp
+++ b/utils/windowfunction/wf_stats.cpp
@@ -189,8 +189,7 @@ void WF_stats<T>::operator()(int64_t b, int64_t e, int64_t c)
             fCount++;
         }
 
-        if ((fCount > 0) &&
-                !(fCount == 1 && (fFunctionId == WF__STDDEV_SAMP || fFunctionId == WF__VAR_SAMP)))
+        if (fCount > 1)
         {
             int scale = fRow.getScale(colIn);
             long double factor = pow(10.0, scale);
@@ -225,9 +224,17 @@ void WF_stats<T>::operator()(int64_t b, int64_t e, int64_t c)
     {
         setValue(CalpontSystemCatalog::DOUBLE, b, e, c, (double*) NULL);
     }
-    else if (fCount == 1 && (fFunctionId == WF__STDDEV_SAMP || fFunctionId == WF__VAR_SAMP))
+    else if (fCount == 1)
     {
-        setValue(CalpontSystemCatalog::DOUBLE, b, e, c, (double*) NULL);
+        if (fFunctionId == WF__STDDEV_SAMP || fFunctionId == WF__VAR_SAMP)
+        {
+            setValue(CalpontSystemCatalog::DOUBLE, b, e, c, (double*) NULL);
+        }
+        else // fFunctionId == WF__STDDEV_POP || fFunctionId == WF__VAR_POP
+        {
+            double temp = 0.0;
+            setValue(CalpontSystemCatalog::DOUBLE, b, e, c, (double*) &temp);
+        }
     }
     else
     {


### PR DESCRIPTION
1. In BatchPrimitiveProcessorJL::countThisMsg(), exit early if the
return code from primproc is non-zero.
2. For statistical window functions (stddev/var), properly handle
the case when there is only one value for the calculation.