### PR TITLE
MCOL-4515 Binlog replication to CS slave hangs for INSERT .. SELECT query on master.

### DIFF
--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -2721,7 +2721,7 @@ int ha_mcs_impl_rnd_next(uchar* buf, TABLE* table)
                 thd->lex->sql_command == SQLCOM_DELETE_MULTI ||
                 thd->lex->sql_command == SQLCOM_TRUNCATE ||
                 thd->lex->sql_command == SQLCOM_LOAD))
-        return 0;
+        return HA_ERR_END_OF_FILE;
 
     if (((thd->lex)->sql_command == SQLCOM_UPDATE)  || ((thd->lex)->sql_command == SQLCOM_DELETE) ||
             ((thd->lex)->sql_command == SQLCOM_DELETE_MULTI) || ((thd->lex)->sql_command == SQLCOM_UPDATE_MULTI))
@@ -4699,7 +4699,7 @@ int ha_mcs_impl_group_by_next(TABLE* table)
                 thd->lex->sql_command == SQLCOM_DELETE_MULTI ||
                 thd->lex->sql_command == SQLCOM_TRUNCATE ||
                 thd->lex->sql_command == SQLCOM_LOAD))
-        return 0;
+        return HA_ERR_END_OF_FILE;
 
     if (thd->killed == KILL_QUERY || thd->killed == KILL_QUERY_HARD)
     {
@@ -5407,7 +5407,7 @@ int ha_mcs_impl_select_next(uchar* buf, TABLE* table)
                 thd->lex->sql_command == SQLCOM_DELETE_MULTI ||
                 thd->lex->sql_command == SQLCOM_TRUNCATE ||
                 thd->lex->sql_command == SQLCOM_LOAD))
-        return 0;
+        return HA_ERR_END_OF_FILE;
 
     if (((thd->lex)->sql_command == SQLCOM_UPDATE)  || ((thd->lex)->sql_command == SQLCOM_DELETE) ||
             ((thd->lex)->sql_command == SQLCOM_DELETE_MULTI) || ((thd->lex)->sql_command == SQLCOM_UPDATE_MULTI))


### PR DESCRIPTION
An INSERT .. SELECT performed on a master node caused an infinite
loop on the slave node with columnstore_replication_slave=OFF.

The issue was ha_mcs_impl_select_next() was returning 0 if
the executing thread is a slave and returning early to avoid DML
execution on the slave. The calling code in select_handler::execute()
ran into an infinite loop due to this as it checked the return code
of the function as 0, and incorrectly thought there are more rows
to process.

The fix is to return HA_ERR_END_OF_FILE as the return value,
instead of 0. This is for the case of the query running on the
slave node with columnstore_replication_slave=OFF.