### PR TITLE
New warnfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ IF (MASK_LONGDOUBLE)
 ENDIF()
 
 
-SET (CMAKE_REQUIRED_FLAGS "-Werror -Wall")
+MY_CHECK_AND_SET_COMPILER_FLAG("-Werror -Wall")
 SET (ENGINE_LDFLAGS    "-Wl,--no-as-needed -Wl,--add-needed")
 SET (ENGINE_DT_LIB datatypes)
 SET (ENGINE_COMMON_LIBS     messageqcpp loggingcpp configcpp idbboot ${Boost_LIBRARIES} xml2 pthread rt libmysql_client ${ENGINE_DT_LIB})

--- a/datatypes/mcs_datatype.cpp
+++ b/datatypes/mcs_datatype.cpp
@@ -1915,4 +1915,3 @@ const uint8_t* TypeHandlerUDecimal128::getEmptyValueForType(
 
 }  // end of namespace datatypes
 
-// vim:ts=2 sw=2:

--- a/datatypes/mcs_datatype.h
+++ b/datatypes/mcs_datatype.h
@@ -2521,4 +2521,3 @@ class TypeHandlerTimestamp : public TypeHandlerTemporal
 
 }  // end of namespace datatypes
 
-// vim:ts=2 sw=2:

--- a/datatypes/mcs_datatype_basic.h
+++ b/datatypes/mcs_datatype_basic.h
@@ -78,4 +78,3 @@ uint64_t xFloatToMCSUInt64Round(SRC value)
 
 }  // end of namespace datatypes
 
-// vim:ts=2 sw=2:

--- a/datatypes/mcs_double.h
+++ b/datatypes/mcs_double.h
@@ -54,4 +54,3 @@ class TDouble
 
 }  // end of namespace datatypes
 
-// vim:ts=2 sw=2:

--- a/datatypes/mcs_float128.h
+++ b/datatypes/mcs_float128.h
@@ -724,4 +724,3 @@ class TFloat128
 
 }  // namespace datatypes
 
-// vim:ts=2 sw=2:

--- a/datatypes/mcs_int128.cpp
+++ b/datatypes/mcs_int128.cpp
@@ -113,4 +113,3 @@ std::ostream& operator<<(std::ostream& os, const TSInt128& x)
 }
 
 }  // end of namespace datatypes
-// vim:ts=2 sw=2:

--- a/datatypes/mcs_int128.h
+++ b/datatypes/mcs_int128.h
@@ -322,4 +322,3 @@ class TSInt128
 
 }  // end of namespace datatypes
 
-// vim:ts=2 sw=2:

--- a/datatypes/mcs_int64.h
+++ b/datatypes/mcs_int64.h
@@ -179,4 +179,3 @@ class TSInt64Null : public TSInt64, public TNullFlag
 
 }  // end of namespace datatypes
 
-// vim:ts=2 sw=2:

--- a/datatypes/mcs_longdouble.h
+++ b/datatypes/mcs_longdouble.h
@@ -54,4 +54,3 @@ class TLongDouble
 
 }  // end of namespace datatypes
 
-// vim:ts=2 sw=2:

--- a/dbcon/ddlpackage/CMakeLists.txt
+++ b/dbcon/ddlpackage/CMakeLists.txt
@@ -9,7 +9,7 @@ FIND_PACKAGE(FLEX REQUIRED)
 FLEX_TARGET(ddl_scan ddl.l ${CMAKE_CURRENT_BINARY_DIR}/ddl-scan.cpp COMPILE_FLAGS "-i -L -Pddl")
 ADD_FLEX_BISON_DEPENDENCY(ddl_scan ddl_gram)
 
-set_source_files_properties(ddl-scan.cpp PROPERTIES COMPILE_FLAGS "-Wno-sign-compare -DYY_NO_INPUT")
+set_source_files_properties(ddl-scan.cpp PROPERTIES COMPILE_FLAGS "-Wno-register -Wno-deprecated-register -Wno-sign-compare -DYY_NO_INPUT")
 
 ########### next target ###############
 

--- a/dbcon/ddlpackageproc/altertableprocessor.cpp
+++ b/dbcon/ddlpackageproc/altertableprocessor.cpp
@@ -2539,7 +2539,6 @@ void AlterTableProcessor::renameColumn(uint32_t sessionID, execplan::CalpontSyst
 }
 
 }  // namespace ddlpackageprocessor
-// vim:ts=4 sw=4:
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/dbcon/ddlpackageproc/createtableprocessor.cpp
+++ b/dbcon/ddlpackageproc/createtableprocessor.cpp
@@ -830,4 +830,3 @@ void CreateTableProcessor::rollBackCreateTable(const string& error, BRM::TxnID t
 }
 
 }  // namespace ddlpackageprocessor
-// vim:ts=4 sw=4:

--- a/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
+++ b/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
@@ -1491,4 +1491,3 @@ int DDLPackageProcessor::commitTransaction(uint64_t uniqueId, BRM::TxnID txnID)
 }
 
 }  // namespace ddlpackageprocessor
-// vim:ts=4 sw=4:

--- a/dbcon/ddlpackageproc/ddlpackageprocessor.h
+++ b/dbcon/ddlpackageproc/ddlpackageprocessor.h
@@ -890,4 +890,3 @@ bool from_string(T& t, const std::string& s, std::ios_base& (*f)(std::ios_base&)
 
 #undef EXPORT
 
-// vim:ts=4 sw=4:

--- a/dbcon/ddlpackageproc/droptableprocessor.cpp
+++ b/dbcon/ddlpackageproc/droptableprocessor.cpp
@@ -1367,4 +1367,3 @@ TruncTableProcessor::DDLResult TruncTableProcessor::processPackage(
 
 }  // namespace ddlpackageprocessor
 
-// vim:ts=4 sw=4:

--- a/dbcon/dmlpackage/CMakeLists.txt
+++ b/dbcon/dmlpackage/CMakeLists.txt
@@ -10,7 +10,7 @@ FIND_PACKAGE(FLEX REQUIRED)
 FLEX_TARGET(dml_scan dml.l ${CMAKE_CURRENT_BINARY_DIR}/dml-scan.cpp COMPILE_FLAGS "-i -L -Pdml")
 ADD_FLEX_BISON_DEPENDENCY(dml_scan dml_gram)
 
-set_source_files_properties(dml-scan.cpp PROPERTIES COMPILE_FLAGS "-Wno-sign-compare -DYY_NO_INPUT")
+set_source_files_properties(dml-scan.cpp PROPERTIES COMPILE_FLAGS "-Wno-register -Wno-deprecated-register -Wno-sign-compare -DYY_NO_INPUT")
 
 ########### next target ###############
 

--- a/dbcon/dmlpackageproc/autoincrementdata.cpp
+++ b/dbcon/dmlpackageproc/autoincrementdata.cpp
@@ -97,4 +97,3 @@ AutoincrementData::OIDNextValue& AutoincrementData::getOidNextValueMap()
 
   return fOidNextValueMap;
 }
-// vim:ts=4 sw=4:

--- a/dbcon/dmlpackageproc/autoincrementdata.h
+++ b/dbcon/dmlpackageproc/autoincrementdata.h
@@ -49,4 +49,3 @@ class AutoincrementData
   boost::mutex fOIDnextvalLock;
 };
 
-// vim:ts=4 sw=4:

--- a/dbcon/dmlpackageproc/dmlpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/dmlpackageprocessor.cpp
@@ -913,4 +913,3 @@ int DMLPackageProcessor::endTransaction(uint64_t uniqueId, BRM::TxnID txnID, boo
   return rc;
 }
 }  // namespace dmlpackageprocessor
-// vim:ts=4 sw=4:

--- a/dbcon/dmlpackageproc/insertpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/insertpackageprocessor.cpp
@@ -432,4 +432,3 @@ DMLPackageProcessor::DMLResult InsertPackageProcessor::processPackage(dmlpackage
 
 }  // namespace dmlpackageprocessor
 
-// vim:ts=4 sw=4:

--- a/dbcon/dmlpackageproc/tablelockdata.cpp
+++ b/dbcon/dmlpackageproc/tablelockdata.cpp
@@ -101,4 +101,3 @@ TablelockData::OIDTablelock& TablelockData::getOidTablelockMap()
 }
 
 }  // namespace dmlpackageprocessor
-// vim:ts=4 sw=4:

--- a/dbcon/dmlpackageproc/tablelockdata.h
+++ b/dbcon/dmlpackageproc/tablelockdata.h
@@ -61,4 +61,3 @@ class TablelockData
 
 #undef EXPORT
 
-// vim:ts=4 sw=4:

--- a/dbcon/execplan/calpontselectexecutionplan.h
+++ b/dbcon/execplan/calpontselectexecutionplan.h
@@ -939,4 +939,3 @@ inline std::ostream& operator<<(std::ostream& os, const CalpontSelectExecutionPl
 }
 
 }  // namespace execplan
-// vim:ts=4 sw=4:

--- a/dbcon/execplan/calpontsystemcatalog.h
+++ b/dbcon/execplan/calpontsystemcatalog.h
@@ -1279,4 +1279,3 @@ bool ctListSort(const CalpontSystemCatalog::ColType& a, const CalpontSystemCatal
 
 }  // namespace execplan
 
-// vim:ts=4 sw=4:

--- a/dbcon/execplan/clientrotator.cpp
+++ b/dbcon/execplan/clientrotator.cpp
@@ -399,4 +399,3 @@ void ClientRotator::writeToLog(int line, const string& msg, bool critical) const
 }
 
 }  // namespace execplan
-// vim:ts=4 sw=4:

--- a/dbcon/execplan/clientrotator.h
+++ b/dbcon/execplan/clientrotator.h
@@ -166,4 +166,3 @@ class ClientRotator
 };
 
 }  // namespace execplan
-// vim:ts=4 sw=4:

--- a/dbcon/execplan/constantcolumn.cpp
+++ b/dbcon/execplan/constantcolumn.cpp
@@ -347,4 +347,3 @@ bool ConstantColumn::operator!=(const TreeNode* t) const
 }
 
 }  // namespace execplan
-// vim:ts=4 sw=4:

--- a/dbcon/execplan/constantfilter.cpp
+++ b/dbcon/execplan/constantfilter.cpp
@@ -308,4 +308,3 @@ void ConstantFilter::setSimpleColumnList()
 }
 
 }  // namespace execplan
-// vim:ts=4 sw=4:

