### PR TITLE
MCOL-4613 Garbage result of a union between huge narrow DECIMAL and BIGINT

### DIFF
--- a/dbcon/joblist/tupleunion.cpp
+++ b/dbcon/joblist/tupleunion.cpp
@@ -1104,7 +1104,7 @@ dec4:					/* have to pick a scale to use for the double. using 5... */
                         if (out->getScale(i) == scale)
                             out->setIntField(val, i);
                         else if (out->getScale(i) > scale)
-                            out->setIntField(IDB_pow[out->getScale(i) - scale]*val, i);
+                            out->setIntField(IDB_pow[out->getScale(i) - scale] * val, i);
                         else // should not happen, the output's scale is the largest
                             throw logic_error("TupleUnion::normalize(): incorrect scale setting");
 

--- a/mysql-test/columnstore/csinternal/devregression/r/mcs7147_regression_bug4388.result
+++ b/mysql-test/columnstore/csinternal/devregression/r/mcs7147_regression_bug4388.result
@@ -1,9 +1,11 @@
 USE tpch1;
-create table if not exists bug4388(
+set default_storage_engine=columnstore;
+drop table if exists bug4388;
+create table bug4388(
 `venta_clave` int(10) DEFAULT NULL,
 `cantidad` decimal(10,3) DEFAULT NULL,
 `changev` decimal(18,4) DEFAULT NULL
-) engine=columnstore;
+);
 insert into bug4388 values (null,null,6.8000);
 select coalesce(sum(changev),0) as col1 from bug4388;
 col1
@@ -38,4 +40,50 @@ select sum(co) from ( select sum(col1) as co from (select sum(changev)
 as col1 from bug4388 ) t ) res;
 sum(co)
 6.8000
+select sum(col1) as co from  ( select 984467440737095516
+as col1 union all select coalesce(sum(changev),0) as col1 from
+bug4388 ) t;
+co
+984467440737095558.8100
+select sum(col1) as co from  ( select 18446744073709551612
+as col1 union all select coalesce(sum(changev),0) as col1 from
+bug4388 ) t;
+co
+18446744073709551622.0000
+#
+# MCOL-4613 Garbage result of a union between huge narrow DECIMAL and BIGINT
+#
+drop table if exists t1;
+drop table if exists t2;
+create table t1 (a decimal(17,1), b bigint);
+insert into t1 values (9999999999999999.9, 999999999999999999);
+select * from (select a from t1 union select b from t1) tu order by a;
+a
+10000000000000000.0
+1000000000000000000.0
+drop table t1;
+create table t1 (a decimal(18,5), b decimal(18,5) unsigned);
+create table t2 (a bigint, b bigint unsigned);
+insert into t1 values
+(-1234567890123.12345, 1234567890123.12345),
+(-1234567890123.1234, 1234567890123.1234),
+(-9999999999999.99999, 9999999999999.99999),
+(-999999999999.99999, 999999999999.99999),
+(-99999999999.99999, 99999999999.99999);
+insert into t2 values
+(-123456789012345, 123456789012345),
+(9223372036854775807, 18446744073709551613),
+(-9223372036854775806, 0);
+select * from (select a,b from t1 union select a,b from t2) tu order by a,b;
+a	b
+-9223372036854775810.00000	0.00000
+-123456789012345.00000	123456789012345.00000
+-10000000000000.00000	10000000000000.00000
+-1234567890123.12354	1234567890123.12354
+-1234567890123.12329	1234567890123.12329
+-1000000000000.00000	1000000000000.00000
+-100000000000.00000	100000000000.00000
+9223372036854775810.00000	18446744073709551600.00000
+drop table t1;
+drop table t2;
 drop table bug4388;

--- a/mysql-test/columnstore/csinternal/devregression/t/mcs7147_regression_bug4388.test
+++ b/mysql-test/columnstore/csinternal/devregression/t/mcs7147_regression_bug4388.test
@@ -8,11 +8,17 @@
 #
 USE tpch1;
 #
