### PR TITLE
MCOL-4852: Eliminate build race condition, messageids is generated

### DIFF
--- a/utils/loggingcpp/CMakeLists.txt
+++ b/utils/loggingcpp/CMakeLists.txt
@@ -15,6 +15,7 @@ ADD_CUSTOM_COMMAND(
     DEPENDS genErrId.pl
      )
 
+set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/messageids.h PROPERTIES GENERATED TRUE)
 set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/errorids.h PROPERTIES GENERATED TRUE)
 
 add_library(loggingcpp SHARED


### PR DESCRIPTION
This ensures that building loggingcpp has messageids.h generated beforehand, just like errorids.h .