### PR TITLE
MCOL-4177 Add support for bulk insertion for wide decimals.

### DIFF
--- a/datatypes/mcs_datatype.h
+++ b/datatypes/mcs_datatype.h
@@ -167,6 +167,11 @@ public:
           scale(0),
           precision(-1)
       {}
+      TypeAttributesStd(int32_t w, int32_t s, int32_t p)
+         :colWidth(w),
+          scale(s),
+          precision(p)
+      {}
       /**
           @brief Convenience method to get int128 from a std::string.
       */

--- a/dbcon/joblist/batchprimitiveprocessor-jl.cpp
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.cpp
@@ -351,8 +351,8 @@ void BatchPrimitiveProcessorJL::addElementType(const ElementType& et, uint32_t d
         absRids[ridCount] = et.first;
     else
     {
-        relRids[ridCount] = et.first & 0x1fff;  // 8192 rows per logical block
-        ridMap |= 1 << (relRids[ridCount] >> 10);	// LSB -> 0-1023, MSB -> 7168-8191
+        relRids[ridCount] = et.first & 0x1fff;   // 8192 rows per logical block
+        ridMap |= 1 << (relRids[ridCount] >> 9); // LSB -> 0-511, MSB -> 7680-8191
     }
 
     if (sendValues)

--- a/dbcon/joblist/batchprimitiveprocessor-jl.h
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.h
@@ -297,7 +297,7 @@ private:
     uint16_t filterCount;
     uint16_t projectCount;
     bool needRidsAtDelivery;
-    uint8_t ridMap;
+    uint16_t ridMap;
 
 //	TableBand templateTB;
     uint32_t tableOID;

--- a/dbcon/joblist/primitivemsg.h
+++ b/dbcon/joblist/primitivemsg.h
@@ -314,7 +314,7 @@ struct ColByScanRequestHeader
     ColRequestHeaderDataType colType;
     uint8_t OutputType;     // 1 = RID, 2 = Token, 3 = Both
     uint8_t BOP;            // 0 = N/A, 1 = AND, 2 = OR
-    uint8_t RidFlags;		// a bitmap indicating the rid ranges in the resultM SB => row 7168-8191
+    uint16_t RidFlags;		// a bitmap indicating the rid ranges in the result MSB => row 7680-8191
     uint16_t NOPS;
     uint16_t NVALS;
     uint8_t sort;
@@ -336,7 +336,7 @@ struct ColByScanRangeRequestHeader
     ColRequestHeaderDataType colType;
     uint8_t OutputType;     // 1 = RID, 2 = Token, 3 = Both
     uint8_t BOP;            // 0 = N/A, 1 = AND, 2 = OR
-    uint8_t RidFlags;		// a bitmap indicating the rid ranges in the result MSB => row 7168-8191
+    uint16_t RidFlags;		// a bitmap indicating the rid ranges in the result MSB => row 7680-8191
     uint16_t NOPS;
     uint16_t NVALS;
     uint8_t sort;
@@ -409,7 +409,7 @@ struct ColResultHeader
 {
     PrimitiveHeader Hdr;
     uint64_t LBID;
-    uint8_t RidFlags;
+    uint16_t RidFlags;
     uint16_t NVALS;
     uint16_t ValidMinMax; 			  // 1 if Min/Max are valid, otherwise 0
     uint32_t OutputType;
@@ -695,7 +695,7 @@ struct NewColRequestHeader
     uint8_t OutputType;		// OT_DATAVALUE, OT_RID, or OT_BOTH
     uint8_t BOP;
 // 	uint8_t InputFlags;		// 1 = interpret each NOP & RID as a pair (deprecated)
-    uint8_t RidFlags;		// a bitmap indicating the rid ranges in the result MSB => row 7168-8191
+    uint16_t RidFlags;		// a bitmap indicating the rid ranges in the result MSB => row 7680-8191
     uint16_t NOPS;
     uint16_t NVALS;
     uint8_t sort;				//1 to sort
@@ -730,7 +730,7 @@ struct NewColResultHeader
     ISMPacketHeader ism;
     PrimitiveHeader hdr;
     uint64_t LBID;
-    uint8_t RidFlags;
+    uint16_t RidFlags;
     uint16_t NVALS;
     uint16_t ValidMinMax;		// 1 if Min/Max are valid, otherwise 0
     uint32_t OutputType;

--- a/primitives/linux-port/column.cpp
+++ b/primitives/linux-port/column.cpp
@@ -774,7 +774,7 @@ inline void store(const NewColRequestHeader* in,
         }
 
 #endif
-        out->RidFlags |= (1 << (rid >> 10)); // set the (row/1024)'th bit
+        out->RidFlags |= (1 << (rid >> 9)); // set the (row/512)'th bit
         memcpy(&out8[*written], &rid, 2);
         *written += 2;
     }

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -525,7 +525,7 @@ void BatchPrimitiveProcessor::resetBPP(ByteStream& bs, const SP_UM_MUTEX& w,
         for (uint32_t i = 0; i < ridCount; i++)
         {
             relRids[i] = absRids[i] - baseRid;
-            ridMap |= 1 << (relRids[i] >> 10);
+            ridMap |= 1 << (relRids[i] >> 9);
         }
     }
     else
@@ -1481,7 +1481,7 @@ void BatchPrimitiveProcessor::execute()
                 if (accumulator[i])
                 {
                     relRids[ridCount] = i;
-                    ridMap |= 1 << (relRids[ridCount] >> 10);
+                    ridMap |= 1 << (relRids[ridCount] >> 9);
                     ++ridCount;
                 }
             }

