### PR TITLE
MCOL-4535: Cleanup workaround as mariadb-10.5/10.6 have updated

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -325,8 +325,6 @@ local Pipeline(branch, platform, event) = {
                "sed -i '/test-embedded/d' debian/mariadb-test.install",
                // Change plugin_maturity level
                // "sed -i 's/BETA/GAMMA/' storage/columnstore/CMakeLists.txt",
-               // Workaround till upstream removes 4535 workaround (workaround for workaround!)
-               "sed -i '/MCOL-4535/,/^$/d' debian/autobake-deb.sh",
                platformMap(branch, platform),
                if (pkg_format == 'rpm') then 'createrepo .' else 'dpkg-scanpackages ../ | gzip > ../Packages.gz',
              ],


### PR DESCRIPTION
Merge this in once https://github.com/MariaDB/server/pull/1802
is on MariaDB 10.5 and 10.6.

Related:
- https://jira.mariadb.org/browse/MDEV-24798
- https://jira.mariadb.org/browse/MCOL-4535