### PR TITLE
Mcol 4779 invalid extent ranges for short character columns

### DIFF
--- a/writeengine/shared/we_brm.h
+++ b/writeengine/shared/we_brm.h
@@ -34,6 +34,7 @@
 #include<sys/time.h>
 #include "brmtypes.h"
 #include "mcs_datatype.h"
+#include "dataconvert.h"
 #include "IDBDataFile.h"
 #include "IDBPolicy.h"
 
@@ -77,6 +78,11 @@ struct ExtCPInfo
 	mm.int128Max = fCPInfo.bigMax;
 	mm.int128Min = fCPInfo.bigMin;
 	return datatypes::MinMaxInfo::isRangeInvalid(mm, fColType, fColWidth);
+    }
+    void fromToChars()
+    {
+        fCPInfo.max = static_cast<int64_t>(uint64ToStr(fCPInfo.max));
+        fCPInfo.min = static_cast<int64_t>(uint64ToStr(fCPInfo.min));
     }
     bool isBinaryColumn()
     {


### PR DESCRIPTION
What is in pull request changes:

1. First, added a support for CHAR(n) columns. It was missing due to oversight.
2. Second, I changed logic of supported (in the "can keep ranges" sense) column type determination to be unified. We now switching on the internal Write Engine column type, not on the Calpont column types.
3. Third, extended CPInfo has a method for to/from string conversion. It is wrong (ranges should be kept differently) but it is in line with other parts of code.
4. This method is used before and after range updates to, again, be in line with other parts of code.
5. The values fetched from CHAR column are converted in same manner for them to be kept in a compatible format.

That's about it. I guess it warrants a test in the basic suite which I'll do shortly.