### PR TITLE
MCOL-4652 Fixes for wide-decimal support in bulk insert operations

### DIFF
--- a/mysql-test/columnstore/basic/r/mcol4652-cpimport-sets-wide-decimals-ranges.result
+++ b/mysql-test/columnstore/basic/r/mcol4652-cpimport-sets-wide-decimals-ranges.result
@@ -1,0 +1,18 @@
+DROP DATABASE IF EXISTS mcol4652;
+CREATE DATABASE mcol4652;
+USE mcol4652;
+create table customer (
+c_custkey decimal(38),
+c_name varchar (25),
+c_address varchar (40),
+c_nationkey int,
+c_phone char (15),
+c_acctbal decimal(12,2),
+c_mktsegment char (10),
+c_comment varchar (117)
+) engine=columnstore;
+LOAD DATA LOCAL infile 'MTR_SUITE_DIR/../std_data/100Krows.dat' INTO TABLE customer FIELDS TERMINATED BY '|';
+SELECT e.min_value, e.max_value FROM information_schema.columnstore_extents e, information_schema.columnstore_columns c where e.object_id = c.object_id and column_name = 'c_custkey';
+min_value	max_value
+0	32767
+DROP DATABASE mcol4652;

--- a/mysql-test/columnstore/basic/t/mcol4652-cpimport-sets-wide-decimals-ranges.test
+++ b/mysql-test/columnstore/basic/t/mcol4652-cpimport-sets-wide-decimals-ranges.test
@@ -1,0 +1,26 @@
+-- source ../include/have_columnstore.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol4652;
+--enable_warnings
+
+CREATE DATABASE mcol4652;
+USE mcol4652;
+
+create table customer (
+        c_custkey decimal(38),
+        c_name varchar (25),
+        c_address varchar (40),
+        c_nationkey int,
+        c_phone char (15),
+        c_acctbal decimal(12,2),
+        c_mktsegment char (10),
+        c_comment varchar (117)
+) engine=columnstore;
+
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+--disable_warnings
+--eval LOAD DATA LOCAL infile '$MTR_SUITE_DIR/../std_data/100Krows.dat' INTO TABLE customer FIELDS TERMINATED BY '|'
+--enable_warnings
+SELECT e.min_value, e.max_value FROM information_schema.columnstore_extents e, information_schema.columnstore_columns c where e.object_id = c.object_id and column_name = 'c_custkey';
+DROP DATABASE mcol4652;

--- a/writeengine/bulk/we_brmreporter.cpp
+++ b/writeengine/bulk/we_brmreporter.cpp
@@ -310,11 +310,11 @@ void BRMReporter::sendCPToFile( )
             if (!datatypes::isWideDecimalType(fCPInfo[i].type, fCPInfo[i].colWidth))
             {
                 fRptFile << "CP: " << fCPInfo[i].startLbid << ' ' <<
-                         fCPInfo[i].max       << ' ' <<
-                         fCPInfo[i].min       << ' ' <<
                          fCPInfo[i].seqNum    << ' ' <<
                          fCPInfo[i].type      << ' ' <<
                          fCPInfo[i].colWidth  << ' ' <<
+                         fCPInfo[i].max       << ' ' <<
+                         fCPInfo[i].min       << ' ' <<
                          fCPInfo[i].newExtent << std::endl;
             }
             else
@@ -323,10 +323,11 @@ void BRMReporter::sendCPToFile( )
                 datatypes::TSInt128 bigMax(&fCPInfo[i].bigMax);
         
                 fRptFile << "CP: " << fCPInfo[i].startLbid << ' ' <<
-                         bigMax               << ' ' <<
-                         bigMin               << ' ' <<
                          fCPInfo[i].seqNum    << ' ' <<
                          fCPInfo[i].type      << ' ' <<
+                         fCPInfo[i].colWidth  << ' ' <<
+                         bigMax               << ' ' <<
+                         bigMin               << ' ' <<
                          fCPInfo[i].newExtent << std::endl;
             }
         }
@@ -413,7 +414,7 @@ int BRMReporter::openRptFile( )
         return rc;
     }
 
-    fRptFile << "#CP:   startLBID max min seqnum type colwidth newExtent"    << std::endl;
+    fRptFile << "#CP:   startLBID seqnum type colwidth max min newExtent"    << std::endl;
     fRptFile << "#HWM:  oid partition segment hwm"                           << std::endl;
     fRptFile << "#ROWS: numRowsRead numRowsInserted"                         << std::endl;
     fRptFile << "#DATA: columNum columnType columnOid numOutOfRangeValues"   << std::endl;

--- a/writeengine/splitter/we_brmupdater.cpp
+++ b/writeengine/splitter/we_brmupdater.cpp
@@ -314,26 +314,6 @@ bool WEBrmUpdater::prepareCasualPartitionInfo()
             pTok = strtok(NULL, " ");
 
             if (pTok)
-                cpInfoMerge.max = boost::lexical_cast<int64_t>(pTok);
-            else
-            {
-                //cout << "CP Entry : " << aEntry << endl;
-                throw (runtime_error("Bad MAX in CP entry string"));
-            }
-
-            pTok = strtok(NULL, " ");
-
-            if (pTok)
-                cpInfoMerge.min = boost::lexical_cast<int64_t>(pTok);
-            else
-            {
-                //cout << "CP Entry : " << aEntry << endl;
-                throw (runtime_error("Bad MIN in CP entry string"));
-            }
-
-            pTok = strtok(NULL, " ");
-
-            if (pTok)
                 cpInfoMerge.seqNum = atoi(pTok);
             else
             {
@@ -360,6 +340,57 @@ bool WEBrmUpdater::prepareCasualPartitionInfo()
                 //cout << "CP Entry : " << aEntry << endl;
                 throw (runtime_error("Bad column width in CP entry string"));
             }
+
+            if (datatypes::isWideDecimalType(cpInfoMerge.type, cpInfoMerge.colWidth))
+            {
+                datatypes::SystemCatalog::TypeAttributesStd tyAttr(cpInfoMerge.colWidth,
+                                                                   0,
+                                                                   datatypes::INT128MAXPRECISION);
+
+                pTok = strtok(NULL, " ");
+
+                if (pTok)
+                    cpInfoMerge.bigMax = tyAttr.decimal128FromString(std::string(pTok), NULL);
+                else
+                {
+                    //cout << "CP Entry : " << aEntry << endl;
+                    throw (runtime_error("Bad MAX in CP entry string"));
+                }
+
+                pTok = strtok(NULL, " ");
+
+                if (pTok)
+                    cpInfoMerge.bigMin = tyAttr.decimal128FromString(std::string(pTok), NULL);
+                else
+                {
+                    //cout << "CP Entry : " << aEntry << endl;
+                    throw (runtime_error("Bad MIN in CP entry string"));
+                }
+            }
+            else
+            {
+
+                pTok = strtok(NULL, " ");
+
+                if (pTok)
+                    cpInfoMerge.max = boost::lexical_cast<int64_t>(pTok);
+                else
+                {
+                    //cout << "CP Entry : " << aEntry << endl;
+                    throw (runtime_error("Bad MAX in CP entry string"));
+                }
+
+                pTok = strtok(NULL, " ");
+
+                if (pTok)
+                    cpInfoMerge.min = boost::lexical_cast<int64_t>(pTok);
+                else
+                {
+                    //cout << "CP Entry : " << aEntry << endl;
+                    throw (runtime_error("Bad MIN in CP entry string"));
+                }
+            }
+
             pTok = strtok(NULL, " ");
 
             if (pTok)


### PR DESCRIPTION
Previously cpimport didn't send wide min/max-es talking to BRM