### PR TITLE
Part#3 : MCOL-4678 MTR tests fail because of /tmp and ./ with LOAD DATA

### DIFF
--- a/mysql-test/columnstore/basic/r/mcs28_load_data_local_infile.result
+++ b/mysql-test/columnstore/basic/r/mcs28_load_data_local_infile.result
@@ -2,7 +2,7 @@ DROP DATABASE IF EXISTS mcs28_db1;
 CREATE DATABASE mcs28_db1;
 USE mcs28_db1;
 CREATE TABLE t1 (a DATE, b DATE, c DATE not null, d DATE) ENGINE=Columnstore;
-LOAD DATA LOCAL infile './suite/columnstore/std_data/loaddata1.dat' IGNORE INTO TABLE t1 FIELDS TERMINATED BY ',';;
+LOAD DATA LOCAL infile 'MTR_SUITE_DIR/../std_data/loaddata1.dat' IGNORE INTO TABLE t1 FIELDS TERMINATED BY ',';;
 Warnings:
 Warning	1265	Data truncated for column 'a' at row 1
 Warning	1265	Data truncated for column 'c' at row 1
@@ -10,7 +10,7 @@ Warning	1265	Data truncated for column 'd' at row 1
 Warning	1265	Data truncated for column 'a' at row 2
 Warning	1265	Data truncated for column 'b' at row 2
 Warning	1265	Data truncated for column 'd' at row 2
-LOAD DATA LOCAL infile './suite/columnstore/std_data/loaddata1.dat' INTO TABLE t1 FIELDS TERMINATED BY ',' IGNORE 2 LINES;;
+LOAD DATA LOCAL infile 'MTR_SUITE_DIR/../std_data/loaddata1.dat' INTO TABLE t1 FIELDS TERMINATED BY ',' IGNORE 2 LINES;;
 SELECT * FROM t1;
 a	b	c	d
 0000-00-00	NULL	0000-00-00	0000-00-00
@@ -18,7 +18,7 @@ a	b	c	d
 2003-03-03	2003-03-03	2003-03-03	NULL
 2003-03-03	2003-03-03	2003-03-03	NULL
 TRUNCATE TABLE t1;
-LOAD DATA LOCAL infile './suite/columnstore/std_data/loaddata1.dat' IGNORE INTO TABLE t1 FIELDS TERMINATED BY ',' LINES STARTING BY ',' (b,c,d);;
+LOAD DATA LOCAL infile 'MTR_SUITE_DIR/../std_data/loaddata1.dat' IGNORE INTO TABLE t1 FIELDS TERMINATED BY ',' LINES STARTING BY ',' (b,c,d);;
 Warnings:
 Warning	1265	Data truncated for column 'c' at row 1
 Warning	1265	Data truncated for column 'd' at row 1
@@ -31,7 +31,7 @@ NULL	0000-00-00	0000-00-00	0000-00-00
 NULL	2003-03-03	2003-03-03	NULL
 DROP TABLE t1;
 CREATE TABLE t1 (a TEXT, b TEXT) ENGINE=Columnstore;
-LOAD DATA LOCAL infile './suite/columnstore/std_data/loaddata2.dat' IGNORE INTO TABLE t1 FIELDS TERMINATED BY ',' ENCLOSED BY '''';;
+LOAD DATA LOCAL infile 'MTR_SUITE_DIR/../std_data/loaddata2.dat' IGNORE INTO TABLE t1 FIELDS TERMINATED BY ',' ENCLOSED BY '''';;
 Warnings:
 Warning	1261	Row 3 doesn't contain data for all columns
 SELECT CONCAT('|',a,'|'), CONCAT('|',b,'|') FROM t1;
@@ -43,7 +43,7 @@ Field 3,'Field 4|
 |Field 6|	| 'Field 7'|
 DROP TABLE t1;
 CREATE TABLE t1 (a INT, b CHAR(10)) ENGINE=Columnstore;
