### PR TITLE
MCOL-4440 Cluster unusable after primary node failover

### DIFF
--- a/oam/install_scripts/mcs-loadbrm.py.in
+++ b/oam/install_scripts/mcs-loadbrm.py.in
@@ -8,6 +8,7 @@ import configparser
 import os
 import glob
 import shutil
+import socket
 
 API_CONFIG_PATH = '/etc/columnstore/cmapi_server.conf'
 BYPASS_SM_PATH = '/tmp/columnstore_tmp_files/rdwrscratch/BRM_saves'
@@ -54,8 +55,9 @@ if __name__ == '__main__':
     loadbrm = '@ENGINE_BINDIR@/load_brm'
 
     brm_saves_current = ''
+    use_s3 = storage.lower() == 's3' and not bucket.lower() == 'some_bucket'
 
-    if storage.lower() == 's3' and not bucket.lower() == 'some_bucket':
+    if use_s3:
         # start SM using systemd
         if use_systemd is True:
             cmd = 'systemctl start mcs-storagemanager'
@@ -80,7 +82,7 @@ if __name__ == '__main__':
                    '/etc/columnstore/Columnstore.xml')    # atomic replacement
 
     # Single-node on S3
-    if storage.lower() == 's3' and not bucket.lower() == 'some_bucket' and pmCount == 1:
+    if use_s3 and pmCount == 1:
         try:
             if use_systemd:
                 args = ['su', '-s', '/bin/sh', '-c', 'smcat {}'.format(brm), USER]
@@ -112,12 +114,46 @@ file=sys.stderr)
                 headers = {'x-api-key': api_key}
                 api_version = get_version()
                 api_port = get_port()
+
+                is_primary = False
+                if use_s3:
+                    url = "https://127.0.0.1:{}/cmapi/{}/node/primary".format(api_port, api_version)
+                    r = requests.get(url, verify=False, headers=headers, timeout=10)
+                    if (r.status_code == 200):
+                        is_primary = r.json().get('is_primary', False)
+
                 elems = ['em', 'journal', 'vbbm', 'vss']
                 for e  in elems:
+                    if use_s3 and not is_primary:
+                        success = False
+                        retry = 5
+                        while not success and retry > 0:
+                            try:
+                                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                                sock.settimeout(5)
+                                # if using s3 we need to make sure storagemanager on primary is running
+                                # wait for workernode, since SM not accessible
+                                # if workernode has started, storagemanager is running
+                                result = sock.connect_ex((primary_address, 8700))
+                                if result == 0:
+                                    success = True
+                                    sock.close()
+                            except socket.timeout:
+                                pass
+                            else:
+                                sock.close()
+                            if not success:
+                                time.sleep(1)
+                            retry -= 1
+
+                        if not success:
+                            print('Timed out. StorageManager on {str(primary_address)} is not reachable.')
+
                     print("Pulling {} from the primary node.".format(e))
                     url = "https://{}:{}/cmapi/{}/node/meta/{}".format(primary_address, \
 api_port, api_version, e)
-                    r = requests.get(url, verify=False, headers=headers, timeout=30)
+
+                    r = requests.get(url, verify=False, headers=headers, timeout=60)
                     if (r.status_code != 200):
                         raise RuntimeError("Error requesting {} from the primary \
 node.".format(e))

--- a/utils/messageqcpp/messagequeue.h
+++ b/utils/messageqcpp/messagequeue.h
@@ -269,6 +269,8 @@ public:
      */
     inline bool isSameAddr(const MessageQueueClient& rhs) const;
 
+    inline bool isSameAddr(const std::string& rhs) const;
+
     bool isConnected()
     {
         return fClientSock.isConnected();
@@ -319,6 +321,10 @@ inline const std::string MessageQueueClient::addr2String() const
 inline bool MessageQueueClient::isSameAddr(const MessageQueueClient& rhs) const
 {
     return fClientSock.isSameAddr(&rhs.fClientSock);
+}
+inline bool MessageQueueClient::isSameAddr(const std::string& rhs) const
+{
+    return fClientSock.addr2String() == rhs;
 }
 inline void MessageQueueClient::syncProto(bool use)
 {

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -883,6 +883,18 @@ reconnect:
 
     try
     {
+        // master may have changed but old msgclient connection might be in use
+        if (!msgClient->isSameAddr(config->getConfig(masterName, "IPAddr")))
+        {
+            if (firstAttempt)
+            {
+                firstAttempt = false;
+                MessageQueueClientPool::deleteInstance(msgClient);
+                msgClient = NULL;
+                goto reconnect;
+            }
+        }
+
         msgClient->write(in);
         out = msgClient->read();
     }


### PR DESCRIPTION
A couple issues arise after a primary node failover.

One is the plugin code is still connected to old primary node. This PR addresses this, destroying old connection and creating new connection to new primary.

Another occurs only when using storagemanager. There is a race condition occurring where a non-primary occasionally attempts to pull metadata from primary node before the primary node has started its storagemanger process, creating loadbrm failure. 

This PR is in combination with https://github.com/mariadb-corporation/mariadb-columnstore-cmapi/pull/110