### PR TITLE
MCOL-4566: Update on review.

### DIFF
--- a/writeengine/shared/we_convertor.h
+++ b/writeengine/shared/we_convertor.h
@@ -142,7 +142,7 @@ private:
     struct dmFilePathArgs_t;
     static int dmOid2FPath(uint32_t oid, uint32_t partition, uint32_t segment,
                            dmFilePathArgs_t* pArgs);
-    static int32_t dmFPath2Oid(dmFilePathArgs_t* pArgs, uint32_t& oid,
+    static int32_t dmFPath2Oid(const dmFilePathArgs_t& pArgs, uint32_t& oid,
                                uint32_t& partition, uint32_t& segment);
 };
 


### PR DESCRIPTION
* Use `literal::UnsignedInteger` instead of `atoi`.
* Combine common code for `_fromDir`, `_fromFile` to `_fromText`.
* Pass `dmFilePathArgs_t` as a const reference instead of pointer,
  don't write result codes to this struct.