### PR TITLE
A cleanup for MCOL-4064 Make JOIN collation aware

### DIFF
--- a/datatypes/mcs_string.h
+++ b/datatypes/mcs_string.h
@@ -20,6 +20,7 @@
 #define MCS_DATATYPES_STRING_H
 
 #include "conststring.h"
+#include "collation.h"
 
 namespace datatypes
 {
@@ -35,6 +36,13 @@ public:
     {
       utils::ConstString res = utils::ConstString((const char *) &mValue, 8);
       return res.rtrimZero();
+    }
+    static int strnncollsp(const datatypes::Charset &cs, int64_t a, int64_t b)
+    {
+      datatypes::TCharShort sa(a);
+      datatypes::TCharShort sb(b);
+      return cs.strnncollsp(static_cast<utils::ConstString>(sa),
+                            static_cast<utils::ConstString>(sb));
     }
 };
 

--- a/dbcon/joblist/lbidlist.cpp
+++ b/dbcon/joblist/lbidlist.cpp
@@ -24,6 +24,7 @@
 #include "primitivemsg.h"
 #include "blocksize.h"
 #include "lbidlist.h"
+#include "mcs_string.h"
 #include "calpontsystemcatalog.h"
 #include "brm.h"
 #include "brmtypes.h"
@@ -39,18 +40,6 @@ using namespace BRM;
 
 namespace joblist
 {
-
-inline uint64_t order_swap(uint64_t x)
-{
-    return (x >> 56) |
-           ((x << 40) & 0x00FF000000000000ULL) |
-           ((x << 24) & 0x0000FF0000000000ULL) |
-           ((x << 8)  & 0x000000FF00000000ULL) |
-           ((x >> 8)  & 0x00000000FF000000ULL) |
-           ((x >> 24) & 0x0000000000FF0000ULL) |
-           ((x >> 40) & 0x000000000000FF00ULL) |
-           (x << 56);
-}
 
 LBIDList::LBIDList()
 {
@@ -322,7 +311,8 @@ int LBIDList::getMinMaxFromEntries(int64_t& min, int64_t& max, int32_t& seq,
 }
 
 //
-void LBIDList::UpdateMinMax(int64_t min, int64_t max, int64_t lbid, CalpontSystemCatalog::ColDataType type,
+void LBIDList::UpdateMinMax(int64_t min, int64_t max, int64_t lbid,
+                            const CalpontSystemCatalog::ColType &type,
                             bool validData)
 {
     MinMaxPartition* mmp = NULL;
@@ -361,17 +351,18 @@ void LBIDList::UpdateMinMax(int64_t min, int64_t max, int64_t lbid, CalpontSyste
 
             if (mmp->isValid == BRM::CP_INVALID)
             {
-                if (execplan::isCharType(type))
+                if (execplan::isCharType(type.colDataType))
                 {
-                    if (order_swap(min) < order_swap(mmp->min) ||
+                    datatypes::Charset cs(const_cast<CalpontSystemCatalog::ColType &>(type).getCharset());
+                    if (datatypes::TCharShort::strnncollsp(cs, min, mmp->min) < 0 ||
                             mmp->min == numeric_limits<int64_t>::max())
                         mmp->min = min;
 
-                    if (order_swap(max) > order_swap(mmp->max) ||
+                    if (datatypes::TCharShort::strnncollsp(cs, max, mmp->max) > 0 ||
                             mmp->max == numeric_limits<int64_t>::min())
                         mmp->max = max;
                 }
-                else if (execplan::isUnsigned(type))
+                else if (execplan::isUnsigned(type.colDataType))
                 {
                     if (static_cast<uint64_t>(min) < static_cast<uint64_t>(mmp->min))
                         mmp->min = min;
@@ -637,16 +628,15 @@ static inline bool compareStr(const datatypes::Charset &cs,
 }
 
 bool LBIDList::checkSingleValue(int64_t min, int64_t max, int64_t value,
-                                execplan::CalpontSystemCatalog::ColDataType type)
+                                const execplan::CalpontSystemCatalog::ColType &type)
 {
-    if (isCharType(type))
+    if (isCharType(type.colDataType))
     {
-        uint64_t mmin = order_swap(min);
-        uint64_t mmax = order_swap(max);
-        uint64_t vvalue = order_swap(value);
-        return (vvalue >= mmin && vvalue <= mmax);
+        datatypes::Charset cs(const_cast<execplan::CalpontSystemCatalog::ColType&>(type).getCharset());
+        return datatypes::TCharShort::strnncollsp(cs, value, min) >= 0 &&
+               datatypes::TCharShort::strnncollsp(cs, value, max) <= 0;
     }
-    else if (isUnsigned(type))
+    else if (isUnsigned(type.colDataType))
     {
         return (static_cast<uint64_t>(value) >= static_cast<uint64_t>(min) &&
                 static_cast<uint64_t>(value) <= static_cast<uint64_t>(max));
@@ -658,17 +648,15 @@ bool LBIDList::checkSingleValue(int64_t min, int64_t max, int64_t value,
 }
 
 bool LBIDList::checkRangeOverlap(int64_t min, int64_t max, int64_t tmin, int64_t tmax,
-                                 execplan::CalpontSystemCatalog::ColDataType type)
+                                 const execplan::CalpontSystemCatalog::ColType & type)
 {
-    if (isCharType(type))
+    if (isCharType(type.colDataType))
     {
-        uint64_t min2 = order_swap(min);
-        uint64_t max2 = order_swap(max);
-        uint64_t tmin2 = order_swap(tmin);
-        uint64_t tmax2 = order_swap(tmax);
-        return (tmin2 <= max2 && tmax2 >= min2);
+        datatypes::Charset cs(const_cast<execplan::CalpontSystemCatalog::ColType&>(type).getCharset());
+        return datatypes::TCharShort::strnncollsp(cs, tmin, max) <= 0 &&
+               datatypes::TCharShort::strnncollsp(cs, tmax, min) >= 0;
     }
-    else if (isUnsigned(type))
+    else if (isUnsigned(type.colDataType))
     {
         return (static_cast<uint64_t>(tmin) <= static_cast<uint64_t>(max) &&
                 static_cast<uint64_t>(tmax) >= static_cast<uint64_t>(min));

--- a/dbcon/joblist/lbidlist.h
+++ b/dbcon/joblist/lbidlist.h
@@ -93,7 +93,7 @@ public:
                    execplan::CalpontSystemCatalog::ColDataType type);
 
     void UpdateMinMax(int64_t min, int64_t max, int64_t lbid,
-                      execplan::CalpontSystemCatalog::ColDataType type, bool validData = true);
+                      const execplan::CalpontSystemCatalog::ColType &type, bool validData = true);
 
     void UpdateAllPartitionInfo();
 
@@ -107,10 +107,10 @@ public:
                                   const uint8_t BOP);
 
     bool checkSingleValue(int64_t min, int64_t max, int64_t value,
-                          execplan::CalpontSystemCatalog::ColDataType type);
+                          const execplan::CalpontSystemCatalog::ColType &type);
 
     bool checkRangeOverlap(int64_t min, int64_t max, int64_t tmin, int64_t tmax,
-                           execplan::CalpontSystemCatalog::ColDataType type);
+                           const execplan::CalpontSystemCatalog::ColType &type);
 
     // check the column data type and the column size to determine if it
     // is a data type  to apply casual paritioning.

--- a/dbcon/joblist/tuple-bps.cpp
+++ b/dbcon/joblist/tuple-bps.cpp
@@ -2344,7 +2344,7 @@ void TupleBPS::receiveMultiPrimitiveMessages(uint32_t threadID)
 
                 for (i = 0; i < size; i++)
                 {
-                    lbidList->UpdateMinMax(cpv[i].min, cpv[i].max, cpv[i].LBID, fColType.colDataType,
+                    lbidList->UpdateMinMax(cpv[i].min, cpv[i].max, cpv[i].LBID, fColType,
                                            cpv[i].valid);
                 }
 
@@ -3222,14 +3222,14 @@ void TupleBPS::addCPPredicates(uint32_t OID, const vector<int64_t>& vals, bool i
                 {
                     if (isRange)
                         runtimeCPFlags[j] = ll.checkRangeOverlap(min, max, vals[0], vals[1],
-                                            cmd->getColType().colDataType) && runtimeCPFlags[j];
+                                            cmd->getColType()) && runtimeCPFlags[j];
                     else
                     {
                         intersection = false;
 
                         for (k = 0; k < vals.size(); k++)
                             intersection = intersection ||
-                                           ll.checkSingleValue(min, max, vals[k], cmd->getColType().colDataType);
+                                           ll.checkSingleValue(min, max, vals[k], cmd->getColType());
 
                         runtimeCPFlags[j] = intersection && runtimeCPFlags[j];
                     }

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -29,6 +29,7 @@
 #include "lbidlist.h"
 #include "spinlock.h"
 #include "vlarray.h"
+#include "mcs_string.h"
 
 using namespace std;
 using namespace rowgroup;
@@ -1078,15 +1079,16 @@ void TupleJoiner::updateCPData(const Row& r)
 
         if (r.isCharType(smallKeyColumns[col]))
         {
+            datatypes::Charset cs(r.getCharset(col));
             int64_t val = r.getIntField(smallKeyColumns[col]);
 
-            if (order_swap(val) < order_swap(min) ||
+            if (datatypes::TCharShort::strnncollsp(cs, val, min) < 0 ||
                     min == numeric_limits<int64_t>::max())
             {
                 min = val;
             }
 
-            if (order_swap(val) > order_swap(max) ||
+            if (datatypes::TCharShort::strnncollsp(cs, val, max) > 0 ||
                     max == numeric_limits<int64_t>::min())
             {
                 max = val;

--- a/utils/joiner/tuplejoiner.h
+++ b/utils/joiner/tuplejoiner.h
@@ -43,18 +43,6 @@
 namespace joiner
 {
 
-inline uint64_t order_swap(uint64_t x)
-{
-    return (x >> 56) |
-           ((x << 40) & 0x00FF000000000000ULL) |
-           ((x << 24) & 0x0000FF0000000000ULL) |
-           ((x << 8)  & 0x000000FF00000000ULL) |
-           ((x >> 8)  & 0x00000000FF000000ULL) |
-           ((x >> 24) & 0x0000000000FF0000ULL) |
-           ((x >> 40) & 0x000000000000FF00ULL) |
-           (x << 56);
-}
-
 class TypelessData
 {
 public:


### PR DESCRIPTION
After creating and populating tables with CHAR(5) case insensitive columns,
in a set of consequent joins like:

select * from t1, t2 where t1.c1=t2.c1;
select * from t1, t2 where t1.c1=t2.c2;
select * from t1, t2 where t1.c2=t2.c1;
select * from t1, t2 where t1.c2=t2.c2;

only the first join worked reliably case insensitively.

Removing the remaining pieces of the code that used order_swap() to compare
short CHAR columns, and using Charset::strnncollsp() instead.
This fixes the issue.