### PR TITLE
MCOL-4425 INSERT..SELECT hangs on cpimport when MCS is installed in a…

### DIFF
--- a/mcsconfig.h.in
+++ b/mcsconfig.h.in
@@ -390,6 +390,8 @@
 
 #define MCSSBINDIR "${ENGINE_SBINDIR}"
 
+#define MCSBINDIR "${ENGINE_BINDIR}"
+
 #define MCSMYCNFDIR "${MARIADB_MYCNFDIR}"
 
 #endif

--- a/writeengine/splitter/we_cmdargs.cpp
+++ b/writeengine/splitter/we_cmdargs.cpp
@@ -43,6 +43,7 @@ using namespace oam;
 #include "we_cmdargs.h"
 
 #include "installdir.h"
+#include "mcsconfig.h"
 
 namespace WriteEngine
 {
@@ -598,7 +599,7 @@ void WECmdArgs::parseCmdLineArgs(int argc, char** argv)
 
 
     if (argc > 0)
-        fPrgmName = "cpimport.bin"; //argv[0] is splitter but we need cpimport
+        fPrgmName = string(MCSBINDIR) + "/" + "cpimport.bin"; //argv[0] is splitter but we need cpimport
 
     while ((aCh = getopt(argc, argv,
                          "d:j:w:s:v:l:r:b:e:B:f:q:ihm:E:C:P:I:n:p:c:ST:Ny:K:t:H:g:U:"))


### PR DESCRIPTION
… non-default path

Using absolute path when building cpimport command line for execvp().