### PR TITLE
ci: mtr platforms list

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -13,6 +13,8 @@ local any_branch = '**';
 local platforms_custom = ['opensuse/leap:15', 'centos:7', 'centos:8', 'debian:9', 'debian:10', 'ubuntu:18.04', 'ubuntu:20.04'];
 local platforms_arm_custom = ['centos:8'];
 
+local platforms_mtr = ['centos:7', 'centos:8', 'ubuntu:20.04'];
+
 local server_ref_map = {
   develop: '10.6',
   'develop-5': '10.5',
@@ -373,8 +375,8 @@ local Pipeline(branch, platform, event, arch='amd64') = {
          // (if (platform == 'centos:8' && event == 'cron') then [pipeline.dockerfile] + [pipeline.docker] + [pipeline.ecr] else []) +
          [pipeline.smoke] +
          [pipeline.smokelog] +
-         (if (pkg_format == 'rpm') then [pipeline.mtr] + [pipeline.mtrlog] + [pipeline.publish('mtr')] else []) +
-         (if (event == 'cron' && pkg_format == 'rpm') || (event == 'push') then [pipeline.publish('mtr latest', 'latest')] else []) +
+         (if (std.member(platforms_mtr, platform)) then [pipeline.mtr] + [pipeline.mtrlog] + [pipeline.publish('mtr')] else []) +
+         (if (event == 'cron' && std.member(platforms_mtr, platform)) || (event == 'push') then [pipeline.publish('mtr latest', 'latest')] else []) +
          [pipeline.regression] +
          [pipeline.regressionlog] +
          [pipeline.publish('regression')] +


### PR DESCRIPTION
This PR changes mtr runs on CI.

- removed opensuse mtr run
- added ubuntu:20.04 mtr run

If you want to add or remove mtr on some platforms feel free to change `platforms_mtr` variable in `.drone.jsonnet` file.
