### PR TITLE
A cleanup for MCOL-4464 Bitwise operations not like in MariaDB

### DIFF
--- a/dbcon/execplan/treenode.h
+++ b/dbcon/execplan/treenode.h
@@ -267,13 +267,13 @@ public:
     }
     datatypes::TUInt64Null toTUInt64Null(rowgroup::Row& row)
     {
-        bool isNull;
+        bool isNull = false;
         uint64_t val = getUintVal(row, isNull);
         return datatypes::TUInt64Null(val, isNull);
     }
     datatypes::TSInt64Null toTSInt64Null(rowgroup::Row& row)
     {
-        bool isNull;
+        bool isNull = false;
         int64_t val = getIntVal(row, isNull);
         return datatypes::TSInt64Null(val, isNull);
     }

--- a/utils/funcexp/func_bitwise.cpp
+++ b/utils/funcexp/func_bitwise.cpp
@@ -142,7 +142,7 @@ datatypes::TUInt64Null GenericToBitOperand(
         case execplan::CalpontSystemCatalog::UDOUBLE:
         case execplan::CalpontSystemCatalog::UFLOAT:
         {
-            bool tmpIsNull;
+            bool tmpIsNull = false;
             double val = parm->data()->getDoubleVal(row, tmpIsNull);
             return tmpIsNull ? datatypes::TUInt64Null() :
                                ConvertToBitOperand<double>(round(val));
@@ -159,7 +159,7 @@ datatypes::TUInt64Null GenericToBitOperand(
         case execplan::CalpontSystemCatalog::CHAR:
         case execplan::CalpontSystemCatalog::TEXT:
         {
-            bool tmpIsNull;
+            bool tmpIsNull = false;
             const string& str = parm->data()->getStrVal(row, tmpIsNull);
             if (tmpIsNull)
                 return datatypes::TUInt64Null();
@@ -177,7 +177,7 @@ datatypes::TUInt64Null GenericToBitOperand(
 
         case execplan::CalpontSystemCatalog::DATE:
         {
-            bool tmpIsNull;
+            bool tmpIsNull = false;
             int32_t time = parm->data()->getDateIntVal(row, tmpIsNull);
             if (tmpIsNull)
                 return datatypes::TUInt64Null();
@@ -188,7 +188,7 @@ datatypes::TUInt64Null GenericToBitOperand(
 
         case execplan::CalpontSystemCatalog::DATETIME:
         {
-            bool tmpIsNull;
+            bool tmpIsNull = false;
             int64_t time = parm->data()->getDatetimeIntVal(row, tmpIsNull);
             if (tmpIsNull)
                 return datatypes::TUInt64Null();
@@ -203,7 +203,7 @@ datatypes::TUInt64Null GenericToBitOperand(
 
         case execplan::CalpontSystemCatalog::TIMESTAMP:
         {
-            bool tmpIsNull;
+            bool tmpIsNull = false;
             int64_t time = parm->data()->getTimestampIntVal(row, tmpIsNull);
             if (tmpIsNull)
                 return datatypes::TUInt64Null();
@@ -217,7 +217,7 @@ datatypes::TUInt64Null GenericToBitOperand(
 
         case execplan::CalpontSystemCatalog::TIME:
         {
-            bool tmpIsNull;
+            bool tmpIsNull = false;
             int64_t time = parm->data()->getTimeIntVal(row, tmpIsNull);
 
             Time dt(time);


### PR DESCRIPTION
CI with RelWithDebInfo builds revealed a problem in the main
patch for MCOL-4464, which did not show up with Debug builds.

Methods like:
- getDoubleVal()
- getDateIntVal()
- getDatetimeIntVal()
- getTimestampIntVal()
- getTimeIntVal()
- getUintVal()
- getIntVal()
- getStrVal()
require the caller to initialize the isNull argument to false.
This fact was not taken into account in MCOL-4464.

Adding proper initializations.