-LOAD DATA LOCAL infile './suite/columnstore/std_data/loaddata3.dat' IGNORE INTO TABLE t1 FIELDS TERMINATED BY '' ENCLOSED BY '' IGNORE 1 LINES;;
+LOAD DATA LOCAL infile 'MTR_SUITE_DIR/../std_data/loaddata3.dat' IGNORE INTO TABLE t1 FIELDS TERMINATED BY '' ENCLOSED BY '' IGNORE 1 LINES;;
 Warnings:
 Note	1265	Data truncated for column 'a' at row 1
 Note	1265	Data truncated for column 'a' at row 2
@@ -60,7 +60,7 @@ a	b
 3	row 3
 0	1234567890
 TRUNCATE TABLE t1;
-LOAD DATA LOCAL infile './suite/columnstore/std_data/loaddata4.dat' IGNORE INTO TABLE t1 FIELDS TERMINATED BY '' ENCLOSED BY '' LINES TERMINATED BY '' IGNORE 1 LINES;;
+LOAD DATA LOCAL infile 'MTR_SUITE_DIR/../std_data/loaddata4.dat' IGNORE INTO TABLE t1 FIELDS TERMINATED BY '' ENCLOSED BY '' LINES TERMINATED BY '' IGNORE 1 LINES;;
 Warnings:
 Note	1265	Data truncated for column 'a' at row 1
 Note	1265	Data truncated for column 'a' at row 2

