### PR TITLE
MCOL-4177 Add support for bulk insertion for wide decimals.

### DIFF
--- a/datatypes/mcs_datatype.cpp
+++ b/datatypes/mcs_datatype.cpp
@@ -57,7 +57,9 @@ using namespace dataconvert;
 namespace datatypes
 {
 
-int128_t SystemCatalog::TypeAttributesStd::decimal128FromString(const std::string& value) const
+int128_t
+SystemCatalog::TypeAttributesStd::decimal128FromString(
+    const std::string& value, bool *saturate) const
 {
   int128_t result = 0;
   bool pushWarning = false;
@@ -67,7 +69,8 @@ int128_t SystemCatalog::TypeAttributesStd::decimal128FromString(const std::strin
                                           *this,
                                           pushWarning,
                                           noRoundup,
-                                          result);
+                                          result,
+                                          saturate);
   return result;
 }
 

--- a/datatypes/mcs_datatype.h
+++ b/datatypes/mcs_datatype.h
@@ -167,10 +167,15 @@ public:
           scale(0),
           precision(-1)
       {}
+      TypeAttributesStd(int32_t w, int32_t s, int32_t p)
+         :colWidth(w),
+          scale(s),
+          precision(p)
+      {}
       /**
           @brief Convenience method to get int128 from a std::string.
       */
-      int128_t decimal128FromString(const std::string& value) const;
+      int128_t decimal128FromString(const std::string& value, bool *saturate = 0) const;
 
       /**
           @brief The method sets the legacy scale and precision of a wide decimal

--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -111,7 +111,7 @@ void number_int_value(const string& data,
                       const datatypes::SystemCatalog::TypeAttributesStd& ct,
                       bool& pushwarning,
                       bool noRoundup,
-                      T& intVal)
+                      T& intVal, bool* saturate)
 {
     // copy of the original input
     string valStr(data);
@@ -304,11 +304,17 @@ void number_int_value(const string& data,
             {
                 intVal = MIN_TINYINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
             else if (intVal > MAX_TINYINT)
             {
                 intVal = MAX_TINYINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
 
             break;
@@ -318,11 +324,17 @@ void number_int_value(const string& data,
             {
                 intVal = MIN_SMALLINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
             else if (intVal > MAX_SMALLINT)
             {
                 intVal = MAX_SMALLINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
 
             break;
@@ -332,11 +344,17 @@ void number_int_value(const string& data,
             {
                 intVal = MIN_MEDINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
             else if (intVal > MAX_MEDINT)
             {
                 intVal = MAX_MEDINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
 
             break;
@@ -346,11 +364,17 @@ void number_int_value(const string& data,
             {
                 intVal = MIN_INT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
             else if (intVal > MAX_INT)
             {
                 intVal = MAX_INT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
 
             break;
@@ -360,6 +384,9 @@ void number_int_value(const string& data,
             {
                 intVal = MIN_BIGINT;
                 pushwarning = true;
+
+                if (saturate)
+                    *saturate = true;
             }
 
             break;
@@ -374,6 +401,9 @@ void number_int_value(const string& data,
                 {
                     intVal = tmp + 2;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
             }
             else if (ct.colWidth == 8)
@@ -382,6 +412,9 @@ void number_int_value(const string& data,
                 {
                     intVal = MIN_BIGINT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
             }
             else if (ct.colWidth == 4)
@@ -390,11 +423,17 @@ void number_int_value(const string& data,
                 {
                     intVal = MIN_INT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
                 else if (intVal > MAX_INT)
                 {
                     intVal = MAX_INT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
             }
             else if (ct.colWidth == 2)
@@ -403,11 +442,17 @@ void number_int_value(const string& data,
                 {
                     intVal = MIN_SMALLINT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
                 else if (intVal > MAX_SMALLINT)
                 {
                     intVal = MAX_SMALLINT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
             }
             else if (ct.colWidth == 1)
@@ -416,11 +461,17 @@ void number_int_value(const string& data,
                 {
                     intVal = MIN_TINYINT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
                 else if (intVal > MAX_TINYINT)
                 {
                     intVal = MAX_TINYINT;
                     pushwarning = true;
+
+                    if (saturate)
+                        *saturate = true;
                 }
             }
 
@@ -454,11 +505,17 @@ void number_int_value(const string& data,
         {
             intVal = rangeUp;
             pushwarning = true;
+
+            if (saturate)
+                *saturate = true;
         }
         else if (intVal < rangeLow)
         {
             intVal = rangeLow;
             pushwarning = true;
+
+            if (saturate)
+                *saturate = true;
         }
     }
 }
@@ -470,7 +527,7 @@ void number_int_value<int64_t>(const std::string& data,
                                const datatypes::SystemCatalog::TypeAttributesStd& ct,
                                bool& pushwarning,
                                bool noRoundup,
-                               int64_t& intVal);
+                               int64_t& intVal, bool* saturate);
 
 template
 void number_int_value<int128_t>(const std::string& data,
@@ -478,7 +535,7 @@ void number_int_value<int128_t>(const std::string& data,
                                 const datatypes::SystemCatalog::TypeAttributesStd& ct,
                                 bool& pushwarning,
                                 bool noRoundup,
-                                int128_t& intVal);
+                                int128_t& intVal, bool* saturate);
 
 uint64_t number_uint_value(const string& data,
                            cscDataType typeCode,

--- a/utils/dataconvert/dataconvert.h
+++ b/utils/dataconvert/dataconvert.h
@@ -882,7 +882,7 @@ void number_int_value(const std::string& data,
                       const datatypes::SystemCatalog::TypeAttributesStd &ct,
                       bool& pushwarning,
                       bool noRoundup,
-                      T& intVal);
+                      T& intVal, bool* saturate = 0);
 
 uint64_t number_uint_value(const string& data,
                            cscDataType typeCode,

--- a/writeengine/bulk/we_columninfo.cpp
+++ b/writeengine/bulk/we_columninfo.cpp
@@ -204,6 +204,7 @@ ColumnInfo::ColumnInfo(Log*             logger,
         case WriteEngine::WR_ULONGLONG:
         case WriteEngine::WR_UMEDINT:
         case WriteEngine::WR_UINT:
+        case WriteEngine::WR_BINARY:
         default:
         {
             fColExtInf = new ColExtInf(column.mapOid, logger);

--- a/writeengine/shared/we_type.h
+++ b/writeengine/shared/we_type.h
@@ -367,6 +367,7 @@ struct JobColumn                        /** @brief Job Column Structure */
     long long      fDefaultInt;         /** @brief Integer column default */
     unsigned long long fDefaultUInt;    /** @brief UnsignedInt col default*/
     double         fDefaultDbl;         /** @brief Dbl/Flt column default */
