### PR TITLE
MCOL-2055 Fix. Flush PrimProc Cache during batchinserts

### DIFF
--- a/writeengine/wrapper/writeengine.cpp
+++ b/writeengine/wrapper/writeengine.cpp
@@ -1690,10 +1690,20 @@ int WriteEngineWrapper::insertColumnRecs(const TxnID& txnid,
 
         if (rc == NO_ERROR)
         {
-            rc = cacheutils::flushPrimProcCache();
-            if (rc != 0)
-                rc = ERR_BLKCACHE_FLUSH_LIST; // translate to WE error
-        }
+            if (dctnryStructList.size() > 0)
+            {
+                vector<BRM::OID_t> oids {static_cast<int32_t>(tableOid)};
+                for (const DctnryStruct &dctnryStruct : dctnryStructList)
+                {
+                    oids.push_back(dctnryStruct.dctnryOid);
+                }
+
+                rc = flushOIDsFromCache(oids);
+
+                if (rc != 0)
+                    rc = ERR_BLKCACHE_FLUSH_LIST; // translate to WE error
+            }
+       }
     }
 
     return rc;

--- a/writeengine/wrapper/writeengine.cpp
+++ b/writeengine/wrapper/writeengine.cpp
@@ -1687,6 +1687,13 @@ int WriteEngineWrapper::insertColumnRecs(const TxnID& txnid,
         // Write row(s) to database file(s)
         //----------------------------------------------------------------------
         rc = writeColumnRec(txnid, colStructList, colOldValueList, rowIdArray, newColStructList, colNewValueList, tableOid, useTmpSuffix); // @bug 5572 HDFS tmp file
+
+        if (rc == NO_ERROR)
+        {
+            rc = cacheutils::flushPrimProcCache();
+            if (rc != 0)
+                rc = ERR_BLKCACHE_FLUSH_LIST; // translate to WE error
+        }
     }
 
     return rc;


### PR DESCRIPTION
From Ticket: insert..select inserts shorter strings when columnstore_use_import_for_batchinsert is disabled, for data types BLOCK LONGBLOB TEXT LONGTEXT

After investigating, I discovered the first block of the dictionary writeengineserver writes to during the insert/select is not found when trying to retrieve the newly inserted value(s). Restarting DMLProc after the insert/select would fix this issue due to a primproc cache flush.

This fix flushes the dict oids from the primproc cache after the batch insert, which allows retrieval of the entire text/blob without having to restart DMLProc.