### PR TITLE
MCOL-4766 ROLLBACK kept ranges changed inside rolled back transaction

### DIFF
--- a/dbcon/dmlpackageproc/commandpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/commandpackageprocessor.cpp
@@ -373,7 +373,7 @@ CommandPackageProcessor::processPackage(dmlpackage::CalpontDMLPackage& cpackage)
                     if (weRc == 0)
                     {
                         //@Bug 4560 invalidate cp first as bulkrollback will truncate the newly added lbids.
-                        fDbrm->invalidateUncommittedExtentLBIDs(0, &lbidList);
+                        fDbrm->invalidateUncommittedExtentLBIDs(0, true, &lbidList);
                         cpInvalidated = true;
                         weRc = rollBackBatchAutoOnTransaction(uniqueId, txnid, fSessionID, cpackage.getTableOid(), errorMsg);
 
@@ -430,7 +430,7 @@ CommandPackageProcessor::processPackage(dmlpackage::CalpontDMLPackage& cpackage)
 
                 if (!cpInvalidated)
                 {
-                    fDbrm->invalidateUncommittedExtentLBIDs(0, &lbidList);
+                    fDbrm->invalidateUncommittedExtentLBIDs(0, stmt == "ROLLBACK", &lbidList);
                 }
             }
         }

--- a/dmlproc/dmlproc.cpp
+++ b/dmlproc/dmlproc.cpp
@@ -277,7 +277,7 @@ void rollbackAll(DBRM* dbrm)
             args1.add(oss.str());
             message2.format( args1 );
             ml.logInfoMessage( message2 );
-            dbrm->invalidateUncommittedExtentLBIDs(tableLocks[i].ownerTxnID);
+            dbrm->invalidateUncommittedExtentLBIDs(tableLocks[i].ownerTxnID, false);
             uint32_t sessionid = 0;
             txnId.id = tableLocks[i].ownerTxnID;
             txnId.valid = true;
@@ -447,7 +447,7 @@ void rollbackAll(DBRM* dbrm)
 
         for (curTxnID = txnList.begin(); curTxnID != txnList.end(); ++curTxnID)
         {
-            dbrm->invalidateUncommittedExtentLBIDs(*curTxnID);
+            dbrm->invalidateUncommittedExtentLBIDs(*curTxnID, false);
             txnId.id = *curTxnID;
             txnId.valid = true;
             uint32_t sessionid = 0;

--- a/dmlproc/dmlprocessor.cpp
+++ b/dmlproc/dmlprocessor.cpp
@@ -199,7 +199,7 @@ struct CancellationThread
 
                                 if ( rc == 0 )
                                 {
-                                    fDbrm->invalidateUncommittedExtentLBIDs(txnId.id);
+                                    fDbrm->invalidateUncommittedExtentLBIDs(txnId.id, false);
 
                                     //@Bug 4524. In case it is batchinsert, call bulkrollback.
                                     rc = rollbackProcessor.rollBackBatchAutoOnTransaction(uniqueId, txnId, sessionID, tableLocks[i].tableOID, errorMsg);

--- a/mysql-test/columnstore/basic/r/mcol4766-rollback-ranges.result
+++ b/mysql-test/columnstore/basic/r/mcol4766-rollback-ranges.result
@@ -1,0 +1,27 @@
+DROP DATABASE IF EXISTS MCOL4766;
+CREATE DATABASE MCOL4766;
+USE MCOL4766;
+CREATE TABLE t(x integer) ENGINE=COLUMNSTORE;
+INSERT INTO t(x) VALUES (1), (2);
+SELECT c.table_schema, c.table_name, c.column_name, e.min_value, e.max_value FROM information_schema.columnstore_extents e, information_schema.columnstore_columns c WHERE c.table_schema='MCOL4766' and c.table_name='t' and c.column_name='x' and c.object_id=e.object_id;
+table_schema	table_name	column_name	min_value	max_value
+MCOL4766	t	x	1	2
+START TRANSACTION;
+INSERT INTO t(x) VALUES (-1), (100);
+ROLLBACK;
+SELECT c.table_schema, c.table_name, c.column_name, e.min_value, e.max_value FROM information_schema.columnstore_extents e, information_schema.columnstore_columns c WHERE c.table_schema='MCOL4766' and c.table_name='t' and c.column_name='x' and c.object_id=e.object_id;
+table_schema	table_name	column_name	min_value	max_value
+MCOL4766	t	x	NULL	NULL
+START TRANSACTION;
+UPDATE t SET x = 100 WHERE x = 2;
+SELECT c.table_schema, c.table_name, c.column_name, e.min_value, e.max_value FROM information_schema.columnstore_extents e, information_schema.columnstore_columns c WHERE c.table_schema='MCOL4766' and c.table_name='t' and c.column_name='x' and c.object_id=e.object_id;
+table_schema	table_name	column_name	min_value	max_value
+MCOL4766	t	x	1	100
+ROLLBACK;
+SELECT c.table_schema, c.table_name, c.column_name, e.min_value, e.max_value FROM information_schema.columnstore_extents e, information_schema.columnstore_columns c WHERE c.table_schema='MCOL4766' and c.table_name='t' and c.column_name='x' and c.object_id=e.object_id;
+table_schema	table_name	column_name	min_value	max_value
+MCOL4766	t	x	NULL	NULL
+SELECT * FROM t;
+x
+1
+2

--- a/mysql-test/columnstore/basic/t/mcol4766-rollback-ranges.test
+++ b/mysql-test/columnstore/basic/t/mcol4766-rollback-ranges.test
@@ -1,0 +1,18 @@
+--disable_warnings
+DROP DATABASE IF EXISTS MCOL4766;
+--enable_warnings
+CREATE DATABASE MCOL4766;
+USE MCOL4766;
+CREATE TABLE t(x integer) ENGINE=COLUMNSTORE;
+INSERT INTO t(x) VALUES (1), (2);
+SELECT c.table_schema, c.table_name, c.column_name, e.min_value, e.max_value FROM information_schema.columnstore_extents e, information_schema.columnstore_columns c WHERE c.table_schema='MCOL4766' and c.table_name='t' and c.column_name='x' and c.object_id=e.object_id;
+START TRANSACTION;
+INSERT INTO t(x) VALUES (-1), (100);
+ROLLBACK;
+SELECT c.table_schema, c.table_name, c.column_name, e.min_value, e.max_value FROM information_schema.columnstore_extents e, information_schema.columnstore_columns c WHERE c.table_schema='MCOL4766' and c.table_name='t' and c.column_name='x' and c.object_id=e.object_id;
+START TRANSACTION;
+UPDATE t SET x = 100 WHERE x = 2;
+SELECT c.table_schema, c.table_name, c.column_name, e.min_value, e.max_value FROM information_schema.columnstore_extents e, information_schema.columnstore_columns c WHERE c.table_schema='MCOL4766' and c.table_name='t' and c.column_name='x' and c.object_id=e.object_id;
+ROLLBACK;
+SELECT c.table_schema, c.table_name, c.column_name, e.min_value, e.max_value FROM information_schema.columnstore_extents e, information_schema.columnstore_columns c WHERE c.table_schema='MCOL4766' and c.table_name='t' and c.column_name='x' and c.object_id=e.object_id;
+SELECT * FROM t;

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -4501,7 +4501,7 @@ void DBRM::deleteAISequence(uint32_t OID)
     }
 }
 
