### PR TITLE
obviously wrong bytesTx assignment

### DIFF
--- a/writeengine/splitter/we_splclient.h
+++ b/writeengine/splitter/we_splclient.h
@@ -213,7 +213,7 @@ public:
     void setBytesTx(uint32_t BytesTx)
     {
         boost::mutex::scoped_lock aLock(fTxMutex);
-        BytesTx = BytesTx;
+        fBytesTx = BytesTx;
         aLock.unlock();
     }
     void updateBytesTx(uint32_t fBytes)


### PR DESCRIPTION
```
BytesTx = BytesTx;
```
argument was assigned to itself, we should assign member 