### PR TITLE
MDB Columnstore build instructions, phase 1: install dependencies

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,36 @@
+## Checking out the source
+
+Since MCS is not meant to be built independently outside outside of MariaDB server, we should checkout the [server](https://github.com/MariaDB/server) code first.
+
+You can clone from github with
+
+	git clone git@github.com:MariaDB/server.git
+
+or if you are not a github user,
+
+	git clone https://github.com/MariaDB/server.git
+
+branch 10.5 was suggested despite the fact that develop branch of the engine will eventually work with 10.6
+
+	git checkout -b 10.5 origin/10.5
+
+MariaDB server contains many git submodules that need to be checked out with,
+
+	git submodule update --init --recursive --depth=1
+
+This would be automatically done when you excute cmake, but consider we are focus MCS here, so dependencies of MCS should be installed first.
+
+## Build Prerequisites
+
+The list of Debian or RPM packages dependencies can be installed with:
+
+	./install-deps.sh
+
+## Building phase
+
+After the dependencies had been installed, just follow the normal building instrutions to build, MCS will be compiled along with mariadbd.
+
+But for development convenience, we supply a script to build and run Mariadb server in MCS repo.
+
+	# TODO
+	

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository is not meant to be built independently outside of MariaDB server
 
   https://github.com/MariaDB/server
 
-Building instructions are coming soon.
+See building instructions [here](BUILD.md).
 
 # Issue tracking
 

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -e
+if test $(id -u) != 0 ; then
+    SUDO=sudo
+fi
+export LC_ALL=C
+
+source /etc/os-release
+
+case "$ID" in
+ubuntu|debian)
+    echo "Using apt-get to install dependencies"
+    $SUDO apt-get update -y
+    $SUDO apt-get install -y build-essential automake libboost-all-dev bison \
+        cmake libncurses5-dev libreadline-dev libperl-dev libssl-dev \
+        libxml2-dev libkrb5-dev flex libpam-dev libreadline-dev libsnappy-dev \
+        libcurl4-openssl-dev
+    $SUDO apt-get install -y libboost-dev libboost-all-dev
+    case "$VERSION" in
+        *Bionic*)
+            echo "Install dependencies specific to Ubuntu Bionic"
+            ;;
+        *Focal*)
+            echo "Install dependencies specific to Ubuntu Focal"
+            ;;
+        *)
+            echo "Unknown OS distribution"
+            ;;
+    esac
+    ;;
+centos)
+    echo "Using yum to install dependencies"
+    $SUDO yum -y install epel-release
+    $SUDO yum -y groupinstall "Development Tools"
+    $SUDO yum -y install bison ncurses-devel readline-devel perl-devel \
+        openssl-devel cmake libxml2-devel gperf libaio-devel libevent-devel \
+        python-devel ruby-devel tree wget pam-devel snappy-devel libicu \
+        wget strace ltrace gdb rsyslog net-tools openssh-server expect boost \
+        perl-DBI libicu boost-devel initscripts jemalloc-devel libcurl-devel
+    ;;
+opensuse*|suse|sles)
+    echo "Using zypper to install dependencies"
+    $SUDO zypper install -y bison ncurses-devel readline-devel \
+        libopenssl-devel cmake libxml2-devel gperf libaio-devel \
+        libevent-devel python-devel ruby-devel tree wget pam-devel \
+        snappy-devel libicu-devel libboost_system-devel \
+        libboost_filesystem-devel libboost_thread-devel libboost_regex-devel \
+        libboost_date_time-devel libboost_chrono-devel wget strace ltrace gdb \
+        rsyslog net-tools expect perl-DBI libicu boost-devel jemalloc-devel \
+        libcurl-devel gcc gcc-c++ automake libtool
+    ;;
+*)
+    echo "$ID is unknown, dependencies will have to be installed manually."
+    exit 1
+    ;;
+esac
+
+echo "Dependencies have been installed successfully"


### PR DESCRIPTION
This patch installs MCS dependencies so that it can build. Most of
the code are from git@github.com:drrtuy/cs-docker-tools.git.

Signed-off-by: Zhao Junwang <zhjwpku@gmail.com>