### PR TITLE
Revert "MCOL-4626: Low memory on primproc errors instead of crashing"

### DIFF
--- a/oam/etc/Columnstore.xml
+++ b/oam/etc/Columnstore.xml
@@ -95,8 +95,6 @@
 		<!-- <HighPriorityPercentage>60</HighPriorityPercentage> -->
 		<!-- <MediumPriorityPercentage>30</MediumPriorityPercentage> -->
 		<!-- <LowPriorityPercentage>10</LowPriorityPercentage> -->
-		<!-- MaxPct is maximum percentage of total system memory PrimProc can consume before query will report error-->
-		<!-- <MaxPct>70</MaxPct> -->
 		<DirectIO>y</DirectIO>
         <HighPriorityPercentage/>
         <MediumPriorityPercentage/>

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -1364,11 +1364,6 @@ void BatchPrimitiveProcessor::execute()
 
     try
     {
-        // Check memory up front
-        if (MonitorProcMem::checkMemlimit())
-        {
-            throw logging::IDBExcept(logging::ERR_PRIMPROC_LOW_MEMORY);
-        }
 #ifdef PRIMPROC_STOPWATCH
         stopwatch->start("BatchPrimitiveProcessor::execute first part");
 #endif
@@ -1705,10 +1700,6 @@ void BatchPrimitiveProcessor::execute()
                     {
                         //cerr <<" * serialzing " << nextRG.toString() << endl;
                         nextRG.serializeRGData(*serialized);
-                        if (MonitorProcMem::checkMemlimit())
-                        {
-                            throw logging::IDBExcept(logging::ERR_PRIMPROC_LOW_MEMORY);
-                        }
                     }
 
                     /* send the msg & reinit the BS */
@@ -1756,10 +1747,6 @@ void BatchPrimitiveProcessor::execute()
                     *serialized << (uint8_t) 1;  // the "count this msg" var
                     fe2Output.setDBRoot(dbRoot);
                     fe2Output.serializeRGData(*serialized);
-                    if (MonitorProcMem::checkMemlimit())
-                    {
-                        throw logging::IDBExcept(logging::ERR_PRIMPROC_LOW_MEMORY);
-                    }
                     //*serialized << fe2Output.getDataSize();
                     //serialized->append(fe2Output.getData(), fe2Output.getDataSize());
                 }
@@ -1800,10 +1787,7 @@ void BatchPrimitiveProcessor::execute()
                 outputRG.setDBRoot(dbRoot);
                 //cerr << "serializing " << outputRG.toString() << endl;
                 outputRG.serializeRGData(*serialized);
-                if (MonitorProcMem::checkMemlimit())
-                {
-                    throw logging::IDBExcept(logging::ERR_PRIMPROC_LOW_MEMORY);
-                }
+
                 //*serialized << outputRG.getDataSize();
                 //serialized->append(outputRG.getData(), outputRG.getDataSize());
                 if (doJoin)
@@ -2704,22 +2688,6 @@ void BatchPrimitiveProcessor::buildVSSCache(uint32_t loopCount)
             vssCache.insert(make_pair(lbidList[i], vssData[i]));
 
 //	cout << "buildVSSCache inserted " << vssCache.size() << " elements" << endl;
-}
-
-void BatchPrimitiveProcessor::resetMem()
-{
-    serialized.reset();
-    outputMsg.reset();
-    std::vector<SCommand>().swap(filterSteps);
-    std::vector<SCommand>().swap(projectSteps);
-    vssCache.clear();
-#ifndef __FreeBSD__
-    pthread_mutex_unlock(&objLock);
-#endif
-    outRowGroupData.reset();
-    fe1Data.reset();
-    fe2Data.reset();
-    joinedRGMem.reset();
 }
 
 }

--- a/primitives/primproc/batchprimitiveprocessor.h
+++ b/primitives/primproc/batchprimitiveprocessor.h
@@ -169,7 +169,6 @@ public:
     {
         return doJoin;
     }