--- a/dbcon/execplan/sessionmanager.h
+++ b/dbcon/execplan/sessionmanager.h
@@ -213,4 +213,3 @@ class SessionManager
 
 }  // namespace execplan
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/anydatalist.cpp
+++ b/dbcon/joblist/anydatalist.cpp
@@ -170,4 +170,3 @@ std::ostream& omitOidInDL(std::ostream& strm)
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/batchprimitiveprocessor-jl.h
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.h
@@ -366,4 +366,3 @@ class BatchPrimitiveProcessorJL
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/columncommand-jl.h
+++ b/dbcon/joblist/columncommand-jl.h
@@ -129,4 +129,3 @@ class ColumnCommandJL : public CommandJL
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/crossenginestep.cpp
+++ b/dbcon/joblist/crossenginestep.cpp
@@ -828,4 +828,3 @@ void CrossEngineStep::formatMiniStats()
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/crossenginestep.h
+++ b/dbcon/joblist/crossenginestep.h
@@ -249,4 +249,3 @@ class CrossEngineStep : public BatchPrimitive, public TupleDeliveryStep
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/diskjoinstep.cpp
+++ b/dbcon/joblist/diskjoinstep.cpp
@@ -163,7 +163,7 @@ void DiskJoinStep::smallReader()
   RGData rgData;
   bool more = true;
   int64_t memUsage = 0, combinedMemUsage = 0;
-  int rowCount = 0;
+  [[maybe_unused]] int rowCount = 0;
   RowGroup l_smallRG = smallRG;
 
   try
@@ -224,7 +224,7 @@ void DiskJoinStep::largeReader()
   RGData rgData;
   bool more = true;
   int64_t largeSize = 0;
-  int rowCount = 0;
+  [[maybe_unused]] int rowCount = 0;
   RowGroup l_largeRG = largeRG;
 
   largeIterationCount++;

--- a/dbcon/joblist/distributedenginecomm.cpp
+++ b/dbcon/joblist/distributedenginecomm.cpp
@@ -1146,4 +1146,3 @@ uint32_t DistributedEngineComm::MQE::getNextConnectionId(const size_t pmIndex,
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/elementtype.h
+++ b/dbcon/joblist/elementtype.h
@@ -638,4 +638,3 @@ extern std::ostream& omitOidInDL(std::ostream& strm);
 
 #endif
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/errorinfo.h
+++ b/dbcon/joblist/errorinfo.h
@@ -52,4 +52,3 @@ typedef boost::shared_ptr<ErrorInfo> SErrorInfo;
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/expressionstep.cpp
+++ b/dbcon/joblist/expressionstep.cpp
@@ -790,4 +790,3 @@ const string ExpressionStep::toString() const
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/fifo.h
+++ b/dbcon/joblist/fifo.h
@@ -529,4 +529,3 @@ void FIFO<element_t>::totalFileCounts(uint64_t& numFiles, uint64_t& numBytes) co
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/groupconcat.cpp
+++ b/dbcon/joblist/groupconcat.cpp
@@ -1051,4 +1051,3 @@ const string GroupConcatNoOrder::toString() const
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/jlf_common.cpp
+++ b/dbcon/joblist/jlf_common.cpp
@@ -822,4 +822,3 @@ bool compatibleColumnTypes(const CalpontSystemCatalog::ColDataType& dt1, uint32_
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/jlf_execplantojoblist.cpp
+++ b/dbcon/joblist/jlf_execplantojoblist.cpp
@@ -3446,7 +3446,6 @@ void JLF_ExecPlanToJobList::addJobSteps(JobStepVector& nsv, JobInfo& jobInfo, bo
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/dbcon/joblist/jlf_graphics.cpp
+++ b/dbcon/joblist/jlf_graphics.cpp
@@ -418,7 +418,6 @@ ostream& writeDotCmds(ostream& dotFile, const JobStepVector& query, const JobSte
 
 }  // end namespace jlf_graphics
 
-// vim:ts=4 sw=4 syntax=cpp:
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/dbcon/joblist/jlf_subquery.cpp
+++ b/dbcon/joblist/jlf_subquery.cpp
@@ -875,4 +875,3 @@ SJSTEP doUnionSub(CalpontExecutionPlan* ep, JobInfo& jobInfo)
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/jlf_tuplejoblist.cpp
+++ b/dbcon/joblist/jlf_tuplejoblist.cpp
@@ -4559,7 +4559,6 @@ SJSTEP unionQueries(JobStepVector& queries, uint64_t distinctUnionNum, JobInfo& 
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/dbcon/joblist/joblist.cpp
+++ b/dbcon/joblist/joblist.cpp
@@ -1233,4 +1233,3 @@ void TupleJobList::abort()
 #pragma clang diagnostic pop
 #endif
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/joblist.h
+++ b/dbcon/joblist/joblist.h
@@ -260,4 +260,3 @@ typedef boost::shared_ptr<TupleJobList> STJLP;
 
 #undef EXPORT
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/joblistfactory.cpp
+++ b/dbcon/joblist/joblistfactory.cpp
@@ -2316,7 +2316,6 @@ SJLP JobListFactory::makeJobList(CalpontExecutionPlan* cplan, ResourceManager* r
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/dbcon/joblist/jobstep.cpp
+++ b/dbcon/joblist/jobstep.cpp
@@ -244,4 +244,3 @@ void JobStep::handleException(std::exception_ptr e, const int errorCode, const u
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/jobstep.h
+++ b/dbcon/joblist/jobstep.h
@@ -566,4 +566,3 @@ typedef boost::shared_ptr<JobStep> SJSTEP;
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/lbidlist.cpp
+++ b/dbcon/joblist/lbidlist.cpp
@@ -920,4 +920,3 @@ template bool LBIDList::checkRangeOverlap<int64_t>(int64_t min, int64_t max, int
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/limitedorderby.cpp
+++ b/dbcon/joblist/limitedorderby.cpp
@@ -303,4 +303,3 @@ const string LimitedOrderBy::toString() const
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/passthrucommand-jl.cpp
+++ b/dbcon/joblist/passthrucommand-jl.cpp
@@ -110,4 +110,3 @@ uint16_t PassThruCommandJL::getWidth()
 }
 
 };  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/pcolscan.cpp
+++ b/dbcon/joblist/pcolscan.cpp
@@ -1224,4 +1224,3 @@ void pColScanStep::appendFilter(const std::vector<const execplan::Filter*>& fs)
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/pcolstep.cpp
+++ b/dbcon/joblist/pcolstep.cpp
@@ -1511,4 +1511,3 @@ void pColStep::appendFilter(const std::vector<const execplan::Filter*>& fs)
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/pdictionaryscan.cpp
+++ b/dbcon/joblist/pdictionaryscan.cpp
@@ -916,4 +916,3 @@ void pDictionaryScan::abort()
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/primitivemsg.h
+++ b/dbcon/joblist/primitivemsg.h
@@ -884,4 +884,3 @@ struct LbidAtVer
 
 #pragma pack(pop)
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/primitivestep.h
+++ b/dbcon/joblist/primitivestep.h
@@ -1835,4 +1835,3 @@ class PseudoColStep : public pColStep
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/rowestimator.cpp
+++ b/dbcon/joblist/rowestimator.cpp
@@ -269,8 +269,8 @@ float RowEstimator::estimateRowReturnFactor(const BRM::EMEntry& emEntry, const m
   float tempFactor = 1.0;
 
   uint64_t adjustedMin = 0, adjustedMax = 0;
-  uint128_t adjustedBigMin, adjustedBigMax;
-  uint32_t distinctValuesEstimate;
+  uint128_t adjustedBigMin = 0, adjustedBigMax = 0;
+  uint32_t distinctValuesEstimate = 0;
 
   // Adjust values based on column type and estimate the
   if (!ct.isWideDecimalType())

--- a/dbcon/joblist/subquerystep.cpp
+++ b/dbcon/joblist/subquerystep.cpp
@@ -533,4 +533,3 @@ void SubAdapterStep::formatMiniStats()
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/subquerystep.h
+++ b/dbcon/joblist/subquerystep.h
@@ -273,4 +273,3 @@ class SubAdapterStep : public JobStep, public TupleDeliveryStep
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/subquerytransformer.cpp
+++ b/dbcon/joblist/subquerytransformer.cpp
@@ -622,4 +622,3 @@ void SimpleScalarTransformer::getScalarResult()
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/subquerytransformer.h
+++ b/dbcon/joblist/subquerytransformer.h
@@ -223,4 +223,3 @@ class SimpleScalarTransformer : public SubQueryTransformer
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/tuple-bps.cpp
+++ b/dbcon/joblist/tuple-bps.cpp
@@ -3356,4 +3356,3 @@ template bool TupleBPS::compareSingleValue<int64_t>(uint8_t COP, int64_t val1, i
 template bool TupleBPS::compareSingleValue<int128_t>(uint8_t COP, int128_t val1, int128_t val2) const;
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -5962,4 +5962,3 @@ void TupleAggregateStep::formatMiniStats()
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/tupleaggregatestep.h
+++ b/dbcon/joblist/tupleaggregatestep.h
@@ -224,4 +224,3 @@ class TupleAggregateStep : public JobStep, public TupleDeliveryStep
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/tupleannexstep.cpp
+++ b/dbcon/joblist/tupleannexstep.cpp
@@ -1258,4 +1258,3 @@ void TupleAnnexStep::formatMiniStats()
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/tupleannexstep.h
+++ b/dbcon/joblist/tupleannexstep.h
@@ -193,4 +193,3 @@ class reservablePQ : private std::priority_queue<T>
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/tupleconstantstep.cpp
+++ b/dbcon/joblist/tupleconstantstep.cpp
@@ -842,4 +842,3 @@ const string TupleConstantBooleanStep::toString() const
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/tupleconstantstep.h
+++ b/dbcon/joblist/tupleconstantstep.h
@@ -189,4 +189,3 @@ class TupleConstantBooleanStep : public TupleConstantStep
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -1997,4 +1997,3 @@ void TupleHashJoinStep::abort()
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/tuplehashjoin.h
+++ b/dbcon/joblist/tuplehashjoin.h
@@ -633,4 +633,3 @@ class TupleHashJoinStep : public JobStep, public TupleDeliveryStep
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/tuplehavingstep.cpp
+++ b/dbcon/joblist/tuplehavingstep.cpp
@@ -408,4 +408,3 @@ void TupleHavingStep::formatMiniStats()
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/tuplehavingstep.h
+++ b/dbcon/joblist/tuplehavingstep.h
@@ -115,4 +115,3 @@ class TupleHavingStep : public ExpressionStep, public TupleDeliveryStep
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/virtualtable.cpp
+++ b/dbcon/joblist/virtualtable.cpp
@@ -158,4 +158,3 @@ const CalpontSystemCatalog::ColType& VirtualTable::columnType(uint32_t i) const
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/windowfunctionstep.cpp
+++ b/dbcon/joblist/windowfunctionstep.cpp
@@ -1597,4 +1597,3 @@ void WindowFunctionStep::formatMiniStats()
 }
 
 }  // namespace joblist
-// vim:ts=4 sw=4:

--- a/dbcon/joblist/windowfunctionstep.h
+++ b/dbcon/joblist/windowfunctionstep.h
@@ -225,4 +225,3 @@ class WindowFunctionStep : public JobStep, public TupleDeliveryStep
 
 }  // namespace joblist
 
-// vim:ts=4 sw=4:

--- a/dbcon/mysql/ha_autoi.cpp
+++ b/dbcon/mysql/ha_autoi.cpp
@@ -176,4 +176,3 @@ bool parseAutoincrementColumnComment(std::string comment, uint64_t& startValue)
   return autoincrement;
 }
 
-// vim:ts=4 sw=4:

--- a/dbcon/mysql/ha_mcs_datatype.h
+++ b/dbcon/mysql/ha_mcs_datatype.h
@@ -841,4 +841,3 @@ class WriteBatchFieldMariaDB : public WriteBatchField
 
 }  // end of namespace datatypes
 
-// vim:ts=2 sw=2:

--- a/dbcon/mysql/ha_mcs_ddl.cpp
+++ b/dbcon/mysql/ha_mcs_ddl.cpp
@@ -2807,4 +2807,3 @@ extern "C"
   }
 }
 
