### PR TITLE
MCOL-4525 Implement columnstore_select_handler=AUTO.

### DIFF
--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include "idb_mysql.h"
+#include "ha_mcs_sysvars.h"
 
 struct st_ha_create_information;
 class ha_columnstore_select_handler;
@@ -274,7 +275,7 @@ struct cal_connection_info
         filePtr(0),
         headerLength(0),
         useXbit(false),
-        useCpimport(1),
+        useCpimport(mcs_use_import_for_batchinsert_mode_t::ON),
         delimiter('\7'),
         affectedRows(0)
     {
@@ -341,7 +342,7 @@ struct cal_connection_info
     FILE* filePtr;
     uint8_t headerLength;
     bool useXbit;
-    uint8_t useCpimport;
+    mcs_use_import_for_batchinsert_mode_t useCpimport;
     char delimiter;
     char enclosed_by;
     std::vector <execplan::CalpontSystemCatalog::ColType> columnTypes;

--- a/dbcon/mysql/ha_mcs_opt_rewrites.h
+++ b/dbcon/mysql/ha_mcs_opt_rewrites.h
@@ -21,6 +21,8 @@
 #include "idb_mysql.h"
 
 bool in_subselect_rewrite(SELECT_LEX *select_lex);
-void opt_flag_unset_PS(SELECT_LEX *select_lex);
+void first_cond_optimization_flag_toggle(SELECT_LEX *select_lex, void (*func)(SELECT_LEX*));
+void first_cond_optimization_flag_unset(SELECT_LEX*);
+void first_cond_optimization_flag_set(SELECT_LEX*);
 
 #endif

--- a/dbcon/mysql/ha_mcs_pushdown.h
+++ b/dbcon/mysql/ha_mcs_pushdown.h
@@ -138,10 +138,12 @@ class ha_columnstore_select_handler: public select_handler
 {
 private:
   COLUMNSTORE_SHARE *share;
+  bool prepared;
+  bool scan_ended;
 
 public:
-  bool rewrite_error;
-  std::string err_msg;
+  bool scan_initialized;
+  int pushdown_init_rc;
   // MCOL-4525 Store the original TABLE_LIST::outer_join value in a hash map.
   // This will be used to restore to the original state later in case
   // query execution fails using the select_handler.
@@ -151,6 +153,7 @@ public:
   int init_scan() override;
   int next_row() override;
   int end_scan() override;
+  bool prepare() override;
 };
 
 #endif

--- a/dbcon/mysql/ha_mcs_sysvars.cpp
+++ b/dbcon/mysql/ha_mcs_sysvars.cpp
@@ -71,13 +71,28 @@ static MYSQL_THDVAR_ULONGLONG(
     1
 );
 
-static MYSQL_THDVAR_BOOL(
+const char* mcs_select_handler_mode_values[] = {
+    "OFF",
+    "ON",
+    "AUTO",
+    NullS
+};
+
+static TYPELIB mcs_select_handler_mode_values_lib = {
+    array_elements(mcs_select_handler_mode_values) - 1,
+    "mcs_select_handler_mode_values",
+    mcs_select_handler_mode_values,
+    NULL
+};
+
+static MYSQL_THDVAR_ENUM(
     select_handler,
-    PLUGIN_VAR_NOCMDARG,
-    "Enable/Disable the MCS select_handler",
-    NULL,
-    NULL,
-    1
+    PLUGIN_VAR_RQCMDARG,
+    "Set the MCS select_handler to Disabled, Enabled, or Automatic",
+    NULL, // check
+    NULL, // update
+    1, // default
+    &mcs_select_handler_mode_values_lib // values lib
 );
 
 static MYSQL_THDVAR_BOOL(
@@ -288,17 +303,17 @@ static MYSQL_THDVAR_ULONG(
     1 // block size
 );
 
-const char* mcs_use_import_for_batchinsert_values[] = {
+const char* mcs_use_import_for_batchinsert_mode_values[] = {
     "OFF",
     "ON",
     "ALWAYS",
     NullS
 };
 
-static TYPELIB mcs_use_import_for_batchinsert_values_lib = {
-    array_elements(mcs_use_import_for_batchinsert_values) - 1,
-    "mcs_use_import_for_batchinsert_values",
-    mcs_use_import_for_batchinsert_values,
+static TYPELIB mcs_use_import_for_batchinsert_mode_values_lib = {
+    array_elements(mcs_use_import_for_batchinsert_mode_values) - 1,
+    "mcs_use_import_for_batchinsert_mode_values",
+    mcs_use_import_for_batchinsert_mode_values,
     NULL
 };
 
@@ -309,7 +324,7 @@ static MYSQL_THDVAR_ENUM(
     NULL, // check
     NULL, // update
     1, // default
-    &mcs_use_import_for_batchinsert_values_lib // values lib
+    &mcs_use_import_for_batchinsert_mode_values_lib // values lib
 );
 
 static MYSQL_THDVAR_BOOL(
@@ -412,11 +427,12 @@ void set_original_optimizer_flags(ulonglong ptr, THD* thd)
     THDVAR(current_thd, original_optimizer_flags) = (uint64_t)(ptr);
 }
 
-bool get_select_handler(THD* thd)
+mcs_select_handler_mode_t get_select_handler_mode(THD* thd)
 {
-    return ( thd == NULL ) ? false : THDVAR(thd, select_handler);
+    return ( thd == NULL ) ? mcs_select_handler_mode_t::ON :
+           (mcs_select_handler_mode_t) THDVAR(thd, select_handler);
 }
-void set_select_handler(THD* thd, bool value)
+void set_select_handler_mode(THD* thd, ulong value)
 {
     THDVAR(thd, select_handler) = value;
 }
@@ -585,12 +601,12 @@ void set_local_query(THD* thd, ulong value)
     THDVAR(thd, local_query) = value;
 }
 
-mcs_use_import_for_batchinsert_t get_use_import_for_batchinsert(THD* thd)
+mcs_use_import_for_batchinsert_mode_t get_use_import_for_batchinsert_mode(THD* thd)
 {
-    return ( thd == NULL ) ? mcs_use_import_for_batchinsert_t::ON :
-           (mcs_use_import_for_batchinsert_t) THDVAR(thd, use_import_for_batchinsert);
+    return ( thd == NULL ) ? mcs_use_import_for_batchinsert_mode_t::ON :
+           (mcs_use_import_for_batchinsert_mode_t) THDVAR(thd, use_import_for_batchinsert);
 }
-void set_use_import_for_batchinsert(THD* thd, ulong value)
+void set_use_import_for_batchinsert_mode(THD* thd, ulong value)
 {
     THDVAR(thd, use_import_for_batchinsert) = value;
 }

--- a/dbcon/mysql/ha_mcs_sysvars.h
+++ b/dbcon/mysql/ha_mcs_sysvars.h
@@ -33,11 +33,18 @@ enum mcs_compression_type_t {
     SNAPPY = 2
 };
 
-// use_import_for_batchinsert
-enum mcs_use_import_for_batchinsert_t {
+// use_import_for_batchinsert mode
+enum class mcs_use_import_for_batchinsert_mode_t {
     OFF = 0,
     ON = 1,
     ALWAYS = 2
+};
+
+// select_handler mode
+enum class mcs_select_handler_mode_t {
+    OFF = 0,
+    ON = 1,
+    AUTO = 2
 };
 
 // simple setters/getters
@@ -53,8 +60,8 @@ void set_fe_conn_info_ptr(void* ptr, THD* thd = NULL);
 ulonglong get_original_optimizer_flags(THD* thd = NULL);
 void set_original_optimizer_flags(ulonglong ptr, THD* thd = NULL);
 
-bool get_select_handler(THD* thd);
-void set_select_handler(THD* thd, bool value);
+mcs_select_handler_mode_t get_select_handler_mode(THD* thd);
+void set_select_handler_mode(THD* thd, ulong value);
 
 bool get_derived_handler(THD* thd);
 void set_derived_handler(THD* thd, bool value);
@@ -107,8 +114,8 @@ void set_decimal_overflow_check(THD* thd, bool value);
 ulong get_local_query(THD* thd);
 void set_local_query(THD* thd, ulong value);
 
-mcs_use_import_for_batchinsert_t get_use_import_for_batchinsert(THD* thd);
-void set_use_import_for_batchinsert(THD* thd, ulong value);
+mcs_use_import_for_batchinsert_mode_t get_use_import_for_batchinsert_mode(THD* thd);
+void set_use_import_for_batchinsert_mode(THD* thd, ulong value);
 
 ulong get_import_for_batchinsert_delimiter(THD* thd);
 void set_import_for_batchinsert_delimiter(THD* thd, ulong value);

--- a/dbcon/mysql/idb_mysql.h
+++ b/dbcon/mysql/idb_mysql.h
@@ -81,6 +81,7 @@ template <class T> bool isnan(T);
 #include "select_handler.h"
 #include "rpl_rli.h"
 #include "my_dbug.h"
+#include "sql_show.h"
 
 // Now clean up the pollution as best we can...
 #include "mcsconfig_conflicting_defs_undef.h"

--- a/mysql-test/columnstore/basic/r/mcol-424.result
+++ b/mysql-test/columnstore/basic/r/mcol-424.result
@@ -1,0 +1,33 @@
+# MCOL-424
+# Cross engine subquery losing where clause causing incorrect results
+DROP DATABASE IF EXISTS mcol424;
+CREATE DATABASE mcol424;
+USE mcol424;
+CREATE USER IF NOT EXISTS'cejuser'@'localhost' IDENTIFIED BY 'Vagrant1|0000001';
+GRANT ALL PRIVILEGES ON *.* TO 'cejuser'@'localhost';
+FLUSH PRIVILEGES;
+CREATE TABLE `trans_test` (
+`id` int(11) DEFAULT NULL,
+`member_id` int(11) DEFAULT NULL,
+`name` varchar(50) DEFAULT NULL
+) ENGINE=Columnstore DEFAULT CHARSET=latin1;
+insert  into `trans_test`(`id`,`member_id`,`name`) values (1,1,'trans 1');
+insert  into `trans_test`(`id`,`member_id`,`name`) values (2,2,'trans 2');
+insert  into `trans_test`(`id`,`member_id`,`name`) values (3,1,'trans 3');
+insert  into `trans_test`(`id`,`member_id`,`name`) values (4,2,'trans 4');
+insert  into `trans_test`(`id`,`member_id`,`name`) values (5,1,'trans 5');
+CREATE TABLE `member_test` (
+`id` int(11) NOT NULL AUTO_INCREMENT,
+`name` varchar(50) NOT NULL,
+PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+insert  into `member_test`(`id`,`name`) values (1,'member 1');
+insert  into `member_test`(`id`,`name`) values (2,'member 2');
+insert  into `member_test`(`id`,`name`) values (3,'member 3');
+SELECT * FROM trans_test t WHERE t.`member_id` IN (SELECT id FROM member_test WHERE id =1);
+id	member_id	name
+1	1	trans 1
+3	1	trans 3
+5	1	trans 5
+DROP USER 'cejuser'@'localhost';
+DROP DATABASE mcol424;

--- a/mysql-test/columnstore/basic/r/mcol-4525.result
+++ b/mysql-test/columnstore/basic/r/mcol-4525.result
@@ -1,0 +1,337 @@
+# MCOL-4525
+# Automatic select_handler
+# columnstore_select_handler=AUTO allows query execution
+# to fallback to the server, in case the execution using
+# select_handler fails.
+SET default_storage_engine=columnstore;
+DROP DATABASE IF EXISTS mcol4525;
+CREATE DATABASE mcol4525;
+USE mcol4525;
+CREATE TABLE t1 (a int, b int);
+INSERT INTO t1 VALUES (1, 1), (5, 0);
+SET columnstore_select_handler=ON;
+SELECT a xor b FROM t1;
+ERROR 42000: The storage engine for the table doesn't support IDB-2030: Predicate and Logic operators can not be used where an expression is expected.
+SET columnstore_select_handler=AUTO;
+SELECT a xor b FROM t1;
+a xor b
+0
+1
+SET columnstore_select_handler=ON;
+SELECT DISTINCT a FROM t1 WHERE a IN (SELECT a FROM t1) OR a IN (SELECT a FROM t1);
+ERROR HY000: Internal error: IDB-3033: Correlated subquery within OR operator is currently not supported.
+SET columnstore_select_handler=AUTO;
+SELECT DISTINCT a FROM t1 WHERE a IN (SELECT a FROM t1) OR a IN (SELECT a FROM t1);
+a
+1
+5
+DROP TABLE t1;
+CREATE TABLE bug4767 (c1 float, c2 double);
+INSERT INTO bug4767 VALUES (1.234, 3.4556), (2.3345456, 2.3345456);
+SET columnstore_select_handler=ON;
+SELECT * FROM bug4767 a JOIN bug4767 b ON (a.c1=b.c2);
+ERROR HY000: Internal error: IDB-1002: 'a' and 'b' have incompatible column type specified for join condition.
+SET columnstore_select_handler=AUTO;
+SELECT * FROM bug4767 a JOIN bug4767 b ON (a.c1=b.c2);
+c1	c2	c1	c2
+DROP TABLE bug4767;
+CREATE TABLE t1 (a int);
+INSERT INTO t1 VALUES (1), (2);
+CREATE TABLE t2 (b int);
+INSERT INTO t2 VALUES (2);
+SET columnstore_select_handler=ON;
+SELECT a FROM t1 WHERE a IN (SELECT a FROM t2);
+ERROR HY000: Internal error: IDB-1000: 't1' and 't2' are not joined.
+SET columnstore_select_handler=AUTO;
+SELECT a FROM t1 WHERE a IN (SELECT a FROM t2);
+a
+1
+2
+DROP TABLE t1;
+DROP TABLE t2;
+CREATE TABLE t1 (a int);
+INSERT INTO t1 VALUES (1), (2), (3);
+CREATE TABLE t2 (a int);
+INSERT INTO t2 VALUES (2), (3);
+CREATE TABLE t3 (a int);
+INSERT INTO t3 VALUES (3);
+SET columnstore_select_handler=ON;
+SELECT * FROM t1 JOIN t2 ON t1.a=t2.a JOIN t3 ON t2.a=t3.a AND t3.a=t1.a;
+ERROR HY000: Internal error: IDB-1003: Circular joins are not supported.
+SET columnstore_select_handler=AUTO;
+SELECT * FROM t1 JOIN t2 ON t1.a=t2.a JOIN t3 ON t2.a=t3.a AND t3.a=t1.a;
+a	a	a
+3	3	3
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+CREATE TABLE l(c1 int, c2 int);
+CREATE TABLE r(c1 int, c2 int);
+CREATE TABLE s(c1 int, c2 int);
+INSERT INTO l VALUES (1, 1);
+INSERT INTO l VALUES (2, 2);
+INSERT INTO r VALUES (1, 1);
+INSERT INTO r VALUES (5, 5);
+INSERT INTO s VALUES (1, 1);
+INSERT INTO s VALUES (9, 9);
+SET columnstore_select_handler=ON;
+SELECT 'q1', l.c1, r.c1 FROM l LEFT JOIN r ON l.c1 = r.c1 AND l.c1 IN (SELECT c1 FROM s) ORDER BY 1, 2, 3;
+ERROR HY000: Internal error: IDB-1015: Subquery on OUTER JOIN ON clause is currently not supported.
+SET columnstore_select_handler=AUTO;
+SELECT 'q1', l.c1, r.c1 FROM l LEFT JOIN r ON l.c1 = r.c1 AND l.c1 IN (SELECT c1 FROM s) ORDER BY 1, 2, 3;
+q1	c1	c1
+q1	1	1
+q1	2	NULL
+DROP TABLE l;
+DROP TABLE r;
+DROP TABLE s;
+CREATE TABLE t1 (col1 int, col2 varchar(5), col_t1 int);
+INSERT INTO t1 VALUES(10,'hello',10);
+INSERT INTO t1 VALUES(20,'hello',20);
+INSERT INTO t1 VALUES(30,'hello',30);
+INSERT INTO t1 VALUES(10,'bye',10);
+INSERT INTO t1 VALUES(10,'sam',10);
+INSERT INTO t1 VALUES(10,'bob',10);
+SET columnstore_select_handler=ON;
+SELECT SUM(col1) AS col2 FROM t1 GROUP BY col2;
+ERROR 42000: The storage engine for the table doesn't support IDB-2016: Non supported item 'col2' on the GROUP BY list.
+SELECT col1 c FROM t1 ORDER BY AVG(col1);
+ERROR HY000: Internal error: IDB-2021: 'c' is not in GROUP BY clause. All non-aggregate columns in the SELECT and ORDER BY clause must be included in the GROUP BY clause.
+SET columnstore_select_handler=AUTO;
+SELECT SUM(col1) AS col2 FROM t1 GROUP BY col2;
+col2
+10
+10
+60
+10
+SELECT col1 c FROM t1 ORDER BY AVG(col1);
+c
+10
+DROP TABLE t1;
+CREATE TABLE t1 (a int);
+INSERT INTO t1 VALUES (1);
+SET columnstore_select_handler=ON;
+SELECT minute(sleep(a)) FROM t1;
+ERROR 42000: The storage engine for the table doesn't support IDB-1001: Function 'minute' isn't supported.
+SET columnstore_select_handler=AUTO;
+SELECT minute(sleep(a)) FROM t1;
+minute(sleep(a))
+0
+DROP TABLE t1;
+CREATE TABLE t1 (a int);
+CREATE TABLE t2 (a int);
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES (2), (3);
+SET columnstore_select_handler=ON;
+SELECT SUM(a) FROM t1 WHERE EXISTS (SELECT MAX(a) FROM t2);
+ERROR HY000: Internal error: IDB-3008: Aggregate function in EXISTS subquery is currently not supported.
+SELECT * FROM t1 WHERE (a,a) < (SELECT a,a FROM t2 WHERE a=2);
+ERROR HY000: Internal error: IDB-3006: This operator cannot be used with lists.
+SET columnstore_select_handler=AUTO;
+SELECT SUM(a) FROM t1 WHERE EXISTS (SELECT MAX(a) FROM t2);
+SUM(a)
+3
+SELECT * FROM t1 WHERE (a,a) < (SELECT a,a FROM t2 WHERE a=2);
+a
+1
+DROP TABLE t1;
+DROP TABLE t2;
+CREATE TABLE gen (i int, i2 int);
+INSERT INTO gen VALUES (1,0), (1,1), (1,2), (1,3), (1,4), (1,5), (1,6), (1,7), (1,8), (1,9);
+SET columnstore_select_handler=ON;
+SELECT i2, (SELECT MAX(g2.i2) FROM gen g2 WHERE g2.i = g1.i AND g2.i2 > g1.i2) sub FROM gen g1;
+ERROR HY000: Internal error: IDB-3035: Not equal comparison between a column within a subquery with an aggregate result and a column outside of the subquery is not supported.
+SET columnstore_select_handler=AUTO;
+SELECT i2, (SELECT MAX(g2.i2) FROM gen g2 WHERE g2.i = g1.i AND g2.i2 > g1.i2) sub FROM gen g1;
+i2	sub
+0	9
+1	9
+2	9
+3	9
+4	9
+5	9
+6	9
+7	9
+8	9
+9	NULL
+DROP TABLE gen;
+CREATE TABLE t1(a int);
+INSERT INTO t1 VALUES (0), (1), (2), (3);
+CREATE TABLE t2 (a int);
+INSERT INTO t2 VALUES (2), (3);
+CREATE VIEW v1 AS SELECT a FROM t1 WHERE a > 1;
+SET columnstore_select_handler=ON;
+SELECT * FROM t1 LEFT JOIN (t2 AS t, v1) ON v1.a=t1.a ORDER BY 1;
+ERROR HY000: Internal error: IDB-1000: 'v1, t1' and 't' are not joined.
+SET columnstore_select_handler=AUTO;
+SELECT * FROM t1 LEFT JOIN (t2 AS t, v1) ON v1.a=t1.a ORDER BY 1;
+a	a	a
+0	NULL	NULL
+1	NULL	NULL
+2	2	2
+2	3	2
+3	2	3
+3	3	3
+DROP TABLE t1;
+DROP TABLE t2;
+DROP VIEW v1;
+CREATE TABLE c1 (a int);
+INSERT INTO c1 VALUES (1), (2), (3);
+CREATE TABLE c2 (a int);
+INSERT INTO c2 VALUES (2);
+CREATE TABLE c3 (a int);
+CREATE TABLE c4 (a int);
+CREATE TABLE c5 (a int);
+SET columnstore_select_handler=ON;
+SELECT c1.a AS col1, c2.a AS col2, c1.a xor c2.a FROM
+c1 LEFT JOIN
+(
+(c2 LEFT JOIN c3 ON c2.a=c3.a) LEFT JOIN
+(c4 JOIN c5 ON c4.a=c5.a)
+ON c2.a=c4.a
+)
+ON c1.a=c2.a WHERE c2.a < 100;
+ERROR 42000: The storage engine for the table doesn't support IDB-2030: Predicate and Logic operators can not be used where an expression is expected.
+SET columnstore_select_handler=AUTO;
+SELECT c1.a AS col1, c2.a AS col2, c1.a xor c2.a FROM
+c1 LEFT JOIN
+(
+(c2 LEFT JOIN c3 ON c2.a=c3.a) LEFT JOIN
+(c4 JOIN c5 ON c4.a=c5.a)
+ON c2.a=c4.a
+)
+ON c1.a=c2.a WHERE c2.a < 100;
+col1	col2	c1.a xor c2.a
+2	2	0
+DROP TABLE c1;
+DROP TABLE c2;
+DROP TABLE c3;
+DROP TABLE c4;
+DROP TABLE c5;
+CREATE TABLE t1 (a int);
+INSERT INTO t1 VALUES (1), (2), (3), (4);
+SET columnstore_select_handler=ON;
+PREPARE stmt FROM "SELECT a, a xor 0 FROM t1 WHERE a > 1 AND a < 4";
+EXECUTE stmt;
+ERROR 42000: The storage engine for the table doesn't support IDB-2030: Predicate and Logic operators can not be used where an expression is expected.
+EXECUTE stmt;
+ERROR 42000: The storage engine for the table doesn't support IDB-2030: Predicate and Logic operators can not be used where an expression is expected.
+EXECUTE stmt;
+ERROR 42000: The storage engine for the table doesn't support IDB-2030: Predicate and Logic operators can not be used where an expression is expected.
+EXECUTE stmt;
+ERROR 42000: The storage engine for the table doesn't support IDB-2030: Predicate and Logic operators can not be used where an expression is expected.
+DROP PREPARE stmt;
+SET columnstore_select_handler=AUTO;
+PREPARE stmt FROM "SELECT a, a xor 0 FROM t1 WHERE a > 1 AND a < 4";
+EXECUTE stmt;
+a	a xor 0
+2	1
+3	1
+EXECUTE stmt;
+a	a xor 0
+2	1
+3	1
+EXECUTE stmt;
+a	a xor 0
+2	1
+3	1
+EXECUTE stmt;
+a	a xor 0
+2	1
+3	1
+EXECUTE stmt;
+a	a xor 0
+2	1
+3	1
+DROP PREPARE stmt;
+SET columnstore_select_handler=ON;
+CREATE PROCEDURE mcol4525_proc()
+BEGIN
+SELECT a, a xor 0 FROM t1 WHERE a > 1 AND a < 4;
+END
+//
+CALL mcol4525_proc();
+ERROR 42000: The storage engine for the table doesn't support IDB-2030: Predicate and Logic operators can not be used where an expression is expected.
+CALL mcol4525_proc();
+ERROR 42000: The storage engine for the table doesn't support IDB-2030: Predicate and Logic operators can not be used where an expression is expected.
+CALL mcol4525_proc();
+ERROR 42000: The storage engine for the table doesn't support IDB-2030: Predicate and Logic operators can not be used where an expression is expected.
+DROP PROCEDURE mcol4525_proc;
+SET columnstore_select_handler=AUTO;
+CREATE PROCEDURE mcol4525_proc()
+BEGIN
+SELECT a, a xor 0 FROM t1 WHERE a > 1 AND a < 4;
+END
+//
+CALL mcol4525_proc();
+a	a xor 0
+2	1
+3	1
+CALL mcol4525_proc();
+a	a xor 0
+2	1
+3	1
+CALL mcol4525_proc();
+a	a xor 0
+2	1
+3	1
+DROP PROCEDURE mcol4525_proc;
+DROP TABLE t1;
+CREATE TABLE `giorno` (
+`giorno` date NOT NULL DEFAULT '0000-00-00',
+`giornoa` mediumint(7) DEFAULT NULL,
+`mese` mediumint(6) DEFAULT NULL,
+`settimana` mediumint(6) DEFAULT NULL,
+`quindicina` mediumint(6) DEFAULT NULL,
+`trimestre` smallint(5) DEFAULT NULL,
+`quadrimestre` smallint(5) DEFAULT NULL,
+`semestre` smallint(5) DEFAULT NULL,
+`bimestre` smallint(5) DEFAULT NULL,
+`anno` smallint(4) DEFAULT NULL,
+PRIMARY KEY (`giorno`),
+KEY `mese` (`mese`),
+KEY `quindicina` (`quindicina`),
+KEY `settimana` (`settimana`),
+KEY `trimestre` (`trimestre`),
+KEY `semestre` (`semestre`),
+KEY `bimestre` (`bimestre`),
+KEY `quadrimestre` (`quadrimestre`),
+KEY `giornoa` (`giornoa`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Giorni';
+CREATE TABLE `campagna_web_codice` (
+`cwc_id` int(11) DEFAULT NULL,
+`cwc_cw_id` int(11) DEFAULT NULL,
+`cwc_cd_id` int(11) DEFAULT NULL,
+`cwc_codice` varchar(30) DEFAULT NULL,
+`cwc_va_id` int(11) DEFAULT NULL,
+`cwc_prezzo` decimal(12,2) DEFAULT NULL,
+`cwc_prezzoListino` decimal(12,2) DEFAULT NULL,
+`cwc_prezzoSpedizione` decimal(8,2) DEFAULT NULL,
+`cwc_in_id` int(11) DEFAULT NULL,
+`cwc_na_id` int(11) DEFAULT NULL,
+`cwc_desc` varchar(100) DEFAULT NULL,
+`cwc_datainizio` date DEFAULT NULL,
+`cwc_datafine` date DEFAULT NULL,
+`cwc_mo_id` int(11) DEFAULT NULL,
+`cwc_ma_id` int(11) DEFAULT NULL,
+`cwc_pd_id` int(11) DEFAULT NULL,
+`cwc_set_id` int(11) DEFAULT NULL,
+`cwc_mr_id` int(11) DEFAULT NULL,
+`cwc_ca_id` int(11) DEFAULT NULL,
+`cwc_fa_id` int(11) DEFAULT NULL,
+`cwc_ti_id` int(11) DEFAULT NULL,
+`cwc_azws` varchar(255) DEFAULT NULL
+) ENGINE=Columnstore DEFAULT CHARSET=utf8;
+SET columnstore_select_handler=ON;
+SELECT COUNT(DISTINCT cwc_id) npres,COUNT(DISTINCT cwc_cw_id) ncw,cwc_in_id insegna
+FROM (giorno,campagna_web_codice)
+WHERE cwc_fa_id IN (23) AND giorno BETWEEN cwc_datainizio AND cwc_datafine AND mese IN (202009)
+GROUP BY insegna;
+ERROR HY000: Internal error: IDB-1000: 'giorno' and 'campagna_web_codice' are not joined.
+SET columnstore_select_handler=AUTO;
+SELECT COUNT(DISTINCT cwc_id) npres,COUNT(DISTINCT cwc_cw_id) ncw,cwc_in_id insegna
+FROM (giorno,campagna_web_codice)
+WHERE cwc_fa_id IN (23) AND giorno BETWEEN cwc_datainizio AND cwc_datafine AND mese IN (202009)
+GROUP BY insegna;
+npres	ncw	insegna
+DROP DATABASE mcol4525;

--- a/mysql-test/columnstore/basic/t/mcol-424.test
+++ b/mysql-test/columnstore/basic/t/mcol-424.test
@@ -1,0 +1,62 @@
+--source ../include/have_columnstore.inc
+
+--echo # MCOL-424
+--echo # Cross engine subquery losing where clause causing incorrect results
+
+if (!$MASTER_MYPORT)
+{
+  # Running with --extern
+  let $MASTER_MYPORT=`SELECT @@port`;
+}
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol424;
+--enable_warnings
+
+CREATE DATABASE mcol424;
+USE mcol424;
+
+#
+# Enable cross engine join
+# Configure user and password in Columnstore.xml file
+#
+--exec $MCS_MCSSETCONFIG CrossEngineSupport User 'cejuser'
+--exec $MCS_MCSSETCONFIG CrossEngineSupport Password 'Vagrant1|0000001'
+--exec $MCS_MCSSETCONFIG CrossEngineSupport Port $MASTER_MYPORT
+
+#
+# Create corresponding in the server
+#
+--disable_warnings
+CREATE USER IF NOT EXISTS'cejuser'@'localhost' IDENTIFIED BY 'Vagrant1|0000001';
+--enable_warnings
+GRANT ALL PRIVILEGES ON *.* TO 'cejuser'@'localhost';
+FLUSH PRIVILEGES;
+
+CREATE TABLE `trans_test` (
+  `id` int(11) DEFAULT NULL,
+  `member_id` int(11) DEFAULT NULL,
+  `name` varchar(50) DEFAULT NULL
+) ENGINE=Columnstore DEFAULT CHARSET=latin1;
+
+insert  into `trans_test`(`id`,`member_id`,`name`) values (1,1,'trans 1');
+insert  into `trans_test`(`id`,`member_id`,`name`) values (2,2,'trans 2');
+insert  into `trans_test`(`id`,`member_id`,`name`) values (3,1,'trans 3');
+insert  into `trans_test`(`id`,`member_id`,`name`) values (4,2,'trans 4');
+insert  into `trans_test`(`id`,`member_id`,`name`) values (5,1,'trans 5');
+
+CREATE TABLE `member_test` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+insert  into `member_test`(`id`,`name`) values (1,'member 1');
+insert  into `member_test`(`id`,`name`) values (2,'member 2');
+insert  into `member_test`(`id`,`name`) values (3,'member 3');
+
+SELECT * FROM trans_test t WHERE t.`member_id` IN (SELECT id FROM member_test WHERE id =1);
+
+# Clean UP
+DROP USER 'cejuser'@'localhost';
+DROP DATABASE mcol424;

--- a/mysql-test/columnstore/basic/t/mcol-4525.test
+++ b/mysql-test/columnstore/basic/t/mcol-4525.test
@@ -1,0 +1,312 @@
+--source ../include/have_columnstore.inc
+
+--echo # MCOL-4525
+--echo # Automatic select_handler
+--echo # columnstore_select_handler=AUTO allows query execution
+--echo # to fallback to the server, in case the execution using
+--echo # select_handler fails.
+
+SET default_storage_engine=columnstore;
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol4525;
+
+CREATE DATABASE mcol4525;
+USE mcol4525;
+
+# Test case from working_tpch1/qa_fe_cnxFunctions/xor.sql.negative.sql
+CREATE TABLE t1 (a int, b int);
+INSERT INTO t1 VALUES (1, 1), (5, 0);
+SET columnstore_select_handler=ON;
+--error 1178
+SELECT a xor b FROM t1;
+SET columnstore_select_handler=AUTO;
+SELECT a xor b FROM t1;
+
+# Test case from MCOL-428
+# This also tests in-to-exists predicate creation and injection
+SET columnstore_select_handler=ON;
+--error 1815
+SELECT DISTINCT a FROM t1 WHERE a IN (SELECT a FROM t1) OR a IN (SELECT a FROM t1);
+SET columnstore_select_handler=AUTO;
+SELECT DISTINCT a FROM t1 WHERE a IN (SELECT a FROM t1) OR a IN (SELECT a FROM t1);
+DROP TABLE t1;
+
+# Test case from working_tpch1/misc/bug4767.negative.sql
+CREATE TABLE bug4767 (c1 float, c2 double);
+INSERT INTO bug4767 VALUES (1.234, 3.4556), (2.3345456, 2.3345456);
+SET columnstore_select_handler=ON;
+--error 1815
+SELECT * FROM bug4767 a JOIN bug4767 b ON (a.c1=b.c2);
+SET columnstore_select_handler=AUTO;
+SELECT * FROM bug4767 a JOIN bug4767 b ON (a.c1=b.c2);
+DROP TABLE bug4767;
+
+# Test case from working_tpch1/misc/bug5126.negative.sql
+CREATE TABLE t1 (a int);
+INSERT INTO t1 VALUES (1), (2);
+CREATE TABLE t2 (b int);
+INSERT INTO t2 VALUES (2);
+SET columnstore_select_handler=ON;
+--error 1815
+SELECT a FROM t1 WHERE a IN (SELECT a FROM t2);
+SET columnstore_select_handler=AUTO;
+SELECT a FROM t1 WHERE a IN (SELECT a FROM t2);
+DROP TABLE t1;
+DROP TABLE t2;
+
+# Test case for MCOL-1205 Circular Joins not supported
+CREATE TABLE t1 (a int);
+INSERT INTO t1 VALUES (1), (2), (3);
+CREATE TABLE t2 (a int);
+INSERT INTO t2 VALUES (2), (3);
+CREATE TABLE t3 (a int);
+INSERT INTO t3 VALUES (3);
+SET columnstore_select_handler=ON;
+--error 1815
+SELECT * FROM t1 JOIN t2 ON t1.a=t2.a JOIN t3 ON t2.a=t3.a AND t3.a=t1.a;
+SET columnstore_select_handler=AUTO;
+SELECT * FROM t1 JOIN t2 ON t1.a=t2.a JOIN t3 ON t2.a=t3.a AND t3.a=t1.a;
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+
+# Test case from working_tpch1_compareLogOnly/onClauseJoins/03.sql
+CREATE TABLE l(c1 int, c2 int);
+CREATE TABLE r(c1 int, c2 int);
+CREATE TABLE s(c1 int, c2 int);
+INSERT INTO l VALUES (1, 1);
+INSERT INTO l VALUES (2, 2);
+INSERT INTO r VALUES (1, 1);
+INSERT INTO r VALUES (5, 5);
+INSERT INTO s VALUES (1, 1);
+INSERT INTO s VALUES (9, 9);
+SET columnstore_select_handler=ON;
+--error 1815
+SELECT 'q1', l.c1, r.c1 FROM l LEFT JOIN r ON l.c1 = r.c1 AND l.c1 IN (SELECT c1 FROM s) ORDER BY 1, 2, 3;
+SET columnstore_select_handler=AUTO;
+SELECT 'q1', l.c1, r.c1 FROM l LEFT JOIN r ON l.c1 = r.c1 AND l.c1 IN (SELECT c1 FROM s) ORDER BY 1, 2, 3;
+DROP TABLE l;
+DROP TABLE r;
+DROP TABLE s;
+
+# Test case from working_tpch1_compareLogOnly/having/having_mysql.sql
+CREATE TABLE t1 (col1 int, col2 varchar(5), col_t1 int);
+INSERT INTO t1 VALUES(10,'hello',10);
+INSERT INTO t1 VALUES(20,'hello',20);
+INSERT INTO t1 VALUES(30,'hello',30);
+INSERT INTO t1 VALUES(10,'bye',10);
+INSERT INTO t1 VALUES(10,'sam',10);
+INSERT INTO t1 VALUES(10,'bob',10);
+SET columnstore_select_handler=ON;
+--error 1178
+SELECT SUM(col1) AS col2 FROM t1 GROUP BY col2;
+--error 1815
+SELECT col1 c FROM t1 ORDER BY AVG(col1);
+SET columnstore_select_handler=AUTO;
+SELECT SUM(col1) AS col2 FROM t1 GROUP BY col2;
+SELECT col1 c FROM t1 ORDER BY AVG(col1);
+DROP TABLE t1;
+
+# Test case from working_tpch1_compareLogOnly/misc/bug2891_negative.sql
+CREATE TABLE t1 (a int);
+INSERT INTO t1 VALUES (1);
+SET columnstore_select_handler=ON;
+--error 1178
+SELECT minute(sleep(a)) FROM t1;
+SET columnstore_select_handler=AUTO;
+SELECT minute(sleep(a)) FROM t1;
+DROP TABLE t1;
+
+# Test case from working_tpch1_compareLogOnly/sub/g3_simple_semi_join.negative.sql
+CREATE TABLE t1 (a int);
+CREATE TABLE t2 (a int);
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES (2), (3);
+SET columnstore_select_handler=ON;
+--error 1815
+SELECT SUM(a) FROM t1 WHERE EXISTS (SELECT MAX(a) FROM t2);
+# Test case from working_tpch1_compareLogOnly/sub/g2_simple_scalar.negative.sql
+--error 1815
+SELECT * FROM t1 WHERE (a,a) < (SELECT a,a FROM t2 WHERE a=2);
+SET columnstore_select_handler=AUTO;
+SELECT SUM(a) FROM t1 WHERE EXISTS (SELECT MAX(a) FROM t2);
+SELECT * FROM t1 WHERE (a,a) < (SELECT a,a FROM t2 WHERE a=2);
+DROP TABLE t1;
+DROP TABLE t2;
+
+# Test case from working_tpch1_compareLogOnly/sub/bug3767.sql
+CREATE TABLE gen (i int, i2 int);
+INSERT INTO gen VALUES (1,0), (1,1), (1,2), (1,3), (1,4), (1,5), (1,6), (1,7), (1,8), (1,9);
+SET columnstore_select_handler=ON;
+--error 1815
+SELECT i2, (SELECT MAX(g2.i2) FROM gen g2 WHERE g2.i = g1.i AND g2.i2 > g1.i2) sub FROM gen g1;
+SET columnstore_select_handler=AUTO;
+SELECT i2, (SELECT MAX(g2.i2) FROM gen g2 WHERE g2.i = g1.i AND g2.i2 > g1.i2) sub FROM gen g1;
+DROP TABLE gen;
+
+# Test case from working_tpch1_compareLogOnly/view/mts_view.30.sql
+CREATE TABLE t1(a int);
+INSERT INTO t1 VALUES (0), (1), (2), (3);
+CREATE TABLE t2 (a int);
+INSERT INTO t2 VALUES (2), (3);
+CREATE VIEW v1 AS SELECT a FROM t1 WHERE a > 1;
+SET columnstore_select_handler=ON;
+--error 1815
+SELECT * FROM t1 LEFT JOIN (t2 AS t, v1) ON v1.a=t1.a ORDER BY 1;
+SET columnstore_select_handler=AUTO;
+SELECT * FROM t1 LEFT JOIN (t2 AS t, v1) ON v1.a=t1.a ORDER BY 1;
+DROP TABLE t1;
+DROP TABLE t2;
+DROP VIEW v1;
+
+# Modified test case from MCOL-4680:
+# FROM subquery containing nested joins returns an error
+CREATE TABLE c1 (a int);
+INSERT INTO c1 VALUES (1), (2), (3);
+CREATE TABLE c2 (a int);
+INSERT INTO c2 VALUES (2);
+CREATE TABLE c3 (a int);
+CREATE TABLE c4 (a int);
+CREATE TABLE c5 (a int);
+SET columnstore_select_handler=ON;
+--error 1178
+SELECT c1.a AS col1, c2.a AS col2, c1.a xor c2.a FROM
+  c1 LEFT JOIN
+  (
+    (c2 LEFT JOIN c3 ON c2.a=c3.a) LEFT JOIN
+    (c4 JOIN c5 ON c4.a=c5.a)
+    ON c2.a=c4.a
+  )
+  ON c1.a=c2.a WHERE c2.a < 100;
+SET columnstore_select_handler=AUTO;
+SELECT c1.a AS col1, c2.a AS col2, c1.a xor c2.a FROM
+  c1 LEFT JOIN
+  (
+    (c2 LEFT JOIN c3 ON c2.a=c3.a) LEFT JOIN
+    (c4 JOIN c5 ON c4.a=c5.a)
+    ON c2.a=c4.a
+  )
+  ON c1.a=c2.a WHERE c2.a < 100;
+DROP TABLE c1;
+DROP TABLE c2;
+DROP TABLE c3;
+DROP TABLE c4;
+DROP TABLE c5;
+
+# Test case for prepared statements
+CREATE TABLE t1 (a int);
+INSERT INTO t1 VALUES (1), (2), (3), (4);
+SET columnstore_select_handler=ON;
+PREPARE stmt FROM "SELECT a, a xor 0 FROM t1 WHERE a > 1 AND a < 4";
+--error 1178
+EXECUTE stmt;
+--error 1178
+EXECUTE stmt;
+--error 1178
+EXECUTE stmt;
+--error 1178
+EXECUTE stmt;
+DROP PREPARE stmt;
+SET columnstore_select_handler=AUTO;
+PREPARE stmt FROM "SELECT a, a xor 0 FROM t1 WHERE a > 1 AND a < 4";
+EXECUTE stmt;
+EXECUTE stmt;
+EXECUTE stmt;
+EXECUTE stmt;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+# Test case for stored procedures
+SET columnstore_select_handler=ON;
+delimiter //;
+CREATE PROCEDURE mcol4525_proc()
+ BEGIN
+  SELECT a, a xor 0 FROM t1 WHERE a > 1 AND a < 4;
+ END
+//
+delimiter ;//
+--error 1178
+CALL mcol4525_proc();
+--error 1178
+CALL mcol4525_proc();
+--error 1178
+CALL mcol4525_proc();
+DROP PROCEDURE mcol4525_proc;
+SET columnstore_select_handler=AUTO;
+delimiter //;
+CREATE PROCEDURE mcol4525_proc()
+ BEGIN
+  SELECT a, a xor 0 FROM t1 WHERE a > 1 AND a < 4;
+ END
+//
+delimiter ;//
+CALL mcol4525_proc();
+CALL mcol4525_proc();
+CALL mcol4525_proc();
+DROP PROCEDURE mcol4525_proc;
+DROP TABLE t1;
+
+# Test case taken verbatim from MCOL-4525 issue description
+CREATE TABLE `giorno` (
+`giorno` date NOT NULL DEFAULT '0000-00-00',
+`giornoa` mediumint(7) DEFAULT NULL,
+`mese` mediumint(6) DEFAULT NULL,
+`settimana` mediumint(6) DEFAULT NULL,
+`quindicina` mediumint(6) DEFAULT NULL,
+`trimestre` smallint(5) DEFAULT NULL,
+`quadrimestre` smallint(5) DEFAULT NULL,
+`semestre` smallint(5) DEFAULT NULL,
+`bimestre` smallint(5) DEFAULT NULL,
+`anno` smallint(4) DEFAULT NULL,
+PRIMARY KEY (`giorno`),
+KEY `mese` (`mese`),
+KEY `quindicina` (`quindicina`),
+KEY `settimana` (`settimana`),
+KEY `trimestre` (`trimestre`),
+KEY `semestre` (`semestre`),
+KEY `bimestre` (`bimestre`),
+KEY `quadrimestre` (`quadrimestre`),
+KEY `giornoa` (`giornoa`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Giorni';
+
+CREATE TABLE `campagna_web_codice` (
+`cwc_id` int(11) DEFAULT NULL,
+`cwc_cw_id` int(11) DEFAULT NULL,
+`cwc_cd_id` int(11) DEFAULT NULL,
+`cwc_codice` varchar(30) DEFAULT NULL,
+`cwc_va_id` int(11) DEFAULT NULL,
+`cwc_prezzo` decimal(12,2) DEFAULT NULL,
+`cwc_prezzoListino` decimal(12,2) DEFAULT NULL,
+`cwc_prezzoSpedizione` decimal(8,2) DEFAULT NULL,
+`cwc_in_id` int(11) DEFAULT NULL,
+`cwc_na_id` int(11) DEFAULT NULL,
+`cwc_desc` varchar(100) DEFAULT NULL,
+`cwc_datainizio` date DEFAULT NULL,
+`cwc_datafine` date DEFAULT NULL,
+`cwc_mo_id` int(11) DEFAULT NULL,
+`cwc_ma_id` int(11) DEFAULT NULL,
+`cwc_pd_id` int(11) DEFAULT NULL,
+`cwc_set_id` int(11) DEFAULT NULL,
+`cwc_mr_id` int(11) DEFAULT NULL,
+`cwc_ca_id` int(11) DEFAULT NULL,
+`cwc_fa_id` int(11) DEFAULT NULL,
+`cwc_ti_id` int(11) DEFAULT NULL,
+`cwc_azws` varchar(255) DEFAULT NULL
+) ENGINE=Columnstore DEFAULT CHARSET=utf8;
+
+SET columnstore_select_handler=ON;
+--error 1815
+SELECT COUNT(DISTINCT cwc_id) npres,COUNT(DISTINCT cwc_cw_id) ncw,cwc_in_id insegna
+FROM (giorno,campagna_web_codice)
+WHERE cwc_fa_id IN (23) AND giorno BETWEEN cwc_datainizio AND cwc_datafine AND mese IN (202009)
+GROUP BY insegna;
+
+SET columnstore_select_handler=AUTO;
+SELECT COUNT(DISTINCT cwc_id) npres,COUNT(DISTINCT cwc_cw_id) ncw,cwc_in_id insegna
+FROM (giorno,campagna_web_codice)
+WHERE cwc_fa_id IN (23) AND giorno BETWEEN cwc_datainizio AND cwc_datafine AND mese IN (202009)
+GROUP BY insegna;
+
+DROP DATABASE mcol4525;
+--enable_warnings


### PR DESCRIPTION
This feature allows a query execution to fallback to the server,
in case query execution using the select_handler (SH) fails. In case
of fallback, a warning message containing the original reason for
query failure using SH is generated.

To accomplish this task, SH execution is moved to an earlier step when
we create the SH in create_columnstore_select_handler(), instead of the
previous call to SH execution in ha_columnstore_select_handler::init_scan().
This requires some pre-requisite steps that occur in the server in
JOIN::optimize() and JOIN::exec() to be performed before starting SH execution.

In addition, missing test cases from MCOL-424 are also added to the MTR suite,
and the corresponding fix using disable_indices_for_CEJ() is reverted back
since the original fix now appears to be redundant.