### PR TITLE
MCOL-2000 Yet another fixes for column charsets

### DIFF
--- a/dbcon/ddlpackage/ddlpkg.cpp
+++ b/dbcon/ddlpackage/ddlpkg.cpp
@@ -93,7 +93,8 @@ ColumnType::ColumnType(int prec, int scale) :
     fPrecision(prec),
     fScale(scale),
     fWithTimezone(false),
-    fCharset(NULL)
+    fCharset(NULL),
+    fExplicitLength(false)
 {
     fLength = precision_width(fPrecision);
 }
@@ -103,7 +104,8 @@ ColumnType::ColumnType(int type) :
     fLength(0),
     fScale(0),
     fWithTimezone(false),
-    fCharset(NULL)
+    fCharset(NULL),
+    fExplicitLength(false)
 {
     switch ( type )
     {

--- a/dbcon/ddlpackage/ddlpkg.h
+++ b/dbcon/ddlpackage/ddlpkg.h
@@ -1004,7 +1004,7 @@ struct ColumnType
     EXPORT virtual int serialize(messageqcpp::ByteStream& bs);
 
     /** @brief For deserialization. */
-    ColumnType() : fCharset(NULL)
+    ColumnType() : fCharset(NULL), fExplicitLength(false)
     {}
 
     friend std::ostream& operator<<(std::ostream& os, const ColumnType& ac);
@@ -1044,7 +1044,11 @@ struct ColumnType
 
     uint64_t fNextvalue;
 
+    /** @brief Column charset (CHAR, VARCHAR and TEXT only) */
     const char* fCharset;
+
+    /** @brief Is the TEXT column has explicit defined length, ie TEXT(1717) */
+    bool fExplicitLength;
 
 };
 


### PR DESCRIPTION
* make respect for column (including table/db/server default) charsets
  for the TEXT(n) fields
* round TEXT(n) column length up to the next default length of TEXT-like
  subtypes, 255 (TINYTEXT), 65535 (TEXT) and so on up to 2100000000
  (LONGTEXT)