### PR TITLE
Fix build with duplicate lz4 header

### DIFF
--- a/utils/compress/CMakeLists.txt
+++ b/utils/compress/CMakeLists.txt
@@ -1,7 +1,10 @@
 
 include_directories( ${ENGINE_COMMON_INCLUDES} ${SNAPPY_INCLUDE_DIR} )
 
-########### next target ###############
+#hack for lz4 duplicate header
+GET_PROPERTY(dirs DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
+LIST(REMOVE_ITEM dirs ${CMAKE_SOURCE_DIR}/include/providers)
+SET_PROPERTY(DIRECTORY PROPERTY INCLUDE_DIRECTORIES "${dirs}")
 
 set(compress_LIB_SRCS
     idbcompress.cpp)


### PR DESCRIPTION
Some one wrote in CMakeLists.txt
```
INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/include
${CMAKE_SOURCE_DIR}/include/providers)
```
I hope he will be punished, it killed our builds
