### PR TITLE
MCOL-4841 dev-6 Handle large join results

### DIFF
--- a/dbcon/joblist/diskjoinstep.cpp
+++ b/dbcon/joblist/diskjoinstep.cpp
@@ -424,8 +424,8 @@ void DiskJoinStep::joinFcn()
             while (largeData)
             {
                 l_largeRG.setData(largeData.get());
-                thjs->joinOneRG(0, &joinResults, l_largeRG, l_outputRG, l_largeRow, l_joinFERow,
-                                l_outputRow, baseRow, joinMatches, smallRowTemplates,
+                thjs->joinOneRG(0, joinResults, l_largeRG, l_outputRG, l_largeRow, l_joinFERow,
+                                l_outputRow, baseRow, joinMatches, smallRowTemplates, outputDL.get(),
                                 &joiners, &colMappings, &fergMappings, &smallNullMem);
 
                 for (j = 0; j < (int) joinResults.size(); j++)
@@ -434,7 +434,7 @@ void DiskJoinStep::joinFcn()
                     //cout << "got joined output " << l_outputRG.toString() << endl;
                     outputDL->insert(joinResults[j]);
                 }
-
+                thjs->returnMemory();
                 joinResults.clear();
                 largeData = in->jp->getNextLargeRGData();
             }
@@ -443,7 +443,6 @@ void DiskJoinStep::joinFcn()
             {
                 if (!lastLargeIteration)
                 {
-
                     /* TODO: an optimization would be to detect whether any new rows were marked and if not
                        suppress the save operation */
                     vector<Row::Pointer> unmatched;
@@ -454,7 +453,6 @@ void DiskJoinStep::joinFcn()
                 }
                 else
                 {
-
                     //cout << "finishing small-outer output" << endl;
                     vector<Row::Pointer> unmatched;
                     RGData rgData(l_outputRG);
@@ -484,6 +482,21 @@ void DiskJoinStep::joinFcn()
                         {
                             outputDL->insert(rgData);
                             //cout << "inserting a full RG" << endl;
+                            if (thjs)
+                            {
+                                if (!thjs->getMemory(l_outputRG.getMaxDataSize()))
+                                {
+                                    // calculate guess of size required for error message
+                                    uint64_t memReqd = (unmatched.size() * outputRG.getDataSize(1)) / 1048576;;
+                                    Message::Args args;
+                                    args.add(memReqd);
+                                    args.add(thjs->resourceManager->getConfiguredUMMemLimit() / 1048576);
+                                    std::cerr << logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_JOIN_RESULT_TOO_BIG, args)
+                                    << " @" << __FILE__ << ":" << __LINE__;
+                                    throw logging::IDBExcept(logging::ERR_JOIN_RESULT_TOO_BIG, args);
+                                }
+                            }
+
                             rgData.reinit(l_outputRG);
                             l_outputRG.setData(&rgData);
                             l_outputRG.resetRowGroup(0);
@@ -497,6 +510,10 @@ void DiskJoinStep::joinFcn()
                     {
                         //cout << "inserting an rg with " << l_outputRG.getRowCount() << endl;
                         outputDL->insert(rgData);
+                    }
+                    if (thjs)
+                    {
+                        thjs->returnMemory();
                     }
                 }
             }

--- a/dbcon/joblist/distributedenginecomm.cpp
+++ b/dbcon/joblist/distributedenginecomm.cpp
@@ -308,6 +308,12 @@ void DistributedEngineComm::Setup()
 
             writeToLog(__FILE__, __LINE__, "Could not connect to PMS" + std::to_string(connectionId) + ": " + ex.what(), LOG_TYPE_ERROR);
             cerr << "Could not connect to PMS" << std::to_string(connectionId) << ": " << ex.what() << endl;
+            
+            if (newPmCount == 0)
+            {
+                writeToLog(__FILE__, __LINE__, "No more PMs to try to connect to", LOG_TYPE_ERROR);
+                break;
+            }
         }
         catch (...)
         {
@@ -315,6 +321,11 @@ void DistributedEngineComm::Setup()
                 newPmCount--;
 
             writeToLog(__FILE__, __LINE__, "Could not connect to PMS" + std::to_string(connectionId), LOG_TYPE_ERROR);
+            if (newPmCount == 0)
+            {
+                writeToLog(__FILE__, __LINE__, "No more PMs to try to connect to", LOG_TYPE_ERROR);
+                                break;
+            }
         }
     }
 

--- a/dbcon/joblist/primitivestep.h
+++ b/dbcon/joblist/primitivestep.h
@@ -1421,7 +1421,8 @@ private:
     bool BPPIsAllocated;
     uint32_t uniqueID;
     ResourceManager* fRm;
-
+    boost::shared_ptr<int64_t> fJoinMemLimit;
+    
     /* HashJoin support */
 
     void serializeJoiner();
@@ -1430,8 +1431,10 @@ private:
     void generateJoinResultSet(const std::vector<std::vector<rowgroup::Row::Pointer> >& joinerOutput,
                                rowgroup::Row& baseRow, const std::vector<boost::shared_array<int> >& mappings,
                                const uint32_t depth, rowgroup::RowGroup& outputRG, rowgroup::RGData& rgData,
-                               std::vector<rowgroup::RGData>* outputData,
-                               const boost::scoped_array<rowgroup::Row>& smallRows, rowgroup::Row& joinedRow);
+                               std::vector<rowgroup::RGData>& outputData,
+                               const boost::scoped_array<rowgroup::Row>& smallRows, rowgroup::Row& joinedRow,
+                               RowGroupDL* dlp, rowgroup::RowGroup& fe2OutputRG, rowgroup::Row& fe2OutRow,
+                               funcexp::FuncExpWrapper& fe2, uint64_t memSizeForOutputRG);
 
     std::vector<boost::shared_ptr<joiner::TupleJoiner> > tjoiners;
     bool doJoin, hasPMJoin, hasUMJoin;

--- a/dbcon/joblist/primitivestep.h
+++ b/dbcon/joblist/primitivestep.h
@@ -1428,13 +1428,13 @@ private:
     void serializeJoiner();
     void serializeJoiner(uint32_t connectionNumber);
 
-    void generateJoinResultSet(const std::vector<std::vector<rowgroup::Row::Pointer> >& joinerOutput,
+    uint64_t generateJoinResultSet(const std::vector<std::vector<rowgroup::Row::Pointer> >& joinerOutput,
                                rowgroup::Row& baseRow, const std::vector<boost::shared_array<int> >& mappings,
                                const uint32_t depth, rowgroup::RowGroup& outputRG, rowgroup::RGData& rgData,
                                std::vector<rowgroup::RGData>& outputData,
                                const boost::scoped_array<rowgroup::Row>& smallRows, rowgroup::Row& joinedRow,
                                RowGroupDL* dlp, rowgroup::RowGroup& fe2OutputRG, rowgroup::Row& fe2OutRow,
-                               funcexp::FuncExpWrapper& fe2, uint64_t memSizeForOutputRG);
+                               funcexp::FuncExpWrapper& fe2);
 
     std::vector<boost::shared_ptr<joiner::TupleJoiner> > tjoiners;
     bool doJoin, hasPMJoin, hasUMJoin;

--- a/dbcon/joblist/resourcemanager.cpp
+++ b/dbcon/joblist/resourcemanager.cpp
@@ -414,7 +414,7 @@ bool ResourceManager::userPriorityEnabled() const
 // Counts memory. This funtion doesn't actually malloc, just counts against two limits
 // totalUmMemLimit for overall UM counting and (optional) sessionLimit for a single session.
 // If both have space, return true.