-void DBRM::invalidateUncommittedExtentLBIDs(execplan::CalpontSystemCatalog::SCN txnid, vector<LBID_t>* plbidList)
+void DBRM::invalidateUncommittedExtentLBIDs(execplan::CalpontSystemCatalog::SCN txnid, bool allExtents, vector<LBID_t>* plbidList)
 {
     // Here we want to minimize the number of calls to dbrm
     // Given that, and the fact that we need to know the column type
@@ -4594,7 +4594,7 @@ void DBRM::invalidateUncommittedExtentLBIDs(execplan::CalpontSystemCatalog::SCN 
             aInfo.isBinaryColumn = false;
         }
 
-        aInfo.seqNum = SEQNUM_MARK_UPDATING_INVALID_SET_RANGE;
+        aInfo.seqNum = allExtents ? SEQNUM_MARK_INVALID_SET_RANGE : SEQNUM_MARK_UPDATING_INVALID_SET_RANGE;
         cpInfos.push_back(aInfo);
     }
 

--- a/versioning/BRM/dbrm.h
+++ b/versioning/BRM/dbrm.h
@@ -1024,6 +1024,7 @@ public:
      * @return nothing.
     */
     EXPORT void invalidateUncommittedExtentLBIDs(execplan::CalpontSystemCatalog::SCN txnid,
+            bool allExtents,
             std::vector<LBID_t>* plbidList = NULL);
     
 private:

--- a/writeengine/server/we_ddlcommandproc.cpp
+++ b/writeengine/server/we_ddlcommandproc.cpp
@@ -5004,7 +5004,7 @@ void WE_DDLCommandProc::purgeFDCache()
         }
 
         cacheutils::purgePrimProcFdCache(files, Config::getLocalModuleID());
-        fDbrm.invalidateUncommittedExtentLBIDs(0, &lbidList);
+        fDbrm.invalidateUncommittedExtentLBIDs(0, false, &lbidList);
     }
 
     TableMetaData::removeTableMetaData(SYSCOLUMN_BASE);

--- a/writeengine/server/we_dmlcommandproc.cpp
+++ b/writeengine/server/we_dmlcommandproc.cpp
@@ -674,7 +674,7 @@ uint8_t WE_DMLCommandProc::processSingleInsert(messageqcpp::ByteStream& bs, std:
                     cacheutils::purgePrimProcFdCache(files, Config::getLocalModuleID());
 
                 cacheutils::flushOIDsFromCache(oidsToFlush);
-                fDbrm.invalidateUncommittedExtentLBIDs(0, &lbidList);
+                fDbrm.invalidateUncommittedExtentLBIDs(0, false, &lbidList);
 
                 try
                 {
@@ -3942,7 +3942,7 @@ uint8_t WE_DMLCommandProc::processFlushFiles(messageqcpp::ByteStream& bs, std::s
         //@Bug 5700. Purge FD cache after file swap
         cacheutils::purgePrimProcFdCache(files, Config::getLocalModuleID());
         cacheutils::flushOIDsFromCache(oidsToFlush);
-        fDbrm.invalidateUncommittedExtentLBIDs(0, &lbidList);
+        fDbrm.invalidateUncommittedExtentLBIDs(0, false, &lbidList);
     }
 
     //cout << "Purged files.size:moduleId = " << files.size() << ":"<<Config::getLocalModuleID() << endl;


### PR DESCRIPTION
Now ROLLBACK drops ranges to INVALID state which makes engine to rescan
blocks and discover correct ranges.