--- a/primitives/primproc/batchprimitiveprocessor.h
+++ b/primitives/primproc/batchprimitiveprocessor.h
@@ -224,7 +224,7 @@ private:
     uint16_t filterCount;
     uint16_t projectCount;
     bool sendRidsAtDelivery;
-    uint8_t ridMap;
+    uint16_t ridMap;
     bool gotAbsRids;
     bool gotValues;
 

--- a/primitives/primproc/columncommand.cpp
+++ b/primitives/primproc/columncommand.cpp
@@ -127,7 +127,7 @@ void ColumnCommand::makeScanMsg()
     primMsg->ism.Size = baseMsgLength;
     primMsg->NVALS = 0;
     primMsg->LBID = lbid;
-    primMsg->RidFlags = 0xFF;
+    primMsg->RidFlags = 0xFFFF;
 
 // 	cout << "scanning lbid " << lbid << " colwidth = " << primMsg->DataSize <<
 // 		" filterCount = " << filterCount << " outputType = " <<
@@ -148,7 +148,7 @@ void ColumnCommand::loadData()
 {
     uint32_t wasCached;
     uint32_t blocksRead;
-    uint8_t _mask;
+    uint16_t _mask;
     uint64_t oidLastLbid = 0;
     bool lastBlockReached = false;
     oidLastLbid = getLastLbid();
@@ -161,7 +161,7 @@ void ColumnCommand::loadData()
 
 
     _mask = mask;
-// 	primMsg->RidFlags = 0xff;   // disables selective block loading
+// 	primMsg->RidFlags = 0xffff;   // disables selective block loading
     //cout <<__FILE__ << "::issuePrimitive() o: " << getOID() << " l:" << primMsg->LBID << " ll: " << oidLastLbid << endl;
 
     for (i = 0; i < colType.colWidth; ++i, _mask <<= shift)
@@ -599,30 +599,28 @@ void ColumnCommand::prep(int8_t outputType, bool absRids)
 // 	memcpy(primMsg + 1, filterString.buf(), filterString.length());
 
 
-
-    // JFYI This switch results are used by index scan code that is unused
-    // as of 1.5
     switch (colType.colWidth)
     {
         case 1:
+            shift = 16;
+            mask = 0xFFFF;
+            break;
+
+        case 2:
             shift = 8;
             mask = 0xFF;
             break;
 
-        case 2:
+        case 4:
             shift = 4;
             mask = 0x0F;
             break;
 
-        case 4:
+        case 8:
             shift = 2;
             mask = 0x03;
             break;
 
-        case 8:
-            shift = 1;
-            mask = 0x01;
-            break;
         case 16:
             shift = 1;
             mask = 0x01;

--- a/primitives/primproc/columncommand.h
+++ b/primitives/primproc/columncommand.h
@@ -149,7 +149,7 @@ private:
     int64_t* values;      // this is usually bpp->values; RTSCommand needs to use a different container
     int128_t* wide128Values;
 
-    uint8_t mask, shift;  // vars for the selective block loader
+    uint16_t mask, shift;  // vars for the selective block loader
 
     // counters to decide whether to prefetch or not
     uint32_t blockCount, loadCount;

--- a/primitives/primproc/filtercommand.cpp
+++ b/primitives/primproc/filtercommand.cpp
@@ -285,7 +285,7 @@ void FilterCommand::doFilter()
                     bpp->wide128Values[bpp->ridCount] = bpp->fFiltCmdBinaryValues[0][i];
                 else
                     bpp->values[bpp->ridCount] = bpp->fFiltCmdValues[0][i];
-                bpp->ridMap |= 1 << (bpp->relRids[bpp->ridCount] >> 10);
+                bpp->ridMap |= 1 << (bpp->relRids[bpp->ridCount] >> 9);
                 bpp->ridCount++;
             }
 

--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -111,7 +111,7 @@ void number_int_value(const string& data,
                       const datatypes::SystemCatalog::TypeAttributesStd& ct,
                       bool& pushwarning,
                       bool noRoundup,
-                      T& intVal)
+                      T& intVal, bool* saturate)
 {
     // copy of the original input
     string valStr(data);
@@ -304,11 +304,17 @@ void number_int_value(const string& data,
             {
                 intVal = MIN_TINYINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
             else if (intVal > MAX_TINYINT)
             {
                 intVal = MAX_TINYINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
 
             break;
@@ -318,11 +324,17 @@ void number_int_value(const string& data,
             {
                 intVal = MIN_SMALLINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
             else if (intVal > MAX_SMALLINT)
             {
                 intVal = MAX_SMALLINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
 
             break;
@@ -332,11 +344,17 @@ void number_int_value(const string& data,
             {
                 intVal = MIN_MEDINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
             else if (intVal > MAX_MEDINT)
             {
                 intVal = MAX_MEDINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
 
             break;
@@ -346,11 +364,17 @@ void number_int_value(const string& data,
             {
                 intVal = MIN_INT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
             else if (intVal > MAX_INT)
             {
                 intVal = MAX_INT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
 
             break;
@@ -360,6 +384,9 @@ void number_int_value(const string& data,
             {
                 intVal = MIN_BIGINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
 
             break;
@@ -374,6 +401,9 @@ void number_int_value(const string& data,
                 {
                     intVal = tmp + 2;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
             }
             else if (ct.colWidth == 8)
@@ -382,6 +412,9 @@ void number_int_value(const string& data,
                 {
                     intVal = MIN_BIGINT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
             }
             else if (ct.colWidth == 4)
@@ -390,11 +423,17 @@ void number_int_value(const string& data,
                 {
                     intVal = MIN_INT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
                 else if (intVal > MAX_INT)
                 {
                     intVal = MAX_INT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
             }
             else if (ct.colWidth == 2)
@@ -403,11 +442,17 @@ void number_int_value(const string& data,
                 {
                     intVal = MIN_SMALLINT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
                 else if (intVal > MAX_SMALLINT)
                 {
                     intVal = MAX_SMALLINT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
             }
             else if (ct.colWidth == 1)
@@ -416,11 +461,17 @@ void number_int_value(const string& data,
                 {
                     intVal = MIN_TINYINT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
                 else if (intVal > MAX_TINYINT)
                 {
                     intVal = MAX_TINYINT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
             }
 
@@ -454,11 +505,17 @@ void number_int_value(const string& data,
         {
             intVal = rangeUp;
             pushwarning = true;
+
+            if (saturate)
+                *saturate = true;
         }
         else if (intVal < rangeLow)
         {
             intVal = rangeLow;
             pushwarning = true;
+
+            if (saturate)
+                *saturate = true;
         }
     }
 }
@@ -470,7 +527,7 @@ void number_int_value<int64_t>(const std::string& data,
                                const datatypes::SystemCatalog::TypeAttributesStd& ct,
                                bool& pushwarning,
                                bool noRoundup,
-                               int64_t& intVal);
+                               int64_t& intVal, bool* saturate);
 
 template
 void number_int_value<int128_t>(const std::string& data,
@@ -478,7 +535,7 @@ void number_int_value<int128_t>(const std::string& data,
                                 const datatypes::SystemCatalog::TypeAttributesStd& ct,
                                 bool& pushwarning,
                                 bool noRoundup,
-                                int128_t& intVal);
+                                int128_t& intVal, bool* saturate);
 
 uint64_t number_uint_value(const string& data,
                            cscDataType typeCode,

--- a/utils/dataconvert/dataconvert.h
+++ b/utils/dataconvert/dataconvert.h
@@ -882,7 +882,7 @@ void number_int_value(const std::string& data,
                       const datatypes::SystemCatalog::TypeAttributesStd &ct,
                       bool& pushwarning,
                       bool noRoundup,
-                      T& intVal);
+                      T& intVal, bool* saturate = 0);
 
 uint64_t number_uint_value(const string& data,
                            cscDataType typeCode,

--- a/writeengine/bulk/we_columninfo.cpp
+++ b/writeengine/bulk/we_columninfo.cpp
@@ -204,6 +204,7 @@ ColumnInfo::ColumnInfo(Log*             logger,
         case WriteEngine::WR_ULONGLONG:
         case WriteEngine::WR_UMEDINT:
         case WriteEngine::WR_UINT:
+        case WriteEngine::WR_BINARY:
         default:
         {
             fColExtInf = new ColExtInf(column.mapOid, logger);

--- a/writeengine/shared/we_type.h
+++ b/writeengine/shared/we_type.h
@@ -367,6 +367,7 @@ struct JobColumn                        /** @brief Job Column Structure */
     long long      fDefaultInt;         /** @brief Integer column default */
     unsigned long long fDefaultUInt;    /** @brief UnsignedInt col default*/
     double         fDefaultDbl;         /** @brief Dbl/Flt column default */
+    int128_t       fDefaultWideDecimal; /** @brief Wide decimal column default */
     std::string    fDefaultChr;         /** @brief Char column default */
     JobColumn() : mapOid(0), dataType(execplan::CalpontSystemCatalog::INT), weType(WR_INT),
         typeName("integer"), emptyVal(0),
@@ -376,7 +377,8 @@ struct JobColumn                        /** @brief Job Column Structure */
         compressionType(0), autoIncFlag(false),
         fMinIntSat(0), fMaxIntSat(0),
         fMinDblSat(0), fMaxDblSat(0), fWithDefault(false),
-        fDefaultInt(0), fDefaultUInt(0), fDefaultDbl(0.0)
+        fDefaultInt(0), fDefaultUInt(0), fDefaultDbl(0.0),
+        fDefaultWideDecimal(0)
     { }
 };
 

--- a/writeengine/xml/we_xmljob.cpp
+++ b/writeengine/xml/we_xmljob.cpp
@@ -1087,13 +1087,24 @@ void XMLJob::fillInXMLDataNotNullDefault(
             case execplan::CalpontSystemCatalog::DECIMAL:
             case execplan::CalpontSystemCatalog::UDECIMAL:
             {
-                col.fDefaultInt = Convertor::convertDecimalString(
-                                      col_defaultValue.c_str(),
-                                      col_defaultValue.length(),
-                                      colType.scale);
+                if (LIKELY(colType.colWidth == datatypes::MAXDECIMALWIDTH))
+                {
+                    bool dummy = false;
+                    dataconvert::number_int_value(col_defaultValue, colType.colDataType,
+                        datatypes::SystemCatalog::TypeAttributesStd(
+                            colType.colWidth, colType.scale, colType.precision),
+                        dummy, false, col.fDefaultWideDecimal, &bDefaultConvertError);
+                }
+                else
+                {
+                    col.fDefaultInt = Convertor::convertDecimalString(
+                                          col_defaultValue.c_str(),
+                                          col_defaultValue.length(),
+                                          colType.scale);
 
-                if (errno == ERANGE)
-                    bDefaultConvertError = true;
+                    if (errno == ERANGE)
+                        bDefaultConvertError = true;
+                }
 
                 break;
             }


### PR DESCRIPTION
  1. This patch adds support for wide decimals with/without scale
     to cpimport. In addition, INSERT ... SELECT and LDI are also
     now supported.
  2. Logic to compute the number of bytes to convert a binary
     representation in the buffer to a narrow decimal is also
     simplified.
  3. Support for selective block loading for 16 bytes columns
     is also added to PrimProc.