### PR TITLE
A clean-up for MCOL-4791 Fix ColumnCommand fudged data type format to…

### DIFF
--- a/primitives/primproc/columncommand.cpp
+++ b/primitives/primproc/columncommand.cpp
@@ -829,10 +829,7 @@ void ColumnCommand::duplicate(ColumnCommand* cc)
     cc->_isScan = _isScan;
     cc->traceFlags = traceFlags;
     cc->filterString = filterString;
-    cc->colType.colDataType = colType.colDataType;
-    cc->colType.compressionType = colType.compressionType;
-    cc->colType.colWidth = colType.colWidth;
-    cc->colType.charsetNumber = colType.charsetNumber;
+    cc->colType = colType;
     cc->BOP = BOP;
     cc->filterCount = filterCount;
     cc->fFilterFeeder = fFilterFeeder;


### PR DESCRIPTION
… clearly identify CHAR vs VARCHAR

The "mIsDict" member was not copied in ColumnCommand::duplicate.
Thus store() erroneously entered colCompare() for dictionary commands.