### PR TITLE
MCOL-1482 An UPDATE operation on a non-ColumnStore table involving a cross-engine join

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -6325,6 +6325,48 @@ bool isMCSTable(TABLE* table_ptr)
         return false;
 }
 
+bool isForeignTableUpdate(THD* thd)
+{
+    LEX* lex = thd->lex;
+
+    if (lex->sql_command != SQLCOM_UPDATE_MULTI)
+        return false;
+
+    Item_field* item;
+    List_iterator_fast<Item> field_it(lex->first_select_lex()->item_list);
+
+    while ((item = (Item_field*) field_it++))
+    {
+        if (item->field && item->field->table && !isMCSTable(item->field->table))
+            return true;
+    }
+
+    return false;
+}
+
+// This function is different from isForeignTableUpdate()
+// above as it only checks if any of the tables involved
+// in the multi-table update statement is a foreign table,
+// irrespective of whether the update is performed on the
+// foreign table or not, as in isForeignTableUpdate().
+bool isUpdateHasForeignTable(THD* thd)
+{
+    LEX* lex = thd->lex;
+
+    if (lex->sql_command != SQLCOM_UPDATE_MULTI)
+        return false;
+
+    TABLE_LIST* table_ptr = lex->first_select_lex()->get_table_list();
+
+    for (; table_ptr; table_ptr = table_ptr->next_local)
+    {
+        if (table_ptr->table && !isMCSTable(table_ptr->table))
+            return true;
+    }
+
+    return false;
+}
+
 /*@brief  set some runtime params to run the query         */
 /***********************************************************
  * DESCRIPTION:
@@ -6576,10 +6618,7 @@ int processWhere(SELECT_LEX &select_lex,
         else if (select_lex.where)
             icp = select_lex.where;
     }
-    else if (!join && ( ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE ) ||
-                        ((gwi.thd->lex)->sql_command == SQLCOM_DELETE ) ||
-                        ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE_MULTI ) ||
-                        ((gwi.thd->lex)->sql_command == SQLCOM_DELETE_MULTI )))
+    else if (!join && isUpdateOrDeleteStatement(gwi.thd->lex->sql_command))
     {
         isUpdateDelete = true;
     }
@@ -7392,7 +7431,7 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex,
                     }
 
                     //@Bug 3030 Add error check for dml statement
-                    if ( ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE ) || ((gwi.thd->lex)->sql_command == SQLCOM_DELETE ) || ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE_MULTI ) || ((gwi.thd->lex)->sql_command == SQLCOM_DELETE_MULTI ) )
+                    if (isUpdateOrDeleteStatement(gwi.thd->lex->sql_command))
                     {
                         if ( after_size - before_size != 0 )
                         {
@@ -7426,7 +7465,7 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex,
                     case REAL_RESULT:
                     case TIME_RESULT:
                     {
-                        if ( ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE ) || ((gwi.thd->lex)->sql_command == SQLCOM_DELETE ) || ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE_MULTI ) || ((gwi.thd->lex)->sql_command == SQLCOM_DELETE_MULTI ))
+                        if (isUpdateOrDeleteStatement(gwi.thd->lex->sql_command))
                         { }
                         else
                         {
@@ -7458,7 +7497,7 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex,
 
             case Item::NULL_ITEM:
             {
-                if ( ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE ) || ((gwi.thd->lex)->sql_command == SQLCOM_DELETE ) || ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE_MULTI ) || ((gwi.thd->lex)->sql_command == SQLCOM_DELETE_MULTI ) )
+                if (isUpdateOrDeleteStatement(gwi.thd->lex->sql_command))
                 { }
                 else
                 {
@@ -9258,7 +9297,7 @@ int getGroupPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, SCSEP& csep, cal_gro
                     }
 
                     //@Bug 3030 Add error check for dml statement
-                    if ( ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE ) || ((gwi.thd->lex)->sql_command == SQLCOM_DELETE ) || ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE_MULTI ) || ((gwi.thd->lex)->sql_command == SQLCOM_DELETE_MULTI ) )
+                    if (isUpdateOrDeleteStatement(gwi.thd->lex->sql_command))
                     {
                         if ( after_size - before_size != 0 )
                         {
@@ -9289,7 +9328,7 @@ int getGroupPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, SCSEP& csep, cal_gro
                     case REAL_RESULT:
                     case TIME_RESULT:
                     {
-                        if ( ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE ) || ((gwi.thd->lex)->sql_command == SQLCOM_DELETE ) || ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE_MULTI ) || ((gwi.thd->lex)->sql_command == SQLCOM_DELETE_MULTI ))
+                        if (isUpdateOrDeleteStatement(gwi.thd->lex->sql_command))
                         { }
                         else
                         {
@@ -9321,7 +9360,7 @@ int getGroupPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, SCSEP& csep, cal_gro
 
             case Item::NULL_ITEM:
             {
-                if ( ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE ) || ((gwi.thd->lex)->sql_command == SQLCOM_DELETE ) || ((gwi.thd->lex)->sql_command == SQLCOM_UPDATE_MULTI ) || ((gwi.thd->lex)->sql_command == SQLCOM_DELETE_MULTI ) )
+                if (isUpdateOrDeleteStatement(gwi.thd->lex->sql_command))
                 { }
                 else
                 {

--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -366,6 +366,8 @@ void gp_walk(const Item* item, void* arg);
 void parse_item (Item* item, std::vector<Item_field*>& field_vec, bool& hasNonSupportItem, uint16& parseInfo, gp_walk_info* gwip = NULL);
 const std::string bestTableName(const Item_field* ifp);
 bool isMCSTable(TABLE* table_ptr);
+bool isForeignTableUpdate(THD* thd);
+bool isUpdateHasForeignTable(THD* thd);
 
 // execution plan util functions prototypes
 execplan::ReturnedColumn* buildReturnedColumn(Item* item, gp_walk_info& gwi, bool& nonSupport, bool isRefItem = false);
@@ -408,6 +410,24 @@ bool buildEqualityPredicate(execplan::ReturnedColumn* lhs,
     const Item_func::Functype& funcType,
     const std::vector<Item*>& itemList,
     bool isInSubs = false);
+
+inline bool isUpdateStatement(const enum_sql_command& command)
+{
+    return (command == SQLCOM_UPDATE) ||
+        (command == SQLCOM_UPDATE_MULTI);
+}
+
+inline bool isDeleteStatement(const enum_sql_command& command)
+{
+    return (command == SQLCOM_DELETE) ||
+        (command == SQLCOM_DELETE_MULTI);
+}
+
+inline bool isUpdateOrDeleteStatement(const enum_sql_command& command)
+{
+    return isUpdateStatement(command) ||
+        isDeleteStatement(command);
+}
 
 #ifdef DEBUG_WALK_COND
 void debug_walk(const Item* item, void* arg);

--- a/mysql-test/columnstore/basic/r/mcs45_write_crossengine_join.result
+++ b/mysql-test/columnstore/basic/r/mcs45_write_crossengine_join.result
@@ -6,6 +6,7 @@ GRANT ALL PRIVILEGES ON *.* TO 'cejuser'@'localhost';
 FLUSH PRIVILEGES;
 CREATE TABLE t1 (t1_int INT, t1_char CHAR(5))ENGINE=Innodb;
 CREATE TABLE t2 (t2_int INT, t2_char CHAR(5))ENGINE=Columnstore;
+CREATE VIEW v1 AS SELECT * FROM t1;
 INSERT INTO t1 VALUES (NULL,''),(1,'aaa'),(2,'bbb'),(3,'ccc'),(4,'ddd'),(5,'eee'),(6,'ffff'),(7,'ggggg');
 INSERT INTO t2 VALUES (NULL,''),(1,'hhhh'),(3,'iii'),(5,'jjj'),(7,'kkkk'),(9,'lll'),(11,'m'),(13,'nnn');
 SELECT * FROM t1, t2 WHERE t1.t1_int = t2.t2_int AND t1.t1_int = 3;
@@ -23,17 +24,38 @@ t1_int	t1_char	t2_int	t2_char
 5	eee	5	sssss
 7	ggggg	7	sssss
 UPDATE t1 JOIN t2 on t1.t1_int=t2.t2_int SET t1.t1_char='s';
-ERROR HY000: Internal error: IDB-2006: 'mcs45_db.t1' does not exist in Columnstore.
 SELECT * FROM t1;
 t1_int	t1_char
 NULL	
-1	aaa
+1	s
 2	bbb
-3	ccc
+3	s
 4	ddd
-5	eee
+5	s
 6	ffff
-7	ggggg
+7	s
+UPDATE v1 JOIN t2 on v1.t1_int=t2.t2_int SET v1.t1_char='t';
+SELECT * FROM t1;
+t1_int	t1_char
+NULL	
+1	t
+2	bbb
+3	t
+4	ddd
+5	t
+6	ffff
+7	t
+UPDATE t1 JOIN (SELECT * FROM t2 WHERE t2_int < 5) d_t2 on t1.t1_int=d_t2.t2_int SET t1.t1_char='u';
+SELECT * FROM t1;
+t1_int	t1_char
+NULL	
+1	u
+2	bbb
+3	u
+4	ddd
+5	t
+6	ffff
+7	t
 SELECT * FROM t2;
 t2_int	t2_char
 NULL	NULL
@@ -48,13 +70,13 @@ DELETE t2 FROM t2 JOIN t1 ON t1.t1_int = t2.t2_int AND t1.t1_int = 7;
 SELECT * FROM t1;
 t1_int	t1_char
 NULL	
-1	aaa
+1	u
 2	bbb
-3	ccc
+3	u
 4	ddd
-5	eee
+5	t
 6	ffff
-7	ggggg
+7	t
 SELECT * FROM t2;
 t2_int	t2_char
 NULL	NULL
@@ -66,5 +88,21 @@ NULL	NULL
 13	nnn
 DELETE t1 FROM t1 JOIN t2 ON t1.t1_int = t2.t2_int AND t1.t1_int = 5;
 ERROR HY000: Internal error: IDB-2006: 'mcs45_db.t1' does not exist in Columnstore.
+CREATE TABLE mcs(a INT, b INT)ENGINE=Columnstore;
+CREATE TABLE idb(a INT, b INT)ENGINE=Innodb;
+INSERT INTO mcs(a,b) VALUES (1,2),(2,3),(4,5);
+INSERT INTO idb(a,b) VALUES (1,2),(2,3),(4,5);
+UPDATE idb dest JOIN mcs src ON dest.a=src.a SET dest.b = dest.b + src.b + 100;
+SELECT * FROM idb;
+a	b
+1	104
+2	106
+4	110
+UPDATE idb dest JOIN mcs src ON dest.a=src.a SET dest.b = dest.b + src.b + 100;
+SELECT * FROM idb;
+a	b
+1	206
+2	209
+4	215
 DROP USER 'cejuser'@'localhost';
 DROP DATABASE mcs45_db;

--- a/mysql-test/columnstore/basic/t/mcs45_write_crossengine_join.test
+++ b/mysql-test/columnstore/basic/t/mcs45_write_crossengine_join.test
@@ -38,6 +38,7 @@ FLUSH PRIVILEGES;
 # Create tables with Innodb and Columnstore engines
 CREATE TABLE t1 (t1_int INT, t1_char CHAR(5))ENGINE=Innodb;
 CREATE TABLE t2 (t2_int INT, t2_char CHAR(5))ENGINE=Columnstore;
+CREATE VIEW v1 AS SELECT * FROM t1;
 INSERT INTO t1 VALUES (NULL,''),(1,'aaa'),(2,'bbb'),(3,'ccc'),(4,'ddd'),(5,'eee'),(6,'ffff'),(7,'ggggg');
 INSERT INTO t2 VALUES (NULL,''),(1,'hhhh'),(3,'iii'),(5,'jjj'),(7,'kkkk'),(9,'lll'),(11,'m'),(13,'nnn');
 
@@ -46,18 +47,35 @@ UPDATE t2, t1 SET t2.t2_char = 'zzz' WHERE t1.t1_int = t2.t2_int AND t1.t1_int =
 SELECT * FROM t1, t2 WHERE t1.t1_int = t2.t2_int AND t1.t1_int = 3;
 UPDATE t1 JOIN t2 on t1.t1_int=t2.t2_int SET t2.t2_char='sssss';
 SELECT * FROM t1, t2 WHERE t1.t1_int = t2.t2_int;
+
 # MCOL-1482
---error ER_INTERNAL_ERROR
 UPDATE t1 JOIN t2 on t1.t1_int=t2.t2_int SET t1.t1_char='s';
+SELECT * FROM t1;
+# Update foreign view
+UPDATE v1 JOIN t2 on v1.t1_int=t2.t2_int SET v1.t1_char='t';
+SELECT * FROM t1;
+# Update foreign table with a subquery as the source
+UPDATE t1 JOIN (SELECT * FROM t2 WHERE t2_int < 5) d_t2 on t1.t1_int=d_t2.t2_int SET t1.t1_char='u';
 
 SELECT * FROM t1;
 SELECT * FROM t2;
 DELETE t2 FROM t2 JOIN t1 ON t1.t1_int = t2.t2_int AND t1.t1_int = 7;
 SELECT * FROM t1;
 SELECT * FROM t2;
-# Similar error as MCOL-1482
+# Similar error as MCOL-1482, but for a foreign engine DELETE.
 --error ER_INTERNAL_ERROR
 DELETE t1 FROM t1 JOIN t2 ON t1.t1_int = t2.t2_int AND t1.t1_int = 5;
+
+# Test case from MCOL-1482 issue description
+CREATE TABLE mcs(a INT, b INT)ENGINE=Columnstore;
+CREATE TABLE idb(a INT, b INT)ENGINE=Innodb;
+
+INSERT INTO mcs(a,b) VALUES (1,2),(2,3),(4,5);
+INSERT INTO idb(a,b) VALUES (1,2),(2,3),(4,5);
+UPDATE idb dest JOIN mcs src ON dest.a=src.a SET dest.b = dest.b + src.b + 100;
+SELECT * FROM idb;
+UPDATE idb dest JOIN mcs src ON dest.a=src.a SET dest.b = dest.b + src.b + 100;
+SELECT * FROM idb;
 
 # Clean UP
 DROP USER 'cejuser'@'localhost';


### PR DESCRIPTION
with a ColumnStore table errors out.

ColumnStore cannot directly update a foreign table. We detect whether
a multi-table UPDATE operation is performed on a foreign table, if so,
do not create the select_handler and let the server execute the UPDATE
operation instead.