### PR TITLE
MCOL-4642 NOT IN subquery containing an isnull in the OR predicate crashes server.

### DIFF
--- a/mysql-test/columnstore/basic/r/mcol-4642.result
+++ b/mysql-test/columnstore/basic/r/mcol-4642.result
@@ -1,0 +1,49 @@
+#
+# MCOL-4642 NOT IN subquery containing an isnull in the OR predicate crashes server
+#
+DROP DATABASE IF EXISTS mcol4642;
+CREATE DATABASE mcol4642;
+USE mcol4642;
+CREATE TABLE cs1 (a int);
+INSERT INTO cs1 VALUES (1), (2), (3), (4), (null);
+CREATE TABLE cs2 (b int, c int);
+INSERT INTO cs2 VALUES (1, 100), (1, 101), (2, 200),(3, 300), (3, 301), (3, 302), (null, null);
+SELECT * FROM cs1 WHERE a NOT IN (SELECT b FROM cs2 WHERE b is not null OR b is null);
+a
+SELECT * FROM cs1 WHERE a NOT IN (SELECT b FROM cs2 WHERE b is null OR b is not null);
+a
+SELECT * FROM cs1 WHERE a IN (SELECT b FROM cs2 WHERE b is not null OR b is null);
+a
+1
+2
+3
+SELECT * FROM cs1 WHERE a IN (SELECT b FROM cs2 WHERE b is null OR b is not null);
+a
+1
+2
+3
+SELECT * FROM cs1 WHERE a NOT IN (SELECT b FROM cs2 WHERE b=123 OR b is null);
+a
+SELECT * FROM cs1 WHERE a NOT IN (SELECT b FROM cs2 WHERE b is null OR b=123);
+a
+SELECT * FROM cs1 WHERE a IN (SELECT b FROM cs2 WHERE b=123 OR b is null);
+a
+SELECT * FROM cs1 WHERE a IN (SELECT b FROM cs2 WHERE b is null OR b=123);
+a
+SELECT * FROM cs1 WHERE a NOT IN (SELECT b FROM cs2 WHERE b=123 OR b is not null);
+a
+4
+SELECT * FROM cs1 WHERE a NOT IN (SELECT b FROM cs2 WHERE b is not null OR b=123);
+a
+4
+SELECT * FROM cs1 WHERE a IN (SELECT b FROM cs2 WHERE b=123 OR b is not null);
+a
+1
+2
+3
+SELECT * FROM cs1 WHERE a IN (SELECT b FROM cs2 WHERE b is not null OR b=123);
+a
+1
+2
+3
+DROP DATABASE mcol4642;

--- a/mysql-test/columnstore/basic/t/mcol-4642.test
+++ b/mysql-test/columnstore/basic/t/mcol-4642.test
@@ -1,0 +1,35 @@
+--source ../include/have_columnstore.inc
+--source ctype_cmp_combinations.inc
+
+--echo #
+--echo # MCOL-4642 NOT IN subquery containing an isnull in the OR predicate crashes server
+--echo #
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol4642;
+--enable_warnings
+
+CREATE DATABASE mcol4642;
+USE mcol4642;
+
+CREATE TABLE cs1 (a int);
+INSERT INTO cs1 VALUES (1), (2), (3), (4), (null);
+CREATE TABLE cs2 (b int, c int);
+INSERT INTO cs2 VALUES (1, 100), (1, 101), (2, 200),(3, 300), (3, 301), (3, 302), (null, null);
+
+SELECT * FROM cs1 WHERE a NOT IN (SELECT b FROM cs2 WHERE b is not null OR b is null);
+SELECT * FROM cs1 WHERE a NOT IN (SELECT b FROM cs2 WHERE b is null OR b is not null);
+SELECT * FROM cs1 WHERE a IN (SELECT b FROM cs2 WHERE b is not null OR b is null);
+SELECT * FROM cs1 WHERE a IN (SELECT b FROM cs2 WHERE b is null OR b is not null);
+
+SELECT * FROM cs1 WHERE a NOT IN (SELECT b FROM cs2 WHERE b=123 OR b is null);
+SELECT * FROM cs1 WHERE a NOT IN (SELECT b FROM cs2 WHERE b is null OR b=123);
+SELECT * FROM cs1 WHERE a IN (SELECT b FROM cs2 WHERE b=123 OR b is null);
+SELECT * FROM cs1 WHERE a IN (SELECT b FROM cs2 WHERE b is null OR b=123);
+
+SELECT * FROM cs1 WHERE a NOT IN (SELECT b FROM cs2 WHERE b=123 OR b is not null);
+SELECT * FROM cs1 WHERE a NOT IN (SELECT b FROM cs2 WHERE b is not null OR b=123);
+SELECT * FROM cs1 WHERE a IN (SELECT b FROM cs2 WHERE b=123 OR b is not null);
+SELECT * FROM cs1 WHERE a IN (SELECT b FROM cs2 WHERE b is not null OR b=123);
+
+DROP DATABASE mcol4642;


### PR DESCRIPTION
InSub::handleFunc() was incorrectly exiting early for an IN subquery
containing an isnull predicate in the OR operation in the WHERE clause.
This patch properly handles the OR predicate containing an isnull/isnotnull
predicate in the WHERE clause. When the OR operation contains:
(cache=item or isnull(item)), we remove the isnull(item) from the operation
which gets added by the server during the in-to-exists predicate creation
and injection during in_subselect_rewrite() call in
create_columnstore_select_handler().