### PR TITLE
targetDbroot should be assigned, not compared

### DIFF
--- a/writeengine/redistribute/we_redistributecontrolthread.cpp
+++ b/writeengine/redistribute/we_redistributecontrolthread.cpp
@@ -460,7 +460,7 @@ int RedistributeControlThread::makeRedistributePlan()
                     {
                         if (targetDbroot == targetDbroots.end())
                         {
-                            targetDbroot == targetDbroots.begin();
+                            targetDbroot = targetDbroots.begin();
                         }
 
                         if (dbPartVec[*targetDbroot].size() < partCount)


### PR DESCRIPTION
Second compare is senseless, we obviously should assign 