### PR TITLE
MCOL-5009 fix deadlock

### DIFF
--- a/primitives/primproc/bppsendthread.cpp
+++ b/primitives/primproc/bppsendthread.cpp
@@ -75,11 +75,9 @@ void BPPSendThread::sendResult(const Msg_t& msg, bool newConnection)
     std::unique_lock<std::mutex> sl1(respondLock);
     while (currentByteSize >= maxByteSize && msgQueue.size() > 3 && !die)
     {
-      respondWait = true;
       fProcessorPool->incBlockedThreads();
       okToRespond.wait(sl1);
       fProcessorPool->decBlockedThreads();
-      respondWait = false;
     }
   }
   if (die)
@@ -122,11 +120,9 @@ void BPPSendThread::sendResults(const vector<Msg_t>& msgs, bool newConnection)
     std::unique_lock<std::mutex> sl1(respondLock);
     while (currentByteSize >= maxByteSize && msgQueue.size() > 3 && !die)
     {
-      respondWait = true;
       fProcessorPool->incBlockedThreads();
       okToRespond.wait(sl1);
       fProcessorPool->decBlockedThreads();
-      respondWait = false;
     }
   }
   if (die)
@@ -278,7 +274,7 @@ void BPPSendThread::mainLoop()
         msg[msgsSent].msg.reset();
       }
 
-      if (respondWait && currentByteSize < maxByteSize)
+      if (fProcessorPool->blockedThreadCount() > 0 && currentByteSize < maxByteSize)
       {
         okToRespond.notify_one();
       }

--- a/primitives/primproc/bppsendthread.h
+++ b/primitives/primproc/bppsendthread.h
@@ -120,7 +120,6 @@ class BPPSendThread
   std::mutex ackLock;
   std::condition_variable okToSend;
   // Condition to prevent run away queue
-  bool respondWait;
   std::mutex respondLock;
   std::condition_variable okToRespond;
 

--- a/utils/threadpool/prioritythreadpool.h
+++ b/utils/threadpool/prioritythreadpool.h
@@ -113,6 +113,10 @@ class PriorityThreadPool
   {
     blockedThreads--;
   }
+  uint32_t blockedThreadCount()
+  {
+    return blockedThreads;
+  }
 
  protected:
  private:


### PR DESCRIPTION
respondWait could be set to false while other threads were waiting. With respondWait false, okToRrespond wouldn't ever get notify_one().
Get rid of respondWait and use fProcessorPool->blockedThreadCount to determine if any threads may be waiting.