### PR TITLE
We forgot to initilize longdoublenull value

### DIFF
--- a/utils/funcexp/functor.cpp
+++ b/utils/funcexp/functor.cpp
@@ -61,7 +61,7 @@ void Func::init()
     double* dp = reinterpret_cast<double*>(&dni);
     fDoubleNullVal = *dp;
 
-    fDoubleNullVal = joblist::LONGDOUBLENULL;
+    fLongDoubleNullVal = joblist::LONGDOUBLENULL;
 }
 
 


### PR DESCRIPTION
we will return trash in 
```
long double Func_searched_case::getLongDoubleVal(Row& row,
                                        FunctionParm& parm,
                                        bool& isNull,
                                        CalpontSystemCatalog::ColType&)
{
    uint64_t i = searched_case_cmp(row, parm, isNull);

    if (isNull)
        return longDoubleNullVal();

    return parm[i]->data()->getLongDoubleVal(row, isNull);
}
```
because instead of ```fLongDoubleNullVal``` we initilize ```fDoubleNullVal``` twice