### PR TITLE
GetInterrupted returned bool instead of bool *

### DIFF
--- a/utils/windowfunction/wf_udaf.h
+++ b/utils/windowfunction/wf_udaf.h
@@ -74,7 +74,7 @@ public:
     {
         return bInterrupted;
     }
-    bool getInterruptedPtr()
+    bool * getInterruptedPtr()
     {
         return &bInterrupted;
     }
@@ -98,7 +98,7 @@ protected:
     bool bHasDropValue;                   // Set to false when we discover the UDAnF doesn't implement dropValue.
     // To hold distinct values and their counts
 	typedef std::tr1::unordered_map<static_any::any, uint64_t, DistinctHasher, DistinctEqual> DistinctMap;
-	DistinctMap fDistinctMap;             
+	DistinctMap fDistinctMap;
 
     static_any::any fValOut;              // The return value
 


### PR DESCRIPTION
This is a bug
And it was hidden, because we have overloaded 
```
inline void mcsv1Context::setInterrupted(bool* interrupted)
inline void mcsv1Context::setInterrupted(bool interrupted)
```
So instead of setting pointer, we just set true value in 
```
 bool getInterruptedPtr()
{
      return &bInterrupted;
}
```
