### PR TITLE
Remove global lock from OAMCache

### DIFF
--- a/dbcon/joblist/resourcemanager.cpp
+++ b/dbcon/joblist/resourcemanager.cpp
@@ -365,19 +365,16 @@ void  ResourceManager::hbrPredicate() { }
 bool  ResourceManager::getMysqldInfo(
     std::string& h, std::string& u, std::string& w, unsigned int& p) const
 {
-    h = getStringVal("CrossEngineSupport", "Host", "unassigned");
+    static const std::string hostUserUnassignedValue("unassigned");
+    // MCS will read username and pass from disk if the config changed.
+    bool reReadConfig = true;
+    u = getStringVal("CrossEngineSupport", "User", hostUserUnassignedValue, reReadConfig);
+    w = getStringVal("CrossEngineSupport", "Password", "", reReadConfig);
+    // MCS will not read username and pass from disk if the config changed.
+    h = getStringVal("CrossEngineSupport", "Host", hostUserUnassignedValue);
     p = getUintVal("CrossEngineSupport", "Port", 0);
-    u = getStringVal("CrossEngineSupport", "User", "unassigned");
-    w = getStringVal("CrossEngineSupport", "Password", "");
 
-    bool rc = true;
-
-    if ((h.compare("unassigned") == 0) ||
-            (u.compare("unassigned") == 0) ||
-            (p == 0))
-        rc = false;
-
-    return rc;
+    return h != hostUserUnassignedValue && u != hostUserUnassignedValue && p;
 }
 
 bool ResourceManager::queryStatsEnabled() const

--- a/dbcon/joblist/resourcemanager.h
+++ b/dbcon/joblist/resourcemanager.h
@@ -35,6 +35,7 @@
 #include "calpontselectexecutionplan.h"
 #include "resourcedistributor.h"
 #include "installdir.h"
+#include "branchpred.h"
 
 #include "atomicops.h"
 
@@ -547,7 +548,10 @@ private:
      * @param name the param name whose value is to be returned
      * @param defVal the default value returned if the value is missing
      */
-    std::string getStringVal(const std::string& section, const std::string& name, const std::string& defVal) const;
+    std::string getStringVal(const std::string& section,
+                             const std::string& name,
+                             const std::string& defVal,
+                             const bool reReadConfigIfNeeded = false) const;
 
     template<typename IntType>
     IntType getUintVal(const std::string& section, const std::string& name, IntType defval) const;
@@ -603,13 +607,20 @@ private:
 };
 
 
-inline std::string ResourceManager::getStringVal(const std::string& section, const std::string& name, const std::string& defval) const
+inline std::string ResourceManager::getStringVal(const std::string& section,
+                                                 const std::string& name,
+                                                 const std::string& defval,
+                                                 const bool reReadConfigIfNeeded) const
 {
-    std::string val = fConfig->getConfig(section, name);
+    std::string val = UNLIKELY(reReadConfigIfNeeded)
+                        ? fConfig->getFromActualConfig(section, name)
+                        : fConfig->getConfig(section, name);
 #ifdef DEBUGRM
     std::cout << "RM getStringVal for " << section << " : " << name << " val: " << val << " default: " << defval << std::endl;
 #endif
-    return (0 == val.length() ? defval : val);
+    if (val.empty())
+        val = defval;
+    return val;
 }
 
 template<typename IntType>

--- a/oam/oamcpp/oamcache.cpp
+++ b/oam/oamcpp/oamcache.cpp
@@ -21,10 +21,10 @@
 #include <cassert>
 #include <map>
 #include <set>
+#include <atomic>
 using namespace std;
 
 #include <boost/thread.hpp>
-#include <boost/shared_ptr.hpp>
 using namespace boost;
 
 #define OAMCACHE_DLLEXPORT
