### PR TITLE
Fix compilation failure on aarch64 with gcc 10.3 Ubuntu 21.04

### DIFF
--- a/writeengine/wrapper/we_colop.h
+++ b/writeengine/wrapper/we_colop.h
@@ -221,9 +221,9 @@ public:
     /**
      * @brief Check whether it is an empty row
      */
-    EXPORT virtual bool isEmptyRow(uint64_t* curVal,
-                                   const uint8_t* emptyVal,
-                                   const int colWidth);
+    inline bool isEmptyRow(uint64_t* curVal,
+                           const uint8_t* emptyVal,
+                           const int colWidth);
 
     /**
      * @brief Check whether it is a valid column


### PR DESCRIPTION
According to C++ spec:
If an inline function [or variable (since C++17)] with external linkage is defined
differently in different translation units, the behavior is undefined.
https://en.cppreference.com/w/cpp/language/inline (See Notes)

The undefined behaviour causes link errors for cpimport binary.
/usr/bin/ld: /tmp/cpimport.bin.av067N.ltrans0.ltrans.o:(.data.rel.ro+0x6c8):
undefined reference to `WriteEngine::ColumnOp::isEmptyRow(unsigned long*, unsigned char const*, int)'
https://buildbot.mariadb.org/#/builders/301/builds/1560

The isEmptyRow method is defined as inline in the cpp file and not
inline in the header file. As the method is not used as part of an
external API by any of the callers, nor is it subclassed, mark it as a
normal (non virtual) *inline* member function.