### PR TITLE
MCOL-987 Refactor compression interface.

### DIFF
--- a/dbcon/joblist/pcolstep.cpp
+++ b/dbcon/joblist/pcolstep.cpp
@@ -146,9 +146,7 @@ pColStep::pColStep(
     if (fOid < 1000)
         throw runtime_error("pColStep: invalid column");
 
-    compress::IDBCompressInterface cmpif;
-
-    if (!cmpif.isCompressionAvail(fColType.compressionType))
+    if (!compress::CompressInterface::isCompressionAvail(fColType.compressionType))
     {
         ostringstream oss;
         oss << "Unsupported compression type " << fColType.compressionType;

--- a/dbcon/mysql/ha_mcs_ddl.cpp
+++ b/dbcon/mysql/ha_mcs_ddl.cpp
@@ -771,7 +771,6 @@ int ProcessDDLStatement(string& ddlStatement, string& schema, const string& tabl
     parser.setDefaultSchema(schema);
     parser.setDefaultCharset(default_table_charset);
     int rc = 0;
-    IDBCompressInterface idbCompress;
     parser.Parse(ddlStatement.c_str());
 
     if (get_fe_conn_info_ptr() == NULL)
@@ -975,7 +974,9 @@ int ProcessDDLStatement(string& ddlStatement, string& schema, const string& tabl
 
                     if (compressionType == 1) compressionType = 2;
 
-                    if (( compressionType > 0 ) && !(idbCompress.isCompressionAvail( compressionType )))
+                    if ((compressionType > 0) &&
+                        !(compress::CompressInterface::isCompressionAvail(
+                            compressionType)))
                     {
                         rc = 1;
                         ci->alterTableState = cal_connection_info::NOT_ALTER;
@@ -1362,7 +1363,9 @@ int ProcessDDLStatement(string& ddlStatement, string& schema, const string& tabl
                             return rc;
                         }
 
-                        if (( compressionType > 0 ) && !(idbCompress.isCompressionAvail( compressionType )))
+                        if ((compressionType > 0) &&
+                            !(compress::CompressInterface::isCompressionAvail(
+                                compressionType)))
                         {
                             rc = 1;
                             thd->raise_error_printf(ER_INTERNAL_ERROR, (IDBErrorInfo::instance()->errorMsg(ERR_INVALID_COMPRESSION_TYPE)).c_str());
@@ -1707,7 +1710,9 @@ int ProcessDDLStatement(string& ddlStatement, string& schema, const string& tabl
                             return rc;
                         }
 
-                        if (( compressionType > 0 ) && !(idbCompress.isCompressionAvail( compressionType )))
+                        if ((compressionType > 0) &&
+                            !(compress::CompressInterface::isCompressionAvail(
+                                compressionType)))
                         {
                             rc = 1;
                             thd->raise_error_printf(ER_INTERNAL_ERROR, (IDBErrorInfo::instance()->errorMsg(ERR_INVALID_COMPRESSION_TYPE)).c_str());
@@ -1836,7 +1841,9 @@ int ProcessDDLStatement(string& ddlStatement, string& schema, const string& tabl
                             return rc;
                         }
 
-                        if (( compressionType > 0 ) && !(idbCompress.isCompressionAvail( compressionType )))
+                        if ((compressionType > 0) &&
+                            !(compress::CompressInterface::isCompressionAvail(
+                                compressionType)))
                         {
                             rc = 1;
                             thd->raise_error_printf(ER_INTERNAL_ERROR, (IDBErrorInfo::instance()->errorMsg(ERR_INVALID_COMPRESSION_TYPE)).c_str());
@@ -2349,9 +2356,8 @@ int ha_mcs_impl_create_(const char* name, TABLE* table_arg, HA_CREATE_INFO* crea
 
     if (compressiontype == 1) compressiontype = 2;
 
-    IDBCompressInterface idbCompress;
-
-    if ( ( compressiontype > 0 ) && !(idbCompress.isCompressionAvail( compressiontype )) )
+    if ((compressiontype > 0) &&
+        !(compress::CompressInterface::isCompressionAvail(compressiontype)))
     {
         string emsg = IDBErrorInfo::instance()->errorMsg(ERR_INVALID_COMPRESSION_TYPE);
         setError(thd, ER_INTERNAL_ERROR, emsg);

--- a/primitives/blockcache/iomanager.cpp
+++ b/primitives/blockcache/iomanager.cpp
@@ -308,7 +308,7 @@ void waitForRetry(long count)
 
 
 //Must hold the FD cache lock!
-int updateptrs(char* ptr, FdCacheType_t::iterator fdit, const IDBCompressInterface& decompressor)
+static int updateptrs(char* ptr, FdCacheType_t::iterator fdit)
 {
     ssize_t i;
     uint32_t progress;
@@ -357,7 +357,8 @@ int updateptrs(char* ptr, FdCacheType_t::iterator fdit, const IDBCompressInterfa
         fdit->second->cmpMTime = mtime;
 
     int gplRc = 0;
-    gplRc = decompressor.getPtrList(&ptr[4096], 4096, fdit->second->ptrList);
+    gplRc = compress::CompressInterface::getPtrList(&ptr[4096], 4096,
+                                                    fdit->second->ptrList);
 
     if (gplRc != 0)
         return -5; // go for a retry.
@@ -391,7 +392,8 @@ int updateptrs(char* ptr, FdCacheType_t::iterator fdit, const IDBCompressInterfa
             return -8;
 
         CompChunkPtrList nextPtrList;
-        gplRc = decompressor.getPtrList(&nextHdrBufPtr[0], numHdrs * 4096, nextPtrList);
+        gplRc = compress::CompressInterface::getPtrList(
+            &nextHdrBufPtr[0], numHdrs * 4096, nextPtrList);
 
         if (gplRc != 0)
             return -7; // go for a retry.
@@ -445,7 +447,9 @@ void* thr_popper(ioManager* arg)
     double rqst3;
     bool locked = false;
     SPFdEntry_t fe;
-    IDBCompressInterface decompressor;
+    // FIXME: How to properly specify compression type.
+    std::unique_ptr<CompressInterface> decompressor(
+        new CompressInterfaceSnappy());
     vector<CacheInsert_t> cacheInsertOps;
     bool copyLocked = false;
 
@@ -463,8 +467,9 @@ void* thr_popper(ioManager* arg)
 
     FdCacheType_t::iterator fdit;
     IDBDataFile* fp = 0;
-    uint32_t maxCompSz = IDBCompressInterface::maxCompressedSize(iom->blocksPerRead * BLOCK_SIZE);
-    uint32_t readBufferSz = maxCompSz + pageSize;
+    size_t maxCompSz =
+        decompressor->maxCompressedSize(iom->blocksPerRead * BLOCK_SIZE);
+    size_t readBufferSz = maxCompSz + pageSize;
 
     realbuff.reset(new char[readBufferSz]);
 
@@ -863,7 +868,7 @@ retryReadHeaders:
                         cur_mtime = fp_mtime;
 
                     if (decompRetryCount > 0 || retryReadHeadersCount > 0 || cur_mtime > fdit->second->cmpMTime)
-                        updatePtrsRc = updateptrs(&alignedbuff[0], fdit, decompressor);
+                        updatePtrsRc = updateptrs(&alignedbuff[0], fdit);
 
                     fdMapMutex.unlock();
 
@@ -1052,7 +1057,7 @@ retryReadHeaders:
 #ifdef _MSC_VER
                     unsigned int blen = 4 * 1024 * 1024 + 4;
 #else
-                    uint32_t blen = 4 * 1024 * 1024 + 4;
+                    size_t blen = 4 * 1024 * 1024 + 4;
 #endif
 #ifdef IDB_COMP_POC_DEBUG
                     {
@@ -1060,7 +1065,7 @@ retryReadHeaders:
                         cout << "decompress(0x" << hex << (ptrdiff_t)&alignedbuff[0] << dec << ", " << fdit->second->ptrList[cmpOffFact.quot].second << ", 0x" << hex << (ptrdiff_t)uCmpBuf << dec << ", " << blen << ")" << endl;
                     }
 #endif
-                    int dcrc = decompressor.uncompressBlock(&alignedbuff[0],
+                    int dcrc = decompressor->uncompressBlock(&alignedbuff[0],
                                                             fdit->second->ptrList[cmpOffFact.quot].second, uCmpBuf, blen);
 
                     if (dcrc != 0)

--- a/primitives/primproc/primitiveserver.cpp
+++ b/primitives/primproc/primitiveserver.cpp
@@ -696,13 +696,18 @@ blockReadRetry:
                 i = fp->pread( &cmpHdrBuf[0], 0, 4096 * 3);
 
                 CompChunkPtrList ptrList;
-                IDBCompressInterface decompressor;
+                std::unique_ptr<CompressInterface> decompressor(
+                    compress::getCompressInterfaceByType(
+                        compress::CompressInterface::getCompressionType(
+                            &cmpHdrBuf[0])));
+
                 int dcrc = 0;
 
                 if (i == 4096 * 3)
                 {
                     uint64_t numHdrs = 0; // extra headers
-                    dcrc = decompressor.getPtrList(&cmpHdrBuf[4096], 4096, ptrList);
+                    dcrc = compress::CompressInterface::getPtrList(
+                        &cmpHdrBuf[4096], 4096, ptrList);
 
                     if (dcrc == 0 && ptrList.size() > 0)
                         numHdrs = ptrList[0].first / 4096ULL - 2ULL;
@@ -723,7 +728,8 @@ blockReadRetry:
                         i = fp->pread( &nextHdrBufPtr[0], 4096 * 2, numHdrs * 4096 );
 
                         CompChunkPtrList nextPtrList;
-                        dcrc = decompressor.getPtrList(&nextHdrBufPtr[0], numHdrs * 4096, nextPtrList);
+                        dcrc = compress::CompressInterface::getPtrList(
+                            &nextHdrBufPtr[0], numHdrs * 4096, nextPtrList);
 
                         if (dcrc == 0)
                             ptrList.insert(ptrList.end(), nextPtrList.begin(), nextPtrList.end());
@@ -777,11 +783,11 @@ blockReadRetry:
                         cmpBuf = (char*) alignedBuffer;
                     }
 
-                    unsigned blen = 4 * 1024 * 1024;
+                    size_t blen = 4 * 1024 * 1024;
 
                     i = fp->pread( cmpBuf, cmpBufOff, cmpBufSz );
 
-                    dcrc = decompressor.uncompressBlock(cmpBuf, cmpBufSz, uCmpBuf, blen);
+                    dcrc = decompressor->uncompressBlock(cmpBuf, cmpBufSz, uCmpBuf, blen);
 
                     if (dcrc == 0)
                     {

--- a/tests/shared_components_tests.cpp
+++ b/tests/shared_components_tests.cpp
@@ -383,7 +383,7 @@ public:
         BlockOp   blockOp;
         char     fileName[20];
         int      rc;
-        char hdrs[ IDBCompressInterface::HDR_BUF_LEN * 2 ];
+        char hdrs[ CompressInterface::HDR_BUF_LEN * 2 ];
 
         printf("\nRunning testCreateDeleteFile \n");
         idbdatafile::IDBPolicy::init(true, false, "", 0);
@@ -966,7 +966,7 @@ public:
         BlockOp   blockOp;
         char     fileName[20];
         int      rc;
-        char hdrs[ IDBCompressInterface::HDR_BUF_LEN * 2 ];
+        char hdrs[ CompressInterface::HDR_BUF_LEN * 2 ];
         int dbRoot = 1;
 
         printf("\nRunning testExtensionWOPrealloc \n");
@@ -1565,7 +1565,7 @@ public:
         BlockOp blockOp;
         char fileName[20];
         int rc;
-        char hdrs[ IDBCompressInterface::HDR_BUF_LEN * 2 ];
+        char hdrs[ CompressInterface::HDR_BUF_LEN * 2 ];
         int dbRoot = 1;
 
         idbdatafile::IDBPolicy::init(true, false, "", 0);

--- a/utils/compress/idbcompress.cpp
+++ b/utils/compress/idbcompress.cpp
@@ -39,7 +39,7 @@ const uint64_t MAGIC_NUMBER = 0xfdc119a384d0778eULL;
 const uint64_t VERSION_NUM1 = 1;
 const uint64_t VERSION_NUM2 = 2;
 const int      COMPRESSED_CHUNK_INCREMENT_SIZE = 8192;
-const int      PTR_SECTION_OFFSET = compress::IDBCompressInterface::HDR_BUF_LEN;
+const int      PTR_SECTION_OFFSET = compress::CompressInterface::HDR_BUF_LEN;
 
 // version 1.1 of the chunk data has a short header
 // QuickLZ compressed data never has the high bit set on the first byte
@@ -77,7 +77,7 @@ struct CompressedDBFileHeader
 union CompressedDBFileHeaderBlock
 {
     CompressedDBFileHeader fHeader;
-    char fDummy[compress::IDBCompressInterface::HDR_BUF_LEN];
+    char fDummy[compress::CompressInterface::HDR_BUF_LEN];
 };
 
 void initCompressedDBFileHeader(void* hdrBuf, int compressionType, int hdrSize)
@@ -114,22 +114,19 @@ namespace compress
 {
 #ifndef SKIP_IDB_COMPRESSION
 
-IDBCompressInterface::IDBCompressInterface(unsigned int numUserPaddingBytes) :
+CompressInterface::CompressInterface(unsigned int numUserPaddingBytes) :
     fNumUserPaddingBytes(numUserPaddingBytes)
-{ }
-
-IDBCompressInterface::~IDBCompressInterface()
 { }
 
 /* V1 is really only available for decompression, we kill any DDL using V1 by hand.
  * Maybe should have a new api, isDecompressionAvail() ? Any request to compress
  * using V1 will silently be changed to V2.
 */
-bool IDBCompressInterface::isCompressionAvail(int compressionType) const
+/*static*/
+bool CompressInterface::isCompressionAvail(int compressionType)
 {
-    if ( (compressionType == 0) ||
-            (compressionType == 1) ||
-            (compressionType == 2) )
+    if ((compressionType == 0) || (compressionType == 1) ||
+        (compressionType == 2))
         return true;
 
     return false;
@@ -138,29 +135,33 @@ bool IDBCompressInterface::isCompressionAvail(int compressionType) const
 //------------------------------------------------------------------------------
 // Compress a block of data
 //------------------------------------------------------------------------------
-int IDBCompressInterface::compressBlock(const char* in,
-                                        const size_t   inLen,
+int CompressInterface::compressBlock(const char* in, const size_t inLen,
                                         unsigned char* out,
-                                        unsigned int&  outLen) const
+                                        size_t& outLen) const
 {
     size_t snaplen = 0;
     utils::Hasher128 hasher;
 
     // loose input checking.
-    if (outLen < snappy::MaxCompressedLength(inLen) + HEADER_SIZE)
+    if (outLen < maxCompressedSize(inLen) + HEADER_SIZE)
     {
-        cerr << "got outLen = " << outLen << " for inLen = " << inLen << ", needed " <<
-             (snappy::MaxCompressedLength(inLen) + HEADER_SIZE) << endl;
+        cerr << "got outLen = " << outLen << " for inLen = " << inLen
+             << ", needed " << (maxCompressedSize(inLen) + HEADER_SIZE)
+             << endl;
         return ERR_BADOUTSIZE;
     }
 
-    //apparently this never fails?
-    snappy::RawCompress(in, inLen, reinterpret_cast<char*>(&out[HEADER_SIZE]), &snaplen);
+    auto rc = compress(in, inLen, reinterpret_cast<char*>(&out[HEADER_SIZE]),
+                       &snaplen);
+    if (rc != ERR_OK)
+    {
+        return rc;
+    }
 
     uint8_t* signature = (uint8_t*) &out[SIG_OFFSET];
     uint32_t* checksum = (uint32_t*) &out[CHECKSUM_OFFSET];
     uint32_t* len = (uint32_t*) &out[LEN_OFFSET];
-    *signature = CHUNK_MAGIC3;
+    *signature = getChunkMagicNumber();
     *checksum = hasher((char*) &out[HEADER_SIZE], snaplen);
     *len = snaplen;
 
@@ -175,10 +176,10 @@ int IDBCompressInterface::compressBlock(const char* in,
 //------------------------------------------------------------------------------
 // Decompress a block of data
 //------------------------------------------------------------------------------
-int IDBCompressInterface::uncompressBlock(const char* in, const size_t inLen, unsigned char* out,
-        unsigned int& outLen) const
+int CompressInterface::uncompressBlock(const char* in, const size_t inLen,
+                                       unsigned char* out,
+                                       size_t& outLen) const
 {
-    bool comprc = false;
     size_t ol = 0;
 
     uint32_t realChecksum;
@@ -187,19 +188,20 @@ int IDBCompressInterface::uncompressBlock(const char* in, const size_t inLen, un
     uint8_t storedMagic;
     utils::Hasher128 hasher;
 
-    outLen = 0;
 
     if (inLen < 1)
     {
+        outLen = 0;
         return ERR_BADINPUT;
     }
 
     storedMagic = *((uint8_t*) &in[SIG_OFFSET]);
 
-    if (storedMagic == CHUNK_MAGIC3)
+    if (storedMagic == getChunkMagicNumber())
     {
         if (inLen < HEADER_SIZE)
         {
+            outLen = 0;
             return ERR_BADINPUT;
         }
 
@@ -208,6 +210,7 @@ int IDBCompressInterface::uncompressBlock(const char* in, const size_t inLen, un
 
         if (inLen < storedLen + HEADER_SIZE)
         {
+            outLen = 0;
             return ERR_BADINPUT;
         }
 
@@ -215,25 +218,26 @@ int IDBCompressInterface::uncompressBlock(const char* in, const size_t inLen, un
 
         if (storedChecksum != realChecksum)
         {
+            outLen = 0;
             return ERR_CHECKSUM;
         }
 
-        comprc = snappy::GetUncompressedLength(&in[HEADER_SIZE], storedLen, &ol) &&
-                 snappy::RawUncompress(&in[HEADER_SIZE], storedLen, reinterpret_cast<char*>(out));
+        auto rc = uncompress(&in[HEADER_SIZE], storedLen,
+                             reinterpret_cast<char*>(out), &outLen);
+        if (rc != ERR_OK)
+        {
+            outLen = 0;
+            cerr << "uncompressBlock failed!" << endl;
+            return ERR_DECOMPRESS;
+        }
     }
     else
     {
         // v1 compression or bad header
+        outLen = 0;
         return ERR_BADINPUT;
     }
 
-    if (!comprc)
-    {
-        cerr << "decomp failed!" << endl;
-        return ERR_DECOMPRESS;
-    }
-
-    outLen = ol;
     //cerr << "ub: " << inLen << " : " << outLen << endl;
 
     return ERR_OK;
@@ -242,7 +246,7 @@ int IDBCompressInterface::uncompressBlock(const char* in, const size_t inLen, un
 //------------------------------------------------------------------------------
 // Verify the passed in buffer contains a valid compression file header.
 //------------------------------------------------------------------------------
-int IDBCompressInterface::verifyHdr(const void* hdrBuf) const
+int CompressInterface::verifyHdr(const void* hdrBuf)
 {
     const CompressedDBFileHeader* hdr = reinterpret_cast<const CompressedDBFileHeader*>(hdrBuf);
 
@@ -259,9 +263,8 @@ int IDBCompressInterface::verifyHdr(const void* hdrBuf) const
 // Extract compression pointer information out of the pointer buffer that is
 // passed in.  ptrBuf points to the pointer section of the compression hdr.
 //------------------------------------------------------------------------------
-int IDBCompressInterface::getPtrList(const char* ptrBuf,
-                                     const int ptrBufSize,
-                                     CompChunkPtrList& chunkPtrs ) const
+int CompressInterface::getPtrList(const char* ptrBuf, const int ptrBufSize,
+                                  CompChunkPtrList& chunkPtrs)
 {
     int rc = 0;
     chunkPtrs.clear();
@@ -289,7 +292,7 @@ int IDBCompressInterface::getPtrList(const char* ptrBuf,
 // one for the file header, and one for the list of pointers.
 // Wrapper of above method for backward compatibility.
 //------------------------------------------------------------------------------
-int IDBCompressInterface::getPtrList(const char* hdrBuf, CompChunkPtrList& chunkPtrs ) const
+int CompressInterface::getPtrList(const char* hdrBuf, CompChunkPtrList& chunkPtrs )
 {
     return getPtrList(hdrBuf + HDR_BUF_LEN, HDR_BUF_LEN, chunkPtrs);
 }
@@ -297,8 +300,8 @@ int IDBCompressInterface::getPtrList(const char* hdrBuf, CompChunkPtrList& chunk
 //------------------------------------------------------------------------------
 // Count the number of chunk pointers in the pointer header(s)
 //------------------------------------------------------------------------------
-unsigned int IDBCompressInterface::getPtrCount(const char* ptrBuf,
-        const int ptrBufSize) const
+unsigned int CompressInterface::getPtrCount(const char* ptrBuf,
+                                            const int ptrBufSize)
 {
     unsigned int chunkCount = 0;
 
@@ -322,7 +325,7 @@ unsigned int IDBCompressInterface::getPtrCount(const char* ptrBuf,
 // This should not be used for compressed dictionary files which could have
 // more compression chunk headers.
 //------------------------------------------------------------------------------
-unsigned int IDBCompressInterface::getPtrCount(const char* hdrBuf) const
+unsigned int CompressInterface::getPtrCount(const char* hdrBuf)
 {
     return getPtrCount(hdrBuf + HDR_BUF_LEN, HDR_BUF_LEN);
 }
@@ -330,9 +333,8 @@ unsigned int IDBCompressInterface::getPtrCount(const char* hdrBuf) const
 //------------------------------------------------------------------------------
 // Store list of compression pointers into the specified header.
 //------------------------------------------------------------------------------
-void IDBCompressInterface::storePtrs(const std::vector<uint64_t>& ptrs,
-                                     void* ptrBuf,
-                                     int ptrSectionSize) const
+void CompressInterface::storePtrs(const std::vector<uint64_t>& ptrs,
+                                  void* ptrBuf, int ptrSectionSize)
 {
     memset((ptrBuf), 0, ptrSectionSize); // reset the pointer section to 0
     uint64_t* hdrPtrs = reinterpret_cast<uint64_t*>(ptrBuf);
@@ -346,7 +348,7 @@ void IDBCompressInterface::storePtrs(const std::vector<uint64_t>& ptrs,
 //------------------------------------------------------------------------------
 // Wrapper of above method for backward compatibility
 //------------------------------------------------------------------------------
-void IDBCompressInterface::storePtrs(const std::vector<uint64_t>& ptrs, void* ptrBuf) const
+void CompressInterface::storePtrs(const std::vector<uint64_t>& ptrs, void* ptrBuf)
 {
     storePtrs(ptrs, reinterpret_cast<char*>(ptrBuf) + HDR_BUF_LEN, HDR_BUF_LEN);
 }
@@ -354,7 +356,7 @@ void IDBCompressInterface::storePtrs(const std::vector<uint64_t>& ptrs, void* pt
 //------------------------------------------------------------------------------
 // Initialize the header blocks to be written at the start of a column file.
 //------------------------------------------------------------------------------
-void IDBCompressInterface::initHdr(void* hdrBuf, int compressionType) const
+void CompressInterface::initHdr(void* hdrBuf, int compressionType)
 {
     memset(hdrBuf, 0, HDR_BUF_LEN * 2);
     initCompressedDBFileHeader(hdrBuf, compressionType, HDR_BUF_LEN * 2);
@@ -363,7 +365,8 @@ void IDBCompressInterface::initHdr(void* hdrBuf, int compressionType) const
 //------------------------------------------------------------------------------
 // Initialize the header blocks to be written at the start of a dictionary file.
 //------------------------------------------------------------------------------
-void IDBCompressInterface::initHdr(void* hdrBuf, void* ptrBuf, int compressionType, int hdrSize) const
+void CompressInterface::initHdr(void* hdrBuf, void* ptrBuf,
+                                int compressionType, int hdrSize)
 {
     memset(hdrBuf, 0, HDR_BUF_LEN);
     memset(ptrBuf, 0, hdrSize - HDR_BUF_LEN);
@@ -373,10 +376,10 @@ void IDBCompressInterface::initHdr(void* hdrBuf, void* ptrBuf, int compressionTy
 //------------------------------------------------------------------------------
 // Initialize the header blocks to be written at the start of a column file.
 //------------------------------------------------------------------------------
-void IDBCompressInterface::initHdr(
+void CompressInterface::initHdr(
     void* hdrBuf, uint32_t columnWidth,
     execplan::CalpontSystemCatalog::ColDataType columnType,
-    int compressionType) const
+    int compressionType)
 {
     memset(hdrBuf, 0, HDR_BUF_LEN * 2);
     initCompressedDBFileHeader(hdrBuf, columnWidth, columnType,
@@ -386,7 +389,7 @@ void IDBCompressInterface::initHdr(
 //------------------------------------------------------------------------------
 // Set the file's block count
 //------------------------------------------------------------------------------
-void IDBCompressInterface::setBlockCount(void* hdrBuf, uint64_t count) const
+void CompressInterface::setBlockCount(void* hdrBuf, uint64_t count)
 {
     reinterpret_cast<CompressedDBFileHeader*>(hdrBuf)->fBlockCount = count;
 }
@@ -394,15 +397,24 @@ void IDBCompressInterface::setBlockCount(void* hdrBuf, uint64_t count) const
 //------------------------------------------------------------------------------
 // Get the file's block count
 //------------------------------------------------------------------------------
-uint64_t IDBCompressInterface::getBlockCount(const void* hdrBuf) const
+uint64_t CompressInterface::getBlockCount(const void* hdrBuf)
 {
     return (reinterpret_cast<const CompressedDBFileHeader*>(hdrBuf)->fBlockCount);
 }
 
 //------------------------------------------------------------------------------
+// Get the file's compression type
+//------------------------------------------------------------------------------
+uint64_t CompressInterface::getCompressionType(const void* hdrBuf)
+{
+    return (reinterpret_cast<const CompressedDBFileHeader*>(hdrBuf)
+                ->fCompressionType);
+}
+
+//------------------------------------------------------------------------------
 // Set the overall header size
 //------------------------------------------------------------------------------
-void IDBCompressInterface::setHdrSize(void* hdrBuf, uint64_t size) const
+void CompressInterface::setHdrSize(void* hdrBuf, uint64_t size)
 {
     reinterpret_cast<CompressedDBFileHeader*>(hdrBuf)->fHeaderSize = size;
 }
@@ -410,7 +422,7 @@ void IDBCompressInterface::setHdrSize(void* hdrBuf, uint64_t size) const
 //------------------------------------------------------------------------------
 // Get the overall header size
 //------------------------------------------------------------------------------
-uint64_t IDBCompressInterface::getHdrSize(const void* hdrBuf) const
+uint64_t CompressInterface::getHdrSize(const void* hdrBuf)
 {
     return (reinterpret_cast<const CompressedDBFileHeader*>(hdrBuf)->fHeaderSize);
 }
@@ -419,9 +431,9 @@ uint64_t IDBCompressInterface::getHdrSize(const void* hdrBuf) const
 // Calculates the chunk and block offset within the chunk for the specified
 // block number.
 //------------------------------------------------------------------------------
-void IDBCompressInterface::locateBlock(unsigned int block,
-                                       unsigned int& chunkIndex,
-                                       unsigned int& blockOffsetWithinChunk) const
+void CompressInterface::locateBlock(unsigned int block,
+                                    unsigned int& chunkIndex,
+                                    unsigned int& blockOffsetWithinChunk) const
 {
     const uint64_t BUFLEN  = UNCOMPRESSED_INBUF_LEN;
 
@@ -438,9 +450,8 @@ void IDBCompressInterface::locateBlock(unsigned int block,
 // also expand to allow for user requested padding.  Lastly, initialize padding
 // bytes to 0.
 //------------------------------------------------------------------------------
-int IDBCompressInterface::padCompressedChunks(unsigned char* buf,
-        unsigned int& len,
-        unsigned int  maxLen) const
+int CompressInterface::padCompressedChunks(unsigned char* buf, size_t& len,
+                                           unsigned int maxLen) const
 {
     int nPaddingBytes = 0;
     int nRem = len % COMPRESSED_CHUNK_INCREMENT_SIZE;
@@ -464,28 +475,66 @@ int IDBCompressInterface::padCompressedChunks(unsigned char* buf,
     return 0;
 }
 
-/* static */
-uint64_t IDBCompressInterface::maxCompressedSize(uint64_t uncompSize)
+CompressInterfaceSnappy::CompressInterfaceSnappy(uint32_t numUserPaddingBytes)
+    : CompressInterface(numUserPaddingBytes)
+{
+}
+
+int32_t CompressInterfaceSnappy::compress(const char* in, size_t inLen,
+                                          char* out, size_t* outLen) const
+{
+    snappy::RawCompress(in, inLen, out, outLen);
+    return ERR_OK;
+}
+
+int32_t CompressInterfaceSnappy::uncompress(const char* in, size_t inLen,
+                                            char* out, size_t* outLen) const
+{
+    size_t realOutLen = 0;
+    auto rc = snappy::GetUncompressedLength(in, inLen, &realOutLen);
+
+    if (!rc || realOutLen > *outLen)
+    {
+        cerr << "snappy::GetUncompressedLength failed. InLen: " << inLen
+             << ", outLen: " << *outLen << ", realOutLen: " << realOutLen
+             << endl;
+        return ERR_DECOMPRESS;
+    }
+
+    rc = snappy::RawUncompress(in, inLen, out);
+
+    if (!rc)
+    {
+        cerr << "snappy::RawUnompress failed. InLen: " << inLen
+             << ", outLen: " << *outLen << endl;
+        return ERR_DECOMPRESS;
+    }
+
+    return ERR_OK;
+}
+
+size_t CompressInterfaceSnappy::maxCompressedSize(size_t uncompSize) const
 {
     return (snappy::MaxCompressedLength(uncompSize) + HEADER_SIZE);
 }
 
-int IDBCompressInterface::compress(const char* in, size_t inLen, char* out,
-                                   size_t* outLen) const
-{
-    snappy::RawCompress(in, inLen, out, outLen);
-    return 0;
-}
-
-int IDBCompressInterface::uncompress(const char* in, size_t inLen, char* out) const
-{
-    return !(snappy::RawUncompress(in, inLen, out));
-}
-
-/* static */
-bool IDBCompressInterface::getUncompressedSize(char* in, size_t inLen, size_t* outLen)
+bool CompressInterfaceSnappy::getUncompressedSize(char* in, size_t inLen,
+                                                  size_t* outLen) const
 {
     return snappy::GetUncompressedLength(in, inLen, outLen);
+}
+
+uint8_t CompressInterfaceSnappy::getChunkMagicNumber() const
+{
+    return CHUNK_MAGIC_SNAPPY;
+}
+
+CompressInterface* getCompressInterfaceByType(uint32_t compressionType,
+                                              uint32_t numUserPaddingBytes)
+{
+    idbassert(compressionType > 0 && compressionType <= 2);
+    // Only one compression type is available currently.
+    return new CompressInterfaceSnappy(numUserPaddingBytes);
 }
 
 #endif

--- a/utils/idbdatafile/PosixFileSystem.cpp
+++ b/utils/idbdatafile/PosixFileSystem.cpp
@@ -176,25 +176,24 @@ off64_t PosixFileSystem::compressedSize(const char* path) const
             return -1;
         }
 
-        compress::IDBCompressInterface decompressor;
+        char hdr1[compress::CompressInterface::HDR_BUF_LEN];
+        nBytes = readFillBuffer( pFile, hdr1, compress::CompressInterface::HDR_BUF_LEN);
 
-        char hdr1[compress::IDBCompressInterface::HDR_BUF_LEN];
-        nBytes = readFillBuffer( pFile, hdr1, compress::IDBCompressInterface::HDR_BUF_LEN);
-
-        if ( nBytes != compress::IDBCompressInterface::HDR_BUF_LEN )
+        if ( nBytes != compress::CompressInterface::HDR_BUF_LEN )
         {
             delete pFile;
             return -1;
         }
 
         // Verify we are a compressed file
-        if (decompressor.verifyHdr(hdr1) < 0)
+        if (compress::CompressInterface::verifyHdr(hdr1) < 0)
         {
             delete pFile;
             return -1;
         }
 
-        int64_t ptrSecSize = decompressor.getHdrSize(hdr1) - compress::IDBCompressInterface::HDR_BUF_LEN;
+        int64_t ptrSecSize = compress::CompressInterface::getHdrSize(hdr1) -
+                             compress::CompressInterface::HDR_BUF_LEN;
         char* hdr2 = new char[ptrSecSize];
         nBytes = readFillBuffer( pFile, hdr2, ptrSecSize);
 
@@ -206,7 +205,8 @@ off64_t PosixFileSystem::compressedSize(const char* path) const
         }
 
         compress::CompChunkPtrList chunkPtrs;
-        int rc = decompressor.getPtrList(hdr2, ptrSecSize, chunkPtrs);
+        int rc = compress::CompressInterface::getPtrList(hdr2, ptrSecSize,
+                                                         chunkPtrs);
         delete[] hdr2;
 
         if (rc != 0)

--- a/utils/joiner/joinpartition.h
+++ b/utils/joiner/joinpartition.h
@@ -164,7 +164,7 @@ private:
 
     /* Compression support */
     bool useCompression;
-    compress::IDBCompressInterface compressor;
+    std::shared_ptr<compress::CompressInterface> compressor;
     /* TBD: do the reading/writing in one thread, compression/decompression in another */
 
     /* Some stats for reporting */

--- a/utils/messageqcpp/compressed_iss.cpp
+++ b/utils/messageqcpp/compressed_iss.cpp
@@ -75,6 +75,10 @@ CompressedInetStreamSocket::CompressedInetStreamSocket()
         useCompression = true;
     else
         useCompression = false;
+
+    // FIXME: How to specify compression type? Use Snappy as default.
+    // Should we update a config file to specify network compression type?
+    alg.reset(new compress::CompressInterfaceSnappy());
 }
 
 Socket* CompressedInetStreamSocket::clone() const
@@ -94,13 +98,15 @@ const SBS CompressedInetStreamSocket::read(const struct timespec* timeout, bool*
     if (readBS->length() == 0 || fMagicBuffer == BYTESTREAM_MAGIC)
         return readBS;
 
-    err = alg.getUncompressedSize((char*) readBS->buf(), readBS->length(), &uncompressedSize);
+    err = alg->getUncompressedSize((char*) readBS->buf(), readBS->length(),
+                                   &uncompressedSize);
 
     if (!err)
         return SBS(new ByteStream(0));
 
     ret.reset(new ByteStream(uncompressedSize));
-    alg.uncompress((char*) readBS->buf(), readBS->length(), (char*) ret->getInputPtr());
+    alg->uncompress((char*) readBS->buf(), readBS->length(),
+                   (char*) ret->getInputPtr(), &uncompressedSize);
     ret->advanceInputPtr(uncompressedSize);
 
     return ret;
@@ -113,9 +119,9 @@ void CompressedInetStreamSocket::write(const ByteStream& msg, Stats* stats)
 
     if (useCompression && (len > 512))
     {
-        ByteStream smsg(alg.maxCompressedSize(len));
+        ByteStream smsg(alg->maxCompressedSize(len));
 
-        alg.compress((char*) msg.buf(), len, (char*) smsg.getInputPtr(), &outLen);
+        alg->compress((char*) msg.buf(), len, (char*) smsg.getInputPtr(), &outLen);
         smsg.advanceInputPtr(outLen);
 
         if (outLen < len)

--- a/utils/messageqcpp/compressed_iss.h
+++ b/utils/messageqcpp/compressed_iss.h
@@ -54,7 +54,7 @@ public:
     virtual const IOSocket accept(const struct timespec* timeout);
     virtual void connect(const sockaddr* addr);
 private:
-    compress::IDBCompressInterface alg;
+    std::shared_ptr<compress::CompressInterface> alg;
     bool useCompression;
 };
 

--- a/writeengine/bulk/we_bulkload.cpp
+++ b/writeengine/bulk/we_bulkload.cpp
@@ -337,15 +337,12 @@ int BulkLoad::loadJobInfo(
         }
     }
 
-    // Validate that specified compression type is available
-    compress::IDBCompressInterface compressor;
-
     for (unsigned kT = 0; kT < curJob.jobTableList.size(); kT++)
     {
         for (unsigned kC = 0; kC < curJob.jobTableList[kT].colList.size(); kC++)
         {
-            if ( !compressor.isCompressionAvail(
-                        curJob.jobTableList[kT].colList[kC].compressionType) )
+            if (!compress::CompressInterface::isCompressionAvail(
+                    curJob.jobTableList[kT].colList[kC].compressionType))
             {
                 std::ostringstream oss;
                 oss << "Specified compression type (" <<

--- a/writeengine/bulk/we_colbufcompressed.cpp
+++ b/writeengine/bulk/we_colbufcompressed.cpp
@@ -60,12 +60,12 @@ ColumnBufferCompressed::ColumnBufferCompressed( ColumnInfo* pColInfo,
     fToBeCompressedBuffer(0),
     fToBeCompressedCapacity(0),
     fNumBytes(0),
-    fCompressor(0),
     fPreLoadHWMChunk(true),
     fFlushedStartHwmChunk(false)
 {
     fUserPaddingBytes = Config::getNumCompressedPadBlks() * BYTE_PER_BLOCK;
-    fCompressor = new compress::IDBCompressInterface( fUserPaddingBytes );
+    fCompressorPool = {std::shared_ptr<CompressInterface>(
+        new CompressInterfaceSnappy(fUserPaddingBytes))};
 }
 
 //------------------------------------------------------------------------------
@@ -79,7 +79,6 @@ ColumnBufferCompressed::~ColumnBufferCompressed()
     fToBeCompressedBuffer   = 0;
     fToBeCompressedCapacity = 0;
     fNumBytes               = 0;
-    delete fCompressor;
 }
 
 //------------------------------------------------------------------------------
@@ -91,9 +90,7 @@ int ColumnBufferCompressed::setDbFile(IDBDataFile* f, HWM startHwm, const char* 
     fFile        = f;
     fStartingHwm = startHwm;
 
-    IDBCompressInterface compressor;
-
-    if (compressor.getPtrList(hdrs, fChunkPtrs) != 0)
+    if (compress::CompressInterface::getPtrList(hdrs, fChunkPtrs) != 0)
     {
         return ERR_COMP_PARSE_HDRS;
     }
@@ -102,6 +99,13 @@ int ColumnBufferCompressed::setDbFile(IDBDataFile* f, HWM startHwm, const char* 
     // rollback), that fall after the HWM, then drop those trailing ptrs.
     unsigned int chunkIndex             = 0;
     unsigned int blockOffsetWithinChunk = 0;
+
+    auto fCompressor = getCompressorByType(fColInfo->column.compressionType);
+    if (!fCompressor)
+    {
+        return ERR_COMP_WRONG_COMP_TYPE;
+    }
+
     fCompressor->locateBlock(fStartingHwm, chunkIndex, blockOffsetWithinChunk);
 
     if ((chunkIndex + 1) < fChunkPtrs.size())
@@ -127,11 +131,11 @@ int ColumnBufferCompressed::resetToBeCompressedColBuf(
     if (!fToBeCompressedBuffer)
     {
         fToBeCompressedBuffer =
-            new unsigned char[IDBCompressInterface::UNCOMPRESSED_INBUF_LEN];
+            new unsigned char[CompressInterface::UNCOMPRESSED_INBUF_LEN];
     }
 
     BlockOp::setEmptyBuf( fToBeCompressedBuffer,
-                          IDBCompressInterface::UNCOMPRESSED_INBUF_LEN,
+                          CompressInterface::UNCOMPRESSED_INBUF_LEN,
                           fColInfo->column.emptyVal,
                           fColInfo->column.width );
 
@@ -147,10 +151,10 @@ int ColumnBufferCompressed::resetToBeCompressedColBuf(
         fLog->logMsg( oss.str(), MSGLVL_INFO2 );
     }
 
-    fToBeCompressedCapacity = IDBCompressInterface::UNCOMPRESSED_INBUF_LEN;
+    fToBeCompressedCapacity = CompressInterface::UNCOMPRESSED_INBUF_LEN;
 
     // Set file offset past end of last chunk
-    startFileOffset = IDBCompressInterface::HDR_BUF_LEN * 2;
+    startFileOffset = CompressInterface::HDR_BUF_LEN * 2;
 
     if (fChunkPtrs.size() > 0)
         startFileOffset = fChunkPtrs[ fChunkPtrs.size() - 1 ].first +
@@ -223,7 +227,7 @@ int ColumnBufferCompressed::writeToFile(int startOffset, int writeSize,
 
     // Expand the compression buffer size if working with an abbrev extent, and
     // the bytes we are about to add will overflow the abbreviated extent.
-    if ((fToBeCompressedCapacity < IDBCompressInterface::UNCOMPRESSED_INBUF_LEN) &&
+    if ((fToBeCompressedCapacity < CompressInterface::UNCOMPRESSED_INBUF_LEN) &&
             ((fNumBytes + writeSize + fillUpWEmptiesWriteSize) > fToBeCompressedCapacity) )
     {
         std::ostringstream oss;
@@ -233,7 +237,7 @@ int ColumnBufferCompressed::writeToFile(int startOffset, int writeSize,
             "; part-"     << fColInfo->curCol.dataFile.fPartition <<
             "; seg-"      << fColInfo->curCol.dataFile.fSegment;
         fLog->logMsg( oss.str(), MSGLVL_INFO2 );
-        fToBeCompressedCapacity = IDBCompressInterface::UNCOMPRESSED_INBUF_LEN;
+        fToBeCompressedCapacity = CompressInterface::UNCOMPRESSED_INBUF_LEN;
     }
 
     if ((fNumBytes + writeSize + fillUpWEmptiesWriteSize) <= fToBeCompressedCapacity)
@@ -316,12 +320,12 @@ int ColumnBufferCompressed::writeToFile(int startOffset, int writeSize,
 
                 // Start over again loading a new to-be-compressed buffer
                 BlockOp::setEmptyBuf( fToBeCompressedBuffer,
-                                      IDBCompressInterface::UNCOMPRESSED_INBUF_LEN,
+                                      CompressInterface::UNCOMPRESSED_INBUF_LEN,
                                       fColInfo->column.emptyVal,
                                       fColInfo->column.width );
 
                 fToBeCompressedCapacity =
-                    IDBCompressInterface::UNCOMPRESSED_INBUF_LEN;
+                    CompressInterface::UNCOMPRESSED_INBUF_LEN;
                 bufOffset = fToBeCompressedBuffer;
 
                 fNumBytes = 0;
@@ -377,21 +381,26 @@ int ColumnBufferCompressed::writeToFile(int startOffset, int writeSize,
 //------------------------------------------------------------------------------
 int ColumnBufferCompressed::compressAndFlush( bool bFinishingFile )
 {
-    const int OUTPUT_BUFFER_SIZE = IDBCompressInterface::maxCompressedSize(fToBeCompressedCapacity) +
-                                   fUserPaddingBytes;
+    auto fCompressor = getCompressorByType(fColInfo->column.compressionType);
+    if (!fCompressor)
+    {
+        return ERR_COMP_WRONG_COMP_TYPE;
+    }
+
+    const size_t OUTPUT_BUFFER_SIZE =
+        fCompressor->maxCompressedSize(fToBeCompressedCapacity) +
+        fUserPaddingBytes;
     unsigned char* compressedOutBuf = new unsigned char[ OUTPUT_BUFFER_SIZE ];
     boost::scoped_array<unsigned char> compressedOutBufPtr(compressedOutBuf);
-    unsigned int   outputLen = OUTPUT_BUFFER_SIZE;
+    size_t outputLen = OUTPUT_BUFFER_SIZE;
 
 #ifdef PROFILE
     Stats::startParseEvent(WE_STATS_COMPRESS_COL_COMPRESS);
 #endif
 
     int rc = fCompressor->compressBlock(
-                 reinterpret_cast<char*>(fToBeCompressedBuffer),
-                 fToBeCompressedCapacity,
-                 compressedOutBuf,
-                 outputLen );
+        reinterpret_cast<char*>(fToBeCompressedBuffer),
+        fToBeCompressedCapacity, compressedOutBuf, outputLen);
 
     if (rc != 0)
     {
@@ -581,12 +590,12 @@ int ColumnBufferCompressed::finishFile(bool bTruncFile)
 int ColumnBufferCompressed::saveCompressionHeaders( )
 {
     // Construct the header records
-    char hdrBuf[IDBCompressInterface::HDR_BUF_LEN * 2];
-    fCompressor->initHdr(hdrBuf, fColInfo->column.width,
-                         fColInfo->column.dataType,
-                         fColInfo->column.compressionType);
-    fCompressor->setBlockCount(hdrBuf,
-                               (fColInfo->getFileSize() / BYTE_PER_BLOCK) );
+    char hdrBuf[CompressInterface::HDR_BUF_LEN * 2];
+    compress::CompressInterface::initHdr(hdrBuf, fColInfo->column.width,
+                                         fColInfo->column.dataType,
+                                         fColInfo->column.compressionType);
+    compress::CompressInterface::setBlockCount(
+        hdrBuf, (fColInfo->getFileSize() / BYTE_PER_BLOCK));
 
     std::vector<uint64_t> ptrs;
 
@@ -597,7 +606,7 @@ int ColumnBufferCompressed::saveCompressionHeaders( )
 
     unsigned lastIdx = fChunkPtrs.size() - 1;
     ptrs.push_back( fChunkPtrs[lastIdx].first + fChunkPtrs[lastIdx].second );
-    fCompressor->storePtrs( ptrs, hdrBuf );
+    compress::CompressInterface::storePtrs(ptrs, hdrBuf);
 
     // Write out the header records
     //char resp;
@@ -627,9 +636,9 @@ int ColumnBufferCompressed::initToBeCompressedBuffer(long long& startFileOffset)
     if (!fToBeCompressedBuffer)
     {
         fToBeCompressedBuffer =
-            new unsigned char[IDBCompressInterface::UNCOMPRESSED_INBUF_LEN];
+            new unsigned char[CompressInterface::UNCOMPRESSED_INBUF_LEN];
         BlockOp::setEmptyBuf( fToBeCompressedBuffer,
-                              IDBCompressInterface::UNCOMPRESSED_INBUF_LEN,
+                              CompressInterface::UNCOMPRESSED_INBUF_LEN,
                               fColInfo->column.emptyVal,
                               fColInfo->column.width );
         bNewBuffer = true;
@@ -642,12 +651,18 @@ int ColumnBufferCompressed::initToBeCompressedBuffer(long long& startFileOffset)
     unsigned int blockOffsetWithinChunk = 0;
     bool         bSkipStartingBlks      = false;
 
+    auto fCompressor = getCompressorByType(fColInfo->column.compressionType);
+    if (!fCompressor)
+    {
+        return ERR_COMP_WRONG_COMP_TYPE;
+    }
+
     if (fPreLoadHWMChunk)
     {
         if (fChunkPtrs.size() > 0)
         {
-            fCompressor->locateBlock(fStartingHwm,
-                                     chunkIndex, blockOffsetWithinChunk);
+            fCompressor->locateBlock(fStartingHwm, chunkIndex,
+                                     blockOffsetWithinChunk);
 
             if (chunkIndex < fChunkPtrs.size())
                 startFileOffset  = fChunkPtrs[chunkIndex].first;
@@ -704,7 +719,7 @@ int ColumnBufferCompressed::initToBeCompressedBuffer(long long& startFileOffset)
         }
 
         // Uncompress the chunk into our 4MB buffer
-        unsigned int outLen = IDBCompressInterface::UNCOMPRESSED_INBUF_LEN;
+        size_t outLen = CompressInterface::UNCOMPRESSED_INBUF_LEN;
         int rc = fCompressor->uncompressBlock(
                      compressedOutBuf,
                      fChunkPtrs[chunkIndex].second,
@@ -744,7 +759,7 @@ int ColumnBufferCompressed::initToBeCompressedBuffer(long long& startFileOffset)
         if (!bNewBuffer)
         {
             BlockOp::setEmptyBuf( fToBeCompressedBuffer,
-                                  IDBCompressInterface::UNCOMPRESSED_INBUF_LEN,
+                                  CompressInterface::UNCOMPRESSED_INBUF_LEN,
                                   fColInfo->column.emptyVal,
                                   fColInfo->column.width );
         }
@@ -761,10 +776,10 @@ int ColumnBufferCompressed::initToBeCompressedBuffer(long long& startFileOffset)
             fLog->logMsg( oss.str(), MSGLVL_INFO2 );
         }
 
-        fToBeCompressedCapacity = IDBCompressInterface::UNCOMPRESSED_INBUF_LEN;
+        fToBeCompressedCapacity = CompressInterface::UNCOMPRESSED_INBUF_LEN;
 
         // Set file offset to start after last current chunk
-        startFileOffset     = IDBCompressInterface::HDR_BUF_LEN * 2;
+        startFileOffset     = CompressInterface::HDR_BUF_LEN * 2;
 
         if (fChunkPtrs.size() > 0)
             startFileOffset = fChunkPtrs[ fChunkPtrs.size() - 1 ].first +
@@ -783,4 +798,15 @@ int ColumnBufferCompressed::initToBeCompressedBuffer(long long& startFileOffset)
     return NO_ERROR;
 }
 
+std::shared_ptr<compress::CompressInterface>
+ColumnBufferCompressed::getCompressorByType(uint32_t compressionType)
+{
+    switch (compressionType)
+    {
+    case 1:
+    case 2:
+        return fCompressorPool.front();
+    }
+    return nullptr;
+}
 }

--- a/writeengine/bulk/we_colbufcompressed.h
+++ b/writeengine/bulk/we_colbufcompressed.h
@@ -102,13 +102,17 @@ private:
     // Initialize the to-be-compressed buffer
     int saveCompressionHeaders(); // Saves compression headers to the db file
 
+    // Returs a compressor depends on compression type.
+    std::shared_ptr<compress::CompressInterface>
+    getCompressorByType(uint32_t compressionType);
+
     unsigned char*       fToBeCompressedBuffer; // data waiting to be compressed
     size_t               fToBeCompressedCapacity;//size of comp buffer;
     // should always be 4MB, unless
     // working with abbrev extent.
     size_t               fNumBytes;             // num Bytes in comp buffer
-    compress::IDBCompressInterface*
-    fCompressor;           // data compression object
+    std::vector<std::shared_ptr<compress::CompressInterface>>
+        fCompressorPool; // data compression object pool
     compress::CompChunkPtrList
     fChunkPtrs;            // col file header information
     bool                 fPreLoadHWMChunk;      // preload 1st HWM chunk only

--- a/writeengine/bulk/we_columninfo.cpp
+++ b/writeengine/bulk/we_columninfo.cpp
@@ -667,7 +667,7 @@ int ColumnInfo::extendColumnNewExtent(
     uint16_t    segmentNew   = 0;
     BRM::LBID_t startLbid;
 
-    char hdr[ compress::IDBCompressInterface::HDR_BUF_LEN * 2 ];
+    char hdr[ compress::CompressInterface::HDR_BUF_LEN * 2 ];
 
     // Extend the column by adding an extent to the next
     // DBRoot, partition, and segment file in the rotation

--- a/writeengine/bulk/we_columninfocompressed.cpp
+++ b/writeengine/bulk/we_columninfocompressed.cpp
@@ -108,7 +108,7 @@ int ColumnInfoCompressed::closeColumnFile(bool bCompletingExtent, bool bAbort)
 //------------------------------------------------------------------------------
 int ColumnInfoCompressed::setupInitialColumnFile( HWM oldHwm, HWM hwm )
 {
-    char hdr[ compress::IDBCompressInterface::HDR_BUF_LEN * 2 ];
+    char hdr[ compress::CompressInterface::HDR_BUF_LEN * 2 ];
     RETURN_ON_ERROR( colOp->readHeaders(curCol.dataFile.pFile, hdr) );
 
     // Initialize the output buffer manager for the column.
@@ -129,10 +129,9 @@ int ColumnInfoCompressed::setupInitialColumnFile( HWM oldHwm, HWM hwm )
 
     fColBufferMgr = mgr;
 
-    IDBCompressInterface compressor;
-    int abbrevFlag =
-        ( compressor.getBlockCount(hdr) ==
-          uint64_t(INITIAL_EXTENT_ROWS_TO_DISK * column.width / BYTE_PER_BLOCK) );
+    int abbrevFlag = (compress::CompressInterface::getBlockCount(hdr) ==
+                      uint64_t(INITIAL_EXTENT_ROWS_TO_DISK * column.width /
+                               BYTE_PER_BLOCK));
     setFileSize( hwm, abbrevFlag );
 
     // See if dealing with abbreviated extent that will need expanding.
@@ -324,9 +323,9 @@ int ColumnInfoCompressed::truncateDctnryStore(
             return rc;
         }
 
-        char controlHdr[ IDBCompressInterface::HDR_BUF_LEN ];
+        char controlHdr[ CompressInterface::HDR_BUF_LEN ];
         rc = fTruncateDctnryFileOp.readFile( dFile,
-                                             (unsigned char*)controlHdr, IDBCompressInterface::HDR_BUF_LEN);
+                                             (unsigned char*)controlHdr, CompressInterface::HDR_BUF_LEN);
 
         if (rc != NO_ERROR)
         {
@@ -345,8 +344,7 @@ int ColumnInfoCompressed::truncateDctnryStore(
             return rc;
         }
 
-        IDBCompressInterface compressor;
-        int rc1 = compressor.verifyHdr( controlHdr );
+        int rc1 = compress::CompressInterface::verifyHdr(controlHdr);
 
         if (rc1 != 0)
         {
@@ -372,7 +370,8 @@ int ColumnInfoCompressed::truncateDctnryStore(
         // actually grow the file (something we don't want to do), because we have
         // not yet reserved a full extent (on disk) for this dictionary store file.
         const int PSEUDO_COL_WIDTH = 8;
-        uint64_t numBlocks = compressor.getBlockCount( controlHdr );
+        uint64_t numBlocks =
+            compress::CompressInterface::getBlockCount(controlHdr);
 
         if ( numBlocks == uint64_t
                 (INITIAL_EXTENT_ROWS_TO_DISK * PSEUDO_COL_WIDTH / BYTE_PER_BLOCK) )
@@ -390,8 +389,8 @@ int ColumnInfoCompressed::truncateDctnryStore(
             return NO_ERROR;
         }
 
-        uint64_t hdrSize    = compressor.getHdrSize(controlHdr);
-        uint64_t ptrHdrSize = hdrSize - IDBCompressInterface::HDR_BUF_LEN;
+        uint64_t hdrSize = compress::CompressInterface::getHdrSize(controlHdr);
+        uint64_t ptrHdrSize = hdrSize - CompressInterface::HDR_BUF_LEN;
         char*    pointerHdr = new char[ptrHdrSize];
 
         rc = fTruncateDctnryFileOp.readFile(dFile,
@@ -416,7 +415,8 @@ int ColumnInfoCompressed::truncateDctnryStore(
         }
 
         CompChunkPtrList chunkPtrs;
-        rc1 = compressor.getPtrList( pointerHdr, ptrHdrSize, chunkPtrs );
+        rc1 = compress::CompressInterface::getPtrList(pointerHdr, ptrHdrSize,
+                                                      chunkPtrs);
         delete[] pointerHdr;
 
         if (rc1 != 0)

--- a/writeengine/server/we_getfilesizes.cpp
+++ b/writeengine/server/we_getfilesizes.cpp
@@ -96,7 +96,7 @@ size_t readFillBuffer(
     return totalBytesRead;
 }
 
-off64_t getCompressedDataSize(string& fileName)
+static off64_t getCompressedDataSize(string& fileName)
 {
     off64_t dataSize = 0;
     IDBDataFile* pFile = 0;
@@ -119,21 +119,21 @@ off64_t getCompressedDataSize(string& fileName)
         throw std::runtime_error(oss.str());
     }
 
-    IDBCompressInterface decompressor;
     //--------------------------------------------------------------------------
     // Read headers and extract compression pointers
     //--------------------------------------------------------------------------
-    char hdr1[IDBCompressInterface::HDR_BUF_LEN];
-    nBytes = readFillBuffer( pFile, hdr1, IDBCompressInterface::HDR_BUF_LEN);
+    char hdr1[CompressInterface::HDR_BUF_LEN];
+    nBytes = readFillBuffer( pFile, hdr1, CompressInterface::HDR_BUF_LEN);
 
-    if ( nBytes != IDBCompressInterface::HDR_BUF_LEN )
+    if ( nBytes != CompressInterface::HDR_BUF_LEN )
     {
         std::ostringstream oss;
         oss << "Error reading first header from file " << fileName;
         throw std::runtime_error(oss.str());
     }
 
-    int64_t ptrSecSize = decompressor.getHdrSize(hdr1) - IDBCompressInterface::HDR_BUF_LEN;
+    int64_t ptrSecSize = compress::CompressInterface::getHdrSize(hdr1) -
+                         CompressInterface::HDR_BUF_LEN;
     char* hdr2 = new char[ptrSecSize];
     nBytes = readFillBuffer( pFile, hdr2, ptrSecSize);
 
@@ -145,7 +145,8 @@ off64_t getCompressedDataSize(string& fileName)
     }
 
     CompChunkPtrList chunkPtrs;
-    int rc = decompressor.getPtrList(hdr2, ptrSecSize, chunkPtrs);
+    int rc =
+        compress::CompressInterface::getPtrList(hdr2, ptrSecSize, chunkPtrs);
     delete[] hdr2;
 
     if (rc != 0)

--- a/writeengine/shared/we_bulkrollbackfilecompressed.h
+++ b/writeengine/shared/we_bulkrollbackfilecompressed.h
@@ -148,7 +148,11 @@ private:
                                 uint64_t&   ptrHdrSize,
                                 std::string& errMsg ) const;
 
-    compress::IDBCompressInterface fCompressor;
+    // Returs a compressor depending on compressionType.
+    std::shared_ptr<compress::CompressInterface>
+    getCompressorByType(uint32_t compressionType);
+
+    std::vector<std::shared_ptr<compress::CompressInterface>> fCompressorPool;
 };
 
 } //end of namespace

--- a/writeengine/shared/we_chunkmanager.cpp
+++ b/writeengine/shared/we_chunkmanager.cpp
@@ -67,8 +67,6 @@ namespace WriteEngine
 extern int NUM_BLOCKS_PER_INITIAL_EXTENT; // defined in we_dctnry.cpp
 extern WErrorCodes ec;                    // defined in we_log.cpp
 
-const int COMPRESSED_CHUNK_SIZE = compress::IDBCompressInterface::maxCompressedSize(UNCOMPRESSED_CHUNK_SIZE) + 64 + 3 + 8 * 1024;
-
 //------------------------------------------------------------------------------
 // Search for the specified chunk in fChunkList.
 //------------------------------------------------------------------------------
@@ -91,24 +89,35 @@ ChunkData* CompFileData::findChunk(int64_t id) const
 //------------------------------------------------------------------------------
 // ChunkManager constructor
 //------------------------------------------------------------------------------
-ChunkManager::ChunkManager() : fMaxActiveChunkNum(100), fLenCompressed(0), fIsBulkLoad(false),
-    fDropFdCache(false), fIsInsert(false), fIsHdfs(IDBPolicy::useHdfs()),
-    fFileOp(0), fSysLogger(NULL), fTransId(-1),
-    fLocalModuleId(Config::getLocalModuleID()),
-    fFs(fIsHdfs ?
-        IDBFileSystem::getFs(IDBDataFile::HDFS) :
-        IDBPolicy::useCloud() ?
-            IDBFileSystem::getFs(IDBDataFile::CLOUD) :
-            IDBFileSystem::getFs(IDBDataFile::BUFFERED))
+ChunkManager::ChunkManager()
+    : fMaxActiveChunkNum(100), fLenCompressed(0), fIsBulkLoad(false),
+      fDropFdCache(false), fIsInsert(false), fIsHdfs(IDBPolicy::useHdfs()),
+      fFileOp(0), fSysLogger(NULL), fTransId(-1),
+      fLocalModuleId(Config::getLocalModuleID()),
+      fFs(fIsHdfs ? IDBFileSystem::getFs(IDBDataFile::HDFS)
+                  : IDBPolicy::useCloud()
+                        ? IDBFileSystem::getFs(IDBDataFile::CLOUD)
+                        : IDBFileSystem::getFs(IDBDataFile::BUFFERED))
 {
+    // Snappy.
+    std::shared_ptr<compress::CompressInterface> snappyCompressor(
+        new compress::CompressInterfaceSnappy());
+
+    COMPRESSED_CHUNK_SIZE =
+        snappyCompressor->maxCompressedSize(UNCOMPRESSED_CHUNK_SIZE) + 64 + 3 +
+        8 * 1024;
     fUserPaddings = Config::getNumCompressedPadBlks() * BYTE_PER_BLOCK;
-    fCompressor.numUserPaddingBytes(fUserPaddings);
+    snappyCompressor->numUserPaddingBytes(fUserPaddings);
     fMaxCompressedBufSize = COMPRESSED_CHUNK_SIZE + fUserPaddings;
     fBufCompressed = new char[fMaxCompressedBufSize];
     fSysLogger = new logging::Logger(SUBSYSTEM_ID_WE);
     logging::MsgMap msgMap;
     msgMap[logging::M0080] = logging::Message(logging::M0080);
     fSysLogger->msgMap( msgMap );
+
+    // Push all available types of compressors to compressor pool, we will use
+    // them depending on the compression type of the file.
+    fCompressorPool.push_back(snappyCompressor);
 }
 
 //------------------------------------------------------------------------------
@@ -364,15 +373,21 @@ CompFileData* ChunkManager::getFileData(const FID& fid,
     }
 
     // make sure the header is valid
-    if (fCompressor.verifyHdr(fileData->fFileHeader.fControlData) != 0)
+    if (compress::CompressInterface::verifyHdr(fileData->fFileHeader.fControlData) != 0)
     {
         WE_COMP_DBG(cout << "Invalid header." << endl;)
         delete fileData;
         return NULL;
     }
 
-    int headerSize = fCompressor.getHdrSize(fileData->fFileHeader.fControlData);
+    int headerSize = compress::CompressInterface::getHdrSize(
+        fileData->fFileHeader.fControlData);
     int ptrSecSize = headerSize - COMPRESSED_FILE_HEADER_UNIT;
+
+    // Save segment file compression type.
+    uint32_t compressionType = compress::CompressInterface::getCompressionType(
+        fileData->fFileHeader.fControlData);
+    fileData->fCompressionType = compressionType;
 
     if (ptrSecSize > COMPRESSED_FILE_HEADER_UNIT)
     {
@@ -440,8 +455,12 @@ IDBDataFile* ChunkManager::createDctnryFile(const FID& fid,
         fileData->fFileHeader.fLongPtrSectData.reset(fileData->fFileHeader.fPtrSection);
     }
 
-    fCompressor.initHdr(fileData->fFileHeader.fControlData, fileData->fFileHeader.fPtrSection,
-                        fFileOp->compressionType(), hdrSize);
+    compress::CompressInterface::initHdr(fileData->fFileHeader.fControlData,
+                                         fileData->fFileHeader.fPtrSection,
+                                         fFileOp->compressionType(), hdrSize);
+
+    // Save compression type.
+    fileData->fCompressionType = fFileOp->compressionType();
 
     if (writeHeader(fileData, __LINE__) != NO_ERROR)
     {
@@ -746,9 +765,15 @@ int ChunkManager::fetchChunkFromFile(IDBDataFile* pFile, int64_t id, ChunkData*&
         }
 
         // uncompress the read in buffer
-        unsigned int dataLen = sizeof(chunkData->fBufUnCompressed);
+        size_t dataLen = sizeof(chunkData->fBufUnCompressed);
 
-        if (fCompressor.uncompressBlock((char*)fBufCompressed, chunkSize,
+        auto fCompressor = getCompressorByType(fileData->fCompressionType);
+        if (!fCompressor)
+        {
+            return ERR_COMP_WRONG_COMP_TYPE;
+        }
+
+        if (fCompressor->uncompressBlock((char*)fBufCompressed, chunkSize,
                                         (unsigned char*)chunkData->fBufUnCompressed, dataLen) != 0)
         {
             if (fIsFix)
@@ -759,7 +784,7 @@ int ChunkManager::fetchChunkFromFile(IDBDataFile* pFile, int64_t id, ChunkData*&
                 {
                     char* hdr = fileData->fFileHeader.fControlData;
 
-                    if (fCompressor.getBlockCount(hdr) < 512)
+                    if (compress::CompressInterface::getBlockCount(hdr) < 512)
                         blocks = 256;
                 }
 
@@ -795,7 +820,8 @@ int ChunkManager::fetchChunkFromFile(IDBDataFile* pFile, int64_t id, ChunkData*&
     {
         if (id == 0 && ptrs[id] == 0) // if the 1st ptr is not set for new extent
         {
-            ptrs[0] = fCompressor.getHdrSize(fileData->fFileHeader.fControlData);
+            ptrs[0] = compress::CompressInterface::getHdrSize(
+                fileData->fFileHeader.fControlData);
         }
 
         // load the uncompressed buffer with empty values.
@@ -882,10 +908,16 @@ int ChunkManager::writeChunkToFile(CompFileData* fileData, ChunkData* chunkData)
         // compress the chunk before writing it to file
         fLenCompressed = fMaxCompressedBufSize;
 
-        if (fCompressor.compressBlock((char*)chunkData->fBufUnCompressed,
-                                      chunkData->fLenUnCompressed,
-                                      (unsigned char*)fBufCompressed,
-                                      fLenCompressed) != 0)
+        auto fCompressor = getCompressorByType(fileData->fCompressionType);
+        if (!fCompressor)
+        {
+            return ERR_COMP_WRONG_COMP_TYPE;
+        }
+
+        if (fCompressor->compressBlock((char*) chunkData->fBufUnCompressed,
+                                       chunkData->fLenUnCompressed,
+                                       (unsigned char*) fBufCompressed,
+                                       fLenCompressed) != 0)
         {
             logMessage(ERR_COMP_COMPRESS, logging::LOG_TYPE_ERROR, __LINE__);
             return ERR_COMP_COMPRESS;
@@ -916,7 +948,8 @@ int ChunkManager::writeChunkToFile(CompFileData* fileData, ChunkData* chunkData)
         // [chunkId+0] is the start offset of current chunk.
         // [chunkId+1] is the start offset of next chunk, the offset diff is current chunk size.
         // [chunkId+2] is 0 or not indicates if the next chunk exists.
-        int headerSize = fCompressor.getHdrSize(fileData->fFileHeader.fControlData);
+        int headerSize = compress::CompressInterface::getHdrSize(
+            fileData->fFileHeader.fControlData);
         int ptrSecSize = headerSize - COMPRESSED_FILE_HEADER_UNIT;
         int64_t usablePtrIds = (ptrSecSize / sizeof(uint64_t)) - 2;
 
@@ -943,7 +976,7 @@ int ChunkManager::writeChunkToFile(CompFileData* fileData, ChunkData* chunkData)
         else if (lastChunk)
         {
             // add padding space if the chunk is written first time
-            if (fCompressor.padCompressedChunks(
+            if (fCompressor->padCompressedChunks(
                         (unsigned char*)fBufCompressed, fLenCompressed, fMaxCompressedBufSize) != 0)
             {
                 WE_COMP_DBG(cout << "Last chunk:" << chunkId << ", padding failed." << endl;)
@@ -1247,7 +1280,8 @@ int ChunkManager::closeFile(CompFileData* fileData)
 int ChunkManager::writeHeader(CompFileData* fileData, int ln)
 {
     int rc = NO_ERROR;
-    int headerSize = fCompressor.getHdrSize(fileData->fFileHeader.fControlData);
+    int headerSize = compress::CompressInterface::getHdrSize(
+        fileData->fFileHeader.fControlData);
     int ptrSecSize = headerSize - COMPRESSED_FILE_HEADER_UNIT;
 
     if (!fIsHdfs && !fIsBulkLoad)
@@ -1396,7 +1430,8 @@ int ChunkManager::updateColumnExtent(IDBDataFile* pFile, int addBlockCount)
 
     int rc = NO_ERROR;
     char* hdr = pFileData->fFileHeader.fControlData;
-    fCompressor.setBlockCount(hdr, fCompressor.getBlockCount(hdr) + addBlockCount);
+    compress::CompressInterface::setBlockCount(
+        hdr, compress::CompressInterface::getBlockCount(hdr) + addBlockCount);
     ChunkData* chunkData = (pFileData)->findChunk(0);
 
     if (chunkData != NULL)
@@ -1447,7 +1482,7 @@ int ChunkManager::updateDctnryExtent(IDBDataFile* pFile, int addBlockCount)
 
     char* hdr = i->second->fFileHeader.fControlData;
     char* uncompressedBuf = chunkData->fBufUnCompressed;
-    int currentBlockCount = fCompressor.getBlockCount(hdr);
+    int currentBlockCount = compress::CompressInterface::getBlockCount(hdr);
 
     // Bug 3203, write out the compressed initial extent.
     if (currentBlockCount == 0)
@@ -1483,7 +1518,9 @@ int ChunkManager::updateDctnryExtent(IDBDataFile* pFile, int addBlockCount)
     }
 
     if (rc == NO_ERROR)
-        fCompressor.setBlockCount(hdr, fCompressor.getBlockCount(hdr) + addBlockCount);
+        compress::CompressInterface::setBlockCount(
+            hdr,
+            compress::CompressInterface::getBlockCount(hdr) + addBlockCount);
 
     return rc;
 }
@@ -1650,7 +1687,8 @@ int ChunkManager::getBlockCount(IDBDataFile* pFile)
     map<IDBDataFile*, CompFileData*>::iterator fpIt = fFilePtrMap.find(pFile);
     idbassert(fpIt != fFilePtrMap.end());
 
-    return fCompressor.getBlockCount(fpIt->second->fFileHeader.fControlData);
+    return compress::CompressInterface::getBlockCount(
+        fpIt->second->fFileHeader.fControlData);
 }
 
 //------------------------------------------------------------------------------
@@ -1724,11 +1762,13 @@ int ChunkManager::reallocateChunks(CompFileData* fileData)
     origFilePtr->flush();
 
     // back out the current pointers
-    int headerSize = fCompressor.getHdrSize(fileData->fFileHeader.fControlData);
+    int headerSize = compress::CompressInterface::getHdrSize(
+        fileData->fFileHeader.fControlData);
     int ptrSecSize = headerSize - COMPRESSED_FILE_HEADER_UNIT;
     compress::CompChunkPtrList origPtrs;
 
-    if (fCompressor.getPtrList(fileData->fFileHeader.fPtrSection, ptrSecSize, origPtrs) != 0)
+    if (compress::CompressInterface::getPtrList(
+            fileData->fFileHeader.fPtrSection, ptrSecSize, origPtrs) != 0)
     {
         ostringstream oss;
         oss << "Chunk shifting failed, file:" << origFileName << " -- invalid header.";
@@ -1842,7 +1882,13 @@ int ChunkManager::reallocateChunks(CompFileData* fileData)
             ChunkData* chunkData = chunksTouched[k];
             fLenCompressed = fMaxCompressedBufSize;
 
-            if ((rc = fCompressor.compressBlock((char*)chunkData->fBufUnCompressed,
+            auto fCompressor = getCompressorByType(fileData->fCompressionType);
+            if (!fCompressor)
+            {
+                return ERR_COMP_WRONG_COMP_TYPE;
+            }
+
+            if ((rc = fCompressor->compressBlock((char*)chunkData->fBufUnCompressed,
                                                 chunkData->fLenUnCompressed,
                                                 (unsigned char*)fBufCompressed,
                                                 fLenCompressed)) != 0)
@@ -1860,7 +1906,7 @@ int ChunkManager::reallocateChunks(CompFileData* fileData)
                         << fLenCompressed;)
 
             // shifting chunk, add padding space
-            if ((rc = fCompressor.padCompressedChunks(
+            if ((rc = fCompressor->padCompressedChunks(
                           (unsigned char*)fBufCompressed, fLenCompressed, fMaxCompressedBufSize)) != 0)
             {
                 WE_COMP_DBG(cout << ", but padding failed." << endl;)
@@ -2211,7 +2257,8 @@ int ChunkManager::verifyChunksAfterRealloc(CompFileData* fileData)
     }
 
     // make sure the header is valid
-    if ((rc = fCompressor.verifyHdr(fileData->fFileHeader.fControlData)) != 0)
+    if ((rc = compress::CompressInterface::verifyHdr(
+             fileData->fFileHeader.fControlData)) != 0)
     {
         ostringstream oss;
         oss << "Invalid header in new " << fileData->fFileName << ", roll back";
@@ -2220,7 +2267,8 @@ int ChunkManager::verifyChunksAfterRealloc(CompFileData* fileData)
         return rc;
     }
 
-    int headerSize = fCompressor.getHdrSize(fileData->fFileHeader.fControlData);
+    int headerSize = compress::CompressInterface::getHdrSize(
+        fileData->fFileHeader.fControlData);
     int ptrSecSize = headerSize - COMPRESSED_FILE_HEADER_UNIT;
 
     // read in the pointer section in header
@@ -2236,7 +2284,8 @@ int ChunkManager::verifyChunksAfterRealloc(CompFileData* fileData)
     // get pointer list
     compress::CompChunkPtrList ptrs;
 
-    if (fCompressor.getPtrList(fileData->fFileHeader.fPtrSection, ptrSecSize, ptrs) != 0)
+    if (compress::CompressInterface::getPtrList(
+            fileData->fFileHeader.fPtrSection, ptrSecSize, ptrs) != 0)
     {
         ostringstream oss;
         oss << "Failed to parse pointer list from new " << fileData->fFileName << "@" << __LINE__;
@@ -2247,6 +2296,12 @@ int ChunkManager::verifyChunksAfterRealloc(CompFileData* fileData)
     // now verify each chunk
     ChunkData chunkData;
     int numOfChunks = ptrs.size();  // number of chunks in the file
+
+    auto fCompressor = getCompressorByType(fileData->fCompressionType);
+    if (!fCompressor)
+    {
+        return ERR_COMP_WRONG_COMP_TYPE;
+    }
 
     for (int i = 0; i < numOfChunks && rc == NO_ERROR; i++)
     {
@@ -2270,9 +2325,9 @@ int ChunkManager::verifyChunksAfterRealloc(CompFileData* fileData)
         }
 
         // uncompress the read in buffer
-        unsigned int dataLen = sizeof(chunkData.fBufUnCompressed);
+        size_t dataLen = sizeof(chunkData.fBufUnCompressed);
 
-        if (fCompressor.uncompressBlock((char*)fBufCompressed, chunkSize,
+        if (fCompressor->uncompressBlock((char*)fBufCompressed, chunkSize,
                                         (unsigned char*)chunkData.fBufUnCompressed, dataLen) != 0)
         {
             ostringstream oss;
@@ -2590,13 +2645,15 @@ int ChunkManager::checkFixLastDictChunk(const FID& fid,
     if (mit != fFileMap.end())
     {
 
-        int headerSize = fCompressor.getHdrSize(mit->second->fFileHeader.fControlData);
+        int headerSize = compress::CompressInterface::getHdrSize(
+            mit->second->fFileHeader.fControlData);
         int ptrSecSize = headerSize - COMPRESSED_FILE_HEADER_UNIT;
 
         // get pointer list
         compress::CompChunkPtrList ptrs;
 
-        if (fCompressor.getPtrList(mit->second->fFileHeader.fPtrSection, ptrSecSize, ptrs) != 0)
+        if (compress::CompressInterface::getPtrList(
+                mit->second->fFileHeader.fPtrSection, ptrSecSize, ptrs) != 0)
         {
             ostringstream oss;
             oss << "Failed to parse pointer list from new " << mit->second->fFileName << "@" << __LINE__;
@@ -2628,9 +2685,15 @@ int ChunkManager::checkFixLastDictChunk(const FID& fid,
 
         // uncompress the read in buffer
         chunkData = new ChunkData(numOfChunks - 1);
-        unsigned int dataLen = sizeof(chunkData->fBufUnCompressed);
+        size_t dataLen = sizeof(chunkData->fBufUnCompressed);
 
-        if (fCompressor.uncompressBlock((char*)fBufCompressed, chunkSize,
+        auto fCompressor = getCompressorByType(mit->second->fCompressionType);
+        if (!fCompressor)
+        {
+            return ERR_COMP_WRONG_COMP_TYPE;
+        }
+
+        if (fCompressor->uncompressBlock((char*)fBufCompressed, chunkSize,
                                         (unsigned char*)chunkData->fBufUnCompressed, dataLen) != 0)
         {
             mit->second->fChunkList.push_back(chunkData);
@@ -2642,7 +2705,7 @@ int ChunkManager::checkFixLastDictChunk(const FID& fid,
             {
                 char* hdr = mit->second->fFileHeader.fControlData;
 
-                if (fCompressor.getBlockCount(hdr) < 512)
+                if (compress::CompressInterface::getBlockCount(hdr) < 512)
                     blocks = 256;
             }
 
@@ -2658,6 +2721,19 @@ int ChunkManager::checkFixLastDictChunk(const FID& fid,
     }
 
     return rc;
+}
+
+std::shared_ptr<compress::CompressInterface>
+ChunkManager::getCompressorByType(uint32_t compressionType)
+{
+    switch (compressionType)
+    {
+      case 1:
+      case 2:
+          // Snappy
+          return fCompressorPool.front();
+    }
+    return nullptr;
 }
 
 }

--- a/writeengine/shared/we_chunkmanager.h
+++ b/writeengine/shared/we_chunkmanager.h
@@ -64,8 +64,8 @@ namespace WriteEngine
 // forward reference
 class FileOp;
 
-const int UNCOMPRESSED_CHUNK_SIZE = compress::IDBCompressInterface::UNCOMPRESSED_INBUF_LEN;
-const int COMPRESSED_FILE_HEADER_UNIT = compress::IDBCompressInterface::HDR_BUF_LEN;
+const int UNCOMPRESSED_CHUNK_SIZE = compress::CompressInterface::UNCOMPRESSED_INBUF_LEN;
+const int COMPRESSED_FILE_HEADER_UNIT = compress::CompressInterface::HDR_BUF_LEN;
 
 // assume UNCOMPRESSED_CHUNK_SIZE > 0xBFFF (49151), 8 * 1024 bytes padding
 
@@ -136,7 +136,7 @@ class CompFileData
 public:
     CompFileData(const FileID& id, const FID& fid, const execplan::CalpontSystemCatalog::ColDataType colDataType, int colWidth) :
         fFileID(id), fFid(fid), fColDataType(colDataType), fColWidth(colWidth), fDctnryCol(false),
-        fFilePtr(NULL), fIoBSize(0) {}
+        fFilePtr(NULL), fIoBSize(0), fCompressionType(1) {}
 
     ChunkData* findChunk(int64_t cid) const;
 
@@ -152,6 +152,7 @@ protected:
     std::list<ChunkData*>   fChunkList;
     boost::scoped_array<char> fIoBuffer;
     size_t          fIoBSize;
+    uint32_t        fCompressionType;
 
     friend class ChunkManager;
 };
@@ -353,27 +354,31 @@ protected:
     // @brief construnct a DML log file name
     int getDMLLogFileName(std::string& aDMLLogFileName, const TxnID& txnId) const;
 
+    std::shared_ptr<compress::CompressInterface>
+    getCompressorByType(uint32_t compressionType);
+
     mutable std::map<FileID, CompFileData*>     fFileMap;
     mutable std::map<IDBDataFile*, CompFileData*> fFilePtrMap;
     std::list<std::pair<FileID, ChunkData*> >   fActiveChunks;
     unsigned int                                fMaxActiveChunkNum;  // max active chunks per file
     char*                                       fBufCompressed;
-    unsigned int                                fLenCompressed;
-    unsigned int                                fMaxCompressedBufSize;
-    unsigned int                                fUserPaddings;
+    size_t                                      fLenCompressed;
+    size_t                                      fMaxCompressedBufSize;
+    size_t                                      fUserPaddings;
     bool                                        fIsBulkLoad;
     bool                                        fDropFdCache;
     bool                                        fIsInsert;
     bool                                        fIsHdfs;
     FileOp*                                     fFileOp;
-    compress::IDBCompressInterface              fCompressor;
+    std::vector<std::shared_ptr<compress::CompressInterface>> fCompressorPool;
     logging::Logger*                            fSysLogger;
     TxnID                                       fTransId;
     int                                         fLocalModuleId;
     idbdatafile::IDBFileSystem&                 fFs;
     bool 										fIsFix;
+    size_t COMPRESSED_CHUNK_SIZE;
 
-private:
+  private:
 };
 
 }

--- a/writeengine/shared/we_define.h
+++ b/writeengine/shared/we_define.h
@@ -347,6 +347,7 @@ const int   ERR_COMP_READ_FILE      = ERR_COMPBASE + 16;// Failed to read from a
 const int   ERR_COMP_WRITE_FILE     = ERR_COMPBASE + 17;// Failed to write to a compresssed data file
 const int   ERR_COMP_CLOSE_FILE     = ERR_COMPBASE + 18;// Failed to close a compressed data file
 const int   ERR_COMP_TRUNCATE_ZERO  = ERR_COMPBASE + 19;// Invalid attempt to truncate file to 0 bytes
+const int   ERR_COMP_WRONG_COMP_TYPE = ERR_COMPBASE + 20;// Invalid compression type.
 
 //--------------------------------------------------------------------------
 // Auto-increment error

--- a/writeengine/shared/we_fileop.cpp
+++ b/writeengine/shared/we_fileop.cpp
@@ -649,14 +649,19 @@ int FileOp::extendFile(
         // @bug 5349: check that new extent's fbo is not past current EOF
         if (m_compressionType)
         {
-            char hdrsIn[ compress::IDBCompressInterface::HDR_BUF_LEN * 2 ];
+            char hdrsIn[ compress::CompressInterface::HDR_BUF_LEN * 2 ];
             RETURN_ON_ERROR( readHeaders(pFile, hdrsIn) );
 
-            IDBCompressInterface compressor;
-            unsigned int ptrCount   = compressor.getPtrCount(hdrsIn);
+            std::unique_ptr<compress::CompressInterface> compressor(
+                compress::getCompressInterfaceByType(
+                    compress::CompressInterface::getCompressionType(hdrsIn)));
+
+            unsigned int ptrCount =
+                compress::CompressInterface::getPtrCount(hdrsIn);
             unsigned int chunkIndex = 0;
             unsigned int blockOffsetWithinChunk = 0;
-            compressor.locateBlock((hwm - 1), chunkIndex, blockOffsetWithinChunk);
+            compressor->locateBlock((hwm - 1), chunkIndex,
+                                    blockOffsetWithinChunk);
 
             //std::ostringstream oss1;
             //oss1 << "Extending compressed column file"<<
@@ -813,8 +818,8 @@ int FileOp::extendFile(
 
         if ((m_compressionType) && (hdrs))
         {
-            IDBCompressInterface compressor;
-            compressor.initHdr(hdrs, width, colDataType, m_compressionType);
+            compress::CompressInterface::initHdr(hdrs, width, colDataType,
+                                                 m_compressionType);
         }
     }
 
@@ -971,8 +976,8 @@ int FileOp::addExtentExactFile(
 
         if ((m_compressionType) && (hdrs))
         {
-            IDBCompressInterface compressor;
-            compressor.initHdr(hdrs, width, colDataType, m_compressionType);
+            compress::CompressInterface::initHdr(hdrs, width, colDataType,
+                                                 m_compressionType);
         }
     }
 
@@ -1056,12 +1061,12 @@ int FileOp::initColumnExtent(
 {
     if ((bNewFile) && (m_compressionType))
     {
-        char hdrs[IDBCompressInterface::HDR_BUF_LEN * 2];
-        IDBCompressInterface compressor;
-        compressor.initHdr(hdrs, width, colDataType, m_compressionType);
+        char hdrs[CompressInterface::HDR_BUF_LEN * 2];
+        compress::CompressInterface::initHdr(hdrs, width, colDataType,
+                                             m_compressionType);
 
         if (bAbbrevExtent)
-            compressor.setBlockCount(hdrs, nBlocks);
+            compress::CompressInterface::setBlockCount(hdrs, nBlocks);
 
         RETURN_ON_ERROR(writeHeaders(pFile, hdrs));
     }
@@ -1251,7 +1256,7 @@ int FileOp::initAbbrevCompColumnExtent(
     Stats::startParseEvent(WE_STATS_COMPRESS_COL_INIT_ABBREV_EXT);
 #endif
 
-    char hdrs[IDBCompressInterface::HDR_BUF_LEN * 2];
+    char hdrs[CompressInterface::HDR_BUF_LEN * 2];
     rc = writeInitialCompColumnChunk( pFile,
                                       nBlocks,
                                       INITIAL_EXTENT_ROWS_TO_DISK,
@@ -1295,24 +1300,29 @@ int FileOp::writeInitialCompColumnChunk(
     execplan::CalpontSystemCatalog::ColDataType colDataType,
     char*    hdrs)
 {
-    const int INPUT_BUFFER_SIZE     = nRows * width;
+    const size_t INPUT_BUFFER_SIZE     = nRows * width;
     char* toBeCompressedInput       = new char[INPUT_BUFFER_SIZE];
     unsigned int userPaddingBytes   = Config::getNumCompressedPadBlks() *
                                       BYTE_PER_BLOCK;
-    const int OUTPUT_BUFFER_SIZE    = IDBCompressInterface::maxCompressedSize(INPUT_BUFFER_SIZE) +
-                                      userPaddingBytes;
+    // Compress an initialized abbreviated extent
+    // Initially m_compressionType == 0, but this function is used under
+    // condtion where m_compressionType > 0.
+    std::unique_ptr<CompressInterface> compressor(
+        compress::getCompressInterfaceByType(m_compressionType,
+                                             userPaddingBytes));
+    const size_t OUTPUT_BUFFER_SIZE =
+        compressor->maxCompressedSize(INPUT_BUFFER_SIZE) + userPaddingBytes;
+
     unsigned char* compressedOutput = new unsigned char[OUTPUT_BUFFER_SIZE];
-    unsigned int outputLen          = OUTPUT_BUFFER_SIZE;
+    size_t outputLen          = OUTPUT_BUFFER_SIZE;
     boost::scoped_array<char> toBeCompressedInputPtr( toBeCompressedInput );
     boost::scoped_array<unsigned char> compressedOutputPtr(compressedOutput);
 
     setEmptyBuf( (unsigned char*)toBeCompressedInput,
                  INPUT_BUFFER_SIZE, emptyVal, width);
 
-    // Compress an initialized abbreviated extent
-    IDBCompressInterface compressor( userPaddingBytes );
-    int rc = compressor.compressBlock(toBeCompressedInput,
-                                      INPUT_BUFFER_SIZE, compressedOutput, outputLen );
+    int rc = compressor->compressBlock(toBeCompressedInput, INPUT_BUFFER_SIZE,
+                                       compressedOutput, outputLen);
 
     if (rc != 0)
     {
@@ -1320,8 +1330,8 @@ int FileOp::writeInitialCompColumnChunk(
     }
 
     // Round up the compressed chunk size
-    rc = compressor.padCompressedChunks( compressedOutput,
-                                         outputLen, OUTPUT_BUFFER_SIZE );
+    rc = compressor->padCompressedChunks(compressedOutput, outputLen,
+                                         OUTPUT_BUFFER_SIZE);
 
     if (rc != 0)
     {
@@ -1334,14 +1344,15 @@ int FileOp::writeInitialCompColumnChunk(
 //      "; blkAllocCnt: "   << nBlocksAllocated  <<
 //      "; compressedByteCnt: "  << outputLen << std::endl;
 
-    compressor.initHdr(hdrs, width, colDataType, m_compressionType);
-    compressor.setBlockCount(hdrs, nBlocksAllocated);
+    compress::CompressInterface::initHdr(hdrs, width, colDataType,
+                                         m_compressionType);
+    compress::CompressInterface::setBlockCount(hdrs, nBlocksAllocated);
 
     // Store compression pointers in the header
     std::vector<uint64_t> ptrs;
-    ptrs.push_back( IDBCompressInterface::HDR_BUF_LEN * 2 );
-    ptrs.push_back( outputLen + (IDBCompressInterface::HDR_BUF_LEN * 2) );
-    compressor.storePtrs(ptrs, hdrs);
+    ptrs.push_back( CompressInterface::HDR_BUF_LEN * 2 );
+    ptrs.push_back( outputLen + (CompressInterface::HDR_BUF_LEN * 2) );
+    compress::CompressInterface::storePtrs(ptrs, hdrs);
 
     RETURN_ON_ERROR( writeHeaders(pFile, hdrs) );
 
@@ -1407,7 +1418,7 @@ int FileOp::fillCompColumnExtentEmptyChunks(OID oid,
         return ERR_FILE_OPEN;
     }
 
-    char hdrs[ IDBCompressInterface::HDR_BUF_LEN * 2 ];
+    char hdrs[ CompressInterface::HDR_BUF_LEN * 2 ];
     rc = readHeaders( pFile, hdrs );
 
     if (rc != NO_ERROR)
@@ -1418,9 +1429,14 @@ int FileOp::fillCompColumnExtentEmptyChunks(OID oid,
     }
 
     int userPadBytes = Config::getNumCompressedPadBlks() * BYTE_PER_BLOCK;
-    IDBCompressInterface compressor( userPadBytes );
+
+    std::unique_ptr<CompressInterface> compressor(
+        compress::getCompressInterfaceByType(
+            compress::CompressInterface::getCompressionType(hdrs),
+            userPadBytes));
+
     CompChunkPtrList chunkPtrs;
-    int rcComp = compressor.getPtrList( hdrs, chunkPtrs );
+    int rcComp = compress::CompressInterface::getPtrList(hdrs, chunkPtrs);
 
     if (rcComp != 0)
     {
@@ -1430,7 +1446,7 @@ int FileOp::fillCompColumnExtentEmptyChunks(OID oid,
     }
 
     // Nothing to do if the proposed HWM is < the current block count
-    uint64_t blkCount = compressor.getBlockCount(hdrs);
+    uint64_t blkCount = compress::CompressInterface::getBlockCount(hdrs);
 
     if (blkCount > (hwm + 1))
     {
@@ -1441,7 +1457,7 @@ int FileOp::fillCompColumnExtentEmptyChunks(OID oid,
     const unsigned int ROWS_PER_EXTENT   =
         BRMWrapper::getInstance()->getInstance()->getExtentRows();
     const unsigned int ROWS_PER_CHUNK    =
-        IDBCompressInterface::UNCOMPRESSED_INBUF_LEN / colWidth;
+        CompressInterface::UNCOMPRESSED_INBUF_LEN / colWidth;
     const unsigned int CHUNKS_PER_EXTENT = ROWS_PER_EXTENT / ROWS_PER_CHUNK;
 
     // If this is an abbreviated extent, we first expand to a full extent
@@ -1479,7 +1495,7 @@ int FileOp::fillCompColumnExtentEmptyChunks(OID oid,
 
         CompChunkPtr chunkOutPtr;
         rc = expandAbbrevColumnChunk( pFile, emptyVal, colWidth,
-                                      chunkPtrs[0], chunkOutPtr );
+                                      chunkPtrs[0], chunkOutPtr, hdrs );
 
         if (rc != NO_ERROR)
         {
@@ -1501,7 +1517,7 @@ int FileOp::fillCompColumnExtentEmptyChunks(OID oid,
 
         // Update block count to reflect a full extent
         blkCount = (ROWS_PER_EXTENT * colWidth) / BYTE_PER_BLOCK;
-        compressor.setBlockCount( hdrs, blkCount );
+        compress::CompressInterface::setBlockCount(hdrs, blkCount);
     }
 
     // Calculate the number of empty chunks we need to add to fill this extent
@@ -1518,7 +1534,7 @@ int FileOp::fillCompColumnExtentEmptyChunks(OID oid,
               compressor.getBlockCount(hdrs) << std::endl;
     std::cout << "Pointer Header Size (in bytes): " <<
               (compressor.getHdrSize(hdrs) -
-               IDBCompressInterface::HDR_BUF_LEN) << std::endl;
+               CompressInterface::HDR_BUF_LEN) << std::endl;
     std::cout << "Chunk Pointers (offset,length): " << std::endl;
 
     for (unsigned k = 0; k < chunkPtrs.size(); k++)
@@ -1537,8 +1553,9 @@ int FileOp::fillCompColumnExtentEmptyChunks(OID oid,
     // Fill in or add necessary remaining empty chunks
     if (numChunksToFill > 0)
     {
-        const int IN_BUF_LEN = IDBCompressInterface::UNCOMPRESSED_INBUF_LEN;
-        const int OUT_BUF_LEN = IDBCompressInterface::maxCompressedSize(IN_BUF_LEN) + userPadBytes;
+        const int IN_BUF_LEN = CompressInterface::UNCOMPRESSED_INBUF_LEN;
+        const int OUT_BUF_LEN =
+            compressor->maxCompressedSize(IN_BUF_LEN) + userPadBytes;
 
         // Allocate buffer, and store in scoped_array to insure it's deletion.
         // Create scope {...} to manage deletion of buffers
@@ -1552,9 +1569,9 @@ int FileOp::fillCompColumnExtentEmptyChunks(OID oid,
             // Compress and then pad the compressed chunk
             setEmptyBuf( (unsigned char*)toBeCompressedBuf,
                          IN_BUF_LEN, emptyVal, colWidth );
-            unsigned int outputLen = OUT_BUF_LEN;
-            rcComp = compressor.compressBlock( toBeCompressedBuf,
-                                               IN_BUF_LEN, compressedBuf, outputLen );
+            size_t outputLen = OUT_BUF_LEN;
+            rcComp = compressor->compressBlock(toBeCompressedBuf, IN_BUF_LEN,
+                                               compressedBuf, outputLen);
 
             if (rcComp != 0)
             {
@@ -1565,8 +1582,8 @@ int FileOp::fillCompColumnExtentEmptyChunks(OID oid,
 
             toBeCompressedInputPtr.reset(); // release memory
 
-            rcComp = compressor.padCompressedChunks( compressedBuf,
-                     outputLen, OUT_BUF_LEN );
+            rcComp = compressor->padCompressedChunks(compressedBuf, outputLen,
+                                                     OUT_BUF_LEN);
 
             if (rcComp != 0)
             {
@@ -1625,7 +1642,7 @@ int FileOp::fillCompColumnExtentEmptyChunks(OID oid,
 
         ptrs.push_back( chunkPtrs[chunkPtrs.size() - 1].first +
                         chunkPtrs[chunkPtrs.size() - 1].second );
-        compressor.storePtrs( ptrs, hdrs );
+        compress::CompressInterface::storePtrs(ptrs, hdrs);
 
         rc = writeHeaders( pFile, hdrs );
 
@@ -1683,11 +1700,23 @@ int FileOp::expandAbbrevColumnChunk(
     const uint8_t* emptyVal,
     int   colWidth,
     const CompChunkPtr& chunkInPtr,
-    CompChunkPtr& chunkOutPtr )
+    CompChunkPtr& chunkOutPtr,
+    const char *hdrs )
 {
     int userPadBytes = Config::getNumCompressedPadBlks() * BYTE_PER_BLOCK;
-    const int IN_BUF_LEN = IDBCompressInterface::UNCOMPRESSED_INBUF_LEN;
-    const int OUT_BUF_LEN = IDBCompressInterface::maxCompressedSize(IN_BUF_LEN) + userPadBytes;
+    auto realCompressionType = m_compressionType;
+    if (hdrs)
+    {
+        realCompressionType =
+            compress::CompressInterface::getCompressionType(hdrs);
+    }
+    std::unique_ptr<CompressInterface> compressor(
+        compress::getCompressInterfaceByType(realCompressionType,
+                                             userPadBytes));
+
+    const int IN_BUF_LEN = CompressInterface::UNCOMPRESSED_INBUF_LEN;
+    const int OUT_BUF_LEN =
+        compressor->maxCompressedSize(IN_BUF_LEN) + userPadBytes;
 
     char* toBeCompressedBuf = new char[ IN_BUF_LEN  ];
     boost::scoped_array<char> toBeCompressedPtr(toBeCompressedBuf);
@@ -1703,13 +1732,10 @@ int FileOp::expandAbbrevColumnChunk(
                               chunkInPtr.second) );
 
     // Uncompress an "abbreviated" chunk into our 4MB buffer
-    unsigned int outputLen = IN_BUF_LEN;
-    IDBCompressInterface compressor( userPadBytes );
-    int rc = compressor.uncompressBlock(
-                 compressedInBuf,
-                 chunkInPtr.second,
-                 (unsigned char*)toBeCompressedBuf,
-                 outputLen);
+    size_t outputLen = IN_BUF_LEN;
+    int rc = compressor->uncompressBlock(compressedInBuf, chunkInPtr.second,
+                                         (unsigned char*) toBeCompressedBuf,
+                                         outputLen);
 
     if (rc != 0)
     {
@@ -1725,11 +1751,8 @@ int FileOp::expandAbbrevColumnChunk(
 
     // Compress the data we just read, as a "full" 4MB chunk
     outputLen = OUT_BUF_LEN;
-    rc = compressor.compressBlock(
-             reinterpret_cast<char*>(toBeCompressedBuf),
-             IN_BUF_LEN,
-             compressedOutBuf,
-             outputLen );
+    rc = compressor->compressBlock(reinterpret_cast<char*>(toBeCompressedBuf),
+                                   IN_BUF_LEN, compressedOutBuf, outputLen);
 
     if (rc != 0)
     {
@@ -1737,8 +1760,8 @@ int FileOp::expandAbbrevColumnChunk(
     }
 
     // Round up the compressed chunk size
-    rc = compressor.padCompressedChunks( compressedOutBuf,
-                                         outputLen, OUT_BUF_LEN );
+    rc = compressor->padCompressedChunks(compressedOutBuf, outputLen,
+                                         OUT_BUF_LEN);
 
     if (rc != 0)
     {
@@ -1768,7 +1791,7 @@ int FileOp::writeHeaders(IDBDataFile* pFile, const char* hdr) const
     RETURN_ON_ERROR( setFileOffset(pFile, 0, SEEK_SET) );
 
     // Write the headers
-    if (pFile->write( hdr, IDBCompressInterface::HDR_BUF_LEN * 2 ) != IDBCompressInterface::HDR_BUF_LEN * 2)
+    if (pFile->write( hdr, CompressInterface::HDR_BUF_LEN * 2 ) != CompressInterface::HDR_BUF_LEN * 2)
     {
         return ERR_FILE_WRITE;
     }
@@ -1794,7 +1817,7 @@ int FileOp::writeHeaders(IDBDataFile* pFile, const char* controlHdr,
     RETURN_ON_ERROR( setFileOffset(pFile, 0, SEEK_SET) );
 
     // Write the control header
-    if (pFile->write( controlHdr, IDBCompressInterface::HDR_BUF_LEN ) != IDBCompressInterface::HDR_BUF_LEN)
+    if (pFile->write( controlHdr, CompressInterface::HDR_BUF_LEN ) != CompressInterface::HDR_BUF_LEN)
     {
         return ERR_FILE_WRITE;
     }
@@ -2636,9 +2659,8 @@ int FileOp::readHeaders( IDBDataFile* pFile, char* hdrs ) const
 {
     RETURN_ON_ERROR( setFileOffset(pFile, 0) );
     RETURN_ON_ERROR( readFile( pFile, reinterpret_cast<unsigned char*>(hdrs),
-                               (IDBCompressInterface::HDR_BUF_LEN * 2) ) );
-    IDBCompressInterface compressor;
-    int rc = compressor.verifyHdr( hdrs );
+                               (CompressInterface::HDR_BUF_LEN * 2) ) );
+    int rc = compress::CompressInterface::verifyHdr(hdrs);
 
     if (rc != 0)
     {
@@ -2656,11 +2678,10 @@ int FileOp::readHeaders( IDBDataFile* pFile, char* hdr1, char* hdr2 ) const
     unsigned char* hdrPtr = reinterpret_cast<unsigned char*>(hdr1);
     RETURN_ON_ERROR( setFileOffset(pFile, 0) );
     RETURN_ON_ERROR( readFile( pFile, hdrPtr,
-                               IDBCompressInterface::HDR_BUF_LEN ));
+                               CompressInterface::HDR_BUF_LEN ));
 
-    IDBCompressInterface compressor;
-    int ptrSecSize = compressor.getHdrSize(hdrPtr) -
-                     IDBCompressInterface::HDR_BUF_LEN;
+    int ptrSecSize = compress::CompressInterface::getHdrSize(hdrPtr) -
+                     CompressInterface::HDR_BUF_LEN;
     return readFile( pFile, reinterpret_cast<unsigned char*>(hdr2),
                      ptrSecSize );
 }

--- a/writeengine/shared/we_fileop.h
+++ b/writeengine/shared/we_fileop.h
@@ -526,11 +526,11 @@ private:
     FileOp(const FileOp& rhs);
     FileOp& operator=(const FileOp& rhs);
 
-    int                 expandAbbrevColumnChunk( IDBDataFile* pFile,
-            const uint8_t*   emptyVal,
-            int   colWidth,
-            const compress::CompChunkPtr& chunkInPtr,
-            compress::CompChunkPtr& chunkOutPt);
+    int expandAbbrevColumnChunk(IDBDataFile* pFile, const uint8_t* emptyVal,
+                                int colWidth,
+                                const compress::CompChunkPtr& chunkInPtr,
+                                compress::CompChunkPtr& chunkOutPt,
+                                const char* hdrs = nullptr);
 
     int initAbbrevCompColumnExtent(
         IDBDataFile* pFile, uint16_t dbRoot, int nBlocks,

--- a/writeengine/shared/we_rbmetawriter.cpp
+++ b/writeengine/shared/we_rbmetawriter.cpp
@@ -1007,9 +1007,9 @@ void RBMetaWriter::backupHWMChunk(
     }
 
     // Read Control header
-    char controlHdr[ IDBCompressInterface::HDR_BUF_LEN ];
+    char controlHdr[ CompressInterface::HDR_BUF_LEN ];
     rc = fileOp.readFile( dbFile, (unsigned char*)controlHdr,
-                          IDBCompressInterface::HDR_BUF_LEN );
+                          CompressInterface::HDR_BUF_LEN );
 
     if (rc != NO_ERROR)
     {
@@ -1025,8 +1025,7 @@ void RBMetaWriter::backupHWMChunk(
         throw WeException( oss.str(), rc );
     }
 
-    IDBCompressInterface compressor;
-    int rc1 = compressor.verifyHdr( controlHdr );
+    int rc1 = compress::CompressInterface::verifyHdr(controlHdr);
 
     if (rc1 != 0)
     {
@@ -1045,9 +1044,14 @@ void RBMetaWriter::backupHWMChunk(
         throw WeException( oss.str(), rc );
     }
 
+    auto compressionType =
+        compress::CompressInterface::getCompressionType(controlHdr);
+    std::unique_ptr<compress::CompressInterface> compressor(
+        compress::getCompressInterfaceByType(compressionType));
+
     // Read Pointer header data
-    uint64_t hdrSize    = compressor.getHdrSize(controlHdr);
-    uint64_t ptrHdrSize = hdrSize - IDBCompressInterface::HDR_BUF_LEN;
+    uint64_t hdrSize = compress::CompressInterface::getHdrSize(controlHdr);
+    uint64_t ptrHdrSize = hdrSize - CompressInterface::HDR_BUF_LEN;
     char* pointerHdr    = new char[ptrHdrSize];
     rc = fileOp.readFile( dbFile, (unsigned char*)pointerHdr, ptrHdrSize );
 
@@ -1067,7 +1071,8 @@ void RBMetaWriter::backupHWMChunk(
     }
 
     CompChunkPtrList     chunkPtrs;
-    rc = compressor.getPtrList(pointerHdr, ptrHdrSize, chunkPtrs );
+    rc = compress::CompressInterface::getPtrList(pointerHdr, ptrHdrSize,
+                                                 chunkPtrs);
     delete[] pointerHdr;
 
     if (rc != 0)
@@ -1087,7 +1092,7 @@ void RBMetaWriter::backupHWMChunk(
     unsigned int blockOffsetWithinChunk = 0;
     unsigned char* buffer               = 0;
     uint64_t chunkSize                  = 0;
-    compressor.locateBlock(startingHWM, chunkIndex, blockOffsetWithinChunk);
+    compressor->locateBlock(startingHWM, chunkIndex, blockOffsetWithinChunk);
 
     if (chunkIndex < chunkPtrs.size())
     {

--- a/writeengine/shared/we_type.h
+++ b/writeengine/shared/we_type.h
@@ -296,6 +296,8 @@ struct ColStruct                        /** @brief Column Interface Struct*/
     ColStruct() : dataOid(0), colWidth(0),  /** @brief constructor */
         tokenFlag(false), colDataType(execplan::CalpontSystemCatalog::INT), colType(WR_INT),
         fColPartition(0), fColSegment(0), fColDbRoot(0),
+        // TODO: check that we specify the compression type directly in the entire code,
+        // when we have more than 1 compression algo.
         fCompressionType(idbdatafile::IDBPolicy::useHdfs() ? 2 : 0) { }
 };
 
@@ -320,7 +322,10 @@ struct DctnryStruct                     /** @brief Dctnry Interface Struct*/
     DctnryStruct() : dctnryOid(0), columnOid(0),   /** @brief constructor */
         colWidth(0),
         fColPartition(0), fColSegment(0),
-        fColDbRoot(0), fCompressionType(idbdatafile::IDBPolicy::useHdfs() ? 2 : 0) { }
+        fColDbRoot(0),
+        // TODO: check that we specify the compression type directly in the entire code,
+        // when we have more than 1 compression algo.
+        fCompressionType(idbdatafile::IDBPolicy::useHdfs() ? 2 : 0) { }
 };
 
 struct DctnryTuple                      /** @brief Dictionary Tuple struct*/

--- a/writeengine/wrapper/we_colopcompress.cpp
+++ b/writeengine/wrapper/we_colopcompress.cpp
@@ -164,11 +164,7 @@ bool ColumnOpCompress1::abbreviatedExtent(IDBDataFile* pFile, int colWidth) cons
 
 int ColumnOpCompress1::blocksInFile(IDBDataFile* pFile) const
 {
-    CompFileHeader compFileHeader;
-    readHeaders(pFile, compFileHeader.fControlData, compFileHeader.fPtrSection);
-
-    compress::IDBCompressInterface compressor;
-    return compressor.getBlockCount(compFileHeader.fControlData);
+    return m_chunkManager->getBlockCount(pFile);
 }
 
 


### PR DESCRIPTION
This patch changes compression interface. Motivation is to be able to add
new compression methods.

* All methods which use static data and do not modify any internal data - become `static`,
  so we can use them without creation of the specific object. This is possible, because
  the header specification has not been modified. We still use 2 sections in header, first
  one with file meta data, the second one with pointers for compressed chunks.

* Methods `compress`, `uncompress`, `maxCompressedSize`, `getUncompressedSize` - become
  pure virtual, so we can override them for the other compression algos.

* Adds method `getChunkMagicNumber`, so we can verify chunk magic number
  for each compression algo.

* Renames "s/IDBCompressInterface/CompressInterface/g" according to requirement.