+    int128_t       fDefaultWideDecimal; /** @brief Wide decimal column default */
     std::string    fDefaultChr;         /** @brief Char column default */
     JobColumn() : mapOid(0), dataType(execplan::CalpontSystemCatalog::INT), weType(WR_INT),
         typeName("integer"), emptyVal(0),
@@ -376,7 +377,8 @@ struct JobColumn                        /** @brief Job Column Structure */
         compressionType(0), autoIncFlag(false),
         fMinIntSat(0), fMaxIntSat(0),
         fMinDblSat(0), fMaxDblSat(0), fWithDefault(false),
-        fDefaultInt(0), fDefaultUInt(0), fDefaultDbl(0.0)
+        fDefaultInt(0), fDefaultUInt(0), fDefaultDbl(0.0),
+        fDefaultWideDecimal(0)
     { }
 };
 

--- a/writeengine/xml/we_xmljob.cpp
+++ b/writeengine/xml/we_xmljob.cpp
@@ -1087,13 +1087,21 @@ void XMLJob::fillInXMLDataNotNullDefault(
             case execplan::CalpontSystemCatalog::DECIMAL:
             case execplan::CalpontSystemCatalog::UDECIMAL:
             {
-                col.fDefaultInt = Convertor::convertDecimalString(
-                                      col_defaultValue.c_str(),
-                                      col_defaultValue.length(),
-                                      colType.scale);
+                if (LIKELY(colType.colWidth == datatypes::MAXDECIMALWIDTH))
+                {
+                    col.fDefaultWideDecimal = colType.decimal128FromString(
+                                                  col_defaultValue, &bDefaultConvertError);
+                }
+                else
+                {
+                    col.fDefaultInt = Convertor::convertDecimalString(
+                                          col_defaultValue.c_str(),
+                                          col_defaultValue.length(),
+                                          colType.scale);
 
-                if (errno == ERANGE)
-                    bDefaultConvertError = true;
+                    if (errno == ERANGE)
+                        bDefaultConvertError = true;
+                }
 
                 break;
             }


### PR DESCRIPTION
  1. This patch adds support for wide decimals with/without scale
     to cpimport. In addition, INSERT ... SELECT and LDI are also
     now supported.
  2. Logic to compute the number of bytes to convert a binary
     representation in the buffer to a narrow decimal is also
     simplified.