### PR TITLE
MCOL-4809 This fixes Centos crash caused by combination of ::reserve(…

### DIFF
--- a/primitives/linux-port/column.cpp
+++ b/primitives/linux-port/column.cpp
@@ -1300,7 +1300,7 @@ void vectorizedFiltering(NewColRequestHeader* in, ColResultHeader* out, const T*
       for (uint32_t j = 0; j < filterCount; ++j)
       {
         // Preload filter argument values only once.
-        filterArgsVectors[j] = simdProcessor.loadValue(*((FilterType*)&filterValues[j]));
+        filterArgsVectors.push_back(simdProcessor.loadValue(*((FilterType*)&filterValues[j])));
         switch (filterCOPs[j])
         {
           case (COMPARE_EQ):


### PR DESCRIPTION
…) + vector index access