### PR TITLE
MCOL-4912-MCOL-4917 The patch replaces RBTree-based EM traversal with a

### DIFF
--- a/versioning/BRM/brmtypes.h
+++ b/versioning/BRM/brmtypes.h
@@ -251,6 +251,8 @@ public:
     uint32_t size;
 
     EXPORT LBIDRange();
+    LBIDRange(const LBID_t aStart, const uint32_t aSize)
+        :start(aStart), size(aSize) {}
     EXPORT LBIDRange(const LBIDRange& l);
     EXPORT LBIDRange(const InlineLBIDRange& l);
     EXPORT LBIDRange& operator=(const LBIDRange& l);

--- a/versioning/BRM/extentmap.h
+++ b/versioning/BRM/extentmap.h
@@ -413,6 +413,7 @@ public:
     LBID_tFindResult search2ndLayer(OIDIndexContainerT& oids, const OID_t oid);
     LBID_tFindResult search3dLayer(PartitionIndexContainerT& partitions,
         const PartitionNumberT partitionNumber);
+    bool isDBRootEmpty(const DBRootT dbroot);
     // Delete functions.
     void deleteDbRoot(const DBRootT dbroot);
     void deleteOID(const DBRootT dbroot, const OID_t oid);
@@ -1047,7 +1048,7 @@ private:
   static const constexpr size_t EM_FREELIST_INITIAL_SIZE = 50 * sizeof(InlineLBIDRange);
   static const constexpr size_t EM_FREELIST_INCREMENT = 50 * sizeof(InlineLBIDRange);
   // RBTree constants.
-  static const size_t EM_RB_TREE_NODE_SIZE = 10 * (sizeof(EMEntry) + 8 * sizeof(uint64_t));
+  static const size_t EM_RB_TREE_NODE_SIZE = 2 * (sizeof(EMEntry) + 8 * sizeof(uint64_t));
   static const size_t EM_RB_TREE_EMPTY_SIZE = 1024;
   static const size_t EM_RB_TREE_INITIAL_SIZE =
       EM_INCREMENT_ROWS * 10 * EM_RB_TREE_NODE_SIZE + EM_RB_TREE_EMPTY_SIZE;


### PR DESCRIPTION
combination of EM Index lookup + targeted RBTree search in EM routines
 This combination reduces avg search complexity from O(N) down to 0(1) * O(logN)
 that is crucial for EMs > 50MB.
 This patch also reduces RBTree-based EM footprint on shmem.