### PR TITLE
[MCOL-5001] Explicitly initialize `startupRaceFlag`.

### DIFF
--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -124,7 +124,7 @@ class ServicePrimProc : public Service, public Opt
 
  private:
   // Since C++20 flag's init value is false.
-  std::atomic_flag startupRaceFlag_;
+  std::atomic_flag startupRaceFlag_{false};
 };
 
 namespace primitiveprocessor


### PR DESCRIPTION
Explicitly initialize `startupRaceFlag_` to avoid PrimProc freezing on some platforms.