### PR TITLE
Mcol 4673 regression cal show partition returns na

### DIFF
--- a/dbcon/dmlpackageproc/commandpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/commandpackageprocessor.cpp
@@ -430,14 +430,7 @@ CommandPackageProcessor::processPackage(dmlpackage::CalpontDMLPackage& cpackage)
 
                 if (!cpInvalidated)
                 {
-		    // The code below assumes that in case of COMMIT all ranges for all touched LBIDs
-		    // are either correctly set or correctly reset.
-		    // It is also assumes that ROLLBACK or other operations but COMMIT may not return ranges
-		    // to state that is correct. This is why we invalidate extents when we are not committing.
-		    if (stmt != "COMMIT")
-		    {
-                        fDbrm->invalidateUncommittedExtentLBIDs(0, &lbidList);
-		    }
+                    fDbrm->invalidateUncommittedExtentLBIDs(0, &lbidList);
                 }
             }
         }

--- a/mysql-test/columnstore/basic/r/udf_calshowpartitions.result
+++ b/mysql-test/columnstore/basic/r/udf_calshowpartitions.result
@@ -1,7 +1,6 @@
 #
 # MCOL-4614 calShowPartitions() precision loss for huge narrow decimal
 #
-CREATE FUNCTION calshowpartitions RETURNS STRING SONAME "ha_columnstore.so";
 CREATE TABLE t1 (a DECIMAL(17,1)) ENGINE=ColumnStore;
 INSERT INTO t1 VALUES (-8999999999999999.9);
 SELECT * FROM t1 WHERE a=0;
@@ -11,4 +10,3 @@ calshowpartitions('t1','a')
 Part#     Min                           Max                           Status
   0.0.1     -8999999999999999.9           -8999999999999999.9           Enabled
 DROP TABLE IF EXISTS t1;
-DROP FUNCTION calshowpartitions;

--- a/mysql-test/columnstore/basic/t/udf_calshowpartitions.test
+++ b/mysql-test/columnstore/basic/t/udf_calshowpartitions.test
@@ -1,11 +1,16 @@
---source include/testdb_only.inc
 --source ../include/have_columnstore.inc
 
 --echo #
 --echo # MCOL-4614 calShowPartitions() precision loss for huge narrow decimal
 --echo #
 
-CREATE FUNCTION calshowpartitions RETURNS STRING SONAME "ha_columnstore.so";
+let $func_exists=`SELECT COUNT(*) FROM mysql.func WHERE name='calshowpartitions'`;
+--disable_query_log
+if (!$func_exists)
+{
+  CREATE FUNCTION calshowpartitions RETURNS STRING SONAME "ha_columnstore.so";
+}
+--enable_query_log
 
 CREATE TABLE t1 (a DECIMAL(17,1)) ENGINE=ColumnStore;
 INSERT INTO t1 VALUES (-8999999999999999.9);
@@ -13,4 +18,9 @@ SELECT * FROM t1 WHERE a=0;
 SELECT calshowpartitions('t1','a');
 DROP TABLE IF EXISTS t1;
 
-DROP FUNCTION calshowpartitions;
+--disable_query_log
+if (!$func_exists)
+{
+  DROP FUNCTION calshowpartitions;
+}
+--enable_query_log

--- a/versioning/BRM/brmtypes.h
+++ b/versioning/BRM/brmtypes.h
@@ -146,8 +146,9 @@ typedef struct _SIDTIDEntry SIDTIDEntry;
 // for multiple extents.
 
 // Special seqNum field values.
-#define SEQNUM_MARK_INVALID (-1)
-#define SEQNUM_MARK_INVALID_SET_RANGE (-2)
+#define SEQNUM_MARK_INVALID                    (-1)
+#define SEQNUM_MARK_INVALID_SET_RANGE          (-2)
+#define SEQNUM_MARK_UPDATING_INVALID_SET_RANGE (-3)
 
 // Used in vectors.
 struct CPInfo

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -4594,7 +4594,7 @@ void DBRM::invalidateUncommittedExtentLBIDs(execplan::CalpontSystemCatalog::SCN 
             aInfo.isBinaryColumn = false;
         }
 
-        aInfo.seqNum = SEQNUM_MARK_INVALID_SET_RANGE;
+        aInfo.seqNum = SEQNUM_MARK_UPDATING_INVALID_SET_RANGE;
         cpInfos.push_back(aInfo);
     }
 


### PR DESCRIPTION
The tricky part here is to 1) keep dropped ranged dropped and 2) keep set ranges set. The first part should be compatible with cpimport which utilizes dropping ranges to CP_UPDATING state and then to CP_VALID/CP_INVALID.

This is why we keep CP_UPDATING state notwithstanding that CP_INVALID is pretty sufficient for all purposes.