--- a/mysql-test/columnstore/basic/r/mcs51_cpimport_select_from.result
+++ b/mysql-test/columnstore/basic/r/mcs51_cpimport_select_from.result
@@ -7,6 +7,9 @@ CREATE TABLE mcs51_db1.t_myisam (col1 INT, col2 INT, col3 CHAR(8)) ENGINE=MyISAM
 CREATE TABLE mcs51_db2.t_mcs (col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnstore;
 LOAD DATA LOCAL infile 'MTR_SUITE_DIR/../std_data/100Krows.dat' INTO TABLE mcs51_db1.t_innodb FIELDS TERMINATED BY '|';;
 LOAD DATA LOCAL infile 'MTR_SUITE_DIR/../std_data/100Krows.dat' INTO TABLE mcs51_db1.t_myisam FIELDS TERMINATED BY '|';;
+SELECT COUNT(*) FROM mcs51_db1.t_innodb;
+COUNT(*)
+100001
 SELECT * FROM mcs51_db2.t_mcs ORDER BY col1;
 col1	col2	col3
 0	10332	PhqDBpPa
@@ -100014,6 +100017,9 @@ SELECT COUNT(*) FROM mcs51_db2.t_mcs;
 COUNT(*)
 100001
 TRUNCATE mcs51_db2.t_mcs;
+SELECT COUNT(*) FROM mcs51_db1.t_myisam;
+COUNT(*)
+100001
 SELECT * FROM mcs51_db2.t_mcs ORDER BY col1;
 col1	col2	col3
 0	10332	PhqDBpPa

--- a/mysql-test/columnstore/basic/r/mcs67_ldi_datafile_separators.result
+++ b/mysql-test/columnstore/basic/r/mcs67_ldi_datafile_separators.result
@@ -2,7 +2,7 @@ DROP DATABASE IF EXISTS mcs67_db;
 CREATE DATABASE mcs67_db;
 USE mcs67_db;
 CREATE TABLE t1(col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnstore;
-LOAD DATA LOCAL infile './suite/columnstore/std_data/100Krows.dat' INTO TABLE t1 FIELDS TERMINATED BY '|';
+LOAD DATA LOCAL infile 'MTR_SUITE_DIR/../std_data/100Krows.dat' INTO TABLE t1 FIELDS TERMINATED BY '|';;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 100001

--- a/mysql-test/columnstore/basic/suite.pm
+++ b/mysql-test/columnstore/basic/suite.pm
@@ -8,10 +8,12 @@ my $mcs_ins_dir_installed=$::bindir . '/bin';
 if (-d $mcs_bin_dir_compiled)
 {
   $ENV{MCS_MCSSETCONFIG}=$mcs_bin_dir_compiled . "/mcsSetConfig";
+  $ENV{MCS_CPIMPORT}=$mcs_bin_dir_compiled . "/cpimport";
 }
 elsif (-d $mcs_ins_dir_installed)
 {
   $ENV{MCS_MCSSETCONFIG}=$mcs_ins_dir_installed . "/mcsSetConfig";
+  $ENV{MCS_CPIMPORT}=$mcs_ins_dir_installed . "/cpimport";
 }
 
 sub is_default { 0 }

--- a/mysql-test/columnstore/basic/t/mcs28_load_data_local_infile.test
+++ b/mysql-test/columnstore/basic/t/mcs28_load_data_local_infile.test
@@ -11,30 +11,36 @@ DROP DATABASE IF EXISTS mcs28_db1;
 CREATE DATABASE mcs28_db1;
 USE mcs28_db1;
 
---let $datafile=./suite/columnstore/std_data/loaddata1.dat
+--let $datafile=$MTR_SUITE_DIR/../std_data/loaddata1.dat
 CREATE TABLE t1 (a DATE, b DATE, c DATE not null, d DATE) ENGINE=Columnstore;
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
 --eval LOAD DATA LOCAL infile '$datafile' IGNORE INTO TABLE t1 FIELDS TERMINATED BY ',';
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
 --eval LOAD DATA LOCAL infile '$datafile' INTO TABLE t1 FIELDS TERMINATED BY ',' IGNORE 2 LINES;
 SELECT * FROM t1;
 TRUNCATE TABLE t1;
 
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
 --eval LOAD DATA LOCAL infile '$datafile' IGNORE INTO TABLE t1 FIELDS TERMINATED BY ',' LINES STARTING BY ',' (b,c,d);
 SELECT * FROM t1;
 DROP TABLE t1;
 
---let $datafile=./suite/columnstore/std_data/loaddata2.dat
+--let $datafile=$MTR_SUITE_DIR/../std_data/loaddata2.dat
 CREATE TABLE t1 (a TEXT, b TEXT) ENGINE=Columnstore;
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
 --eval LOAD DATA LOCAL infile '$datafile' IGNORE INTO TABLE t1 FIELDS TERMINATED BY ',' ENCLOSED BY '''';
 SELECT CONCAT('|',a,'|'), CONCAT('|',b,'|') FROM t1;
 DROP TABLE t1;
 
---let $datafile=./suite/columnstore/std_data/loaddata3.dat
+--let $datafile=$MTR_SUITE_DIR/../std_data/loaddata3.dat
 CREATE TABLE t1 (a INT, b CHAR(10)) ENGINE=Columnstore;
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
 --eval LOAD DATA LOCAL infile '$datafile' IGNORE INTO TABLE t1 FIELDS TERMINATED BY '' ENCLOSED BY '' IGNORE 1 LINES;
 SELECT * FROM t1;
 TRUNCATE TABLE t1;
 
---let $datafile=./suite/columnstore/std_data/loaddata4.dat
+--let $datafile=$MTR_SUITE_DIR/../std_data/loaddata4.dat
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
 --eval LOAD DATA LOCAL infile '$datafile' IGNORE INTO TABLE t1 FIELDS TERMINATED BY '' ENCLOSED BY '' LINES TERMINATED BY '' IGNORE 1 LINES;
 # The empty line last comes from the end line field in the file
 SELECT * FROM t1;

--- a/mysql-test/columnstore/basic/t/mcs47_cpimport_central_loc_sin_source.test
+++ b/mysql-test/columnstore/basic/t/mcs47_cpimport_central_loc_sin_source.test
@@ -21,7 +21,7 @@ CREATE TABLE t1(col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnstore;
 #Bulk Load from a central location with single data source file
 #cpimport -m1
 --disable_result_log #cpimport logs thread/timestamps
---exec cpimport -m1 mcs47_db t1 '$MTR_SUITE_DIR/../std_data/100Krows.dat';
+--exec $MCS_CPIMPORT -m1 mcs47_db t1 '$MTR_SUITE_DIR/../std_data/100Krows.dat';
 --enable_result_log
 
 #Validate data
@@ -34,7 +34,7 @@ TRUNCATE TABLE t1;
 
 #cpimport default behavior is same as -m1 option.
 --disable_result_log
---exec cpimport mcs47_db t1 '$MTR_SUITE_DIR/../std_data/100Krows.dat';
+--exec $MCS_CPIMPORT mcs47_db t1 '$MTR_SUITE_DIR/../std_data/100Krows.dat';
 --enable_result_log
 
 let $rowcount2 = query_get_value(SELECT COUNT(*) cnt FROM t1, cnt, 1);

--- a/mysql-test/columnstore/basic/t/mcs48_cpimport_central_loc_dist_source.test
+++ b/mysql-test/columnstore/basic/t/mcs48_cpimport_central_loc_dist_source.test
@@ -15,10 +15,10 @@ CREATE TABLE t1(col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnstore;
 
 # Load fragmented data source files distributed across pm nodes, cpimport -m2
 # This test needs to be extended to cover multi-node setup
---exec yes | cp ./suite/columnstore/std_data/100Krows.dat /tmp
+--exec yes | cp $MTR_SUITE_DIR/../std_data/100Krows.dat /tmp
 
 --disable_result_log #cpimport logs thread/timestamps
---exec cpimport -m2 mcs48_db t1 -f '/tmp' -l '100Krows.dat';
+--exec $MCS_CPIMPORT -m2 mcs48_db t1 -f '/tmp' -l '100Krows.dat';
 --enable_result_log
 
 #Validate data

--- a/mysql-test/columnstore/basic/t/mcs49_cpimport_parallel_dist.test
+++ b/mysql-test/columnstore/basic/t/mcs49_cpimport_parallel_dist.test
@@ -22,7 +22,7 @@ CREATE TABLE t1(col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnstore;
 # This test needs to be extended to cover multi-node setup
 
 --disable_result_log #cpimport logs thread/timestamps
---exec cpimport -m3 mcs49_db t1 -l '$MTR_SUITE_DIR/../std_data/100Krows.dat';
+--exec $MCS_CPIMPORT -m3 mcs49_db t1 -l '$MTR_SUITE_DIR/../std_data/100Krows.dat';
 --enable_result_log
 
 #Validate data

--- a/mysql-test/columnstore/basic/t/mcs50_cpimport_stdin.test
+++ b/mysql-test/columnstore/basic/t/mcs50_cpimport_stdin.test
@@ -19,7 +19,7 @@ USE mcs50_db;
 CREATE TABLE t1(col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnstore;
 
 #Valid data and table
---exec cat $MTR_SUITE_DIR/../std_data/100Krows.dat | cpimport mcs50_db t1 >/dev/null
+--exec cat $MTR_SUITE_DIR/../std_data/100Krows.dat | $MCS_CPIMPORT mcs50_db t1 >/dev/null
 SELECT * FROM t1 ORDER BY col1;
 SELECT COUNT(*) FROM t1;
 
@@ -28,20 +28,20 @@ TRUNCATE t1;
 #Unknown db
 #Error getting OID for table unknown.t1: IDB-2006: 'unknown.t1' does not exist in Columnstore.
 --error 1
---exec cat $MTR_SUITE_DIR/../100Krows.dat | cpimport unknown t1 >/dev/null
+--exec cat $MTR_SUITE_DIR/../100Krows.dat | $MCS_CPIMPORT unknown t1 >/dev/null
 
 #Unknown table
 #Error getting OID for table mcs50_db.unknown: IDB-2006: 'mcs50_db.unknown' does not exist in Columnstore.
 --error 1
---exec cat $MTR_SUITE_DIR/../std_data/100Krows.dat | cpimport mcs50_db unknown >/dev/null
+--exec cat $MTR_SUITE_DIR/../std_data/100Krows.dat | $MCS_CPIMPORT mcs50_db unknown >/dev/null
 
 #Wrong delimiter
 --error 1
---exec cat $MTR_SUITE_DIR/../std_data/100Krows.dat | cpimport mcs50_db t1 -s ',' >/dev/null 
+--exec cat $MTR_SUITE_DIR/../std_data/100Krows.dat | $MCS_CPIMPORT mcs50_db t1 -s ',' >/dev/null 
 
 #Unknown file
 --exec rm -f /tmp/UNKNOWN.dat
---exec cat /tmp/UNKNOWN.dat | cpimport mcs50_db t1 >/dev/null
+--exec cat /tmp/UNKNOWN.dat | $MCS_CPIMPORT mcs50_db t1 >/dev/null
 SELECT * FROM t1 ORDER BY col1;
 SELECT COUNT(*) FROM t1;
 

--- a/mysql-test/columnstore/basic/t/mcs51_cpimport_select_from.test
+++ b/mysql-test/columnstore/basic/t/mcs51_cpimport_select_from.test
@@ -28,13 +28,15 @@ CREATE TABLE mcs51_db2.t_mcs (col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnsto
 --eval LOAD DATA LOCAL infile '$MTR_SUITE_DIR/../std_data/100Krows.dat' INTO TABLE mcs51_db1.t_myisam FIELDS TERMINATED BY '|';
 
 #Bulk load deom Innodb table
---exec mariadb -q -e 'SELECT * FROM mcs51_db1.t_innodb;' -N  | cpimport -s '\t' mcs51_db2 t_mcs >/dev/null
+SELECT COUNT(*) FROM mcs51_db1.t_innodb;
+--exec $MYSQL -q -e 'SELECT * FROM mcs51_db1.t_innodb;' -N  | $MCS_CPIMPORT -s '\t' mcs51_db2 t_mcs >/dev/null
 SELECT * FROM mcs51_db2.t_mcs ORDER BY col1;
 SELECT COUNT(*) FROM mcs51_db2.t_mcs;
 TRUNCATE mcs51_db2.t_mcs;
 
 #Bulk load deom MyISAM table
---exec mariadb -q -e 'SELECT * FROM mcs51_db1.t_myisam;' -N  | cpimport -s '\t' mcs51_db2 t_mcs >/dev/null
+SELECT COUNT(*) FROM mcs51_db1.t_myisam;
+--exec $MYSQL -q -e 'SELECT * FROM mcs51_db1.t_myisam;' -N  | $MCS_CPIMPORT -s '\t' mcs51_db2 t_mcs >/dev/null
 SELECT * FROM mcs51_db2.t_mcs ORDER BY col1;
 SELECT COUNT(*) FROM mcs51_db2.t_mcs;
 TRUNCATE mcs51_db2.t_mcs;

--- a/mysql-test/columnstore/basic/t/mcs55_cpimport_binary_source.test
+++ b/mysql-test/columnstore/basic/t/mcs55_cpimport_binary_source.test
@@ -38,7 +38,7 @@ EOF;
 # Binary mode with NULLs accepted Numeric fields containing NULL will be treated
 # as NULL unless the column has a default value
 --disable_result_log #cpimport logs thread/timestamps
---exec cpimport -I1 mcs55_db t1 '/tmp/mcs55.bin';
+--exec $MCS_CPIMPORT -I1 mcs55_db t1 '/tmp/mcs55.bin';
 --enable_result_log
 
 #Validate data
@@ -49,7 +49,7 @@ TRUNCATE t1;
 
 # Binary mode with NULLs saturated NULLs in numeric fields will be saturated
 --disable_result_log #cpimport logs thread/timestamps
---exec cpimport -I2 mcs55_db t1 '/tmp/mcs55.bin';
+--exec $MCS_CPIMPORT -I2 mcs55_db t1 '/tmp/mcs55.bin';
 --enable_result_log
 
 #Validate data

--- a/mysql-test/columnstore/basic/t/mcs56_cpimport_negative.test
+++ b/mysql-test/columnstore/basic/t/mcs56_cpimport_negative.test
@@ -21,7 +21,7 @@ CREATE TABLE t1(col1 INT, col2 INT) ENGINE=Columnstore;
 # Negative. Non-existing data file.
 exec rm -f /tmp/nonexisting.dat; 
 --disable_result_log #cpimport logs thread/timestamps
-exec cpimport mcs56_db t1 /tmp/nonexisting.dat 2>&1 | tee /tmp/mcs56.out;
+exec $MCS_CPIMPORT mcs56_db t1 /tmp/nonexisting.dat 2>&1 | tee /tmp/mcs56.out;
 --enable_result_log
 
 exec echo "";
@@ -35,7 +35,7 @@ DROP DATABASE IF EXISTS nonexist_tbl;
 
 # Negative. Non-existing db.
 --disable_result_log
-exec cpimport nonexist_db t1 /tmp/nonexisting.dat 2>&1 | tee /tmp/mcs56.out;
+exec $MCS_CPIMPORT nonexist_db t1 /tmp/nonexisting.dat 2>&1 | tee /tmp/mcs56.out;
 --enable_result_log
 
 exec echo "";
@@ -45,7 +45,7 @@ exec grep -q "IDB-2006: 'nonexist_db.t1' does not exist in Columnstore." /tmp/mc
 
 # Negative. Non-existing table.
 --disable_result_log
-exec cpimport mcs56_db nonexist_tbl /tmp/nonexisting.dat 2>&1 | tee /tmp/mcs56.out;
+exec $MCS_CPIMPORT mcs56_db nonexist_tbl /tmp/nonexisting.dat 2>&1 | tee /tmp/mcs56.out;
 --enable_result_log
 
 exec echo "";

--- a/mysql-test/columnstore/basic/t/mcs67_ldi_datafile_separators.test
+++ b/mysql-test/columnstore/basic/t/mcs67_ldi_datafile_separators.test
@@ -14,7 +14,8 @@ USE mcs67_db;
 CREATE TABLE t1(col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnstore;
 
 #Correct delimiter
-LOAD DATA LOCAL infile './suite/columnstore/std_data/100Krows.dat' INTO TABLE t1 FIELDS TERMINATED BY '|';
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+--eval LOAD DATA LOCAL infile '$MTR_SUITE_DIR/../std_data/100Krows.dat' INTO TABLE t1 FIELDS TERMINATED BY '|';
 
 #Validate data
 SELECT COUNT(*) FROM t1;
@@ -23,7 +24,7 @@ TRUNCATE t1;
 
 #Use a non-default delimiter '\t'
 --exec rm -f /tmp/100Krows.dat
---exec cp ./suite/columnstore/std_data/100Krows.dat /tmp/100Krows.dat
+--exec cp $MTR_SUITE_DIR/../std_data/100Krows.dat /tmp/100Krows.dat
 --exec sed -i 's/|/\t/g' /tmp/100Krows.dat
 LOAD DATA LOCAL infile '/tmp/100Krows.dat' INTO TABLE t1 FIELDS TERMINATED BY '\t';
 

--- a/mysql-test/columnstore/basic/t/mcs68_cpimport_datafile_separators.test
+++ b/mysql-test/columnstore/basic/t/mcs68_cpimport_datafile_separators.test
@@ -20,10 +20,10 @@ CREATE TABLE t1(col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnstore;
 
 #Error in loading job data as ',' is not the actual delimiter
 --error 1
---exec cpimport -s ',' mcs68_db t1 '$MTR_SUITE_DIR/../std_data/100Krows.dat' >/dev/null
+--exec $MCS_CPIMPORT -s ',' mcs68_db t1 '$MTR_SUITE_DIR/../std_data/100Krows.dat' >/dev/null
 
 #Correct delimiter
---exec cpimport -s '|' mcs68_db t1 '$MTR_SUITE_DIR/../std_data/100Krows.dat' >/dev/null
+--exec $MCS_CPIMPORT -s '|' mcs68_db t1 '$MTR_SUITE_DIR/../std_data/100Krows.dat' >/dev/null
 
 #Validate data
 SELECT COUNT(*) FROM t1;
@@ -34,7 +34,7 @@ TRUNCATE t1;
 --exec rm -f /tmp/mcs68_100Krows.dat
 --exec cp $MTR_SUITE_DIR/../std_data/100Krows.dat /tmp/mcs68_100Krows.dat
 --exec sed -i 's/|/\t/g' /tmp/mcs68_100Krows.dat
---exec cpimport -s '\t' mcs68_db t1 '/tmp/mcs68_100Krows.dat' >/dev/null
+--exec $MCS_CPIMPORT -s '\t' mcs68_db t1 '/tmp/mcs68_100Krows.dat' >/dev/null
 
 #Validate data
 SELECT COUNT(*) FROM t1;


### PR DESCRIPTION
Some MTR test still failed when running without --extern

Fixing the following problems:
- Changing "--exec mariadb" to "--exect $MYSQL" to properly pass the socket
- Changing ./suite/columnstore/std_data/ to MTR_SUITE_DIR/../std_data/
- Changing "cpimport" to $MCS_CPIMPORT.
  Detecting and exporting a proper $MCS_CPIMPORT in suite.pm