@@ -38,19 +38,27 @@ using namespace boost;
 
 namespace
 {
-oam::OamCache* oamCache = 0;
-boost::mutex cacheLock;
+    oam::OamCache* oamCache = nullptr;
+    boost::mutex cacheLock;
 }
 
 namespace oam
 {
+std::atomic_bool hasOAMCache{false};
 
 OamCache* OamCache::makeOamCache()
 {
-    boost::mutex::scoped_lock lk(cacheLock);
+    if (!hasOAMCache.load(std::memory_order_relaxed))
+    {
+        boost::mutex::scoped_lock lk(cacheLock);
 
-    if (oamCache == 0)
-        oamCache = new OamCache();
+        if (oamCache == nullptr)
+        {
+            oamCache = new OamCache();
+            oamCache->checkReload();
+            hasOAMCache.store(true, std::memory_order_relaxed);
+        }
+    }
 
     return oamCache;
 }
@@ -80,7 +88,7 @@ void OamCache::checkReload()
 
     dbRootPMMap.reset(new map<int, int>());
 
-    //cout << "reloading oamcache\n";
+    //cerr << "reloading oamcache\n";
     for (uint32_t i = 0; i < dbroots.size(); i++)
     {
         oam.getDbrootPmConfig(dbroots[i], temp);
@@ -154,64 +162,41 @@ void OamCache::checkReload()
 
 OamCache::dbRootPMMap_t OamCache::getDBRootToPMMap()
 {
-    boost::mutex::scoped_lock lk(cacheLock);
-
-    checkReload();
     return dbRootPMMap;
 }
 
 OamCache::dbRootPMMap_t OamCache::getDBRootToConnectionMap()
 {
-    boost::mutex::scoped_lock lk(cacheLock);
-
-    checkReload();
     return dbRootConnectionMap;
 }
 
 OamCache::PMDbrootsMap_t OamCache::getPMToDbrootsMap()
 {
-    boost::mutex::scoped_lock lk(cacheLock);
-
-    checkReload();
     return pmDbrootsMap;
 }
 
 uint32_t OamCache::getDBRootCount()
 {
-    boost::mutex::scoped_lock lk(cacheLock);
-
-    checkReload();
     return numDBRoots;
 }
 
 DBRootConfigList& OamCache::getDBRootNums()
 {
-    boost::mutex::scoped_lock lk(cacheLock);
-
-    checkReload();
     return dbroots;
 }
 
 std::vector<int>& OamCache::getModuleIds()
 {
-    boost::mutex::scoped_lock lk(cacheLock);
-
-    checkReload();
     return moduleIds;
 }
 
 std::string OamCache::getOAMParentModuleName()
 {
-    boost::mutex::scoped_lock lk(cacheLock);
-
-    checkReload();
     return OAMParentModuleName;
 }
 
 int OamCache::getLocalPMId()
 {
-    boost::mutex::scoped_lock lk(cacheLock);
-
     // This comes from the file /var/lib/columnstore/local/module, not from the xml.
     // Thus, it's not refreshed during checkReload().
     if (mLocalPMId > 0)
@@ -252,16 +237,11 @@ int OamCache::getLocalPMId()
 
 string OamCache::getSystemName()
 {
-    boost::mutex::scoped_lock lk(cacheLock);
-
-    checkReload();
     return systemName;
 }
 
 string OamCache::getModuleName()
 {
-    boost::mutex::scoped_lock lk(cacheLock);
-
     if (!moduleName.empty())
         return moduleName;
 

--- a/utils/configcpp/configcpp.h
+++ b/utils/configcpp/configcpp.h
@@ -87,6 +87,15 @@ public:
     */
     EXPORT const std::string getConfig(const std::string& section, const std::string& name);
 
+    /** @brief get name's value from section
+    *
+    * get name's value from section in the current config file re-reading the
+    * config file if it was updated.
+    * @param section the name of the config file section to search
+    * @param name the param name whose value is to be returned
+    */
+    const std::string getFromActualConfig(const std::string& section, const std::string& name);
+
     /** @brief get all name's values from a section
     *
     * get name's values from section in the current config file.
@@ -104,6 +113,8 @@ public:
     * @param name the param name whose value is to be updated
     * @param value the param value
     */
+    // !!!Don't ever ever use this in the engine code b/c it might result in a race
+    // b/w getConfig and setConfig methods.!!!
     EXPORT void setConfig(const std::string& section, const std::string& name, const std::string& value);
 
     /** @brief delete name from section


### PR DESCRIPTION
Config now uses a single atomic variable to speed up its operations
Config has a special method to re-read a config file if it changed on disk