### PR TITLE
MCOL-4566: Extend CompressedDBFileHeader struct with new fields.

### DIFF
--- a/tests/shared_components_tests.cpp
+++ b/tests/shared_components_tests.cpp
@@ -404,6 +404,7 @@ public:
             nBlocks, // number of blocks
             emptyVal, // NULL value
             width, // width
+            execplan::CalpontSystemCatalog::BIGINT,
             1 ); // dbroot
         CPPUNIT_ASSERT( rc == NO_ERROR );
 
@@ -987,6 +988,7 @@ public:
             nBlocks, // number of blocks
             emptyVal, // NULL value
             width, // width
+            execplan::CalpontSystemCatalog::BIGINT,
             dbRoot ); // dbroot
         CPPUNIT_ASSERT( rc == NO_ERROR );
 
@@ -1011,6 +1013,7 @@ public:
            BYTE_PER_BLOCK, // number of blocks
            emptyVal,
            width,
+           execplan::CalpontSystemCatalog::BIGINT,
            false, // use existing file
            true,  // expand the extent
            false, // add full (not abbreviated) extent
@@ -1031,6 +1034,7 @@ public:
             nBlocks, // number of blocks
             emptyVal, // NULL value
             width, // width
+            execplan::CalpontSystemCatalog::BIGINT,
             dbRoot ); // dbroot
         CPPUNIT_ASSERT( rc == NO_ERROR );
 
@@ -1054,6 +1058,7 @@ public:
            BYTE_PER_BLOCK, // number of blocks
            emptyVal,
            width,
+           execplan::CalpontSystemCatalog::BIGINT,
            false, // use existing file
            true,  // expand the extent
            false, // add full (not abbreviated) extent

--- a/utils/compress/idbcompress.h
+++ b/utils/compress/idbcompress.h
@@ -27,6 +27,8 @@
 #include <vector>
 #include <utility>
 
+#include "calpontsystemcatalog.h"
+
 #if defined(_MSC_VER) && defined(xxxIDBCOMP_DLLEXPORT)
 #define EXPORT __declspec(dllexport)
 #else
@@ -113,6 +115,15 @@ public:
     * @warning ptrBuf must be at least (hdrSize-HDR_BUF_LEN) bytes
     */
     EXPORT void initHdr(void* hdrBuf, void* ptrBuf, int compressionType, int hdrSize) const;
