### PR TITLE
DO NOT MERGE: MCOL-4440 Related. Check if still connected to old master

### DIFF
--- a/utils/messageqcpp/messagequeue.h
+++ b/utils/messageqcpp/messagequeue.h
@@ -269,6 +269,8 @@ public:
      */
     inline bool isSameAddr(const MessageQueueClient& rhs) const;
 
+    inline bool isSameAddr(const std::stringt& rhs) const;
+
     bool isConnected()
     {
         return fClientSock.isConnected();
@@ -319,6 +321,10 @@ inline const std::string MessageQueueClient::addr2String() const
 inline bool MessageQueueClient::isSameAddr(const MessageQueueClient& rhs) const
 {
     return fClientSock.isSameAddr(&rhs.fClientSock);
+}
+inline bool MessageQueueClient::isSameAddr(const std::string& rhs) const
+{
+    return fClientSock.addr2String() == rhs;
 }
 inline void MessageQueueClient::syncProto(bool use)
 {

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -874,6 +874,18 @@ reconnect:
 
     try
     {
+        // master has changed but mariadbd kept old connection; reconnect
+        if (config->getConfig(masterName, "IPAddr") != msgClient->addr2String())
+        {
+            if (firstAttempt)
+            {
+                firstAttempt = false;
+                MessageQueueClientPool::releaseInstance(msgClient);
+                msgClient = NULL;
+                goto reconnect;
+            }
+        }
+
         msgClient->write(in);
         out = msgClient->read();
     }

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -875,10 +875,7 @@ reconnect:
     try
     {
         // master may have changed but old msgclient connection might be in use
-        // comparing to ModuleIPAddr1-1-3 in case DBRM_Controller is a hostname
-        string clientAddr = msgClient->addr2String();
-        if ((config->getConfig(masterName, "IPAddr") != clientAddr) &&
-            (config->getConfig("SystemModuleConfig", "ModuleIPAddr1-1-3") != clientAddr))
+        if (!msgClient->isSameAddr(config->getConfig(masterName, "IPAddr")))
         {
             if (firstAttempt)
             {

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -880,7 +880,7 @@ reconnect:
             if (firstAttempt)
             {
                 firstAttempt = false;
-                MessageQueueClientPool::releaseInstance(msgClient);
+                MessageQueueClientPool::deleteInstance(msgClient);
                 msgClient = NULL;
                 goto reconnect;
             }

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -874,8 +874,11 @@ reconnect:
 
     try
     {
-        // master has changed but mariadbd kept old connection; reconnect
-        if (config->getConfig(masterName, "IPAddr") != msgClient->addr2String())
+        // master may have changed but old msgclient connection might be in use
+        // comparing to ModuleIPAddr1-1-3 in case DBRM_Controller is a hostname
+        string clientAddr = msgClient->addr2String();
+        if ((config->getConfig(masterName, "IPAddr") != clientAddr) &&
+            (config->getConfig("SystemModuleConfig", "ModuleIPAddr1-1-3") != clientAddr))
         {
             if (firstAttempt)
             {


### PR DESCRIPTION
There is a case where engine plugin code is still connected to old controllernode, causing communication timeouts. Reconnect if the address of the msg client (possibly previous controllernode) does not match the address of controllernode