### PR TITLE
MCOL-4936 Disable binlog for DML statements.

### DIFF
--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -444,6 +444,15 @@ inline bool isUpdateOrDeleteStatement(const enum_sql_command& command)
         isDeleteStatement(command);
 }
 
+inline bool isDMLStatement(const enum_sql_command& command)
+{
+    return (command == SQLCOM_INSERT ||
+        command == SQLCOM_INSERT_SELECT ||
+        command == SQLCOM_TRUNCATE ||
+        command == SQLCOM_LOAD ||
+        isUpdateOrDeleteStatement(command));
+}
+
 #ifdef DEBUG_WALK_COND
 void debug_walk(const Item* item, void* arg);
 #endif

--- a/dbcon/mysql/ha_mcs_sysvars.cpp
+++ b/dbcon/mysql/ha_mcs_sysvars.cpp
@@ -77,6 +77,18 @@ static MYSQL_THDVAR_ULONGLONG(
     1
 );
 
+static MYSQL_THDVAR_ULONGLONG(
+    original_option_bits,
+    PLUGIN_VAR_NOSYSVAR | PLUGIN_VAR_NOCMDOPT,
+    "Storage for thd->variables.option_bits. For internal usage.",
+    NULL,
+    NULL,
+    0,
+    0,
+    ~0U,
+    1
+);
+
 const char* mcs_select_handler_mode_values[] = {
     "OFF",
     "ON",
@@ -377,6 +389,7 @@ st_mysql_sys_var* mcs_system_variables[] =
   MYSQL_SYSVAR(compression_type),
   MYSQL_SYSVAR(fe_conn_info_ptr),
   MYSQL_SYSVAR(original_optimizer_flags),
+  MYSQL_SYSVAR(original_option_bits),
   MYSQL_SYSVAR(select_handler),
   MYSQL_SYSVAR(derived_handler),
   MYSQL_SYSVAR(group_by_handler),
@@ -441,6 +454,21 @@ void set_original_optimizer_flags(ulonglong ptr, THD* thd)
     }
     
     THDVAR(current_thd, original_optimizer_flags) = (uint64_t)(ptr);
+}
+
+ulonglong get_original_option_bits(THD* thd)
+{
+    return (thd == NULL) ? 0 : THDVAR(thd, original_option_bits);
+}
+
+void set_original_option_bits(ulonglong value, THD* thd)
+{
+    if (thd == NULL)
+    {
+        return;
+    }
+
+    THDVAR(thd, original_option_bits) = (uint64_t)(value);
 }
 
 mcs_select_handler_mode_t get_select_handler_mode(THD* thd)

--- a/dbcon/mysql/ha_mcs_sysvars.h
+++ b/dbcon/mysql/ha_mcs_sysvars.h
@@ -64,6 +64,9 @@ void set_fe_conn_info_ptr(void* ptr, THD* thd = NULL);
 ulonglong get_original_optimizer_flags(THD* thd = NULL);
 void set_original_optimizer_flags(ulonglong ptr, THD* thd = NULL);
 
+ulonglong get_original_option_bits(THD* thd = NULL);
+void set_original_option_bits(ulonglong value, THD* thd = NULL);
+
 mcs_select_handler_mode_t get_select_handler_mode(THD* thd);
 void set_select_handler_mode(THD* thd, ulong value);
 


### PR DESCRIPTION
DML statements executed on the primary node in a ColumnStore
cluster do not need to be written to the primary's binlog. This
is due to ColumnStore's distributed storage architecture.

With this patch, we disable writing to binlog when a DML statement
(INSERT/DELETE/UPDATE/LDI/INSERT..SELECT) is performed on a ColumnStore
table. HANDLER::external_lock() calls are used to
  1. Turn OFF the OPTION_BIN_LOG flag
  2. Turn ON the OPTION_BIN_TMP_LOG_OFF flag
in THD::variables.option_bits during a WRITE lock call.

THD::variables.option_bits is restored back to the original state
during the UNLOCK call in HANDLER::external_lock().

Further, isDMLStatement() function is added to reduce code verbosity
to check if a given statement is a DML statement.

Note that with this patch, not writing to primary's binlog means
DML replication from a ColumnStore cluster to another ColumnStore
cluster or to another foreign engine will not work.