-    void resetMem();
 private:
     BatchPrimitiveProcessor();
     BatchPrimitiveProcessor(const BatchPrimitiveProcessor&);

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -403,6 +403,7 @@ int ServicePrimProc::Child()
 
     if (err < 0)
     {
+        Oam oam;
         mlp->logMessage(errMsg);
         cerr << errMsg << endl;
 
@@ -438,15 +439,6 @@ int ServicePrimProc::Child()
     int configNumCores = -1;
     uint32_t highPriorityPercentage, medPriorityPercentage, lowPriorityPercentage;
     utils::CGroupConfigurator cg;
-
-    if (cg.getTotalMemory() < 3221225472)
-    {
-        string errMsg = "Warning total memory available is less than 3GB.";
-        mlp->logMessage(errMsg,false);
-        cerr << errMsg << endl;
-
-        NotifyServiceInitializationFailed();
-    }
 
     gDebugLevel = primitiveprocessor::NONE;
 
@@ -511,26 +503,6 @@ int ServicePrimProc::Child()
     //defaultBufferSize = 512 * 1024; // @bug 2627 - changed default dict buffer from 256K to 512K, allows for cols w/ length of 61.
     defaultBufferSize = 100 * 1024; // 1/17/12 - made the dict buffer dynamic, max size for a numeric col is 80k + ovrhd
 
-    int maxPct = 70; //Reusing this as a method to kill queries on high memory usage threshold
-    temp = toInt(cf->getConfig(primitiveServers, "MaxPct"));
-
-    if (temp >= 0)
-        maxPct = temp;
-
-    // @bug4507, configurable pm aggregation AggregationMemoryCheck
-    // We could use this same mechanism for other growing buffers.
-    int aggPct = 95;
-    temp = toInt(cf->getConfig("SystemConfig", "MemoryCheckPercent"));
-
-    if (temp >= 0)
-        aggPct = temp;
-
-    //...Start the thread to monitor our memory usage
-    // This is just to print a warning right now ...
-    // PrimProc should be able to grab as much as it can but
-    // warn at 75% of total memory - 500MB allowing for default
-    // TotalUMmem and saving a portion for cpimport.bin process if needed
-    new boost::thread(utils::MonitorProcMem(maxPct, aggPct, 28));
 
     // This parm controls whether we rotate through the output sockets
     // when deciding where to send response messages, or whether to simply
@@ -644,6 +616,23 @@ int ServicePrimProc::Child()
         prefetchThreshold = 0;
     else
         prefetchThreshold = temp / 100.0;
+
+    int maxPct = 0; //disable by default
+    temp = toInt(cf->getConfig(primitiveServers, "MaxPct"));
+
+    if (temp >= 0)
+        maxPct = temp;
+
+    // @bug4507, configurable pm aggregation AggregationMemoryCheck
+    // We could use this same mechanism for other growing buffers.
+    int aggPct = 95;
+    temp = toInt(cf->getConfig("SystemConfig", "MemoryCheckPercent"));
+
+    if (temp >= 0)
+        aggPct = temp;
+
+    //...Start the thread to monitor our memory usage
+    new boost::thread(utils::MonitorProcMem(maxPct, aggPct, 28));
 
     // config file priority is 40..1 (highest..lowest)
     string sPriority = cf->getConfig(primitiveServers, "Priority");

--- a/utils/common/MonitorProcMem.h
+++ b/utils/common/MonitorProcMem.h
@@ -29,6 +29,7 @@
 
 #include <sys/types.h>
 #include <unistd.h>
+
 #include "cgroupconfigurator.h"
 
 //#include "pp_logger.h"
@@ -63,7 +64,6 @@ public:
     {
         fMemPctCheck = memChk;
         fMemTotal = memTotal();
-        fMaxPrimProcPct = 100;
     }
 
     virtual ~MonitorProcMem() {};
@@ -86,7 +86,6 @@ public:
      *
      */
     static unsigned memUsedPct();
-    static bool checkMemlimit();
 
     /* return true if memory usage is below configured limit
      *
@@ -120,8 +119,6 @@ protected:
     int      fPageSize;  // page size for this host (in bytes)
 
     // @bug4507, monitor % of total used system memory
-    static size_t   fMaxPrimProcPct; // Replaces usage of fMaxPct if needed (Pct of PrimProc Memory used)
-    static uint64_t fUsedMem;
     static uint64_t fMemTotal;
     static uint64_t fMemFree;
     static int      fMemPctCheck;

--- a/utils/common/cgroupconfigurator.cpp
+++ b/utils/common/cgroupconfigurator.cpp
@@ -73,14 +73,10 @@ CGroupConfigurator::CGroupConfigurator()
     config = config::Config::makeConfig();
 
     cGroupName = config->getConfig("SystemConfig", "CGroup");
-    string containerMode = config->getConfig("SystemConfig", "ContainerMode");
 
     if (cGroupName.empty())
         cGroupDefined = false;
     else
-        cGroupDefined = true;
-
-    if ((containerMode == "y") || (containerMode == "Y"))
         cGroupDefined = true;
 
     totalMemory = 0;
@@ -95,7 +91,7 @@ CGroupConfigurator::~CGroupConfigurator()
 uint32_t CGroupConfigurator::getNumCoresFromCGroup()
 {
     ostringstream filename_os;
-    filename_os << "/sys/fs/cgroup/cpuset/" << cGroupName << "/cpuset.cpus";
+    filename_os << "/sys/fs/cgroup/cpuset/" << cGroupName << "/cpus";
     string filename = filename_os.str();
 
     ifstream in(filename.c_str());

--- a/utils/loggingcpp/ErrorMessage.txt
+++ b/utils/loggingcpp/ErrorMessage.txt
@@ -104,8 +104,6 @@
 2055	ERR_DISKAGG_TOO_BIG	Not enough memory to make disk-based aggregation. Raise TotalUmMemory if possible.
 2056	ERR_DISKAGG_FILEIO_ERROR	There was an IO error during a disk-based aggregation: %1%
 
-2057	ERR_PRIMPROC_LOW_MEMORY	There is insufficient memory to process the query (PrimProc)
-
 # Sub-query errors
 3001	ERR_NON_SUPPORT_SUB_QUERY_TYPE	This subquery type is not supported yet.
 3002	ERR_MORE_THAN_1_ROW	Subquery returns more than 1 row.


### PR DESCRIPTION
Reverts mariadb-corporation/mariadb-columnstore-engine#1952