-// vim:ts=4 sw=4:

--- a/dbcon/mysql/ha_mcs_dml.cpp
+++ b/dbcon/mysql/ha_mcs_dml.cpp
@@ -1001,4 +1001,3 @@ int ha_mcs_impl_close_connection_(handlerton* hton, THD* thd, cal_connection_inf
   return rc;
 }
 
-// vim:ts=4 sw=4:

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -10459,4 +10459,3 @@ int getGroupPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, SCSEP& csep, cal_gro
 }
 
 }  // namespace cal_impl_if
-// vim:ts=4 sw=4:

--- a/dbcon/mysql/ha_pseudocolumn.cpp
+++ b/dbcon/mysql/ha_pseudocolumn.cpp
@@ -579,4 +579,3 @@ execplan::ReturnedColumn* buildPseudoColumn(Item* item, gp_walk_info& gwi, bool&
 }
 
 }  // namespace cal_impl_if
-// vim:ts=4 sw=4:

--- a/dbcon/mysql/idb_mysql.h
+++ b/dbcon/mysql/idb_mysql.h
@@ -118,4 +118,3 @@ inline char* idb_mysql_query_str(THD* thd)
 }
 }  // namespace
 
-// vim:ts=4 sw=4:

--- a/ddlproc/ddlproc.cpp
+++ b/ddlproc/ddlproc.cpp
@@ -248,4 +248,3 @@ int main(int argc, char** argv)
 
   return ServiceDDLProc(opt).Run();
 }
-// vim:ts=4 sw=4:

--- a/ddlproc/ddlprocessor.cpp
+++ b/ddlproc/ddlprocessor.cpp
@@ -876,4 +876,3 @@ int DDLProcessor::commitTransaction(uint32_t txnID, std::string& errorMsg)
   return rc;
 }
 }  // namespace ddlprocessor
-// vim:ts=4 sw=4:

--- a/dmlproc/batchinsertprocessor.cpp
+++ b/dmlproc/batchinsertprocessor.cpp
@@ -547,4 +547,3 @@ void BatchInsertProc::getError(int& errorCode, std::string& errMsg)
   errMsg = fErrMsg;
 }
 }  // namespace dmlprocessor
-// vim:ts=4 sw=4:

--- a/dmlproc/batchinsertprocessor.h
+++ b/dmlproc/batchinsertprocessor.h
@@ -93,4 +93,3 @@ class BatchInsertProc
 };
 
 }  // namespace dmlprocessor
-// vim:ts=4 sw=4:

--- a/dmlproc/dmlproc.cpp
+++ b/dmlproc/dmlproc.cpp
@@ -639,14 +639,7 @@ int ServiceDMLProc::Child()
 
     // Couldn't check the return code b/c
     // fuser returns 1 for unused port.
-#if defined(__GNUC__) && __GNUC__ >= 5
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
-    (void)::system(cmd.c_str());
-#pragma GCC diagnostic pop
-#else
-    (void)::system(cmd.c_str());
-#endif
+    std::ignore = ::system(cmd.c_str());
   }
   catch (...)
   {

--- a/dmlproc/dmlproc.cpp
+++ b/dmlproc/dmlproc.cpp
@@ -691,4 +691,3 @@ int main(int argc, char** argv)
   return ServiceDMLProc(opt).Run();
 }
 
-// vim:ts=4 sw=4:

--- a/dmlproc/dmlprocessor.cpp
+++ b/dmlproc/dmlprocessor.cpp
@@ -2001,4 +2001,3 @@ void DMLProcessor::log(const std::string& msg, logging::LOG_TYPE level)
 }
 
 }  // namespace dmlprocessor
-// vim:ts=4 sw=4:

--- a/dmlproc/dmlprocessor.h
+++ b/dmlproc/dmlprocessor.h
@@ -330,4 +330,3 @@ class RollbackTransactionProcessor : public dmlpackageprocessor::DMLPackageProce
 
 }  // namespace dmlprocessor
 
-// vim:ts=4 sw=4:

--- a/exemgr/activestatementcounter.cpp
+++ b/exemgr/activestatementcounter.cpp
@@ -57,4 +57,3 @@ void ActiveStatementCounter::decr(bool& counted)
   --fStatementCount;
   condvar.notify_one();
 }
-// vim:ts=4 sw=4:

--- a/exemgr/activestatementcounter.h
+++ b/exemgr/activestatementcounter.h
@@ -62,4 +62,3 @@ class ActiveStatementCounter
   BRM::VSS fVss;
 };
 
-// vim:ts=4 sw=4:

--- a/exemgr/main.cpp
+++ b/exemgr/main.cpp
@@ -1825,4 +1825,3 @@ int main(int argc, char* argv[])
   return ServiceExeMgr(opt).Run();
 }
 
-// vim:ts=4 sw=4:

--- a/oam/oamcpp/liboamcpp.cpp
+++ b/oam/oamcpp/liboamcpp.cpp
@@ -1066,4 +1066,3 @@ std::string Oam::itoa(const int i)
   return ss.str();
 }
 }  // namespace oam
-// vim:ts=4 sw=4:

--- a/oam/oamcpp/liboamcpp.h
+++ b/oam/oamcpp/liboamcpp.h
@@ -433,4 +433,3 @@ class Oam
 
 #undef EXPORT
 
-// vim:ts=4 sw=4:

--- a/oamapps/columnstoreDB/columnstoreDB.cpp
+++ b/oamapps/columnstoreDB/columnstoreDB.cpp
@@ -271,7 +271,7 @@ int main(int argc, char** argv)
   Oam oam;
   BRM::DBRM dbrm;
 
-  char c;
+  signed char c;
 
   // Invokes member function `int operator ()(void);'
   while ((c = getopt(argc, argv, "c:h")) != -1)

--- a/oamapps/postConfigure/mycnfUpgrade.cpp
+++ b/oamapps/postConfigure/mycnfUpgrade.cpp
@@ -284,4 +284,3 @@ int main(int argc, char* argv[])
 
   exit(0);
 }
-// vim:ts=4 sw=4:

--- a/oamapps/sessionWalker/sessionwalker.cpp
+++ b/oamapps/sessionWalker/sessionwalker.cpp
@@ -133,4 +133,3 @@ int main(int argc, char** argv)
 
   return 0;
 }
-// vim:ts=4 sw=4:

--- a/primitives/blockcache/blockcacheclient.h
+++ b/primitives/blockcache/blockcacheclient.h
@@ -176,4 +176,3 @@ class blockCacheClient
 
 }  // namespace dbbc
 
-// vim:ts=4 sw=4:

--- a/primitives/blockcache/blockrequestprocessor.h
+++ b/primitives/blockcache/blockrequestprocessor.h
@@ -190,4 +190,3 @@ class BlockRequestProcessor
 };
 
 }  // namespace dbbc
-// vim:ts=4 sw=4:

--- a/primitives/blockcache/filerequest.h
+++ b/primitives/blockcache/filerequest.h
@@ -320,4 +320,3 @@ class fileRequest
 
 }  // namespace dbbc
 
-// vim:ts=4 sw=4:

--- a/primitives/blockcache/iomanager.cpp
+++ b/primitives/blockcache/iomanager.cpp
@@ -1440,4 +1440,3 @@ void ioManager::handleBlockReadError(fileRequest* fr, const string& errMsg, bool
 }
 
 }  // namespace dbbc
-// vim:ts=4 sw=4:

--- a/primitives/blockcache/iomanager.h
+++ b/primitives/blockcache/iomanager.h
@@ -147,4 +147,3 @@ void dropFDCache();
 void purgeFDCache(std::vector<BRM::FileInfo>& files);
 
 }  // namespace dbbc
-// vim:ts=4 sw=4:

--- a/primitives/linux-port/column.cpp
+++ b/primitives/linux-port/column.cpp
@@ -1764,4 +1764,3 @@ template void primitives::PrimitiveProcessor::columnScanAndFilter<int128_t>(NewC
                                                                             ColResultHeader*);
 
 }  // namespace primitives
-// vim:ts=2 sw=2:

--- a/primitives/linux-port/dictionary.cpp
+++ b/primitives/linux-port/dictionary.cpp
@@ -620,4 +620,3 @@ void PrimitiveProcessor::p_Dictionary(const DictInput* in, vector<uint8_t>* out,
 }
 
 }  // namespace primitives
-// vim:ts=4 sw=4:

--- a/primitives/linux-port/index.cpp
+++ b/primitives/linux-port/index.cpp
@@ -1130,4 +1130,3 @@ void PrimitiveProcessor::p_IdxList(const IndexListHeader* rqst, IndexListHeader*
 }
 
 }  // namespace primitives
-// vim:ts=4 sw=4:

--- a/primitives/linux-port/primitiveprocessor.h
+++ b/primitives/linux-port/primitiveprocessor.h
@@ -562,4 +562,3 @@ boost::shared_ptr<ParsedColumnFilter> _parseColumnFilter(
 
 }  // namespace primitives
 
