### PR TITLE
MCOL-4920 Re-enables MDB to re-read Columnstore.xml if it was changed on disk

### DIFF
--- a/dbcon/joblist/resourcemanager.cpp
+++ b/dbcon/joblist/resourcemanager.cpp
@@ -385,16 +385,24 @@ bool  ResourceManager::getMysqldInfo(
 {
     static const std::string hostUserUnassignedValue("unassigned");
     // MCS will read username and pass from disk if the config changed.
-    bool reReadConfig = true;
-    u = getStringVal("CrossEngineSupport", "User", hostUserUnassignedValue, reReadConfig);
-    std::string encryptedPW = getStringVal("CrossEngineSupport", "Password", "", reReadConfig);
+    u = getStringVal("CrossEngineSupport", "User", hostUserUnassignedValue);
+    std::string encryptedPW = getStringVal("CrossEngineSupport", "Password", "");
     //This will return back the plaintext password if there is no MCSDATADIR/.secrets file present
     w = decrypt_password(encryptedPW);
     // MCS will not read username and pass from disk if the config changed.
     h = getStringVal("CrossEngineSupport", "Host", hostUserUnassignedValue);
     p = getUintVal("CrossEngineSupport", "Port", 0);
+    u = getStringVal("CrossEngineSupport", "User", "unassigned");
+    w = getStringVal("CrossEngineSupport", "Password", "");
 
-    return h != hostUserUnassignedValue && u != hostUserUnassignedValue && p;
+    bool rc = true;
+
+    if ((h.compare("unassigned") == 0) ||
+            (u.compare("unassigned") == 0) ||
+            (p == 0))
+        rc = false;
+
+    return rc;
 }
 
 bool ResourceManager::queryStatsEnabled() const

--- a/dbcon/joblist/resourcemanager.h
+++ b/dbcon/joblist/resourcemanager.h
@@ -35,7 +35,6 @@
 #include "calpontselectexecutionplan.h"
 #include "resourcedistributor.h"
 #include "installdir.h"
-#include "branchpred.h"
 
 #include "atomicops.h"
 
@@ -561,10 +560,7 @@ private:
      * @param name the param name whose value is to be returned
      * @param defVal the default value returned if the value is missing
      */
-    std::string getStringVal(const std::string& section,
-                             const std::string& name,
-                             const std::string& defVal,
-                             const bool reReadConfigIfNeeded = false) const;
+    std::string getStringVal(const std::string& section, const std::string& name, const std::string& defVal) const;
 
     template<typename IntType>
     IntType getUintVal(const std::string& section, const std::string& name, IntType defval) const;
@@ -625,20 +621,13 @@ private:
 };
 
 
-inline std::string ResourceManager::getStringVal(const std::string& section,
-                                                 const std::string& name,
-                                                 const std::string& defval,
-                                                 const bool reReadConfigIfNeeded) const
+inline std::string ResourceManager::getStringVal(const std::string& section, const std::string& name, const std::string& defval) const
 {
-    std::string val = UNLIKELY(reReadConfigIfNeeded)
-                        ? fConfig->getFromActualConfig(section, name)
-                        : fConfig->getConfig(section, name);
+    std::string val = fConfig->getConfig(section, name);
 #ifdef DEBUGRM
     std::cout << "RM getStringVal for " << section << " : " << name << " val: " << val << " default: " << defval << std::endl;
 #endif
-    if (val.empty())
-        val = defval;
-    return val;
+    return (0 == val.length() ? defval : val);
 }
 
 template<typename IntType>

--- a/utils/configcpp/configcpp.h
+++ b/utils/configcpp/configcpp.h
@@ -87,15 +87,6 @@ public:
     */
     EXPORT const std::string getConfig(const std::string& section, const std::string& name);
 
-    /** @brief get name's value from section
-    *
-    * get name's value from section in the current config file re-reading the
-    * config file if it was updated.
-    * @param section the name of the config file section to search
-    * @param name the param name whose value is to be returned
-    */
-    const std::string getFromActualConfig(const std::string& section, const std::string& name);
-
     /** @brief get all name's values from a section
     *
     * get name's values from section in the current config file.
@@ -113,8 +104,6 @@ public:
     * @param name the param name whose value is to be updated
     * @param value the param value
     */
-    // !!!Don't ever ever use this in the engine code b/c it might result in a race
-    // b/w getConfig and setConfig methods.!!!
     EXPORT void setConfig(const std::string& section, const std::string& name, const std::string& value);
 
     /** @brief delete name from section


### PR DESCRIPTION
Revert "Remove global lock from OAMCache"
This reverts commit 2aa5380d51ebca5b1fa91d44f0215fc571343b5d.