### PR TITLE
Fix for failure of unsigned_joins test under centos8

### DIFF
--- a/writeengine/bulk/we_brmreporter.cpp
+++ b/writeengine/bulk/we_brmreporter.cpp
@@ -314,6 +314,7 @@ void BRMReporter::sendCPToFile( )
                          fCPInfo[i].min       << ' ' <<
                          fCPInfo[i].seqNum    << ' ' <<
                          fCPInfo[i].type      << ' ' <<
+                         fCPInfo[i].colWidth  << ' ' <<
                          fCPInfo[i].newExtent << std::endl;
             }
             else
@@ -412,13 +413,13 @@ int BRMReporter::openRptFile( )
         return rc;
     }
 
-    fRptFile << "#CP:   startLBID max min seqnum type newExtent" << std::endl;
-    fRptFile << "#HWM:  oid partition segment hwm"               << std::endl;
-    fRptFile << "#ROWS: numRowsRead numRowsInserted"             << std::endl;
+    fRptFile << "#CP:   startLBID max min seqnum type colwidth newExtent"    << std::endl;
+    fRptFile << "#HWM:  oid partition segment hwm"                           << std::endl;
+    fRptFile << "#ROWS: numRowsRead numRowsInserted"                         << std::endl;
     fRptFile << "#DATA: columNum columnType columnOid numOutOfRangeValues"   << std::endl;
-    fRptFile << "#ERR:  error message file"                      << std::endl;
-    fRptFile << "#BAD:  bad data file, with rejected rows"       << std::endl;
-    fRptFile << "#MERR: critical error messages in cpimport.bin" << std::endl;
+    fRptFile << "#ERR:  error message file"                                  << std::endl;
+    fRptFile << "#BAD:  bad data file, with rejected rows"                   << std::endl;
+    fRptFile << "#MERR: critical error messages in cpimport.bin"             << std::endl;
 
     return NO_ERROR;
 }

--- a/writeengine/splitter/we_brmupdater.cpp
+++ b/writeengine/splitter/we_brmupdater.cpp
@@ -354,6 +354,15 @@ bool WEBrmUpdater::prepareCasualPartitionInfo()
             pTok = strtok(NULL, " ");
 
             if (pTok)
+                cpInfoMerge.colWidth = boost::lexical_cast<int32_t>(pTok);
+            else
+            {
+                //cout << "CP Entry : " << aEntry << endl;
+                throw (runtime_error("Bad column width in CP entry string"));
+            }
+            pTok = strtok(NULL, " ");
+
+            if (pTok)
                 cpInfoMerge.newExtent = (atoi(pTok) != 0);
             else
             {


### PR DESCRIPTION
The problem was that column width was not set during BRM reporting stage in cpimport processing. That made column width a garbage, prevented correct ranges to be set and as a result some extents were incorrectly skipped during SELECT operation.

The fixes are in we_brmupdater.cpp: a change to display proper "CP" line format in the comments in the BRM report file, a change to add print of column width into file and a change to parse column width.