### PR TITLE
MCOL-4510 thrift code need to be upgraded to support aarch64

### DIFF
--- a/utils/thrift/thrift/protocol/TProtocol.h
+++ b/utils/thrift/thrift/protocol/TProtocol.h
@@ -77,15 +77,6 @@ static inline To bitwise_cast(From from)
 }
 
 
-namespace apache
-{
-namespace thrift
-{
-namespace protocol
-{
-
-using apache::thrift::transport::TTransport;
-
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
@@ -146,6 +137,15 @@ using apache::thrift::transport::TTransport;
 #else /* __THRIFT_BYTE_ORDER */
 # error "Can't define htonll or ntohll!"
 #endif
+
+namespace apache
+{
+namespace thrift
+{
+namespace protocol
+{
+
+using apache::thrift::transport::TTransport;
 
 /**
  * Enumerated definition of the types that the Thrift protocol supports.


### PR DESCRIPTION
code is from https://bugzilla.redhat.com/show_bug.cgi?id=1273830