### PR TITLE
[DO NOT MERGE] Test columnstore_info.compression_ratio() with LZ4

### DIFF
--- a/utils/compress/idbcompress.h
+++ b/utils/compress/idbcompress.h
@@ -17,6 +17,7 @@
 
 /** @file */
 
+
 #ifndef IDBCOMPRESS_H__
 #define IDBCOMPRESS_H__
 


### PR DESCRIPTION
1. LZ4 build does not have the fix for columnstore_info.compression_ratio().
2. columnstore_info.compression_ratio() does not have LZ4 patch.

We need a build to test LZ4 with columnstore_info.compression_ratio().