### PR TITLE
MCOL-5105 This patch raises pipe read operation timeout to 20 minutes

### DIFF
--- a/utils/common/pipe.h
+++ b/utils/common/pipe.h
@@ -20,6 +20,11 @@
 /*
   A helper class to hold the file descriptors returned from a pipe() call.
 */
+#include <sys/types.h>
+#include <unistd.h>
+#include <cerrno>
+#include <string>
+
 class Pipe
 {
   int fd[2];
@@ -60,7 +65,7 @@ class Pipe
     FD_ZERO(&rfds);
     FD_SET(fd[0], &rfds);
     struct timeval tmptv = tv;
-    int retval = select(fd[0] + 1, &rfds, NULL, NULL, &tmptv);
+    int retval = select(fd[0] + 1, &rfds, nullptr, nullptr, &tmptv);
     if (retval == -1)
       return -1;
     if (!retval)

--- a/utils/common/service.h
+++ b/utils/common/service.h
@@ -18,11 +18,16 @@
 #pragma once
 
 #include <signal.h>
+#include <cstring>
+#include <sstream>
 #include "pipe.h"
 
 class Service
 {
  protected:
+  // The read operation implicitly controls how long binary waits
+  // before it starts. This is import for DMLProc to survive rollbacks. See MCOL-5105.
+  static constexpr const size_t PipeReadTimeout = 1200;
   // The service name, for logging
   const std::string m_name;
   // The pipe to send messages from the child to the parent
@@ -62,7 +67,7 @@ class Service
   {
     char str[100];
     // Read the message from the child
-    ssize_t nbytes = m_pipe.readtm({120, 0}, str, sizeof(str));
+    ssize_t nbytes = m_pipe.readtm({PipeReadTimeout, 0}, str, sizeof(str));
     if (nbytes >= 0)
     {
       ParentLogChildMessage(std::string(str, nbytes));


### PR DESCRIPTION
to enable DMLProc to survive rollbacks on startup.
The patch also fixes linter warnings in service.h and pipe.h.