### PR TITLE
Deb: Define Breaks/Replaces relationship on package libthrift-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,9 +8,11 @@ Depends: binutils,
          python3,
          ${misc:Depends},
          ${shlibs:Depends}
-Breaks: mariadb-columnstore-libs,
+Breaks: libthrift-dev,
+        mariadb-columnstore-libs,
         mariadb-columnstore-platform
-Replaces: mariadb-columnstore-libs,
+Replaces: libthrift-dev,
+          mariadb-columnstore-libs,
           mariadb-columnstore-platform
 Description: MariaDB ColumnStore storage engine
  The MariaDB ColumnStore storage engine is a high-performance columnar

--- a/debian/mariadb-plugin-columnstore.install
+++ b/debian/mariadb-plugin-columnstore.install
@@ -29,8 +29,8 @@ usr/bin/idbmeminfo
 usr/bin/load_brm
 usr/bin/mariadb-columnstore-start.sh
 usr/bin/mariadb-columnstore-stop.sh
-usr/bin/mcs-savebrm.py
 usr/bin/mcs-loadbrm.py
+usr/bin/mcs-savebrm.py
 usr/bin/mcs-stop-controllernode.sh
 usr/bin/mcsGetConfig
 usr/bin/mcsSetConfig


### PR DESCRIPTION
The package libthrift-dev contains a file with the same name and
path as a file in mariadb-plugin-columnstore. The two packages
cannot be installed at the same time and by defining this
relationship in the debian/control file, apt will handle the case
automatically.

Error detected with check_for_missing_breaks_replaces.py:
  [ERROR] mariadb-plugin-columnstore conflicts with libthrift-dev
  files: {'/usr/lib/x86_64-linux-gnu/libthrift.so'}

Also ran 'wrap-and-sort -av' to ensure all debian/* contents is in
a deterministic order (=alphabetic).