+
+    /**
+     * Initialize header buffer at start of compressed db file.
+     *
+     * @warning hdrBuf must be at least HDR_BUF_LEN*2 bytes
+     */
+    EXPORT void initHdr(void* hdrBuf, uint32_t columnWidth,
+                        execplan::CalpontSystemCatalog::ColDataType columnType,
+                        int compressionType) const;
 
     /**
     * Verify the passed in buffer contains a compressed db file header.
@@ -277,6 +288,7 @@ inline int IDBCompressInterface::uncompress(const char* in, size_t inLen, char* 
 }
 inline void IDBCompressInterface::initHdr(void*, int) const {}
 inline void IDBCompressInterface::initHdr(void*, void*, int, int) const {}
+inline void initHdr(void*, uint32_t, execplan::CalpontSystemCatalog::ColDataType, int) const {}
 inline int IDBCompressInterface::verifyHdr(const void*) const
 {
     return -1;

--- a/writeengine/bulk/we_colbufcompressed.cpp
+++ b/writeengine/bulk/we_colbufcompressed.cpp
@@ -582,7 +582,9 @@ int ColumnBufferCompressed::saveCompressionHeaders( )
 {
     // Construct the header records
     char hdrBuf[IDBCompressInterface::HDR_BUF_LEN * 2];
-    fCompressor->initHdr( hdrBuf, fColInfo->column.compressionType );
+    fCompressor->initHdr(hdrBuf, fColInfo->column.width,
+                         fColInfo->column.dataType,
+                         fColInfo->column.compressionType);
     fCompressor->setBlockCount(hdrBuf,
                                (fColInfo->getFileSize() / BYTE_PER_BLOCK) );
 

--- a/writeengine/bulk/we_columninfo.cpp
+++ b/writeengine/bulk/we_columninfo.cpp
@@ -897,7 +897,8 @@ int ColumnInfo::extendColumnOldExtent(
         }
 
         rc = colOp->expandAbbrevColumnExtent( pFile, dbRootNext,
-                                              column.emptyVal, column.width);
+                                              column.emptyVal, column.width,
+                                              column.dataType );
 
         if (rc != NO_ERROR)
         {

--- a/writeengine/bulk/we_columninfocompressed.cpp
+++ b/writeengine/bulk/we_columninfocompressed.cpp
@@ -544,6 +544,7 @@ int ColumnInfoCompressed::extendColumnOldExtent(
                  curCol.dataFile.fDbRoot,
                  curCol.dataFile.fPartition,
                  curCol.dataFile.fSegment,
+                 curCol.colDataType,
                  curCol.dataFile.hwm,
                  segFileName,
                  errTask);

--- a/writeengine/shared/we_fileop.h
+++ b/writeengine/shared/we_fileop.h
@@ -43,6 +43,7 @@
 #include "we_config.h"
 #include "we_stats.h"
 #include "idbcompress.h"
+#include "calpontsystemcatalog.h"
 
 #if defined(_MSC_VER) && defined(WRITEENGINE_DLLEXPORT)
 #define EXPORT __declspec(dllexport)
@@ -101,6 +102,7 @@ public:
      */
     int                 createFile( const char* fileName, int fileSize,
                                     const uint8_t* emptyVal, int width,
+                                    execplan::CalpontSystemCatalog::ColDataType colDataType,
                                     uint16_t dbRoot );
 
     /**
@@ -159,12 +161,14 @@ public:
      * @param dbRoot   DBRoot of the file being updated.
      * @param emptyVal Empty value used in initializing extents for this column
      * @param width    Width of this column (in bytes)
+     * @param colDataType Column data type.
      */
     EXPORT virtual int  expandAbbrevColumnExtent(
         IDBDataFile*    pFile,
         uint16_t dbRoot,
         const uint8_t*  emptyVal,
-        int      width );
+        int      width,
+        execplan::CalpontSystemCatalog::ColDataType colDataType);
 
     /**
      * @brief Add an extent to the specified Column OID and DBRoot.
@@ -200,6 +204,7 @@ public:
      */
     EXPORT int          extendFile(OID oid, const uint8_t* emptyVal,
                                    int          width,
+                                   execplan::CalpontSystemCatalog::ColDataType colDataType,
                                    HWM          hwm,
                                    BRM::LBID_t  startLbid,
                                    int          allocSize,
@@ -246,6 +251,7 @@ public:
      * @param dbRoot DBRoot of the extent to be filled
      * @param partition Partition of the extent to be filled
      * @param segment Segment file number of the extent to be filled
+     * @param colDataType Column data type
      * @param hwm New HWM blk setting for the segment file after extent is padded
      * @param segFile (out) Name of updated segment file
      * @param errTask (out) Task that failed if error occurs
@@ -257,6 +263,7 @@ public:
             uint16_t     dbRoot,
             uint32_t     partition,
             uint16_t     segment,
+            execplan::CalpontSystemCatalog::ColDataType colDataType,
             HWM          hwm,
             std::string& segFile,
             std::string& errTask);
@@ -499,6 +506,7 @@ public:
                                           int      nBlocks,
                                           const uint8_t* emptyVal,
                                           int      width,
+                                          execplan::CalpontSystemCatalog::ColDataType colDataType,
                                           bool     bNewFile,
                                           bool     bExpandExtent,
                                           bool     bAbbrevExtent,
@@ -524,21 +532,18 @@ private:
             const compress::CompChunkPtr& chunkInPtr,
             compress::CompChunkPtr& chunkOutPt);
 
-    int                 initAbbrevCompColumnExtent( IDBDataFile* pFile,
-            uint16_t dbRoot,
-            int      nBlocks,
-            const uint8_t*      emptyVal,
-            int      width);
+    int initAbbrevCompColumnExtent(
+        IDBDataFile* pFile, uint16_t dbRoot, int nBlocks,
+        const uint8_t* emptyVal, int width,
+        execplan::CalpontSystemCatalog::ColDataType colDataType);
 
     static void         initDbRootExtentMutexes();
     static void         removeDbRootExtentMutexes();
 
-    int                 writeInitialCompColumnChunk( IDBDataFile* pFile,
-            int      nBlocksAllocated,
-            int      nRows,
-            const uint8_t* emptyVal,
-            int      width,
-            char*    hdrs);
+    int writeInitialCompColumnChunk(
+        IDBDataFile* pFile, int nBlocksAllocated, int nRows,
+        const uint8_t* emptyVal, int width,
+        execplan::CalpontSystemCatalog::ColDataType colDataType, char* hdrs);
 
     TxnID       m_transId;
     bool 		m_isBulk;