-bool ResourceManager::getMemory(int64_t amount, boost::shared_ptr<int64_t> sessionLimit, bool patience)
+bool ResourceManager::getMemory(int64_t amount, boost::shared_ptr<int64_t>& sessionLimit, bool patience)
 {
     bool ret1 = (atomicops::atomicSub(&totalUmMemLimit, amount) >= 0);
     bool ret2 = sessionLimit ? (atomicops::atomicSub(sessionLimit.get(), amount) >= 0) : ret1;
@@ -434,11 +434,6 @@ bool ResourceManager::getMemory(int64_t amount, boost::shared_ptr<int64_t> sessi
         // If  we  didn't  get any memory, restore the counters.
         atomicops::atomicAdd(&totalUmMemLimit, amount);
         sessionLimit ? atomicops::atomicAdd(sessionLimit.get(), amount) : 0;
-    }
-    // Debug: a place to put a breakpoint if totalUMMemLimit drops below 0. It should enver do that.
-    if  (totalUmMemLimit < 0)
-    {
-        return (ret1 && ret2);
     }
     return (ret1 && ret2);
 }

--- a/dbcon/joblist/resourcemanager.cpp
+++ b/dbcon/joblist/resourcemanager.cpp
@@ -411,22 +411,35 @@ bool ResourceManager::userPriorityEnabled() const
     return "Y" == val;
 }
 
+// Counts memory. This funtion doesn't actually malloc, just counts against two limits
+// totalUmMemLimit for overall UM counting and (optional) sessionLimit for a single session.
+// If both have space, return true.
 bool ResourceManager::getMemory(int64_t amount, boost::shared_ptr<int64_t> sessionLimit, bool patience)
 {
     bool ret1 = (atomicops::atomicSub(&totalUmMemLimit, amount) >= 0);
-    bool ret2 = (atomicops::atomicSub(sessionLimit.get(), amount) >= 0);
+    bool ret2 = sessionLimit ? (atomicops::atomicSub(sessionLimit.get(), amount) >= 0) : ret1;
 
     uint32_t retryCounter = 0, maxRetries = 20;   // 10s delay
 
     while (patience && !(ret1 && ret2) && retryCounter++ < maxRetries)
     {
         atomicops::atomicAdd(&totalUmMemLimit, amount);
-        atomicops::atomicAdd(sessionLimit.get(), amount);
+        sessionLimit ? atomicops::atomicAdd(sessionLimit.get(), amount) : 0;
         usleep(500000);
         ret1 = (atomicops::atomicSub(&totalUmMemLimit, amount) >= 0);
-        ret2 = (atomicops::atomicSub(sessionLimit.get(), amount) >= 0);
+        ret2 = sessionLimit ? (atomicops::atomicSub(sessionLimit.get(), amount) >= 0) : ret1;
     }
-
+    if  (!(ret1 && ret2))
+    {
+        // If  we  didn't  get any memory, restore the counters.
+        atomicops::atomicAdd(&totalUmMemLimit, amount);
+        sessionLimit ? atomicops::atomicAdd(sessionLimit.get(), amount) : 0;
+    }
+    // Debug: a place to put a breakpoint if totalUMMemLimit drops below 0. It should enver do that.
+    if  (totalUmMemLimit < 0)
+    {
+        return (ret1 && ret2);
+    }
     return (ret1 && ret2);
 }
 

--- a/dbcon/joblist/resourcemanager.h
+++ b/dbcon/joblist/resourcemanager.h
@@ -82,6 +82,7 @@ const uint32_t defaultRequestSize  = 1;
 const uint32_t defaultMaxOutstandingRequests = 20;
 const uint32_t defaultProcessorThreadsPerScan = 16;
 const uint32_t defaultJoinerChunkSize = 16 * 1024 * 1024;
+const uint64_t defaultMaxBPPSendQueue = 250000000; // 250MB
 
 //bucketreuse
 const std::string defaultTempDiskPath = "/tmp";
@@ -381,6 +382,11 @@ public:
         return getUintVal(fJobListStr, "DECThrottleThreshold", defaultDECThrottleThreshold);
     }
 
+    uint64_t    getMaxBPPSendQueue() const
+    {
+        return getUintVal(fPrimitiveServersStr, "MaxBPPSendQueue", defaultMaxBPPSendQueue);
+    }
+    
     EXPORT void  emServerThreads();
     EXPORT void  emServerQueueSize();
     EXPORT void  emSecondsBetweenMemChecks();