-// vim:ts=2 sw=2:

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -2746,4 +2746,3 @@ void BatchPrimitiveProcessor::buildVSSCache(uint32_t loopCount)
 }
 
 }  // namespace primitiveprocessor
-// vim:ts=4 sw=4:

--- a/primitives/primproc/columncommand.cpp
+++ b/primitives/primproc/columncommand.cpp
@@ -1226,4 +1226,3 @@ void ColumnCommandInt128::issuePrimitive()
 }
 
 }  // namespace primitiveprocessor
-// vim:ts=4 sw=4:

--- a/primitives/primproc/columncommand.h
+++ b/primitives/primproc/columncommand.h
@@ -306,4 +306,3 @@ inline void ColumnCommand::fillEmptyBlock<messageqcpp::ByteStream::hexbyte>(uint
 
 }  // namespace primitiveprocessor
 
-// vim:ts=4 sw=4:

--- a/primitives/primproc/primitiveserver.cpp
+++ b/primitives/primproc/primitiveserver.cpp
@@ -2575,4 +2575,3 @@ bool BPPV::aborted()
 // end workaround
 
 }  // namespace primitiveprocessor
-// vim:ts=4 sw=4:

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -784,4 +784,3 @@ int main(int argc, char** argv)
 
   return ServicePrimProc(opt).Run();
 }
-// vim:ts=4 sw=4:

--- a/primitives/primproc/udf.cpp
+++ b/primitives/primproc/udf.cpp
@@ -69,4 +69,3 @@ void loadUDFs()
 }
 
 }  // namespace primitiveprocessor
-// vim:ts=4 sw=4:

--- a/storage-manager/src/smcat.cpp
+++ b/storage-manager/src/smcat.cpp
@@ -93,7 +93,7 @@ void catFileOffline(const char* filename, int prefixlen)
 void catFileOnline(const char* filename, int prefixlen)
 {
   uint8_t data[8192];
-  off_t offset = 0;
+  [[maybe_unused]] off_t offset = 0;
   int read_err, write_err, count;
   idbdatafile::SMDataFile df(filename, O_RDONLY, 0);
 

--- a/storage-manager/src/unit_tests.cpp
+++ b/storage-manager/src/unit_tests.cpp
@@ -1056,10 +1056,10 @@ bool copytask(bool connectionTest = false)
   copy_cmd* cmd = (copy_cmd*)buf;
   cmd->opcode = COPY;
   cmd->file1.flen = strlen(source);
-  strncpy(cmd->file1.filename, source, cmd->file1.flen);
+  memcpy(cmd->file1.filename, source, cmd->file1.flen);
   f_name* file2 = (f_name*)&cmd->file1.filename[cmd->file1.flen];
   file2->flen = strlen(dest);
-  strncpy(file2->filename, dest, file2->flen);
+  memcpy(file2->filename, dest, file2->flen);
 
   uint len = (uint64_t)&file2->filename[file2->flen] - (uint64_t)buf;
 

--- a/tests/primitives_column_scan_and_filter.cpp
+++ b/tests/primitives_column_scan_and_filter.cpp
@@ -965,4 +965,3 @@ TEST_F(ColumnScanFilterTest, ColumnScan16Bytes2CompFilters)
   EXPECT_EQ(out->Max, __col16block_cdf_umax);
   EXPECT_EQ(out->Min, __col16block_cdf_umin);
 }
-// vim:ts=2 sw=2:

--- a/tests/primitives_scan_bench.cpp
+++ b/tests/primitives_scan_bench.cpp
@@ -427,4 +427,3 @@ BENCHMARK_DEFINE_F(FilterBenchFixture, BM_ColumnScan8Byte1FilterVectorizedCode)(
 BENCHMARK_REGISTER_F(FilterBenchFixture, BM_ColumnScan8Byte1FilterVectorizedCode);
 
 BENCHMARK_MAIN();
-// vim:ts=2 sw=2:

--- a/tools/bincvt/li2bin.cpp
+++ b/tools/bincvt/li2bin.cpp
@@ -278,4 +278,3 @@ int main(int argc, char** argv)
 
   return 0;
 }
-// vim:ts=4 sw=4:

--- a/tools/clearShm/main.cpp
+++ b/tools/clearShm/main.cpp
@@ -239,4 +239,3 @@ int main(int argc, char** argv)
 
   return 0;
 }
-// vim:ts=4 sw=4:

--- a/tools/dbbuilder/dbbuilder.cpp
+++ b/tools/dbbuilder/dbbuilder.cpp
@@ -324,4 +324,3 @@ int main(int argc, char* argv[])
 
   return 1;
 }
-// vim:ts=4 sw=4:

--- a/tools/ddlcleanup/ddlcleanup.cpp
+++ b/tools/ddlcleanup/ddlcleanup.cpp
@@ -80,4 +80,3 @@ int main(int argc, char** argv)
   return ddlcleanuputil::ddl_cleanup();
 }
 
-// vim:ts=4 sw=4:

--- a/tools/editem/editem.cpp
+++ b/tools/editem/editem.cpp
@@ -1040,4 +1040,3 @@ int main(int argc, char** argv)
 
   return 0;
 }
-// vim:ts=4 sw=4:

--- a/tools/qfe/server.cpp
+++ b/tools/qfe/server.cpp
@@ -513,4 +513,3 @@ int main(int argc, char** argv)
 
   return 0;
 }
-// vim:ts=4 sw=4:

--- a/tools/sendPlan/sendplan.cpp
+++ b/tools/sendPlan/sendplan.cpp
@@ -390,4 +390,3 @@ int main(int argc, char** argv)
 
   return 0;
 }
-// vim:ts=4 sw=4:

--- a/tools/setConfig/main.cpp
+++ b/tools/setConfig/main.cpp
@@ -148,4 +148,3 @@ int main(int argc, char** argv)
 
   return 0;
 }
-// vim:ts=4 sw=4:

--- a/utils/cacheutils/cacheutils.cpp
+++ b/utils/cacheutils/cacheutils.cpp
@@ -354,4 +354,3 @@ int purgePrimProcFdCache(const std::vector<BRM::FileInfo> files, const int pmId)
 }
 }  // namespace cacheutils
 
-// vim:ts=4 sw=4:

--- a/utils/cacheutils/cacheutils.h
+++ b/utils/cacheutils/cacheutils.h
@@ -72,4 +72,3 @@ int dropPrimProcFdCache();
 int purgePrimProcFdCache(const std::vector<BRM::FileInfo> files, const int pmId);
 
 }  // namespace cacheutils
-// vim:ts=4 sw=4:

--- a/utils/common/hashfamily.h
+++ b/utils/common/hashfamily.h
@@ -50,4 +50,3 @@ class HashFamily
 };
 
 }  // namespace utils
-// vim:ts=2 sw=2:

--- a/utils/common/mcs_basic_types.h
+++ b/utils/common/mcs_basic_types.h
@@ -21,4 +21,3 @@
 using int128_t = __int128;
 using uint128_t = unsigned __int128;
 
-// vim:ts=2 sw=2:

--- a/utils/common/simd_sse.h
+++ b/utils/common/simd_sse.h
@@ -896,4 +896,3 @@ class SimdFilterProcessor<
 }  // namespace simd
 
 #endif  // if defined(__x86_64__ )
-// vim:ts=2 sw=2:

--- a/utils/compress/idbcompress.cpp
+++ b/utils/compress/idbcompress.cpp
@@ -672,4 +672,3 @@ std::shared_ptr<CompressInterface> getCompressorByType(
 #endif
 
 }  // namespace compress
-// vim:ts=4 sw=4:

--- a/utils/configcpp/configcpp.cpp
+++ b/utils/configcpp/configcpp.cpp
@@ -684,4 +684,3 @@ std::string Config::getTempFileDir(Config::TempDirPurpose what)
 }
 
 }  // namespace config
-// vim:ts=4 sw=4:

--- a/utils/configcpp/configcpp.h
+++ b/utils/configcpp/configcpp.h
@@ -254,4 +254,3 @@ class Config
 
 #undef EXPORT
 
-// vim:ts=4 sw=4:

--- a/utils/configcpp/configstream.cpp
+++ b/utils/configcpp/configstream.cpp
@@ -64,4 +64,3 @@ void ConfigStream::init(const xmlChar* xp)
 }
 
 }  // namespace config
-// vim:ts=4 sw=4:

--- a/utils/configcpp/configstream.h
+++ b/utils/configcpp/configstream.h
@@ -61,4 +61,3 @@ class ConfigStream
 
 }  // namespace config
 
-// vim:ts=4 sw=4:

--- a/utils/configcpp/xmlparser.cpp
+++ b/utils/configcpp/xmlparser.cpp
@@ -285,4 +285,3 @@ const vector<string> XMLParser::enumSection(const xmlDocPtr doc, const string& s
 }
 
 }  // namespace config
-// vim:ts=4 sw=4:

--- a/utils/configcpp/xmlparser.h
+++ b/utils/configcpp/xmlparser.h
@@ -63,4 +63,3 @@ class XMLParser
 
 }  // namespace config
 
-// vim:ts=4 sw=4:

--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -3388,4 +3388,3 @@ void DataConvert::joinColTypeForUnion(datatypes::SystemCatalog::TypeHolderStd& u
 }
 
 }  // namespace dataconvert
-// vim:ts=4 sw=4:

--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -1418,7 +1418,7 @@ boost::any DataConvert::StringToUDecimal(const datatypes::SystemCatalog::TypeAtt
   {
     int64_t val64;
     number_int_value(data, typeCode, colType, pushWarning, prm.noRoundup(), val64);
-    char ival = (char)val64;
+    signed char ival = (signed char)val64;
 
     if (ival < 0 && ival != static_cast<int8_t>(joblist::TINYINTEMPTYROW) &&
         ival != static_cast<int8_t>(joblist::TINYINTNULL))

--- a/utils/ddlcleanup/ddlcleanuputil.cpp
+++ b/utils/ddlcleanup/ddlcleanuputil.cpp
@@ -270,4 +270,3 @@ int ddl_cleanup()
 }
 
 }  // namespace ddlcleanuputil
-// vim:ts=4 sw=4:

