### PR TITLE
[MCOL-4849] Parallelize the processing of the bytestream vector.

### DIFF
--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -908,8 +908,7 @@ void TupleJoiner::setInUM(vector<RGData> &rgs)
     }
 }
 
-void TupleJoiner::setPMJoinResults(boost::shared_array<vector<uint32_t> > jr,
-                                   uint32_t threadID)
+void TupleJoiner::setPMJoinResults(boost::shared_array<vector<uint32_t>> jr, uint32_t threadID)
 {
     pmJoinResults[threadID] = jr;
 }
@@ -950,7 +949,7 @@ boost::shared_array<std::vector<uint32_t> > TupleJoiner::getPMJoinArrays(uint32_
 void TupleJoiner::setThreadCount(uint32_t cnt)
 {
     threadCount = cnt;
-    pmJoinResults.reset(new boost::shared_array<vector<uint32_t> >[cnt]);
+    pmJoinResults.reset(new boost::shared_array<vector<uint32_t>>[cnt]);
     smallRow.reset(new Row[cnt]);
 
     for (uint32_t i = 0; i < cnt; i++)

--- a/utils/threadpool/threadpool.h
+++ b/utils/threadpool/threadpool.h
@@ -225,6 +225,10 @@ public:
         return fMaxThreads;
     }
 
+    /** @brief get the issued number of threads
+      */
+    inline size_t getIssuedThreads() { return fIssued; }
+
     /** @brief queue size accessor
       *
       */
@@ -291,6 +295,7 @@ public:
     {
         fDebug = d;
     }
+
 
     friend class ThreadPoolMonitor;
 protected:


### PR DESCRIPTION
This patch changes the logic of the `receiveMultiPrimitiveMessages`
function in the following way:

1. We have only one aggregation thread which reads the data from Queue (which is populated
by messages from BPPs).
2. Processing of the received `bytestream vector` could be in parallel depends on the
type of `TupleBPS` operation (join, fe2, ...) and actual thread pool workload.

The motivation is to eliminate some amount of context switches.