### PR TITLE
[MCOL-563] Fix disk aggregation bug

### DIFF
--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -5205,7 +5205,8 @@ void TupleAggregateStep::threadedAggregateFinalize(uint32_t threadID)
     {
       try
       {
-        fAggregators[i]->finalAggregation();
+        if (fAggregators[i])
+          fAggregators[i]->finalAggregation();
       }
       catch (...)
       {
@@ -5606,6 +5607,7 @@ uint64_t TupleAggregateStep::doThreadedAggregate(ByteStream& bs, RowGroupDL* dlp
             jobstepThreadPool.join(runners);
         }
 
+        if (!cancelled())
         {
             vector<uint64_t> runners;
             // use half of the threads because finalizing requires twice as

--- a/utils/rowgroup/rowstorage.cpp
+++ b/utils/rowgroup/rowstorage.cpp
@@ -1262,7 +1262,12 @@ private:
     fPosHashes.reserve(groups);
     for (size_t i = 0; i < groups; ++i)
     {
-      fMM->acquire(fMaxRows * sizeof(RowPosHash));
+      if (!fMM->acquire(fMaxRows * sizeof(RowPosHash)))
+      {
+        throw logging::IDBExcept(logging::IDBErrorInfo::instance()->errorMsg(
+            logging::ERR_AGGREGATION_TOO_BIG),
+                                 logging::ERR_AGGREGATION_TOO_BIG);
+      }
       auto *ptr = new RowPosHash[fMaxRows];
       memset(ptr, 0, fMaxRows * sizeof(RowPosHash));
       fPosHashes.push_back(ptr);
@@ -1751,7 +1756,12 @@ void RowAggStorage::initData(size_t elems)
   const auto bytes = calcBytes(sizeWithBuffer);
 
   fHashes = fHashes->clone(elems, fGeneration);
-  fMM->acquire(bytes);
+  if (!fMM->acquire(bytes))
+  {
+    throw logging::IDBExcept(logging::IDBErrorInfo::instance()->errorMsg(
+                                 logging::ERR_AGGREGATION_TOO_BIG),
+                             logging::ERR_AGGREGATION_TOO_BIG);
+  }
   fInfo = reinterpret_cast<uint8_t*>(calloc(1, bytes));
   fInfo[sizeWithBuffer] = 1;
   fInfoInc = INIT_INFO_INC;


### PR DESCRIPTION
In the case of a memory shortage, the occurrence of the IDB-2003 error
took a long time when disk aggregation is disabled.