--- a/utils/ddlcleanup/ddlcleanuputil.h
+++ b/utils/ddlcleanup/ddlcleanuputil.h
@@ -28,4 +28,3 @@ namespace ddlcleanuputil
 {
 int ddl_cleanup();
 }
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_abs.cpp
+++ b/utils/funcexp/func_abs.cpp
@@ -79,4 +79,3 @@ long double Func_abs::getLongDoubleVal(Row& row, FunctionParm& parm, bool& isNul
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_add_time.cpp
+++ b/utils/funcexp/func_add_time.cpp
@@ -303,4 +303,3 @@ int64_t Func_add_time::getTimeIntVal(rowgroup::Row& row, FunctionParm& parm, boo
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_ascii.cpp
+++ b/utils/funcexp/func_ascii.cpp
@@ -56,4 +56,3 @@ int64_t Func_ascii::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isNu
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_between.cpp
+++ b/utils/funcexp/func_between.cpp
@@ -376,4 +376,3 @@ bool Func_notbetween::getBoolVal(rowgroup::Row& row, FunctionParm& pm, bool& isN
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_bitwise.cpp
+++ b/utils/funcexp/func_bitwise.cpp
@@ -494,4 +494,3 @@ bool Func_bit_count::fix(execplan::FunctionColumn& col) const
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_case.cpp
+++ b/utils/funcexp/func_case.cpp
@@ -723,4 +723,3 @@ int64_t Func_searched_case::getTimeIntVal(rowgroup::Row& row, FunctionParm& parm
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_cast.cpp
+++ b/utils/funcexp/func_cast.cpp
@@ -1549,4 +1549,3 @@ double Func_cast_double::getDoubleVal(Row& row, FunctionParm& parm, bool& isNull
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_ceil.cpp
+++ b/utils/funcexp/func_ceil.cpp
@@ -598,4 +598,3 @@ IDB_Decimal Func_ceil::getDecimalVal(Row& row, FunctionParm& parm, bool& isNull,
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_char.cpp
+++ b/utils/funcexp/func_char.cpp
@@ -178,4 +178,3 @@ string Func_char::getStrVal(Row& row, FunctionParm& parm, bool& isNull, CalpontS
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_char_length.cpp
+++ b/utils/funcexp/func_char_length.cpp
@@ -121,4 +121,3 @@ int64_t Func_char_length::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_coalesce.cpp
+++ b/utils/funcexp/func_coalesce.cpp
@@ -244,4 +244,3 @@ execplan::IDB_Decimal Func_coalesce::getDecimalVal(rowgroup::Row& row, FunctionP
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_concat.cpp
+++ b/utils/funcexp/func_concat.cpp
@@ -65,4 +65,3 @@ string Func_concat::getStrVal(Row& row, FunctionParm& parm, bool& isNull, Calpon
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_concat_oracle.cpp
+++ b/utils/funcexp/func_concat_oracle.cpp
@@ -71,4 +71,3 @@ string Func_concat_oracle::getStrVal(Row& row, FunctionParm& parm, bool& isNull,
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_concat_ws.cpp
+++ b/utils/funcexp/func_concat_ws.cpp
@@ -121,4 +121,3 @@ string Func_concat_ws::getStrVal(Row& row, FunctionParm& parm, bool& isNull,
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_conv.cpp
+++ b/utils/funcexp/func_conv.cpp
@@ -304,4 +304,3 @@ string Func_conv::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& isNull
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_convert_tz.cpp
+++ b/utils/funcexp/func_convert_tz.cpp
@@ -220,4 +220,3 @@ string Func_convert_tz::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& 
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_crc32.cpp
+++ b/utils/funcexp/func_crc32.cpp
@@ -64,4 +64,3 @@ int64_t Func_crc32::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isNu
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_date.cpp
+++ b/utils/funcexp/func_date.cpp
@@ -149,4 +149,3 @@ string Func_date::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& isNull
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_date_add.cpp
+++ b/utils/funcexp/func_date_add.cpp
@@ -816,4 +816,3 @@ string Func_date_add::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_date_format.cpp
+++ b/utils/funcexp/func_date_format.cpp
@@ -416,4 +416,3 @@ int64_t Func_date_format::getTimestampIntVal(rowgroup::Row& row, FunctionParm& p
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_day.cpp
+++ b/utils/funcexp/func_day.cpp
@@ -143,4 +143,3 @@ int64_t Func_day::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isNull
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_dayname.cpp
+++ b/utils/funcexp/func_dayname.cpp
@@ -179,4 +179,3 @@ string Func_dayname::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& isN
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_dayofweek.cpp
+++ b/utils/funcexp/func_dayofweek.cpp
@@ -166,4 +166,3 @@ int64_t Func_dayofweek::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& 
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_dayofyear.cpp
+++ b/utils/funcexp/func_dayofyear.cpp
@@ -160,4 +160,3 @@ int64_t Func_dayofyear::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& 
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_div.cpp
+++ b/utils/funcexp/func_div.cpp
@@ -108,4 +108,3 @@ string Func_div::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& isNull,
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_elt.cpp
+++ b/utils/funcexp/func_elt.cpp
@@ -96,4 +96,3 @@ string Func_elt::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& isNull,
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_exp.cpp
+++ b/utils/funcexp/func_exp.cpp
@@ -110,4 +110,3 @@ long double Func_exp::getLongDoubleVal(Row& row, FunctionParm& parm, bool& isNul
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_extract.cpp
+++ b/utils/funcexp/func_extract.cpp
@@ -254,4 +254,3 @@ int64_t Func_extract::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_find_in_set.cpp
+++ b/utils/funcexp/func_find_in_set.cpp
@@ -127,4 +127,3 @@ execplan::IDB_Decimal Func_find_in_set::getDecimalVal(rowgroup::Row& row, Functi
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_floor.cpp
+++ b/utils/funcexp/func_floor.cpp
@@ -555,4 +555,3 @@ IDB_Decimal Func_floor::getDecimalVal(Row& row, FunctionParm& parm, bool& isNull
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_from_days.cpp
+++ b/utils/funcexp/func_from_days.cpp
@@ -80,4 +80,3 @@ int64_t Func_from_days::getDatetimeIntVal(rowgroup::Row& row, FunctionParm& parm
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_from_unixtime.cpp
+++ b/utils/funcexp/func_from_unixtime.cpp
@@ -212,4 +212,3 @@ long double Func_from_unixtime::getLongDoubleVal(rowgroup::Row& row, FunctionPar
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_get_format.cpp
+++ b/utils/funcexp/func_get_format.cpp
@@ -107,4 +107,3 @@ string Func_get_format::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& 
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_greatest.cpp
+++ b/utils/funcexp/func_greatest.cpp
@@ -240,4 +240,3 @@ int64_t Func_greatest::getTimeIntVal(rowgroup::Row& row, FunctionParm& fp, bool&
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_hex.cpp
+++ b/utils/funcexp/func_hex.cpp
@@ -140,4 +140,3 @@ string Func_hex::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& isNull,
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_hour.cpp
+++ b/utils/funcexp/func_hour.cpp
@@ -156,4 +156,3 @@ int64_t Func_hour::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isNul
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_idbpartition.cpp
+++ b/utils/funcexp/func_idbpartition.cpp
@@ -63,4 +63,3 @@ string Func_idbpartition::getStrVal(Row& row, FunctionParm& parm, bool& isNull,
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_if.cpp
+++ b/utils/funcexp/func_if.cpp
@@ -234,4 +234,3 @@ int64_t Func_if::getTimeIntVal(Row& row, FunctionParm& parm, bool& isNull, Calpo
   }
 }
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_ifnull.cpp
+++ b/utils/funcexp/func_ifnull.cpp
@@ -205,4 +205,3 @@ bool Func_ifnull::getBoolVal(Row& row, FunctionParm& parm, bool& isNull, Calpont
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_in.cpp
+++ b/utils/funcexp/func_in.cpp
@@ -386,4 +386,3 @@ bool Func_notin::getBoolVal(rowgroup::Row& row, FunctionParm& pm, bool& isNull,
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_insert.cpp
+++ b/utils/funcexp/func_insert.cpp
@@ -102,4 +102,3 @@ std::string Func_insert::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& i
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_instr.cpp
+++ b/utils/funcexp/func_instr.cpp
@@ -85,4 +85,3 @@ int64_t Func_instr::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isNu
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_isnull.cpp
+++ b/utils/funcexp/func_isnull.cpp
@@ -79,4 +79,3 @@ bool Func_isnull::getBoolVal(Row& row, FunctionParm& parm, bool& isNull, Calpont
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_last_day.cpp
+++ b/utils/funcexp/func_last_day.cpp
@@ -195,4 +195,3 @@ int64_t Func_last_day::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& i
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_lcase.cpp
+++ b/utils/funcexp/func_lcase.cpp
@@ -64,4 +64,3 @@ std::string Func_lcase::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_least.cpp
+++ b/utils/funcexp/func_least.cpp
@@ -218,4 +218,3 @@ int64_t Func_least::getTimeIntVal(rowgroup::Row& row, FunctionParm& fp, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_left.cpp
+++ b/utils/funcexp/func_left.cpp
@@ -73,4 +73,3 @@ std::string Func_left::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& isN
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_length.cpp
+++ b/utils/funcexp/func_length.cpp
@@ -55,4 +55,3 @@ int64_t Func_length::getIntVal(rowgroup::Row& row, FunctionParm& fp, bool& isNul
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_lpad.cpp
+++ b/utils/funcexp/func_lpad.cpp
@@ -127,4 +127,3 @@ std::string Func_lpad::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& isN
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_ltrim.cpp
+++ b/utils/funcexp/func_ltrim.cpp
@@ -93,4 +93,3 @@ std::string Func_ltrim::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_ltrim_oracle.cpp
+++ b/utils/funcexp/func_ltrim_oracle.cpp
@@ -97,4 +97,3 @@ std::string Func_ltrim_oracle::getStrVal(rowgroup::Row& row, FunctionParm& fp, b
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_makedate.cpp
+++ b/utils/funcexp/func_makedate.cpp
@@ -190,4 +190,3 @@ string Func_makedate::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_maketime.cpp
+++ b/utils/funcexp/func_maketime.cpp
@@ -171,4 +171,3 @@ string Func_maketime::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_math.cpp
+++ b/utils/funcexp/func_math.cpp
@@ -2276,4 +2276,3 @@ double Func_degrees::getDoubleVal(Row& row, FunctionParm& parm, bool& isNull, Ca
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_md5.cpp
+++ b/utils/funcexp/func_md5.cpp
@@ -512,4 +512,3 @@ string Func_md5::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& isNull,
 
 }  // namespace funcexp
 
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_microsecond.cpp
+++ b/utils/funcexp/func_microsecond.cpp
@@ -137,4 +137,3 @@ int64_t Func_microsecond::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_minute.cpp
+++ b/utils/funcexp/func_minute.cpp
@@ -137,4 +137,3 @@ int64_t Func_minute::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isN
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_mod.cpp
+++ b/utils/funcexp/func_mod.cpp
@@ -531,4 +531,3 @@ std::string Func_mod::getStrVal(Row& row, FunctionParm& fp, bool& isNull,
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_month.cpp
+++ b/utils/funcexp/func_month.cpp
@@ -142,4 +142,3 @@ int64_t Func_month::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isNu
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_monthname.cpp
+++ b/utils/funcexp/func_monthname.cpp
@@ -191,4 +191,3 @@ execplan::IDB_Decimal Func_monthname::getDecimalVal(rowgroup::Row& row, Function
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_nullif.cpp
+++ b/utils/funcexp/func_nullif.cpp
@@ -1022,4 +1022,3 @@ execplan::IDB_Decimal Func_nullif::getDecimalVal(rowgroup::Row& row, FunctionPar
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_nullif.cpp
+++ b/utils/funcexp/func_nullif.cpp
@@ -964,7 +964,7 @@ execplan::IDB_Decimal Func_nullif::getDecimalVal(rowgroup::Row& row, FunctionPar
       {
         // strip off micro seconds
         value = value.substr(0, 14);
-        int64_t x = atoll(value.c_str());
+        x = atoll(value.c_str());
 
         if (s > 5)
           s = 0;

--- a/utils/funcexp/func_period_add.cpp
+++ b/utils/funcexp/func_period_add.cpp
@@ -94,4 +94,3 @@ int64_t Func_period_add::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool&
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_period_diff.cpp
+++ b/utils/funcexp/func_period_diff.cpp
@@ -113,4 +113,3 @@ int64_t Func_period_diff::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_pow.cpp
+++ b/utils/funcexp/func_pow.cpp
@@ -121,4 +121,3 @@ long double Func_pow::getLongDoubleVal(Row& row, FunctionParm& parm, bool& isNul
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_quarter.cpp
+++ b/utils/funcexp/func_quarter.cpp
@@ -139,4 +139,3 @@ int64_t Func_quarter::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_quote.cpp
+++ b/utils/funcexp/func_quote.cpp
@@ -80,4 +80,3 @@ std::string Func_quote::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_rand.cpp
+++ b/utils/funcexp/func_rand.cpp
@@ -98,4 +98,3 @@ double Func_rand::getDoubleVal(rowgroup::Row& row, FunctionParm& parm, bool& isN
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_regexp.cpp
+++ b/utils/funcexp/func_regexp.cpp
@@ -248,4 +248,3 @@ bool Func_regexp::getBoolVal(rowgroup::Row& row, FunctionParm& pm, bool& isNull,
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_repeat.cpp
+++ b/utils/funcexp/func_repeat.cpp
@@ -90,4 +90,3 @@ std::string Func_repeat::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& i
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_replace.cpp
+++ b/utils/funcexp/func_replace.cpp
@@ -173,4 +173,3 @@ std::string Func_replace::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& 
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_replace_oracle.cpp
+++ b/utils/funcexp/func_replace_oracle.cpp
@@ -167,4 +167,3 @@ std::string Func_replace_oracle::getStrVal(rowgroup::Row& row, FunctionParm& fp,
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_reverse.cpp
+++ b/utils/funcexp/func_reverse.cpp
@@ -93,4 +93,3 @@ std::string Func_reverse::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& 
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_right.cpp
+++ b/utils/funcexp/func_right.cpp
@@ -73,4 +73,3 @@ std::string Func_right::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_round.cpp
+++ b/utils/funcexp/func_round.cpp
@@ -716,4 +716,3 @@ int64_t Func_round::getTimestampIntVal(rowgroup::Row& row, FunctionParm& parm, b
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_round.cpp
+++ b/utils/funcexp/func_round.cpp
@@ -645,7 +645,7 @@ string Func_round::getStrVal(Row& row, FunctionParm& parm, bool& isNull, Calpont
 {
   IDB_Decimal x = getDecimalVal(row, parm, isNull, op_ct);
   int64_t e = (x.scale < 0) ? (-x.scale) : x.scale;
-  int64_t p = 1;
+  [[maybe_unused]] int64_t p = 1;
 
   while (e-- > 0)
     p *= 10;

--- a/utils/funcexp/func_rpad.cpp
+++ b/utils/funcexp/func_rpad.cpp
@@ -127,4 +127,3 @@ std::string Func_rpad::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& isN
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_rtrim.cpp
+++ b/utils/funcexp/func_rtrim.cpp
@@ -157,4 +157,3 @@ std::string Func_rtrim::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_rtrim_oracle.cpp
+++ b/utils/funcexp/func_rtrim_oracle.cpp
@@ -161,4 +161,3 @@ std::string Func_rtrim_oracle::getStrVal(rowgroup::Row& row, FunctionParm& fp, b
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_sec_to_time.cpp
+++ b/utils/funcexp/func_sec_to_time.cpp
@@ -231,4 +231,3 @@ execplan::IDB_Decimal Func_sec_to_time::getDecimalVal(rowgroup::Row& row, Functi
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_second.cpp
+++ b/utils/funcexp/func_second.cpp
@@ -144,4 +144,3 @@ int64_t Func_second::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isN
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_sha.cpp
+++ b/utils/funcexp/func_sha.cpp
@@ -655,4 +655,3 @@ string Func_sha::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& isNull,
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_sign.cpp
+++ b/utils/funcexp/func_sign.cpp
@@ -71,4 +71,3 @@ string Func_sign::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& isNull
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_space.cpp
+++ b/utils/funcexp/func_space.cpp
@@ -57,4 +57,3 @@ std::string Func_space::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_str_to_date.cpp
+++ b/utils/funcexp/func_str_to_date.cpp
@@ -264,4 +264,3 @@ int64_t Func_str_to_date::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_strcmp.cpp
+++ b/utils/funcexp/func_strcmp.cpp
@@ -74,4 +74,3 @@ std::string Func_strcmp::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& i
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_substr.cpp
+++ b/utils/funcexp/func_substr.cpp
@@ -98,4 +98,3 @@ std::string Func_substr::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& i
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_substring_index.cpp
+++ b/utils/funcexp/func_substring_index.cpp
@@ -205,4 +205,3 @@ std::string Func_substring_index::getStrVal(rowgroup::Row& row, FunctionParm& fp
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_sysdate.cpp
+++ b/utils/funcexp/func_sysdate.cpp
@@ -105,4 +105,3 @@ int64_t Func_sysdate::getTimeIntVal(rowgroup::Row& row, FunctionParm& parm, bool
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_time.cpp
+++ b/utils/funcexp/func_time.cpp
@@ -169,4 +169,3 @@ double Func_time::getDoubleVal(rowgroup::Row& row, FunctionParm& fp, bool& isNul
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_time_format.cpp
+++ b/utils/funcexp/func_time_format.cpp
@@ -229,4 +229,3 @@ string Func_time_format::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool&
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_time_to_sec.cpp
+++ b/utils/funcexp/func_time_to_sec.cpp
@@ -195,4 +195,3 @@ int64_t Func_time_to_sec::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_timediff.cpp
+++ b/utils/funcexp/func_timediff.cpp
@@ -349,4 +349,3 @@ double Func_timediff::getDoubleVal(rowgroup::Row& row, FunctionParm& fp, bool& i
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_timestampdiff.cpp
+++ b/utils/funcexp/func_timestampdiff.cpp
@@ -196,4 +196,3 @@ int64_t Func_timestampdiff::getTimeIntVal(rowgroup::Row& row, FunctionParm& parm
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_to_days.cpp
+++ b/utils/funcexp/func_to_days.cpp
@@ -151,4 +151,3 @@ int64_t Func_to_days::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_trim.cpp
+++ b/utils/funcexp/func_trim.cpp
@@ -168,4 +168,3 @@ std::string Func_trim::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& isN
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_trim_oracle.cpp
+++ b/utils/funcexp/func_trim_oracle.cpp
@@ -166,4 +166,3 @@ std::string Func_trim_oracle::getStrVal(rowgroup::Row& row, FunctionParm& fp, bo
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_truncate.cpp
+++ b/utils/funcexp/func_truncate.cpp
@@ -721,4 +721,3 @@ int64_t Func_truncate::getTimestampIntVal(rowgroup::Row& row, FunctionParm& parm
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_truncate.cpp
+++ b/utils/funcexp/func_truncate.cpp
@@ -522,7 +522,7 @@ IDB_Decimal Func_truncate::getDecimalVal(Row& row, FunctionParm& parm, bool& isN
       {
         // strip off micro seconds
         value = value.substr(0, 14);
-        int64_t x = atoll(value.c_str());
+        x = atoll(value.c_str());
 
         if (s > 5)
           s = 0;
@@ -613,7 +613,7 @@ IDB_Decimal Func_truncate::getDecimalVal(Row& row, FunctionParm& parm, bool& isN
       {
         // strip off micro seconds
         value = value.substr(0, 14);
-        int64_t x = atoll(value.c_str());
+        x = atoll(value.c_str());
 
         if (s > 5)
           s = 0;

--- a/utils/funcexp/func_ucase.cpp
+++ b/utils/funcexp/func_ucase.cpp
@@ -73,4 +73,3 @@ std::string Func_ucase::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_unhex.cpp
+++ b/utils/funcexp/func_unhex.cpp
@@ -112,4 +112,3 @@ string Func_unhex::getStrVal(rowgroup::Row& row, FunctionParm& parm, bool& isNul
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_unix_timestamp.cpp
+++ b/utils/funcexp/func_unix_timestamp.cpp
@@ -223,4 +223,3 @@ string Func_unix_timestamp::getStrVal(rowgroup::Row& row, FunctionParm& parm, bo
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_week.cpp
+++ b/utils/funcexp/func_week.cpp
@@ -169,4 +169,3 @@ int64_t Func_week::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isNul
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_weekday.cpp
+++ b/utils/funcexp/func_weekday.cpp
@@ -164,4 +164,3 @@ int64_t Func_weekday::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& is
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_year.cpp
+++ b/utils/funcexp/func_year.cpp
@@ -140,4 +140,3 @@ int64_t Func_year::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isNul
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/func_yearweek.cpp
+++ b/utils/funcexp/func_yearweek.cpp
@@ -173,4 +173,3 @@ int64_t Func_yearweek::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& i
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/funcexp/functor.cpp
+++ b/utils/funcexp/functor.cpp
@@ -361,4 +361,3 @@ string Func::longDoubleToString(long double ld)
 }
 
 }  // namespace funcexp
-// vim:ts=4 sw=4:

--- a/utils/libmysql_client/libmysql_client.h
+++ b/utils/libmysql_client/libmysql_client.h
@@ -91,4 +91,3 @@ class LibMySQL
 
 #endif  // UTILS_LIBMYSQL_CL_H
 
-// vim:ts=4 sw=4:

--- a/utils/loggingcpp/errorcodes.cpp
+++ b/utils/loggingcpp/errorcodes.cpp
@@ -103,4 +103,3 @@ string ErrorCodes::errorString(uint16_t code) const
   return (fPreamble + msg);
 }
 }  // namespace logging
-// vim:ts=4 sw=4:

--- a/utils/loggingcpp/exceptclasses.h
+++ b/utils/loggingcpp/exceptclasses.h
@@ -306,4 +306,3 @@ class ProtocolError : public std::logic_error
 
 }  // namespace logging
 
-// vim:ts=4 sw=4:

--- a/utils/messageqcpp/inetstreamsocket.cpp
+++ b/utils/messageqcpp/inetstreamsocket.cpp
@@ -101,8 +101,6 @@ using boost::scoped_array;
 // some static functions
 namespace
 {
-using messageqcpp::ByteStream;
-
 // @bug 2441 - Retry after 512 read() error.
 // ERESTARTSYS (512) is a kernal I/O errno that is similar to a EINTR, except
 // that it is not supposed to "leak" out into the user space.   But we are
@@ -937,16 +935,8 @@ void InetStreamSocket::connect(const sockaddr* serv_addr)
     char buf = '\0';
     (void)::recv(socketParms().sd(), &buf, 1, 0);
 #else
-#if defined(__GNUC__) && __GNUC__ >= 5
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
     char buf = '\0';
-    ::read(socketParms().sd(), &buf, 1);  // we know 1 byte is in the recv buffer
-#pragma GCC diagnostic pop
-#else
-    char buf = '\0';
-    ::read(socketParms().sd(), &buf, 1);  // we know 1 byte is in the recv buffer
-#endif  // pragma
+    std::ignore = ::read(socketParms().sd(), &buf, 1);  // we know 1 byte is in the recv buffer
 #endif
     return;
   }

--- a/utils/messageqcpp/messagequeue.h
+++ b/utils/messageqcpp/messagequeue.h
@@ -336,4 +336,3 @@ inline void MessageQueueClient::syncProto(bool use)
 
 #undef EXPORT
 
-// vim:ts=4 sw=4:

--- a/utils/multicast/multicast.cpp
+++ b/utils/multicast/multicast.cpp
@@ -93,4 +93,3 @@ void MulticastSender::send(const ByteStream& msg)
 
 }  // namespace multicast
 
-// vim:ts=4 sw=4:

--- a/utils/regr/regrmysql.cpp
+++ b/utils/regr/regrmysql.cpp
@@ -1405,4 +1405,3 @@ extern "C"
     return valOut;
   }
 }
-// vim:ts=4 sw=4:

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -1751,4 +1751,3 @@ RowGroup RowGroup::truncate(uint32_t cols)
 
 }  // namespace rowgroup
 
-// vim:ts=4 sw=4:

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -2183,4 +2183,3 @@ inline void RGData::getRow(uint32_t num, Row* row)
 
 }  // namespace rowgroup
 
-// vim:ts=4 sw=4:

--- a/utils/rwlock/rwlock.cpp
+++ b/utils/rwlock/rwlock.cpp
@@ -746,4 +746,3 @@ LockState RWLock::getLockState()
 }
 
 }  // namespace rwlock
-// vim:ts=4 sw=4:

--- a/utils/rwlock/rwlock.h
+++ b/utils/rwlock/rwlock.h
@@ -275,4 +275,3 @@ class RWLock
 
 #undef EXPORT
 
-// vim:ts=4 sw=4:

--- a/utils/startup/installdir.cpp
+++ b/utils/startup/installdir.cpp
@@ -112,4 +112,3 @@ const string StartUp::tmpDir()
 }
 
 }  // namespace startup
-// vim:ts=4 sw=4:

--- a/utils/startup/installdir.h
+++ b/utils/startup/installdir.h
@@ -52,4 +52,3 @@ class StartUp
 
 }  // namespace startup
 
-// vim:ts=4 sw=4:

--- a/utils/testbc/iomanager.cpp
+++ b/utils/testbc/iomanager.cpp
@@ -325,4 +325,3 @@ fileRequest* ioManager::getNextRequest()
 }
 
 }  // namespace dbbc
-// vim:ts=4 sw=4:

--- a/utils/testbc/iomanager.h
+++ b/utils/testbc/iomanager.h
@@ -98,4 +98,3 @@ class ioManager
 };
 
 }  // namespace dbbc
-// vim:ts=4 sw=4:

--- a/utils/threadpool/prioritythreadpool.cpp
+++ b/utils/threadpool/prioritythreadpool.cpp
@@ -290,4 +290,3 @@ void PriorityThreadPool::stop()
 }
 
 }  // namespace threadpool
-// vim:ts=4 sw=4:

--- a/utils/udfsdk/udfmysql.cpp
+++ b/utils/udfsdk/udfmysql.cpp
@@ -535,4 +535,3 @@ extern "C"
     return 0;
   }
 }
-// vim:ts=4 sw=4:

--- a/utils/udfsdk/udfsdk.cpp
+++ b/utils/udfsdk/udfsdk.cpp
@@ -375,4 +375,3 @@ int64_t MCS_isnull::getDatetimeIntVal(Row& row, FunctionParm& parm, bool& isNull
 }
 
 }  // namespace udfsdk
-// vim:ts=4 sw=4:

--- a/utils/udfsdk/udfsdk.h
+++ b/utils/udfsdk/udfsdk.h
@@ -314,4 +314,3 @@ class MCS_isnull : public funcexp::Func
 
 #undef EXPORT
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/framebound.cpp
+++ b/utils/windowfunction/framebound.cpp
@@ -72,4 +72,3 @@ const string FrameBound::toString() const
 }
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/framebound.h
+++ b/utils/windowfunction/framebound.h
@@ -145,4 +145,3 @@ extern std::map<int, std::string> colType2String;
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/frameboundrange.cpp
+++ b/utils/windowfunction/frameboundrange.cpp
@@ -411,4 +411,3 @@ template class FrameBoundExpressionRange<float>;
 template class FrameBoundExpressionRange<uint64_t>;
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/frameboundrange.h
+++ b/utils/windowfunction/frameboundrange.h
@@ -213,4 +213,3 @@ class FrameBoundExpressionRange : public FrameBoundConstantRange<T>
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/frameboundrow.cpp
+++ b/utils/windowfunction/frameboundrow.cpp
@@ -139,4 +139,3 @@ template class FrameBoundExpressionRow<float>;
 template class FrameBoundExpressionRow<uint64_t>;
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/frameboundrow.h
+++ b/utils/windowfunction/frameboundrow.h
@@ -146,4 +146,3 @@ class FrameBoundExpressionRow : public FrameBoundConstantRow
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -900,4 +900,3 @@ bool IdbOrderBy::Eq::operator()(const Row::Pointer& d1, const Row::Pointer& d2) 
 }
 
 }  // namespace ordering
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_count.cpp
+++ b/utils/windowfunction/wf_count.cpp
@@ -184,4 +184,3 @@ template boost::shared_ptr<WindowFunctionType> WF_count<int64_t>::makeFunction(i
                                                                                WindowFunctionColumn*);
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_count.h
+++ b/utils/windowfunction/wf_count.h
@@ -47,4 +47,3 @@ class WF_count : public WindowFunctionType
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_lead_lag.cpp
+++ b/utils/windowfunction/wf_lead_lag.cpp
@@ -306,4 +306,3 @@ template void WF_lead_lag<double>::parseParms(const std::vector<execplan::SRCP>&
 template void WF_lead_lag<string>::parseParms(const std::vector<execplan::SRCP>&);
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_lead_lag.h
+++ b/utils/windowfunction/wf_lead_lag.h
@@ -52,4 +52,3 @@ class WF_lead_lag : public WindowFunctionType
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_min_max.cpp
+++ b/utils/windowfunction/wf_min_max.cpp
@@ -185,4 +185,3 @@ template boost::shared_ptr<WindowFunctionType> WF_min_max<int64_t>::makeFunction
                                                                                  WindowFunctionColumn*);
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_min_max.h
+++ b/utils/windowfunction/wf_min_max.h
@@ -46,4 +46,3 @@ class WF_min_max : public WindowFunctionType
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_nth_value.cpp
+++ b/utils/windowfunction/wf_nth_value.cpp
@@ -271,4 +271,3 @@ template boost::shared_ptr<WindowFunctionType> WF_nth_value<int64_t>::makeFuncti
                                                                                    WindowFunctionColumn*);
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_nth_value.h
+++ b/utils/windowfunction/wf_nth_value.h
@@ -50,4 +50,3 @@ class WF_nth_value : public WindowFunctionType
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_ntile.cpp
+++ b/utils/windowfunction/wf_ntile.cpp
@@ -154,4 +154,3 @@ void WF_ntile::operator()(int64_t b, int64_t e, int64_t c)
 }
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_ntile.h
+++ b/utils/windowfunction/wf_ntile.h
@@ -47,4 +47,3 @@ class WF_ntile : public WindowFunctionType
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_percentile.cpp
+++ b/utils/windowfunction/wf_percentile.cpp
@@ -382,4 +382,3 @@ template boost::shared_ptr<WindowFunctionType> WF_percentile<int64_t>::makeFunct
                                                                                     WindowFunctionColumn*);
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_percentile.h
+++ b/utils/windowfunction/wf_percentile.h
@@ -48,4 +48,3 @@ class WF_percentile : public WindowFunctionType
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_ranking.cpp
+++ b/utils/windowfunction/wf_ranking.cpp
@@ -145,4 +145,3 @@ void WF_ranking::operator()(int64_t b, int64_t e, int64_t c)
 }
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_ranking.h
+++ b/utils/windowfunction/wf_ranking.h
@@ -46,4 +46,3 @@ class WF_ranking : public WindowFunctionType
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_row_number.cpp
+++ b/utils/windowfunction/wf_row_number.cpp
@@ -86,4 +86,3 @@ void WF_row_number::operator()(int64_t b, int64_t e, int64_t c)
 }
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_row_number.h
+++ b/utils/windowfunction/wf_row_number.h
@@ -45,4 +45,3 @@ class WF_row_number : public WindowFunctionType
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_stats.cpp
+++ b/utils/windowfunction/wf_stats.cpp
@@ -239,4 +239,3 @@ template boost::shared_ptr<WindowFunctionType> WF_stats<int64_t>::makeFunction(i
                                                                                WindowFunctionColumn*);
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_stats.h
+++ b/utils/windowfunction/wf_stats.h
@@ -48,4 +48,3 @@ class WF_stats : public WindowFunctionType
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_sum_avg.cpp
+++ b/utils/windowfunction/wf_sum_avg.cpp
@@ -306,4 +306,3 @@ template boost::shared_ptr<WindowFunctionType> WF_sum_avg<int64_t, long double>:
     int, const string&, int, WindowFunctionColumn*);
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_sum_avg.h
+++ b/utils/windowfunction/wf_sum_avg.h
@@ -60,4 +60,3 @@ class WF_sum_avg : public WindowFunctionType
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_udaf.cpp
+++ b/utils/windowfunction/wf_udaf.cpp
@@ -1191,4 +1191,3 @@ void WF_udaf::operator()(int64_t b, int64_t e, int64_t c)
   fPrev = c;
 }
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/wf_udaf.h
+++ b/utils/windowfunction/wf_udaf.h
@@ -112,4 +112,3 @@ class WF_udaf : public WindowFunctionType
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/windowframe.cpp
+++ b/utils/windowfunction/windowframe.cpp
@@ -81,4 +81,3 @@ const string WindowFrame::toString() const
 }
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/windowframe.h
+++ b/utils/windowfunction/windowframe.h
@@ -119,4 +119,3 @@ class WindowFrame
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/windowfunction.cpp
+++ b/utils/windowfunction/windowfunction.cpp
@@ -259,4 +259,3 @@ void WindowFunction::sort(std::vector<RowPosition>::iterator v, uint64_t n)
 }
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/windowfunction.h
+++ b/utils/windowfunction/windowfunction.h
@@ -111,4 +111,3 @@ class WindowFunction
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/windowfunctiontype.cpp
+++ b/utils/windowfunction/windowfunctiontype.cpp
@@ -797,4 +797,3 @@ void WindowFunctionType::constParms(const std::vector<SRCP>& functionParms)
 }
 
 }  // namespace windowfunction
-// vim:ts=4 sw=4:

--- a/utils/windowfunction/windowfunctiontype.h
+++ b/utils/windowfunction/windowfunctiontype.h
@@ -303,4 +303,3 @@ extern std::map<int, std::string> colType2String;
 
 }  // namespace windowfunction
 
-// vim:ts=4 sw=4:

--- a/versioning/BRM/brmshmimpl.cpp
+++ b/versioning/BRM/brmshmimpl.cpp
@@ -240,4 +240,3 @@ void BRMShmImpl::destroy()
 
 }  // namespace BRM
 
-// vim:ts=4 sw=4:

--- a/versioning/BRM/extentmap.cpp
+++ b/versioning/BRM/extentmap.cpp
@@ -5953,4 +5953,3 @@ template int ExtentMap::getMaxMin<int64_t>(const LBID_t lbidRange, int64_t& max,
                                            int32_t& seqNum);
 
 }  // namespace BRM
-// vim:ts=4 sw=4:

--- a/versioning/BRM/load_brm.cpp
+++ b/versioning/BRM/load_brm.cpp
@@ -127,4 +127,3 @@ int main(int argc, char** argv)
 
   return 0;
 }
-// vim:ts=4 sw=4:

--- a/versioning/BRM/slavecomm.cpp
+++ b/versioning/BRM/slavecomm.cpp
@@ -2432,4 +2432,3 @@ void SlaveComm::do_dmlReleaseLBIDRanges(ByteStream& msg)
 
 }  // namespace BRM
 
-// vim:ts=4 sw=4:

--- a/versioning/BRM/vbbm.cpp
+++ b/versioning/BRM/vbbm.cpp
@@ -40,7 +40,6 @@
 
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/mapped_region.hpp>
-namespace bi = boost::interprocess;
 
 #include <boost/scoped_array.hpp>
 #include <boost/scoped_ptr.hpp>
@@ -1076,8 +1075,8 @@ void VBBM::save(string filename)
   }
 
   var = VBBM_MAGIC_V2;
-  int bytesWritten = 0;
-  int bytesToWrite = 12;
+  [[maybe_unused]] int bytesWritten = 0;
+  [[maybe_unused]] int bytesToWrite = 12;
   bytesWritten += out->write((char*)&var, 4);
   bytesWritten += out->write((char*)&vbbm->vbCurrentSize, 4);
   bytesWritten += out->write((char*)&vbbm->nFiles, 4);

--- a/writeengine/client/we_clients.cpp
+++ b/writeengine/client/we_clients.cpp
@@ -545,4 +545,3 @@ void WEClients::addDataToOutput(SBS sbs, uint32_t connIndex)
 
 }  // namespace WriteEngine
 
-// vim:ts=4 sw=4:

--- a/writeengine/client/we_clients.h
+++ b/writeengine/client/we_clients.h
@@ -180,4 +180,3 @@ class WEClients
 
 #undef EXPORT
 
-// vim:ts=4 sw=4:

--- a/writeengine/redistribute/we_redistribute.cpp
+++ b/writeengine/redistribute/we_redistribute.cpp
@@ -52,4 +52,3 @@ void Redistribute::handleRedistributeMessage(ByteStream& bs, IOSocket& ios)
 
 }  // namespace redistribute
 
-// vim:ts=4 sw=4:

--- a/writeengine/redistribute/we_redistribute.h
+++ b/writeengine/redistribute/we_redistribute.h
@@ -44,4 +44,3 @@ class Redistribute
 
 }  // namespace redistribute
 
-// vim:ts=4 sw=4:

--- a/writeengine/redistribute/we_redistributecontrol.cpp
+++ b/writeengine/redistribute/we_redistributecontrol.cpp
@@ -698,4 +698,3 @@ void RedistributeControl::logMessage(const string& msg)
 
 }  // namespace redistribute
 
-// vim:ts=4 sw=4:

--- a/writeengine/redistribute/we_redistributecontrol.h
+++ b/writeengine/redistribute/we_redistributecontrol.h
@@ -126,4 +126,3 @@ class RedistributeControl
 
 }  // namespace redistribute
 
-// vim:ts=4 sw=4:

--- a/writeengine/redistribute/we_redistributecontrolthread.cpp
+++ b/writeengine/redistribute/we_redistributecontrolthread.cpp
@@ -838,4 +838,3 @@ void RedistributeControlThread::doStopAction()
 
 }  // namespace redistribute
 
-// vim:ts=4 sw=4:

--- a/writeengine/redistribute/we_redistributecontrolthread.h
+++ b/writeengine/redistribute/we_redistributecontrolthread.h
@@ -125,4 +125,3 @@ class RedistributeControlThread
 
 }  // namespace redistribute
 