-create table if not exists bug4388(
+
+set default_storage_engine=columnstore;
+
+--disable_warnings
+drop table if exists bug4388;
+--enable_warnings
+create table bug4388(
 `venta_clave` int(10) DEFAULT NULL,
   `cantidad` decimal(10,3) DEFAULT NULL,
   `changev` decimal(18,4) DEFAULT NULL
-) engine=columnstore;
+);
 insert into bug4388 values (null,null,6.8000);
 select coalesce(sum(changev),0) as col1 from bug4388;
 select sum(co) + 0 from ( select sum(col1) as co from  ( select 0 
@@ -31,6 +37,45 @@ select sum(col1) from
 select sum(co) from (select sum(changev) as co from bug4388 ) t;
 select sum(co) from ( select sum(col1) as co from (select sum(changev)
 as col1 from bug4388 ) t ) res;
-drop table bug4388;
-#
 
+select sum(col1) as co from  ( select 984467440737095516
+as col1 union all select coalesce(sum(changev),0) as col1 from
+bug4388 ) t;
+
+select sum(col1) as co from  ( select 18446744073709551612
+as col1 union all select coalesce(sum(changev),0) as col1 from
+bug4388 ) t;
+
+--echo #
+--echo # MCOL-4613 Garbage result of a union between huge narrow DECIMAL and BIGINT
+--echo #
+
+--disable_warnings
+drop table if exists t1;
+drop table if exists t2;
+--enable_warnings
+
+# Original test case from the MCOL-4613 issue description
+create table t1 (a decimal(17,1), b bigint);
+insert into t1 values (9999999999999999.9, 999999999999999999);
+select * from (select a from t1 union select b from t1) tu order by a;
+
+# Additional test cases for MCOL-4613
+drop table t1;
+create table t1 (a decimal(18,5), b decimal(18,5) unsigned);
+create table t2 (a bigint, b bigint unsigned);
+insert into t1 values
+(-1234567890123.12345, 1234567890123.12345),
+(-1234567890123.1234, 1234567890123.1234),
+(-9999999999999.99999, 9999999999999.99999),
+(-999999999999.99999, 999999999999.99999),
+(-99999999999.99999, 99999999999.99999);
+insert into t2 values
+(-123456789012345, 123456789012345),
+(9223372036854775807, 18446744073709551613),
+(-9223372036854775806, 0);
+select * from (select a,b from t1 union select a,b from t2) tu order by a,b;
+drop table t1;
+drop table t2;
+
+drop table bug4388;

--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -3333,6 +3333,24 @@ CalpontSystemCatalog::ColType DataConvert::convertUnionColType(vector<CalpontSys
                     case CalpontSystemCatalog::UINT:
                     case CalpontSystemCatalog::UBIGINT:
                     case CalpontSystemCatalog::UDECIMAL:
+                        // If one of the types is a BIGINT/UBIGINT and the other is
+                        // a DECIMAL/UDECIMAL, then set the unionedType to DOUBLE.
+                        if ((((types[i].colDataType == CalpontSystemCatalog::BIGINT ||
+                             types[i].colDataType == CalpontSystemCatalog::UBIGINT)) &&
+                            ((unionedType.colDataType == CalpontSystemCatalog::DECIMAL ||
+                                  unionedType.colDataType == CalpontSystemCatalog::UDECIMAL))) ||
+                           (((types[i].colDataType == CalpontSystemCatalog::DECIMAL ||
+                             types[i].colDataType == CalpontSystemCatalog::UDECIMAL)) &&
+                            ((unionedType.colDataType == CalpontSystemCatalog::BIGINT ||
+                                  unionedType.colDataType == CalpontSystemCatalog::UBIGINT))))
+                        {
+                            unionedType.colDataType = CalpontSystemCatalog::DOUBLE;
+                            unionedType.scale = (types[i].scale > unionedType.scale) ? types[i].scale : unionedType.scale;
+                            unionedType.precision = -1;
+
+                            break;
+                        }
+
                         if (types[i].colWidth > unionedType.colWidth)
                         {
                             unionedType.colDataType = types[i].colDataType;


### PR DESCRIPTION
We earlier set the unioned column type as DECIMAL/UDECIMAL if one
of the column types involved in the UNION operation was a DECIMAL/UDECIMAL.
However this approach does not work if a BIGINT/UBIGINT column is also
involved in the UNION operation, since a BIGINT/UBIGINT value has a wider range
than a DECIMAL(18)/UDECIMAL(18), causing some high positive/negative values
to overflow. In this patch, we instead set the unioned type to a DOUBLE
for the above case. With the new approach, we do lose some precision of very large
BIGINT values, but the BIGINT/UBIGINT values will no longer overflow.
This limitation, however, will be addressed when we add support for DECIMAL(38).