### PR TITLE
MCOL-4685: Fix GCC warnings.

### DIFF
--- a/dbcon/joblist/tuple-bps.cpp
+++ b/dbcon/joblist/tuple-bps.cpp
@@ -179,8 +179,6 @@ void TupleBPS::initializeConfigParms()
     fProcessorThreadsPerScan = fRm->getJlProcessorThreadsPerScan();
     fNumThreads = 0;
 
-    config::Config* cf = config::Config::makeConfig();
-
     fExtentsPerSegFile = DEFAULT_EXTENTS_PER_SEG_FILE;
 
     if (fRequestSize >= fMaxOutstandingRequests)

--- a/writeengine/bulk/we_colbufcompressed.cpp
+++ b/writeengine/bulk/we_colbufcompressed.cpp
@@ -584,7 +584,7 @@ int ColumnBufferCompressed::saveCompressionHeaders( )
     char hdrBuf[IDBCompressInterface::HDR_BUF_LEN * 2];
     RETURN_ON_ERROR(fColInfo->colOp->readHeaders(fFile, hdrBuf));
 
-    auto lbid = fCompressor->getLBIDByIndex(hdrBuf, 0);
+    BRM::LBID_t lbid = fCompressor->getLBIDByIndex(hdrBuf, 0);
     fCompressor->initHdr(hdrBuf, fColInfo->column.width,
                          fColInfo->column.dataType,
                          fColInfo->column.compressionType);


### PR DESCRIPTION
This patch fixes GCC warnings:
1.'const long int' and 'long unsigned int' [-Werror=sign-compare]
2. unused variable 'cf' [-Werror=unused-variable]