@@ -402,7 +408,7 @@ public:
     inline void returnMemory(int64_t amount, boost::shared_ptr<int64_t> sessionLimit)
     {
         atomicops::atomicAdd(&totalUmMemLimit, amount);
-        atomicops::atomicAdd(sessionLimit.get(), amount);
+        sessionLimit? atomicops::atomicAdd(sessionLimit.get(), amount): 0;
     }
     inline int64_t availableMemory() const
     {
@@ -673,3 +679,4 @@ inline bool ResourceManager::getBoolVal(const std::string& section, const std::s
 #undef EXPORT
 
 #endif
+

--- a/dbcon/joblist/resourcemanager.h
+++ b/dbcon/joblist/resourcemanager.h
@@ -404,11 +404,11 @@ public:
     /* sessionLimit is a pointer to the var holding the session-scope limit, should be JobInfo.umMemLimit
        for the query. */
     /* Temporary parameter 'patience', will wait for up to 10s to get the memory. */
-    EXPORT bool getMemory(int64_t amount, boost::shared_ptr<int64_t> sessionLimit, bool patience = true);
-    inline void returnMemory(int64_t amount, boost::shared_ptr<int64_t> sessionLimit)
+    EXPORT bool getMemory(int64_t amount, boost::shared_ptr<int64_t>& sessionLimit, bool patience = true);
+    inline void returnMemory(int64_t amount, boost::shared_ptr<int64_t>& sessionLimit)
     {
         atomicops::atomicAdd(&totalUmMemLimit, amount);
-        sessionLimit? atomicops::atomicAdd(sessionLimit.get(), amount): 0;
+        sessionLimit ? atomicops::atomicAdd(sessionLimit.get(), amount): 0;
     }
     inline int64_t availableMemory() const
     {

--- a/dbcon/joblist/tuple-bps.cpp
+++ b/dbcon/joblist/tuple-bps.cpp
@@ -272,11 +272,13 @@ TupleBPS::TupleBPS(const pColStep& rhs, const JobInfo& jobInfo) :
     fDelivery = false;
     fExtendedInfo = "TBPS: ";
     fQtc.stepParms().stepType = StepTeleStats::T_BPS;
+    fJoinMemLimit.reset();
+#if 0    
     if (jobInfo.umMemLimit && *jobInfo.umMemLimit > 0)
         fJoinMemLimit.reset(new int64_t(min((uint64_t)*jobInfo.umMemLimit, fRm->getConfiguredUMMemLimit() / 4)));
     else
         fJoinMemLimit.reset(new int64_t(fRm->getConfiguredUMMemLimit() / 4));
-    
+#endif    
     hasPCFilter = hasPMFilter = hasRIDFilter = hasSegmentFilter = hasDBRootFilter = hasSegmentDirFilter =
                                     hasPartitionFilter = hasMaxFilter = hasMinFilter = hasLBIDFilter = hasExtentIDFilter = false;
 }
@@ -360,10 +362,7 @@ TupleBPS::TupleBPS(const pColScanStep& rhs, const JobInfo& jobInfo) :
 
     initExtentMarkers();
     fQtc.stepParms().stepType = StepTeleStats::T_BPS;
-    if (jobInfo.umMemLimit && *jobInfo.umMemLimit > 0)
-        fJoinMemLimit.reset(new int64_t(min((uint64_t)*jobInfo.umMemLimit, fRm->getConfiguredUMMemLimit() / 4)));
-    else
-        fJoinMemLimit.reset(new int64_t(fRm->getConfiguredUMMemLimit() / 4));
+    fJoinMemLimit.reset();
     
     hasPCFilter = hasPMFilter = hasRIDFilter = hasSegmentFilter = hasDBRootFilter = hasSegmentDirFilter =
                                     hasPartitionFilter = hasMaxFilter = hasMinFilter = hasLBIDFilter = hasExtentIDFilter = false;
@@ -431,10 +430,7 @@ TupleBPS::TupleBPS(const PassThruStep& rhs, const JobInfo& jobInfo) :
     fDelivery = false;
     fExtendedInfo = "TBPS: ";
     fQtc.stepParms().stepType = StepTeleStats::T_BPS;
-    if (jobInfo.umMemLimit && *jobInfo.umMemLimit > 0)
-        fJoinMemLimit.reset(new int64_t(min((uint64_t)*jobInfo.umMemLimit, fRm->getConfiguredUMMemLimit() / 4)));
-    else
-        fJoinMemLimit.reset(new int64_t(fRm->getConfiguredUMMemLimit() / 4));
+    fJoinMemLimit.reset();
     
     hasPCFilter = hasPMFilter = hasRIDFilter = hasSegmentFilter = hasDBRootFilter = hasSegmentDirFilter =
                                     hasPartitionFilter = hasMaxFilter = hasMinFilter = hasLBIDFilter = hasExtentIDFilter = false;
@@ -500,10 +496,7 @@ TupleBPS::TupleBPS(const pDictionaryStep& rhs, const JobInfo& jobInfo) :
     fDelivery = false;
     fExtendedInfo = "TBPS: ";
     fQtc.stepParms().stepType = StepTeleStats::T_BPS;
-    if (jobInfo.umMemLimit && *jobInfo.umMemLimit > 0)
-        fJoinMemLimit.reset(new int64_t(min((uint64_t)*jobInfo.umMemLimit, fRm->getConfiguredUMMemLimit() / 4)));
-    else
-        fJoinMemLimit.reset(new int64_t(fRm->getConfiguredUMMemLimit() / 4));
+    fJoinMemLimit.reset();
     
     hasPCFilter = hasPMFilter = hasRIDFilter = hasSegmentFilter = hasDBRootFilter = hasSegmentDirFilter =
                                     hasPartitionFilter = hasMaxFilter = hasMinFilter = hasLBIDFilter = hasExtentIDFilter = false;
@@ -2877,7 +2870,7 @@ uint64_t TupleBPS::generateJoinResultSet(const vector<vector<Row::Pointer> >& jo
     
     if (depth < smallSideCount - 1)
     {
-        for (i = 0; i < joinerOutput[depth].size(); i++)
+        for (i = 0; i < joinerOutput[depth].size() && !fDie; i++)
         {
             smallRow.setPointer(joinerOutput[depth][i]);
             applyMapping(mappings[depth], smallRow, &baseRow);
@@ -2890,7 +2883,7 @@ uint64_t TupleBPS::generateJoinResultSet(const vector<vector<Row::Pointer> >& jo
     {
         outputRG.getRow(outputRG.getRowCount(), &joinedRow);
 
-        for (i = 0; i < joinerOutput[depth].size(); i++, joinedRow.nextRow(),
+        for (i = 0; i < joinerOutput[depth].size() && !fDie; i++, joinedRow.nextRow(),
                 outputRG.incRowCount())
         {
             smallRow.setPointer(joinerOutput[depth][i]);

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -1868,7 +1868,6 @@ void TupleHashJoinStep::generateJoinResultSet(const vector<vector<Row::Pointer> 
                 if (UNLIKELY(!getMemory(l_outputRG.getMaxDataSize())))
                 {
                     // Don't let the join results buffer get out of control.
-                    RowGroup out(outputRG);
                     sendResult(outputData);
                     outputData.clear();
                     returnMemory();

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -407,7 +407,6 @@ void TupleHashJoinStep::smallRunnerFcn(uint32_t index, uint threadID, uint64_t *
 
             rgSize = smallRG.getSizeWithStrings();
             memUsedByThisJoin += rgSize;
-//            atomicops::atomicAdd(&memUsedByEachJoin[index], rgSize);
             gotMem = resourceManager->getMemory(rgSize, sessionMemLimit, false);
             if (!gotMem)
             {

--- a/dbcon/mysql/ha_mcs_dml.cpp
+++ b/dbcon/mysql/ha_mcs_dml.cpp
@@ -758,7 +758,7 @@ int ha_mcs_impl_write_batch_row_(const uchar* buf, TABLE* table, cal_impl_if::ca
     rc = fprintf(ci.filePtr, "\n"); //@bug 6077 check whether thhe pipe is still open
 
     if ( rc < 0)
-        rc = -1;
+        rc = errno;
     else
         rc = 0;
 

--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -3086,7 +3086,7 @@ void ha_mcs_impl_start_bulk_insert(ha_rows rows, TABLE* table, bool is_cache_ins
             //@bug 6122 Check how many columns have not null constraint. columnn with not null constraint will not show up in header.
             unsigned int numberNotNull = 0;
 
-            // THere's a chance that a previously aborted query left garbage in ci->columnTypes
+            // There's a chance that a previously aborted query left garbage in ci->columnTypes
             if (ci->columnTypes.size() > 0)
                 ci->columnTypes.clear();
 

--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -3086,6 +3086,10 @@ void ha_mcs_impl_start_bulk_insert(ha_rows rows, TABLE* table, bool is_cache_ins
             //@bug 6122 Check how many columns have not null constraint. columnn with not null constraint will not show up in header.
             unsigned int numberNotNull = 0;
 
+            // THere's a chance that a previously aborted query left garbage in ci->columnTypes
+            if (ci->columnTypes.size() > 0)
+                ci->columnTypes.clear();
+
             for (unsigned int j = 0; j < colrids.size(); j++)
             {
                 CalpontSystemCatalog::ColType ctype = csc->colType(colrids[j].objnum);

--- a/exemgr/femsghandler.cpp
+++ b/exemgr/femsghandler.cpp
@@ -19,6 +19,7 @@
 #include "iosocket.h"
 
 #include "femsghandler.h"
+#include "threadnaming.h"
 
 using namespace std;
 using namespace joblist;
@@ -35,6 +36,7 @@ public:
     Runner(FEMsgHandler* f) : target(f) { }
     void operator()()
     {
+        utils::setThreadName("FEMsgHandler");
         target->threadFcn();
     }
     FEMsgHandler* target;

--- a/exemgr/main.cpp
+++ b/exemgr/main.cpp
@@ -79,6 +79,7 @@
 
 #include "mariadb_my_sys.h"
 #include "statistics.h"
+#include "threadnaming.h"
 
 class Opt
 {
@@ -640,8 +641,6 @@ private:
 
         if (jl->status() == 0)
         {
-            std::string emsg;
-
             if (jl->putEngineComm(fEc) != 0)
                 throw std::runtime_error(jl->errMsg());
         }
@@ -738,6 +737,7 @@ private:
 
     void operator()()
     {
+        utils::setThreadName("SessionThread");
         messageqcpp::ByteStream bs, inbs;
         execplan::CalpontSelectExecutionPlan csep;
         csep.sessionID(0);

--- a/oam/etc/Columnstore.xml
+++ b/oam/etc/Columnstore.xml
@@ -96,6 +96,7 @@
 		<!-- <MediumPriorityPercentage>30</MediumPriorityPercentage> -->
 		<!-- <LowPriorityPercentage>10</LowPriorityPercentage> -->
 		<DirectIO>y</DirectIO>
+        <MaxBPPSendQueue>250M</MaxBPPSendQueue>
         <HighPriorityPercentage/>
         <MediumPriorityPercentage/>
         <LowPriorityPercentage/>
@@ -486,10 +487,10 @@
 		<MaxBuckets>128</MaxBuckets>
 		<MaxElems>128K</MaxElems>  <!-- 128 buckets * 128K * 16 = 256 MB -->
 		<FifoSizeLargeSide>64</FifoSizeLargeSide>
-		<PmMaxMemorySmallSide>1G</PmMaxMemorySmallSide>
+		<PmMaxMemorySmallSide>100M</PmMaxMemorySmallSide>
 		<TotalUmMemory>25%</TotalUmMemory>
 		<CPUniqueLimit>100</CPUniqueLimit>
-		<AllowDiskBasedJoin>N</AllowDiskBasedJoin>
+		<AllowDiskBasedJoin>Y</AllowDiskBasedJoin>
 		<TempFileCompression>Y</TempFileCompression>
     <TempFileCompressionType>Snappy</TempFileCompressionType> <!-- LZ4, Snappy -->
 	</HashJoin>

--- a/oam/etc/Columnstore.xml
+++ b/oam/etc/Columnstore.xml
@@ -487,10 +487,10 @@
 		<MaxBuckets>128</MaxBuckets>
 		<MaxElems>128K</MaxElems>  <!-- 128 buckets * 128K * 16 = 256 MB -->
 		<FifoSizeLargeSide>64</FifoSizeLargeSide>
-		<PmMaxMemorySmallSide>100M</PmMaxMemorySmallSide>
+		<PmMaxMemorySmallSide>1G</PmMaxMemorySmallSide>
 		<TotalUmMemory>25%</TotalUmMemory>
 		<CPUniqueLimit>100</CPUniqueLimit>
-		<AllowDiskBasedJoin>Y</AllowDiskBasedJoin>
+		<AllowDiskBasedJoin>N</AllowDiskBasedJoin>
 		<TempFileCompression>Y</TempFileCompression>
     <TempFileCompressionType>Snappy</TempFileCompressionType> <!-- LZ4, Snappy -->
 	</HashJoin>

--- a/primitives/blockcache/iomanager.cpp
+++ b/primitives/blockcache/iomanager.cpp
@@ -104,6 +104,7 @@ using namespace compress;
 using namespace idbdatafile;
 
 #include "mcsconfig.h"
+#include "threadnaming.h"
 
 typedef tr1::unordered_set<BRM::OID_t> USOID;
 
@@ -394,6 +395,7 @@ static int updateptrs(char* ptr, FdCacheType_t::iterator fdit)
 
 void* thr_popper(ioManager* arg)
 {
+    utils::setThreadName("thr_popper");
     ioManager* iom = arg;
     FileBufferMgr* fbm;
     int totalRqst = 0;

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -1151,17 +1151,24 @@ void BatchPrimitiveProcessor::initProcessor()
 }
 
 /* This version does a join on projected rows */
-void BatchPrimitiveProcessor::executeTupleJoin()
+// In order to prevent super size result sets in the case of near cartesian joins on three or more joins, 
+// the startRid start at 0) is used to begin the rid loop and if we cut off processing early because of 
+// the size of the result set, we return the next rid to start with. If we finish ridCount rids, return 0-
+uint32_t BatchPrimitiveProcessor::executeTupleJoin(uint32_t startRid)
 {
     uint32_t newRowCount = 0, i, j;
     vector<uint32_t> matches;
     uint64_t largeKey;
-
+    uint64_t resultCount = 0;
+    uint32_t newStartRid = startRid;
     outputRG.getRow(0, &oldRow);
     outputRG.getRow(0, &newRow);
 
     //cout << "before join, RG has " << outputRG.getRowCount() << " BPP ridcount= " << ridCount << endl;
-    for (i = 0; i < ridCount && !sendThread->aborted(); i++, oldRow.nextRow())
+    // ridCount gets modified based on the number of Rids actually processed during this call.
+    // origRidCount is the number of rids for this thread after filter, which are the total
+    // number of rids to be processed from all calls to this function during this thread.
+    for (i = startRid; i < origRidCount && !sendThread->aborted(); i++, oldRow.nextRow())
     {
         /* Decide whether this large-side row belongs in the output.  The breaks
          * in the loop mean that it doesn't.
@@ -1270,10 +1277,9 @@ void BatchPrimitiveProcessor::executeTupleJoin()
 
         if (j == joinerCount)
         {
+            uint32_t matchCount;
             for (j = 0; j < joinerCount; j++)
             {
-                uint32_t matchCount;
-
                 /* The result is already known if...
                  *   -- anti-join with no fcnexp
                  *   -- semi-join with no fcnexp and not scalar
@@ -1361,6 +1367,8 @@ void BatchPrimitiveProcessor::executeTupleJoin()
                     tSmallSideMatches[j][newRowCount].push_back(-1);
                     matchCount = 1;
                 }
+
+                resultCount += matchCount;
             }
 
             /* Finally, copy the row into the output */
@@ -1384,8 +1392,18 @@ void BatchPrimitiveProcessor::executeTupleJoin()
             //else
             // cout << "j != joinerCount\n";
         }
+        // If we've accumulated more than 1048576 (2^20)_ of resultCounts, cut off processing. The caller will
+        // restart to continue where we left off.
+        if (resultCount >= 1048576)
+        {
+            newStartRid += newRowCount;
+            break;
+        }
     }
 
+    if (resultCount < 1048576)
+        newStartRid = 0;
+                
     ridCount = newRowCount;
     outputRG.setRowCount(ridCount);
 
@@ -1404,6 +1422,7 @@ void BatchPrimitiveProcessor::executeTupleJoin()
     		}
     	}
     */
+    return newStartRid;
 }
 
 #ifdef PRIMPROC_STOPWATCH
@@ -1412,6 +1431,9 @@ void BatchPrimitiveProcessor::execute(StopWatch* stopwatch)
 void BatchPrimitiveProcessor::execute()
 #endif
 {
+    uint8_t sendCount = 0;
+    bool smoreRGs = false;
+    uint32_t sStartRid = 0;
     uint32_t i, j;
 
     try
@@ -1616,9 +1638,9 @@ void BatchPrimitiveProcessor::execute()
             }
 
             /* 7/7/09 PL: I Changed the projection alg to reduce block touches when there's
-            a join.  The key columns get projected first, the join is executed to further
+             a join.  The key columns get projected first, the join is executed to further
             reduce the ridlist, then the rest of the columns get projected */
-
+            
             if (!doJoin)
             {
                 for (j = 0; j < projectCount; ++j)
@@ -1638,15 +1660,92 @@ void BatchPrimitiveProcessor::execute()
 //				else
 //					cout << "   no target found for OID " << projectSteps[j]->getOID() << endl;
                 }
+                if (fe2)
+                {
+                    /* functionize this -> processFE2() */
+                    fe2Output.resetRowGroup ( baseRid );
+                    fe2Output.getRow ( 0, &fe2Out );
+                    fe2Input->getRow ( 0, &fe2In );
+
+                    //cerr << "input row: " << fe2In.toString() << endl;
+                    for ( j = 0; j < outputRG.getRowCount(); j++, fe2In.nextRow() )
+                    {
+                        if ( fe2->evaluate ( &fe2In ) )
+                        {
+                            applyMapping ( fe2Mapping, fe2In, &fe2Out );
+                            //cerr << "   passed. output row: " << fe2Out.toString() << endl;
+                            fe2Out.setRid ( fe2In.getRelRid() );
+                            fe2Output.incRowCount();
+                            fe2Out.nextRow();
+                        }
+                    }
+
+                    if ( !fAggregator )
+                    {
+                        *serialized << ( uint8_t ) 1; // the "count this msg" var
+                        fe2Output.setDBRoot ( dbRoot );
+                        fe2Output.serializeRGData ( *serialized );
+                        //*serialized << fe2Output.getDataSize();
+                        //serialized->append(fe2Output.getData(), fe2Output.getDataSize());
+                    }
+                }
+
+                if (fAggregator)
+                {
+                    *serialized << ( uint8_t ) 1; // the "count this msg" var
+
+                    RowGroup& toAggregate = ( fe2 ? fe2Output : outputRG );
+                    //toAggregate.convertToInlineDataInPlace();
+
+                    if ( fe2 )
+                        fe2Output.setDBRoot ( dbRoot );
+                    else
+                        outputRG.setDBRoot ( dbRoot );
+
+                    fAggregator->addRowGroup ( &toAggregate );
+
+                    if ( ( currentBlockOffset + 1 ) == count )                // @bug4507, 8k
+                    {
+                        fAggregator->loadResult ( *serialized );              // @bug4507, 8k
+                    }                                                         // @bug4507, 8k
+                    else if ( utils::MonitorProcMem::isMemAvailable() )       // @bug4507, 8k
+                    {
+                        fAggregator->loadEmptySet ( *serialized );            // @bug4507, 8k
+                    }                                                         // @bug4507, 8k
+                    else                                                      // @bug4507, 8k
+                    {
+                        fAggregator->loadResult ( *serialized );              // @bug4507, 8k
+                        fAggregator->aggReset();                              // @bug4507, 8k
+                    }                                                         // @bug4507, 8k
+                }
+
+                if (!fAggregator && !fe2)
+                {
+                    *serialized << ( uint8_t ) 1; // the "count this msg" var
+                    outputRG.setDBRoot ( dbRoot );
+                    //cerr << "serializing " << outputRG.toString() << endl;
+                    outputRG.serializeRGData ( *serialized );
+
+                    //*serialized << outputRG.getDataSize();
+                    //serialized->append(outputRG.getData(), outputRG.getDataSize());
+                }
+
+#ifdef PRIMPROC_STOPWATCH
+                stopwatch->stop ( "- if(ot != ROW_GROUP) else" );
+#endif                
             }
-            else
+            else // Is doJoin
             {
+                uint32_t startRid = 0;
+                ByteStream preamble = *serialized;
+                origRidCount = ridCount;  // ridCount can get modified by executeTupleJoin(). We need to keep track of the original val.
                 /* project the key columns.  If there's the filter IN the join, project everything.
                    Also need to project 'long' strings b/c executeTupleJoin may copy entire rows
                    using copyRow(), which will try to interpret the uninit'd string ptr.
                    Valgrind will legitimately complain about copying uninit'd values for the
                    other types but that is technically safe. */
                 for (j = 0; j < projectCount; j++)
+                {
                     if (keyColumnProj[j] || (projectionMap[j] != -1 && (hasJoinFEFilters ||
                         oldRow.isLongString(projectionMap[j]))))
                     {
@@ -1658,216 +1757,172 @@ void BatchPrimitiveProcessor::execute()
                         projectSteps[j]->projectIntoRowGroup(outputRG, projectionMap[j]);
 #endif
                     }
-
-
-#ifdef PRIMPROC_STOPWATCH
-                stopwatch->start("-- executeTupleJoin()");
-                executeTupleJoin();
-                stopwatch->stop("-- executeTupleJoin()");
-#else
-                executeTupleJoin();
-#endif
-
-                /* project the non-key columns */
-                for (j = 0; j < projectCount; ++j)
-                {
-                    if (projectionMap[j] != -1 && !keyColumnProj[j] && !hasJoinFEFilters &&
-                        !oldRow.isLongString(projectionMap[j]))
-                    {
-#ifdef PRIMPROC_STOPWATCH
-                        stopwatch->start("-- projectIntoRowGroup");
-                        projectSteps[j]->projectIntoRowGroup(outputRG, projectionMap[j]);
-                        stopwatch->stop("-- projectIntoRowGroup");
-#else
-                        projectSteps[j]->projectIntoRowGroup(outputRG, projectionMap[j]);
-#endif
-                    }
                 }
-            }
 
-            /* The RowGroup is fully joined at this point.
-            Add additional RowGroup processing here.
-            TODO:  Try to clean up all of the switching */
-
-            if (doJoin && (fe2 || fAggregator))
-            {
-                bool moreRGs = true;
-                ByteStream preamble = *serialized;
-                initGJRG();
-
-                while (moreRGs && !sendThread->aborted())
+                do //while (startRid > 0)
                 {
-                    /*
-                    	generate 1 rowgroup (8192 rows max) of joined rows
-                    	if there's an FE2, run it
-                    		-pack results into a new rowgroup
-                    		-if there are < 8192 rows in the new RG, continue
-                    	if there's an agg, run it
-                    	send the result
-                    */
-                    resetGJRG();
-                    moreRGs = generateJoinedRowGroup(baseJRow);
-                    *serialized << (uint8_t) !moreRGs;
-
-                    if (fe2)
+#ifdef PRIMPROC_STOPWATCH
+                    stopwatch->start("-- executeTupleJoin()");
+                    startRid = executeTupleJoin(startRid);
+                    stopwatch->stop("-- executeTupleJoin()");
+#else
+                    startRid = executeTupleJoin(startRid);
+                    sStartRid = startRid;
+                    #endif
+                    /* project the non-key columns */
+                    for (j = 0; j < projectCount; ++j)
                     {
-                        /* functionize this -> processFE2()*/
-                        fe2Output.resetRowGroup(baseRid);
-                        fe2Output.setDBRoot(dbRoot);
-                        fe2Output.getRow(0, &fe2Out);
-                        fe2Input->getRow(0, &fe2In);
-
-                        for (j = 0; j < joinedRG.getRowCount(); j++, fe2In.nextRow())
-                            if (fe2->evaluate(&fe2In))
-                            {
-                                applyMapping(fe2Mapping, fe2In, &fe2Out);
-                                fe2Out.setRid(fe2In.getRelRid());
-                                fe2Output.incRowCount();
-                                fe2Out.nextRow();
-                            }
+                        if (projectionMap[j] != -1 && !keyColumnProj[j] && !hasJoinFEFilters &&
+                            !oldRow.isLongString(projectionMap[j]))
+                        {
+#ifdef PRIMPROC_STOPWATCH
+                            stopwatch->start("-- projectIntoRowGroup");
+                            projectSteps[j]->projectIntoRowGroup(outputRG, projectionMap[j]);
+                            stopwatch->stop("-- projectIntoRowGroup");
+#else
+                            projectSteps[j]->projectIntoRowGroup(outputRG, projectionMap[j]);
+#endif
+                        }
                     }
+                    /* The RowGroup is fully joined at this point.
+                     *            Add additional RowGroup processing here.
+                     *            TODO:  Try to clean up all of the switching */
 
-                    RowGroup& nextRG = (fe2 ? fe2Output : joinedRG);
-                    nextRG.setDBRoot(dbRoot);
-
-                    if (fAggregator)
+                    if (fe2 || fAggregator)
                     {
-                        fAggregator->addRowGroup(&nextRG);
+                        bool moreRGs = true;
+                        initGJRG();
 
-                        if ((currentBlockOffset + 1) == count && moreRGs == false)  // @bug4507, 8k
+                        while (moreRGs && !sendThread->aborted())
                         {
-                            fAggregator->loadResult(*serialized);                   // @bug4507, 8k
-                        }                                                           // @bug4507, 8k
-                        else if (utils::MonitorProcMem::isMemAvailable())           // @bug4507, 8k
+                            /*
+                             *                        generate 1 rowgroup (8192 rows max) of joined rows
+                             *                        if there's an FE2, run it
+                             *                                -pack results into a new rowgroup
+                             *                                -if there are < 8192 rows in the new RG, continue
+                             *                        if there's an agg, run it
+                             *                        send the result
+                             */
+                            resetGJRG();
+                            moreRGs = generateJoinedRowGroup(baseJRow);
+                            smoreRGs = moreRGs;
+                            sendCount = (uint8_t)(!moreRGs && !startRid);
+//                            *serialized << (uint8_t)(!moreRGs && !startRid);   // the "count this msg" var
+                            *serialized << sendCount;
+                            if (fe2)
+                            {
+                                /* functionize this -> processFE2()*/
+                                fe2Output.resetRowGroup(baseRid);
+                                fe2Output.setDBRoot(dbRoot);
+                                fe2Output.getRow(0, &fe2Out);
+                                fe2Input->getRow(0, &fe2In);
+
+                                for (j = 0; j < joinedRG.getRowCount(); j++, fe2In.nextRow())
+                                    if (fe2->evaluate(&fe2In))
+                                    {
+                                        applyMapping(fe2Mapping, fe2In, &fe2Out);
+                                        fe2Out.setRid(fe2In.getRelRid());
+                                        fe2Output.incRowCount();
+                                        fe2Out.nextRow();
+                                    }
+                            }
+
+                            RowGroup& nextRG = (fe2 ? fe2Output : joinedRG);
+                            nextRG.setDBRoot(dbRoot);
+
+                            if (fAggregator)
+                            {
+                                fAggregator->addRowGroup(&nextRG);
+
+                                if ((currentBlockOffset + 1) == count && moreRGs == false && startRid == 0)     // @bug4507, 8k
+                                {
+                                    fAggregator->loadResult(*serialized);                   // @bug4507, 8k
+                                }                                                           // @bug4507, 8k
+                                else if (utils::MonitorProcMem::isMemAvailable())           // @bug4507, 8k
+                                {
+                                    fAggregator->loadEmptySet(*serialized);                 // @bug4507, 8k
+                                }                                                           // @bug4507, 8k
+                                else                                                        // @bug4507, 8k
+                                {
+                                    fAggregator->loadResult(*serialized);                   // @bug4507, 8k
+                                    fAggregator->aggReset();                                // @bug4507, 8k
+                                }                                                           // @bug4507, 8k
+                            }
+                            else
+                            {
+                                //cerr <<" * serialzing " << nextRG.toString() << endl;
+                                nextRG.serializeRGData(*serialized);
+                            }
+
+                            /* send the msg & reinit the BS */
+                            if (moreRGs)
+                            {
+                                sendResponse();
+                                serialized.reset(new ByteStream());
+                                *serialized = preamble;
+                            }
+                        }
+
+                        if ( hasSmallOuterJoin )
                         {
-                            fAggregator->loadEmptySet(*serialized);                 // @bug4507, 8k
-                        }                                                           // @bug4507, 8k
-                        else                                                        // @bug4507, 8k
+                            // Should we happen to finish sending data rows right on the boundary of when moreRGs flips off, then
+                            // we need to start a new buffer. I.e., it needs the count this message byte pushed.
+                            if (serialized->length() == preamble.length())
+                                *serialized << ( uint8_t )(startRid > 0 ? 0 : 1); // the "count this msg" var
+                            
+                            *serialized << ridCount;
+
+                            for ( i = 0; i < joinerCount; i++ )
+                            {
+                                for ( j = 0; j < ridCount; ++j )
+                                {
+                                    serializeInlineVector<uint32_t> ( *serialized,
+                                                                      tSmallSideMatches[i][j] );
+                                    tSmallSideMatches[i][j].clear();
+                                }
+                            }
+                        }
+                        else
                         {
-                            fAggregator->loadResult(*serialized);                   // @bug4507, 8k
-                            fAggregator->aggReset();                                // @bug4507, 8k
-                        }                                                           // @bug4507, 8k
+                            // We hae no more use for this allocation
+                            for ( i = 0; i < joinerCount; i++ )
+                                for ( j = 0; j < ridCount; ++j )
+                                    tSmallSideMatches[i][j].clear();
+                        }
                     }
                     else
                     {
-                        //cerr <<" * serialzing " << nextRG.toString() << endl;
-                        nextRG.serializeRGData(*serialized);
-                    }
+                        *serialized << ( uint8_t )(startRid > 0 ? 0 : 1); // the "count this msg" var
+                        outputRG.setDBRoot ( dbRoot );
+                        //cerr << "serializing " << outputRG.toString() << endl;
+                        outputRG.serializeRGData ( *serialized );
 
-                    /* send the msg & reinit the BS */
-                    if (moreRGs)
-                    {
-                        sendResponse();
-                        serialized.reset(new ByteStream());
-                        *serialized = preamble;
-                    }
-                }
-
-                if (hasSmallOuterJoin)
-                {
-                    *serialized << ridCount;
-
-                    for (i = 0; i < joinerCount; i++)
-                        for (j = 0; j < ridCount; ++j)
-                            serializeInlineVector<uint32_t>(*serialized,
-                                                            tSmallSideMatches[i][j]);
-                }
-            }
-
-            if (!doJoin && fe2)
-            {
-                /* functionize this -> processFE2() */
-                fe2Output.resetRowGroup(baseRid);
-                fe2Output.getRow(0, &fe2Out);
-                fe2Input->getRow(0, &fe2In);
-
-                //cerr << "input row: " << fe2In.toString() << endl;
-                for (j = 0; j < outputRG.getRowCount(); j++, fe2In.nextRow())
-                {
-                    if (fe2->evaluate(&fe2In))
-                    {
-                        applyMapping(fe2Mapping, fe2In, &fe2Out);
-                        //cerr << "   passed. output row: " << fe2Out.toString() << endl;
-                        fe2Out.setRid (fe2In.getRelRid());
-                        fe2Output.incRowCount();
-                        fe2Out.nextRow();
-                    }
-                }
-
-                if (!fAggregator)
-                {
-                    *serialized << (uint8_t) 1;  // the "count this msg" var
-                    fe2Output.setDBRoot(dbRoot);
-                    fe2Output.serializeRGData(*serialized);
-                    //*serialized << fe2Output.getDataSize();
-                    //serialized->append(fe2Output.getData(), fe2Output.getDataSize());
-                }
-            }
-
-            if (!doJoin && fAggregator)
-            {
-                *serialized << (uint8_t) 1;  // the "count this msg" var
-
-                RowGroup& toAggregate = (fe2 ? fe2Output : outputRG);
-                //toAggregate.convertToInlineDataInPlace();
-
-                if (fe2)
-                    fe2Output.setDBRoot(dbRoot);
-                else
-                    outputRG.setDBRoot(dbRoot);
-
-                fAggregator->addRowGroup(&toAggregate);
-
-                if ((currentBlockOffset + 1) == count)                    // @bug4507, 8k
-                {
-                    fAggregator->loadResult(*serialized);                 // @bug4507, 8k
-                }                                                         // @bug4507, 8k
-                else if (utils::MonitorProcMem::isMemAvailable())         // @bug4507, 8k
-                {
-                    fAggregator->loadEmptySet(*serialized);               // @bug4507, 8k
-                }                                                         // @bug4507, 8k
-                else                                                      // @bug4507, 8k
-                {
-                    fAggregator->loadResult(*serialized);                 // @bug4507, 8k
-                    fAggregator->aggReset();                              // @bug4507, 8k
-                }                                                         // @bug4507, 8k
-            }
-
-            if (!fAggregator && !fe2)
-            {
-                *serialized << (uint8_t) 1;  // the "count this msg" var
-                outputRG.setDBRoot(dbRoot);
-                //cerr << "serializing " << outputRG.toString() << endl;
-                outputRG.serializeRGData(*serialized);
-
-                //*serialized << outputRG.getDataSize();
-                //serialized->append(outputRG.getData(), outputRG.getDataSize());
-                if (doJoin)
-                {
-                    for (i = 0; i < joinerCount; i++)
-                    {
-                        for (j = 0; j < ridCount; ++j)
+                        //*serialized << outputRG.getDataSize();
+                        //serialized->append(outputRG.getData(), outputRG.getDataSize());
+                        for ( i = 0; i < joinerCount; i++ )
                         {
-                            serializeInlineVector<uint32_t>(*serialized,
-                                                            tSmallSideMatches[i][j]);
+                            for ( j = 0; j < ridCount; ++j )
+                            {
+                                serializeInlineVector<uint32_t> ( *serialized,
+                                                                  tSmallSideMatches[i][j] );
+                                tSmallSideMatches[i][j].clear();
+                            }
                         }
                     }
-                }
+                    if (startRid > 0)
+                    {
+                        sendResponse();
+                        serialized.reset ( new ByteStream() );
+                        *serialized = preamble;
+                    }
+                }while (startRid > 0);
             }
-
-            // clear small side match vector
-            if (doJoin)
-            {
-                for (i = 0; i < joinerCount; i++)
-                    for (j = 0; j < ridCount; ++j)
-                        tSmallSideMatches[i][j].clear();
-            }
-
 #ifdef PRIMPROC_STOPWATCH
-            stopwatch->stop("- if(ot != ROW_GROUP) else");
+            stopwatch->stop ( "- if(ot != ROW_GROUP) else" );
 #endif
         }
-
+        ridCount = origRidCount;  // May not be needed, but just to be safe.
+        std::cout << "end of send. startRid=" << sStartRid << " moreRG=" << smoreRGs << " sendCount=" << sendCount << std::endl;
         if (projectCount > 0 || ot == ROW_GROUP)
         {
             *serialized << cachedIO;
@@ -2215,8 +2270,9 @@ int BatchPrimitiveProcessor::operator()()
             if (sendThread->aborted())
                 break;
 
-            if (!sendThread->okToProceed())
+            if (sendThread->sizeTooBig())
             {
+                // The send buffer is full of messages yet to be sent, so this thread would block anyway.
                 freeLargeBuffers();
                 return -1; // the reschedule error code
             }

--- a/primitives/primproc/batchprimitiveprocessor.h
+++ b/primitives/primproc/batchprimitiveprocessor.h
@@ -220,6 +220,7 @@ private:
     int128_t wide128Values[LOGICAL_BLOCK_RIDS];
     boost::scoped_array<uint64_t> absRids;
     boost::scoped_array<std::string> strValues;
+    uint16_t origRidCount;
     uint16_t ridCount;
     bool needStrValues;
     uint16_t wideColumnsWidths;
@@ -328,7 +329,7 @@ private:
     boost::shared_array<boost::shared_array<boost::shared_ptr<TJoiner> > > tJoiners;
     typedef std::vector<uint32_t> MatchedData[LOGICAL_BLOCK_RIDS];
     boost::shared_array<MatchedData> tSmallSideMatches;
-    void executeTupleJoin();
+    uint32_t executeTupleJoin(uint32_t startRid);
     bool getTupleJoinRowGroupData;
     std::vector<rowgroup::RowGroup> smallSideRGs;
     rowgroup::RowGroup largeSideRG;

--- a/primitives/primproc/bppsendthread.h
+++ b/primitives/primproc/bppsendthread.h
@@ -20,7 +20,6 @@
  *
  *
  ***********************************************************************/
-/** @file */
 
 #include "batchprimitiveprocessor.h"
 #include "umsocketselector.h"
@@ -29,7 +28,7 @@
 #include <boost/thread/thread.hpp>
 #include <boost/thread/condition.hpp>
 #include "threadnaming.h"
-
+#include "prioritythreadpool.h"
 #ifndef BPPSENDTHREAD_H
 #define BPPSENDTHREAD_H
 
@@ -82,6 +81,10 @@ public:
     inline bool aborted() const
     {
         return die;
+    }
+    void setProcessorPool(boost::shared_ptr<threadpool::PriorityThreadPool> processorPool)
+    {
+        fProcessorPool = processorPool;
     }
 
 private:
@@ -139,6 +142,9 @@ private:
     /* secondary queue size restriction based on byte size */
     volatile uint64_t currentByteSize;
     static uint64_t maxByteSize;
+    // Used to tell the PriorityThreadPool It should consider additional threads because a 
+    // queue full event has happened and a thread has been blocked.
+    boost::shared_ptr<threadpool::PriorityThreadPool> fProcessorPool;
 };
 
 }

--- a/primitives/primproc/primitiveserver.cpp
+++ b/primitives/primproc/primitiveserver.cpp
@@ -1453,7 +1453,7 @@ struct BPPHandler
         SBPPV bppv;
 
         // make the new BPP object
-        bppv.reset(new BPPV());
+        bppv.reset(new BPPV(fPrimitiveServerPtr));
         bpp.reset(new BatchPrimitiveProcessor(bs, fPrimitiveServerPtr->prefetchThreshold(),
                                               bppv->getSendThread(), fPrimitiveServerPtr->ProcessorThreads()));
 
@@ -2526,9 +2526,10 @@ void PrimitiveServer::start(Service *service)
     cerr << "PrimitiveServer::start() exiting!" << endl;
 }
 
-BPPV::BPPV()
+BPPV::BPPV(PrimitiveServer* ps)
 {
     sendThread.reset(new BPPSendThread());
+    sendThread->setProcessorPool(ps->getProcessorThreadPool());
     v.reserve(BPPCount);
     pos = 0;
     joinDataReceived = false;
@@ -2555,7 +2556,7 @@ void BPPV::add(boost::shared_ptr<BatchPrimitiveProcessor> a)
             joinDataReceived = false;
             unusedInstance->unlock();
         }
-        else
+        else                                            
             joinDataReceived = true;
     }
 
@@ -2570,7 +2571,7 @@ const vector<boost::shared_ptr<BatchPrimitiveProcessor> >& BPPV::get()
 boost::shared_ptr<BatchPrimitiveProcessor> BPPV::next()
 {
     uint32_t size = v.size();
-    uint32_t i;
+    uint32_t i = 0;
 
 #if 0
 

--- a/primitives/primproc/primitiveserver.h
+++ b/primitives/primproc/primitiveserver.h
@@ -55,10 +55,12 @@ extern BRM::DBRM* brm;
 extern boost::mutex bppLock;
 extern uint32_t highPriorityThreads, medPriorityThreads, lowPriorityThreads;
 
+class PrimitiveServer;
+
 class BPPV
 {
 public:
-    BPPV();
+    BPPV(PrimitiveServer* ps);
     ~BPPV();
     boost::shared_ptr<BatchPrimitiveProcessor> next();
     void add(boost::shared_ptr<BatchPrimitiveProcessor> a);

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -76,7 +76,7 @@ using namespace idbdatafile;
 #include "mariadb_my_sys.h"
 
 #include "service.h"
-
+#include "threadnaming.h"
 
 class Opt
 {
@@ -259,6 +259,7 @@ public:
 
     void operator()()
     {
+        utils::setThreadName("QszMonThd");
         for (;;)
         {
             uint32_t qd = fPsp->getProcessorThreadPool()->getWaiting();
@@ -304,7 +305,8 @@ private:
 #ifdef DUMP_CACHE_CONTENTS
 void* waitForSIGUSR1(void* p)
 {
-#if defined(__LP64__) || defined(_MSC_VER)
+    utils::setThreadName("waitForSIGUSR1");
+    #if defined(__LP64__) || defined(_MSC_VER)
     ptrdiff_t tmp = reinterpret_cast<ptrdiff_t>(p);
     int cacheCount = static_cast<int>(tmp);
 #else

--- a/utils/common/MonitorProcMem.cpp
+++ b/utils/common/MonitorProcMem.cpp
@@ -42,6 +42,7 @@ using namespace std;
 using namespace logging;
 
 #include "MonitorProcMem.h"
+#include "threadnaming.h"
 
 namespace utils
 {
@@ -57,6 +58,7 @@ int      MonitorProcMem::fMemPctCheck = 0;
 //------------------------------------------------------------------------------
 void MonitorProcMem::operator()() const
 {
+    utils::setThreadName("MonitorProcMem");
     while (1)
     {
         if (fMaxPct > 0)

--- a/utils/common/atomicops.h
+++ b/utils/common/atomicops.h
@@ -165,6 +165,28 @@ inline bool atomicCAS(volatile T* mem, T comp, T swap)
 #endif
 }
 
+// implements a zero out of a variable
+template <typename T>
+inline void atomicZero(volatile T* mem)
+{
+#ifdef _MSC_VER
+    
+    switch (sizeof(T))
+    {
+        case 4:
+        default:
+            InterlockedXor(reinterpret_cast<volatile LONG*>(mem),(static_cast<LONG>(*mem)));
+            break;
+            
+        case 8:
+            InterlockedXor64(reinterpret_cast<volatile LONG*>(mem),(static_cast<LONG>(*mem)));
+            break;
+    }
+    #else
+        __sync_xor_and_fetch(mem, *mem);
+    #endif
+}
+
 //Implements a scheduler yield
 inline void atomicYield()
 {

--- a/utils/joiner/joinpartition.cpp
+++ b/utils/joiner/joinpartition.cpp
@@ -120,7 +120,7 @@ JoinPartition::JoinPartition(const RowGroup& lRG,
         compressor.reset(new compress::CompressInterfaceSnappy());
     }
 
-    for (int i = 0; i < (int) bucketCount; i++)
+    for (uint32_t i = 0; i < bucketCount; i++)
         buckets.push_back(boost::shared_ptr<JoinPartition>(new JoinPartition(*this, false)));
         
         

--- a/utils/joiner/joinpartition.cpp
+++ b/utils/joiner/joinpartition.cpp
@@ -104,9 +104,6 @@ JoinPartition::JoinPartition(const RowGroup& lRG,
 
     buckets.reserve(bucketCount);
 
-    for (int i = 0; i < (int) bucketCount; i++)
-        buckets.push_back(boost::shared_ptr<JoinPartition>(new JoinPartition(*this, false)));
-
     string compressionType;
     try
     {
@@ -122,6 +119,11 @@ JoinPartition::JoinPartition(const RowGroup& lRG,
     {
         compressor.reset(new compress::CompressInterfaceSnappy());
     }
+
+    for (int i = 0; i < (int) bucketCount; i++)
+        buckets.push_back(boost::shared_ptr<JoinPartition>(new JoinPartition(*this, false)));
+        
+        
 }
 
 /* Ctor used by JoinPartition on expansion, creates JP's in filemode */

--- a/utils/loggingcpp/ErrorMessage.txt
+++ b/utils/loggingcpp/ErrorMessage.txt
@@ -103,6 +103,7 @@
 2054	ERR_DISKAGG_ERROR	Unknown error while aggregation.
 2055	ERR_DISKAGG_TOO_BIG	Not enough memory to make disk-based aggregation. Raise TotalUmMemory if possible.
 2056	ERR_DISKAGG_FILEIO_ERROR	There was an IO error during a disk-based aggregation: %1%
+2057	ERR_JOIN_RESULT_TOO_BIG	Not enough memory to consolidate join results. Estimated %1% MB needed. TotalUmMemory is %2% MB.
 
 # Sub-query errors
 3001	ERR_NON_SUPPORT_SUB_QUERY_TYPE	This subquery type is not supported yet.

--- a/utils/threadpool/prioritythreadpool.cpp
+++ b/utils/threadpool/prioritythreadpool.cpp
@@ -41,7 +41,8 @@ namespace threadpool
 
 PriorityThreadPool::PriorityThreadPool(uint targetWeightPerRun, uint highThreads,
                                        uint midThreads, uint lowThreads, uint ID) :
-    _stop(false), weightPerRun(targetWeightPerRun), id(ID)
+    _stop(false), weightPerRun(targetWeightPerRun), id(ID), 
+    blockedThreads(0), extraThreads(0), stopExtra(true)
 {
     boost::thread* newThread;
     for (uint32_t i = 0; i < highThreads; i++)
@@ -100,7 +101,22 @@ void PriorityThreadPool::addJob(const Job& job, bool useLock)
         newThread->detach();
         threadCounts[LOW]++;
     }
-
+    
+    // If some threads have blocked (because of output queue full)
+    // Temporarily add some extra worker threads to make up for the blocked threads.
+    if (blockedThreads > extraThreads)
+    {
+        stopExtra = false;
+        newThread = threads.create_thread(ThreadHelper(this, EXTRA));
+        newThread->detach();
+        extraThreads++;
+    }
+    else if (blockedThreads == 0)
+    {
+        // Release the temporary threads -- some threads have become unblocked.
+        stopExtra = true;
+    }
+    
     if (job.priority > 66)
         jobQueues[HIGH].push_back(job);
     else if (job.priority > 33)
@@ -128,7 +144,7 @@ void PriorityThreadPool::removeJobs(uint32_t id)
 
 PriorityThreadPool::Priority PriorityThreadPool::pickAQueue(Priority preference)
 {
-    if (!jobQueues[preference].empty())
+    if (preference != EXTRA && !jobQueues[preference].empty())
         return preference;
     else if (!jobQueues[HIGH].empty())
         return HIGH;
@@ -140,7 +156,10 @@ PriorityThreadPool::Priority PriorityThreadPool::pickAQueue(Priority preference)
 
 void PriorityThreadPool::threadFcn(const Priority preferredQueue) throw()
 {
-    utils::setThreadName("Idle");
+    if (preferredQueue == EXTRA)
+        utils::setThreadName("Extra");
+    else
+        utils::setThreadName("Idle");
     Priority queue = LOW;
     uint32_t weight, i = 0;
     vector<Job> runList;
@@ -160,6 +179,14 @@ void PriorityThreadPool::threadFcn(const Priority preferredQueue) throw()
 
             if (jobQueues[queue].empty())
             {
+                // If this is an EXTRA thread due toother threads blocking, and all blockers are unblocked, 
+                // we don't want this one any more.
+                if (preferredQueue == EXTRA && stopExtra)
+                {
+                    extraThreads--;
+                    return;
+                }
+                
                 newJob.wait(lk);
                 continue;
             }
@@ -196,8 +223,11 @@ void PriorityThreadPool::threadFcn(const Priority preferredQueue) throw()
                 if (reschedule[i])
                     rescheduleCount++;
             }
-            utils::setThreadName("Idle");
-                
+            if (preferredQueue == EXTRA)
+                utils::setThreadName("Extra (used)");
+            else
+                utils::setThreadName("Idle");
+            
             // no real work was done, prevent intensive busy waiting
             if (rescheduleCount == runList.size())
                 usleep(1000);
@@ -219,6 +249,7 @@ void PriorityThreadPool::threadFcn(const Priority preferredQueue) throw()
             }
 
             runList.clear();
+            
         }
     }
     catch (std::exception& ex)

--- a/utils/threadpool/prioritythreadpool.cpp
+++ b/utils/threadpool/prioritythreadpool.cpp
@@ -28,6 +28,7 @@ using namespace std;
 
 #include "messageobj.h"
 #include "messagelog.h"
+#include "threadnaming.h"
 using namespace logging;
 
 #include "prioritythreadpool.h"
@@ -139,6 +140,7 @@ PriorityThreadPool::Priority PriorityThreadPool::pickAQueue(Priority preference)
 
 void PriorityThreadPool::threadFcn(const Priority preferredQueue) throw()
 {
+    utils::setThreadName("Idle");
     Priority queue = LOW;
     uint32_t weight, i = 0;
     vector<Job> runList;
@@ -194,7 +196,8 @@ void PriorityThreadPool::threadFcn(const Priority preferredQueue) throw()
                 if (reschedule[i])
                     rescheduleCount++;
             }
-
+            utils::setThreadName("Idle");
+                
             // no real work was done, prevent intensive busy waiting
             if (rescheduleCount == runList.size())
                 usleep(1000);

--- a/utils/threadpool/threadpool.cpp
+++ b/utils/threadpool/threadpool.cpp
@@ -88,8 +88,8 @@ void ThreadPool::setQueueSize(size_t queueSize)
 
 void ThreadPool::pruneThread()
 {
-    boost::unique_lock<boost::mutex> lock2(fPruneMutex);
     utils::setThreadName("pruneThread");
+    boost::unique_lock<boost::mutex> lock2(fPruneMutex);
 
     while(true)
     {

--- a/utils/threadpool/threadpool.cpp
+++ b/utils/threadpool/threadpool.cpp
@@ -89,6 +89,7 @@ void ThreadPool::setQueueSize(size_t queueSize)
 void ThreadPool::pruneThread()
 {
     boost::unique_lock<boost::mutex> lock2(fPruneMutex);
+    utils::setThreadName("pruneThread");
 
     while(true)
     {


### PR DESCRIPTION
Use a loop to shrink the number of results reported per message to something manageable.
See MCOL-4841 for more information.

Also in this PR is the fix for MCOL-4846 Switch to disk based join causes segv

Added thread names to some unnamed threads for easier debugging.