### PR TITLE
DO NOT MERGE: MCOL-4440

### DIFF
--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -874,14 +874,15 @@ reconnect:
 
     try
     {
-        if (msgClient && !msgClient->isConnected())
+        // master has changed but mariadbd kept old connection; reconnect
+        if (config->getConfig(masterName, "IPAddr") != msgClient->otherEnd())
         {
-            if (!msgClient->connect())
+            if (firstAttempt)
             {
-                cerr << "class DBRM failed to connect to MessageQueueClient: " << endl;
-                msgClient = nullptr;
-                mutex.unlock();
-                return ERR_NETWORK;
+                firstAttempt = false;
+                MessageQueueClientPool::releaseInstance(msgClient);
+                msgClient = NULL;
+                goto reconnect;
             }
         }
 

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -874,6 +874,17 @@ reconnect:
 
     try
     {
+        if (msgClient && !msgClient->isConnected())
+        {
+            if (!msgClient->connect())
+            {
+                cerr << "class DBRM failed to connect to MessageQueueClient: " << endl;
+                msgClient = nullptr;
+                mutex.unlock();
+                return ERR_NETWORK;
+            }
+        }
+
         msgClient->write(in);
         out = msgClient->read();
     }


### PR DESCRIPTION
Resolves case where the primary node of a cluster goes down, a new primary takes over for cluster, but there is no connection to controllernode