### PR TITLE
MCOL-4626: Check memory > 3G before starting PrimProc.

### DIFF
--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -403,7 +403,6 @@ int ServicePrimProc::Child()
 
     if (err < 0)
     {
-        Oam oam;
         mlp->logMessage(errMsg);
         cerr << errMsg << endl;
 
@@ -439,6 +438,16 @@ int ServicePrimProc::Child()
     int configNumCores = -1;
     uint32_t highPriorityPercentage, medPriorityPercentage, lowPriorityPercentage;
     utils::CGroupConfigurator cg;
+
+    if (cg.getTotalMemory() < 3221225472)
+    {
+        string errMsg = "Error total memory available is less than 3GB.";
+        mlp->logMessage(errMsg);
+        cerr << errMsg << endl;
+
+        NotifyServiceInitializationFailed();
+        return 2;
+    }
 
     gDebugLevel = primitiveprocessor::NONE;
 

--- a/utils/common/cgroupconfigurator.cpp
+++ b/utils/common/cgroupconfigurator.cpp
@@ -73,10 +73,14 @@ CGroupConfigurator::CGroupConfigurator()
     config = config::Config::makeConfig();
 
     cGroupName = config->getConfig("SystemConfig", "CGroup");
+    string containerMode = config->getConfig("SystemConfig", "ContainerMode");
 
     if (cGroupName.empty())
         cGroupDefined = false;
     else
+        cGroupDefined = true;
+
+    if ((containerMode == "y") || (containerMode == "Y"))
         cGroupDefined = true;
 
     totalMemory = 0;
@@ -91,7 +95,7 @@ CGroupConfigurator::~CGroupConfigurator()
 uint32_t CGroupConfigurator::getNumCoresFromCGroup()
 {
     ostringstream filename_os;
-    filename_os << "/sys/fs/cgroup/cpuset/" << cGroupName << "/cpus";
+    filename_os << "/sys/fs/cgroup/cpuset/" << cGroupName << "/cpuset.cpus";
     string filename = filename_os.str();
 
     ifstream in(filename.c_str());


### PR DESCRIPTION
Fix how memory is checked for docker containers.