### PR TITLE
MCOL-4680 FROM subquery containing nested joins returns an error.

### DIFF
--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -373,7 +373,7 @@ bool buildRowColumnFilter(gp_walk_info* gwip, execplan::RowColumn* rhs, execplan
 bool buildPredicateItem(Item_func* ifp, gp_walk_info* gwip);
 void collectAllCols(gp_walk_info& gwi, Item_field* ifp);
 void buildSubselectFunc(Item_func* ifp, gp_walk_info* gwip);
-uint32_t buildOuterJoin(gp_walk_info& gwi, SELECT_LEX& select_lex);
+uint32_t buildJoin(gp_walk_info& gwi, List<TABLE_LIST>& join_list, std::stack<execplan::ParseTree*>& outerJoinStack);
 std::string getViewName(TABLE_LIST* table_ptr);
 bool buildConstPredicate(Item_func* ifp, execplan::ReturnedColumn* rhs, gp_walk_info* gwip);
 execplan::CalpontSystemCatalog::ColType fieldType_MysqlToIDB (const Field* field);

--- a/dbcon/mysql/ha_view.cpp
+++ b/dbcon/mysql/ha_view.cpp
@@ -44,7 +44,8 @@ using namespace execplan;
 
 namespace cal_impl_if
 {
-extern uint32_t buildOuterJoin(gp_walk_info& gwi, SELECT_LEX& select_lex);
+extern uint32_t buildJoin(gp_walk_info& gwi, List<TABLE_LIST>& join_list,
+    std::stack<execplan::ParseTree*>& outerJoinStack);
 extern string getViewName(TABLE_LIST* table_ptr);
 
 CalpontSystemCatalog::TableAliasName& View::viewName()
@@ -182,9 +183,9 @@ void View::transform()
     }
 }
 
-uint32_t View::processOuterJoin(gp_walk_info& gwi)
+uint32_t View::processJoin(gp_walk_info& gwi, std::stack<execplan::ParseTree*>& outerJoinStack)
 {
-    return buildOuterJoin(gwi, fSelect);
+    return buildJoin(gwi, fSelect.top_join_list, outerJoinStack);
 }
 
 }

--- a/dbcon/mysql/ha_view.h
+++ b/dbcon/mysql/ha_view.h
@@ -53,7 +53,7 @@ public:
         parent select.
      */
     void transform();
-    uint32_t processOuterJoin(gp_walk_info& gwi);
+    uint32_t processJoin(gp_walk_info& gwi, std::stack<execplan::ParseTree*>&);
 
 private:
     SELECT_LEX fSelect;

--- a/mysql-test/columnstore/basic/r/mcol_4680.result
+++ b/mysql-test/columnstore/basic/r/mcol_4680.result
@@ -1,0 +1,29 @@
+#
+# FROM subquery containing nested joins returns an error
+#
+DROP DATABASE IF EXISTS mcol4680;
+CREATE DATABASE mcol4680;
+USE mcol4680;
+create table t1 (a int);
+insert into t1 values (1), (2), (3);
+create table t2 (a int);
+insert into t2 values (2);
+create table t3 (a int);
+create table t4 (a int);
+create table t5 (a int);
+select * from
+(
+select t1.a as col1, t2.a as col2 from
+t1 left join
+(
+(t2 left join t3 on t2.a=t3.a) left join
+(t4 left join t5 on t4.a=t5.a)
+on t2.a=t4.a
+)
+on t1.a=t2.a
+) h order by col1;
+col1	col2
+1	NULL
+2	2
+3	NULL
+DROP DATABASE mcol4680;

--- a/mysql-test/columnstore/basic/t/mcol_4680.test
+++ b/mysql-test/columnstore/basic/t/mcol_4680.test
@@ -1,0 +1,41 @@
+--source ../include/have_columnstore.inc
+--source ctype_cmp_combinations.inc
+--source default_storage_engine_by_combination.inc
+
+
+--echo #
+--echo # FROM subquery containing nested joins returns an error
+--echo #
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol4680;
+--enable_warnings
+
+CREATE DATABASE mcol4680;
+USE mcol4680;
+
+create table t1 (a int);
+insert into t1 values (1), (2), (3);
+
+create table t2 (a int);
+insert into t2 values (2);
+
+create table t3 (a int);
+
+create table t4 (a int);
+
+create table t5 (a int);
+
+select * from
+(
+  select t1.a as col1, t2.a as col2 from
+   t1 left join
+   (
+    (t2 left join t3 on t2.a=t3.a) left join
+    (t4 left join t5 on t4.a=t5.a)
+    on t2.a=t4.a
+   )
+   on t1.a=t2.a
+) h order by col1;
+
+DROP DATABASE mcol4680;


### PR DESCRIPTION
Main theme of the patch is to fix joins processing in the plugin
code. We now use SELECT_LEX::top_join_list and process the nested
joins recursively, instead of SELECT_LEX::table_list struct which
we earlier used to build the join filters. The earlier approach
did not process certain nested join ON expressions, causing certain
queries to incorrectly error out such as that described in MCOL-4680.

In addition, some legacy code is also removed.