### PR TITLE
MCOL-4643 reset valOut after processing UDAF

### DIFF
--- a/utils/rowgroup/rowaggregation.cpp
+++ b/utils/rowgroup/rowaggregation.cpp
@@ -3029,6 +3029,8 @@ void RowAggregationUM::SetUDAFValue(static_any::any& valOut, int64_t colOut)
         // This handles the mismatch
         SetUDAFAnyValue(valOut, colOut);
     }
+    // reset valOut to be ready for the next value
+    valOut.reset();
 }
 
 void RowAggregationUM::SetUDAFAnyValue(static_any::any& valOut, int64_t colOut)
@@ -3298,7 +3300,6 @@ void RowAggregationUM::calculateUDAFColumns()
 
             // Set the returned value into the output row
             SetUDAFValue(valOut, colOut);
-            valOut.reset();
         }
 
         fRGContext.setUserData(NULL);


### PR DESCRIPTION
After a UDAF result has been inserted in the output stream, the valOut object needs to be reset to empty in preparation for the next value. Failing to do so may cause what should be a NULL value to erroneously take the last value inserted.
This change moves the reset to a more central location so it gets reset regardless of what function set the value.