### PR TITLE
Set server defaults to keep test results consistent since some test c…

### DIFF
--- a/mysql-test/columnstore/csinternal/regression_env_setup.test
+++ b/mysql-test/columnstore/csinternal/regression_env_setup.test
@@ -65,8 +65,8 @@ USE outerjoin;
 --source ../csinternal/include/dbt3/countTables.inc
 --source ../csinternal/include/autopilot_create_outerjoin_tables.inc
 #
-# Set table name to case insensitive
---exec sed -i 's/\[mysqld\]/\[mysqld\]\nlower_case_table_name=1/g' /etc/my.cnf.d/server.cnf
+# Set table name to case insensitive and couple other defaults
+--exec sed -i 's#\[mysqld\]#\[mysqld\]\nlower_case_table_names=1\ncharacter_set_server=utf8mb3\ncolumnstore_use_import_for_batchinser=ALWAYS#g' /etc/my.cnf.d/server.cnf
 #
 --exec systemctl restart mariadb
 --exec sleep 10


### PR DESCRIPTION
The lower_case_table_name parameter should be lower_case_table_name, with the s at the end.  Server warned about it saying future version may not support it.  Also, the docker project sets couple default values for deployment.  We need to enforce them so that the MTR test would work on cross platforms