### PR TITLE
MCOL-4263 return int for func_floor on datetime

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -4149,6 +4149,14 @@ ReturnedColumn* buildFunctionColumn(
 #endif
 
         fc->operationType(functor->operationType(funcParms, fc->resultType()));
+        // For some reason, MDB has MYSQL_TYPE_DATETIME2 for functions on a TIMESTAMP
+        if (fc->operationType().colDataType == CalpontSystemCatalog::TIMESTAMP)
+        {
+            CalpontSystemCatalog::ColType ct = fc->resultType();
+            ct.colDataType = CalpontSystemCatalog::TIMESTAMP;
+            ct.colWidth = 8;
+            fc->resultType(ct);
+        }
         fc->expressionId(ci->expressionId++);
         // A few functions use a different collation than that found in 
         // the base ifp class

--- a/utils/funcexp/func_floor.cpp
+++ b/utils/funcexp/func_floor.cpp
@@ -114,27 +114,14 @@ int64_t Func_floor::getIntVal(Row& row,
 
         case execplan::CalpontSystemCatalog::DATETIME:
         {
-            string str =
-                DataConvert::datetimeToString1(parm[0]->data()->getDatetimeIntVal(row, isNull));
+            ret = parm[0]->data()->getDatetimeIntVal(row, isNull);
 
-            // strip off micro seconds
-            str = str.substr(0, 14);
-
-            if (!isNull)
-                ret = atoll(str.c_str());
         }
         break;
 
         case execplan::CalpontSystemCatalog::TIMESTAMP:
         {
-            string str =
-                DataConvert::timestampToString1(parm[0]->data()->getTimestampIntVal(row, isNull), timeZone());
-
-            // strip off micro seconds
-            str = str.substr(0, 14);
-
-            if (!isNull)
-                ret = atoll(str.c_str());
+            ret = parm[0]->data()->getTimestampIntVal(row, isNull);
         }
         break;
 


### PR DESCRIPTION
For TIMESTAMP, it should do similar. However, it didn't work. For some reason, MDB has the function set as DATETIME, which for cs, isn't the same thing. Added a kludge to ha_mcs_execplan.cpp to handle it.