### PR TITLE
MCOL-4643 dev 5 reset valOut after processing UDAF

### DIFF
--- a/utils/rowgroup/rowaggregation.cpp
+++ b/utils/rowgroup/rowaggregation.cpp
@@ -2747,6 +2747,8 @@ void RowAggregationUM::SetUDAFValue(static_any::any& valOut, int64_t colOut)
     {
         SetUDAFAnyValue(valOut, colOut);
     }
+    // reset valOut to be ready for the next value
+    valOut.reset();
 }
 
 void RowAggregationUM::SetUDAFAnyValue(static_any::any& valOut, int64_t colOut)


### PR DESCRIPTION
After a UDAF result has been inserted in the output stream, the valOut object needs to be reset to empty in preparation for the next value. Failing to do so may cause what should be a NULL value to erroneously take the last value inserted.