### PR TITLE
MCOL-4810 Redundant copying and wasting memory in PrimProc

### DIFF
--- a/utils/messageqcpp/bytestream.cpp
+++ b/utils/messageqcpp/bytestream.cpp
@@ -59,6 +59,8 @@ void ByteStream::doCopy(const ByteStream& rhs)
     memcpy(fBuf + ISSOverhead, rhs.fCurOutPtr, rlen);
     fCurInPtr = fBuf + ISSOverhead + rlen;
     fCurOutPtr = fBuf + ISSOverhead;
+    // Copy `longStrings` as well.
+    longStrings = rhs.longStrings;
 }
 
 ByteStream::ByteStream(const ByteStream& rhs) :
@@ -87,6 +89,8 @@ ByteStream& ByteStream::operator=(const ByteStream& rhs)
             delete [] fBuf;
             fBuf = fCurInPtr = fCurOutPtr = 0;
             fMaxLen = 0;
+            // Clear `longStrings`.
+            longStrings.clear();
         }
     }
 
@@ -150,6 +154,18 @@ void ByteStream::growBuf(uint32_t toSize)
         fCurInPtr = fBuf + curInOff;
         fCurOutPtr = fBuf + curOutOff;
     }
+}
+
+std::vector<boost::shared_array<uint8_t>>& ByteStream::getLongStrings() { return longStrings; }
+
+const std::vector<boost::shared_array<uint8_t>>& ByteStream::getLongStrings() const
+{
+    return longStrings;
+}
+
+void ByteStream::setLongStrings(const std::vector<boost::shared_array<uint8_t>>& other)
+{
+    longStrings = other;
 }
 
 ByteStream& ByteStream::operator<<(const int8_t b)

--- a/utils/messageqcpp/bytestream.h
+++ b/utils/messageqcpp/bytestream.h
@@ -28,6 +28,7 @@
 #include <vector>
 #include <set>
 #include <boost/shared_ptr.hpp>
+#include <boost/shared_array.hpp>
 #include <boost/version.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <stdint.h>
@@ -445,7 +446,13 @@ public:
     EXPORT static const uint32_t BlockSize = 4096;
 
     /** size of the space we want in front of the data */
-    EXPORT static const uint32_t ISSOverhead = 2 * sizeof(uint32_t); //space for the BS magic & length
+    EXPORT static const uint32_t ISSOverhead =
+        3 * sizeof(uint32_t); // space for the BS magic & length & number of long strings.
+
+    // Methods to get and set `long strings`.
+    EXPORT std::vector<boost::shared_array<uint8_t>>& getLongStrings();
+    EXPORT const std::vector<boost::shared_array<uint8_t>>& getLongStrings() const;
+    EXPORT void setLongStrings(const std::vector<boost::shared_array<uint8_t>>& other);
 
     friend class ::ByteStreamTestSuite;
 
@@ -469,6 +476,8 @@ private:
     uint8_t* fCurInPtr; //the point in fBuf where data is inserted next
     uint8_t* fCurOutPtr; //the point in fBuf where data is extracted from next
     uint32_t fMaxLen; //how big fBuf is currently
+    // Stores `long strings`.
+    std::vector<boost::shared_array<uint8_t>> longStrings;
 };
 
 template<int W, typename T = void>

--- a/utils/messageqcpp/inetstreamsocket.h
+++ b/utils/messageqcpp/inetstreamsocket.h
@@ -237,6 +237,9 @@ protected:
 
     void do_write(const ByteStream& msg, uint32_t magic, Stats* stats = NULL) const;
     ssize_t written(int fd, const uint8_t* ptr, size_t nbytes) const;
+    bool readFixedSizeData(struct pollfd* pfd, uint8_t* buffer, const size_t numberOfBytes,
+                           const struct ::timespec* timeout, bool* isTimeOut, Stats* stats,
+                           int64_t msec) const;
 
     SocketParms fSocketParms;	/// The socket parms
     size_t fBlocksize;

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -173,14 +173,7 @@ void StringStore::serialize(ByteStream& bs) const
         bs.append(mc->data, mc->currentSize);
     }
 
-    bs << (uint64_t) longStrings.size();
-
-    for (i = 0; i < longStrings.size(); i++)
-    {
-        mc = (MemChunk*) longStrings[i].get();
-        bs << (uint64_t) mc->currentSize;
-        bs.append(mc->data, mc->currentSize);
-    }
+    bs.setLongStrings(longStrings);
 }
 
 void StringStore::deserialize(ByteStream& bs)
@@ -211,20 +204,7 @@ void StringStore::deserialize(ByteStream& bs)
         bs.advance(size);
     }
 
-    bs >> count;
-    longStrings.resize(count);
-
-    for (i = 0; i < count; i++)
-    {
-        bs >> size;
-        buf = bs.buf();
-        longStrings[i].reset(new uint8_t[size + sizeof(MemChunk)]);
-        mc = (MemChunk*) longStrings[i].get();
-        mc->capacity = mc->currentSize = size;
-        memcpy(mc->data, buf, size);
-        bs.advance(size);
-    }
-
+    longStrings = bs.getLongStrings();
     return;
 }
 

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -175,13 +175,6 @@ public:
         return fUseStoreStringMutex;
     }
 
-private:
-    std::string empty_str;
-
-    StringStore(const StringStore&);
-    StringStore& operator=(const StringStore&);
-    static const uint32_t CHUNK_SIZE = 64 * 1024;  // allocators like powers of 2
-
     // This is an overlay b/c the underlying data needs to be any size,
     // and alloc'd in one chunk.  data can't be a separate dynamic chunk.
     struct MemChunk
@@ -191,7 +184,14 @@ private:
         uint8_t data[];
     };
 
-    std::vector<boost::shared_array<uint8_t> > mem;
+private:
+    std::string empty_str;
+
+    StringStore(const StringStore&);
+    StringStore& operator=(const StringStore&);
+    static constexpr const uint32_t CHUNK_SIZE = 64 * 1024; // allocators like powers of 2
+
+    std::vector<boost::shared_array<uint8_t>> mem;
 
     // To store strings > 64KB (BLOB/TEXT)
     std::vector<boost::shared_array<uint8_t> > longStrings;


### PR DESCRIPTION
This patch eliminates a copying `long string`s into the bytestream.