### PR TITLE
MCOL-2000 We should not multiply the length of text fields by mbmaxlen, since it is counted in octets

### DIFF
--- a/dbcon/ddlpackage/ddl.y
+++ b/dbcon/ddlpackage/ddl.y
@@ -70,7 +70,6 @@ void fix_column_length(SchemaObject* elem, const CHARSET_INFO* def_cs) {
 
     if (column->fType &&
         (column->fType->fType == DDL_VARCHAR ||
-         column->fType->fType == DDL_TEXT ||
          column->fType->fType == DDL_CHAR))
     {
         unsigned mul = def_cs ? def_cs->mbmaxlen : 1;


### PR DESCRIPTION
…n, since it is counted in octets