### PR TITLE
MCOL-4738 AVG() returns a wrong result.

### DIFF
--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -1306,12 +1306,7 @@ inline void Row::setFloatField(float val, uint32_t colIndex)
 inline void Row::setLongDoubleField(const long double& val, uint32_t colIndex)
 {
     uint8_t* p = &data[offsets[colIndex]];
-    *((long double*)p) = val;
-    if (sizeof(long double) == 16)
-    {
-        // zero out the unused portion as there may be garbage there.
-        *((uint64_t*)p+1) &= 0x000000000000FFFFULL;
-    }
+    *reinterpret_cast<long double*>(p) = val;
 }
 
 inline void Row::setInt128Field(const int128_t& val, uint32_t colIndex)


### PR DESCRIPTION
Release/RelWithDebInfo build on some platforms (Ubuntu18/20, Fedora)
is returning wrong results for the AVG() distributed function.

In Row::setLongDoubleField(), we remove the code that masks higher
bits of a long double field (if sizeof(long double) == 16 on a
given platform) since this masking appears to be redundant and also
fixes the issue with the AVG() function.