### PR TITLE
MaxConcurrentTransactions were not cleared when config is wrong

### DIFF
--- a/versioning/BRM/sessionmanagerserver.cpp
+++ b/versioning/BRM/sessionmanagerserver.cpp
@@ -100,7 +100,7 @@ SessionManagerServer::SessionManagerServer() : unique32(0), unique64(0)
     catch (const std::exception& e)
     {
         cout << e.what() << endl;
-        stmp.empty();
+        stmp.clear();
     }
 
     if (stmp != "")


### PR DESCRIPTION
We wanted to clear string, not to check it is empty without if