--- a/writeengine/wrapper/we_colop.cpp
+++ b/writeengine/wrapper/we_colop.cpp
@@ -286,8 +286,12 @@ int ColumnOp::allocRowId(const TxnID& txnid, bool useStartingExtent,
                         if (newColStructList[i].fCompressionType > 0)
                         {
                             string errorInfo;
-                            rc = fileOp.fillCompColumnExtentEmptyChunks(newColStructList[i].dataOid, newColStructList[i].colWidth,
-                                    emptyVal, dbRoot, partition, segment, newHwm, segFile, errorInfo);
+                            rc = fileOp.fillCompColumnExtentEmptyChunks(
+                                newColStructList[i].dataOid,
+                                newColStructList[i].colWidth, emptyVal, dbRoot,
+                                partition, segment,
+                                newColStructList[i].colDataType, newHwm,
+                                segFile, errorInfo);
 
                             if (rc != NO_ERROR)
                                 return rc;
@@ -310,7 +314,11 @@ int ColumnOp::allocRowId(const TxnID& txnid, bool useStartingExtent,
                                     return rc;
                                 }
 
-                                rc = fileOp.expandAbbrevColumnExtent( pFile, dbRoot, emptyVal, newColStructList[i].colWidth);
+                                rc = fileOp.expandAbbrevColumnExtent(
+                                    pFile, dbRoot, emptyVal,
+                                    newColStructList[i].colWidth,
+                                    newColStructList[i].colDataType);
+
                                 //set hwm for this extent.
                                 fileOp.closeFile(pFile);
 
@@ -1330,6 +1338,7 @@ int ColumnOp::extendColumn(
     int rc = extendFile(column.dataFile.fid,
                         emptyVal,
                         column.colWidth,
+                        column.colDataType,
                         hwm,
                         startLbid,
                         allocSize,
@@ -1401,7 +1410,8 @@ int ColumnOp::expandAbbrevExtent(const Column& column)
     int rc = expandAbbrevColumnExtent(column.dataFile.pFile,
                                       column.dataFile.fDbRoot,
                                       emptyVal,
-                                      column.colWidth);
+                                      column.colWidth,
+                                      column.colDataType);
 
     return rc;
 }

--- a/writeengine/wrapper/we_colopcompress.cpp
+++ b/writeengine/wrapper/we_colopcompress.cpp
@@ -191,7 +191,8 @@ int ColumnOpCompress1::flushFile(int rc, std::map<FID, FID>& columnOids)
 
 
 int ColumnOpCompress1::expandAbbrevColumnExtent(
-    IDBDataFile* pFile, uint16_t dbRoot, const uint8_t* emptyVal, int width)
+    IDBDataFile* pFile, uint16_t dbRoot, const uint8_t* emptyVal, int width,
+    execplan::CalpontSystemCatalog::ColDataType colDataType )
 {
     // update the uncompressed initial chunk to full chunk
     int rc = m_chunkManager->expandAbbrevColumnExtent(pFile, emptyVal, width);
@@ -204,7 +205,8 @@ int ColumnOpCompress1::expandAbbrevColumnExtent(
     }
 
     // let the base to physically expand extent.
-    return FileOp::expandAbbrevColumnExtent(pFile, dbRoot, emptyVal, width);
+    return FileOp::expandAbbrevColumnExtent(pFile, dbRoot, emptyVal, width,
+                                            colDataType);
 }
 
 

--- a/writeengine/wrapper/we_colopcompress.h
+++ b/writeengine/wrapper/we_colopcompress.h
@@ -27,6 +27,7 @@
 
 #include "we_colop.h"
 #include "we_chunkmanager.h"
+#include "calpontsystemcatalog.h"
 
 #if defined(_MSC_VER) && defined(WRITEENGINE_DLLEXPORT)
 #define EXPORT __declspec(dllexport)
@@ -111,7 +112,9 @@ public:
     /**
     * @brief virtual method in FileOp
     */
-    int expandAbbrevColumnExtent(IDBDataFile* pFile, uint16_t dbRoot, const uint8_t* emptyVal, int width);
+    int expandAbbrevColumnExtent(
+        IDBDataFile* pFile, uint16_t dbRoot, const uint8_t* emptyVal,
+        int width, execplan::CalpontSystemCatalog::ColDataType colDataType);
 
     /**
     * @brief virtual method in ColumnOp


### PR DESCRIPTION
* This patch extends CompressedDBFileHeader struct with new fields:
  `fColumWidth`, `fColDataType`, which are necessary to rebuild extent map
  from the given file. Note: new fields do not change the memory
  layout of the struct, because the size is calculated as
  max(sizeof(CompressedDBFileHeader), HDR_BUF_LEN)).

* This patch changes API of some functions, by adding new function
  argument `colDataType` when needed, to be able to call `initHdr`
  function with colDataType value.