-// vim:ts=4 sw=4:

--- a/writeengine/redistribute/we_redistributedef.h
+++ b/writeengine/redistribute/we_redistributedef.h
@@ -203,4 +203,3 @@ struct RedistributeInfo
 
 }  // namespace redistribute
 
-// vim:ts=4 sw=4:

--- a/writeengine/redistribute/we_redistributeworkerthread.cpp
+++ b/writeengine/redistribute/we_redistributeworkerthread.cpp
@@ -1520,4 +1520,3 @@ void RedistributeWorkerThread::logMessage(const string& msg, int line)
 
 }  // namespace redistribute
 
-// vim:ts=4 sw=4:

--- a/writeengine/redistribute/we_redistributeworkerthread.h
+++ b/writeengine/redistribute/we_redistributeworkerthread.h
@@ -141,4 +141,3 @@ class RedistributeWorkerThread
 
 }  // namespace redistribute
 
-// vim:ts=4 sw=4:

--- a/writeengine/server/we_ddlcommandproc.cpp
+++ b/writeengine/server/we_ddlcommandproc.cpp
@@ -4952,4 +4952,3 @@ void WE_DDLCommandProc::purgeFDCache()
 }
 
 }  // namespace WriteEngine
-// vim:ts=4 sw=4:

--- a/writeengine/shared/we_brm.cpp
+++ b/writeengine/shared/we_brm.cpp
@@ -1741,4 +1741,3 @@ int BRMWrapper::getExtentCPMaxMin(const BRM::LBID_t lbid, BRM::CPMaxMin& cpMaxMi
 }
 
 }  // namespace WriteEngine
-// vim:ts=4 sw=4:

--- a/writeengine/shared/we_chunkmanager.cpp
+++ b/writeengine/shared/we_chunkmanager.cpp
@@ -2640,4 +2640,3 @@ int ChunkManager::checkFixLastDictChunk(const FID& fid, uint16_t root, uint32_t 
 }
 }  // namespace WriteEngine
 
-// vim:ts=4 sw=4:

--- a/writeengine/splitter/we_splitterapp.cpp
+++ b/writeengine/splitter/we_splitterapp.cpp
@@ -572,4 +572,3 @@ int main(int argc, char** argv)
 
   return SPLTR_EXIT_STATUS;
 }
-// vim:ts=4 sw=4:

--- a/writeengine/wrapper/we_colop.cpp
+++ b/writeengine/wrapper/we_colop.cpp
@@ -1910,4 +1910,3 @@ int ColumnOp::writeRowsValues(Column& curCol, uint64_t totalRow, const RIDList& 
 }
 
 }  // namespace WriteEngine
-// vim:ts=4 sw=4:

--- a/writeengine/wrapper/we_tablemetadata.cpp
+++ b/writeengine/wrapper/we_tablemetadata.cpp
@@ -109,4 +109,3 @@ ColsExtsInfoMap& TableMetaData::getColsExtsInfoMap()
   return fColsExtsInfoMap;
 }
 }  // namespace WriteEngine
-// vim:ts=4 sw=4:

--- a/writeengine/wrapper/we_tablemetadata.h
+++ b/writeengine/wrapper/we_tablemetadata.h
@@ -98,4 +98,3 @@ class TableMetaData
 
 #undef EXPORT
 
-// vim:ts=4 sw=4:

--- a/writeengine/wrapper/writeengine.cpp
+++ b/writeengine/wrapper/writeengine.cpp
@@ -6628,4 +6628,3 @@ int WriteEngineWrapper::RemoveTxnFromLBIDMap(const TxnID txnid)
 }
 
 }  // end of namespace
-// vim:ts=4 sw=4:


### PR DESCRIPTION
- Fix new clang warnings
- One of them is definitely a bug: see 
```
int64_t x = atoll(value.c_str());
```
pattern, that shadows outer x variable and never uses
- removing vim tab guides

better to review by commits, second one is trivial