### PR TITLE
  Replace gtest_discovery_tests with gtests_add_tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories( ${ENGINE_COMMON_INCLUDES} ${ENGINE_BLOCKCACHE_INCLUDE} ${ENGINE_PRIMPROC_INCLUDE})
 
+cmake_policy(SET CMP0054 NEW)
 if (WITH_UNITTESTS)
     enable_testing()
     include(GoogleTest)
@@ -8,41 +9,41 @@ if (WITH_UNITTESTS)
     #GoogleTest tests
     add_executable(rowgroup_tests rowgroup-tests.cpp)
     target_link_libraries(rowgroup_tests ${ENGINE_LDFLAGS} ${GTEST_LIBRARIES} ${ENGINE_EXEC_LIBS} ${MARIADB_CLIENT_LIBS})
-    gtest_discover_tests(rowgroup_tests TEST_PREFIX columnstore:)
+    gtest_add_tests(TARGET rowgroup_tests TEST_PREFIX columnstore:)
 
     add_executable(arithmeticoperator_tests arithmeticoperator-tests.cpp)
     target_link_libraries(arithmeticoperator_tests ${ENGINE_LDFLAGS} ${GTEST_LIBRARIES} ${ENGINE_EXEC_LIBS} ${MARIADB_CLIENT_LIBS})
-    gtest_discover_tests(arithmeticoperator_tests TEST_PREFIX columnstore:)
+    gtest_add_tests(TARGET arithmeticoperator_tests TEST_PREFIX columnstore:)
 
     add_executable(mcs_decimal_tests mcs_decimal-tests.cpp)
     target_link_libraries(mcs_decimal_tests ${ENGINE_LDFLAGS} ${GTEST_LIBRARIES} ${ENGINE_EXEC_LIBS} ${MARIADB_CLIENT_LIBS})
-    gtest_discover_tests(mcs_decimal_tests TEST_PREFIX columnstore:)
+    gtest_add_tests(TARGET mcs_decimal_tests TEST_PREFIX columnstore:)
 
     add_executable(dataconvert_tests dataconvert-tests.cpp)
     target_link_libraries(dataconvert_tests ${ENGINE_LDFLAGS} ${GTEST_LIBRARIES} ${ENGINE_EXEC_LIBS} ${MARIADB_CLIENT_LIBS})
-    gtest_discover_tests(dataconvert_tests TEST_PREFIX columnstore:)
+    gtest_add_tests(TARGET dataconvert_tests TEST_PREFIX columnstore:)
 
     add_executable(rebuild_em_tests rebuild-em-tests.cpp)
     target_link_libraries(rebuild_em_tests ${ENGINE_LDFLAGS} ${GTEST_LIBRARIES} ${MARIADB_CLIENT_LIBS} ${ENGINE_WRITE_LIBS})
-    gtest_discover_tests(rebuild_em_tests TEST_PREFIX columnstore:)
+    gtest_add_tests(TARGET rebuild_em_tests TEST_PREFIX columnstore:)
 
     add_executable(compression_tests compression-tests.cpp)
     target_link_libraries(compression_tests ${ENGINE_LDFLAGS} ${GTEST_LIBRARIES} ${MARIADB_CLIENT_LIBS} ${ENGINE_WRITE_LIBS})
-    gtest_discover_tests(compression_tests TEST_PREFIX columnstore:)
+    gtest_add_tests(TARGET compression_tests TEST_PREFIX columnstore:)
 
     add_executable(column_scan_filter_tests primitives_column_scan_and_filter.cpp)
     target_link_libraries(column_scan_filter_tests ${ENGINE_LDFLAGS} ${MARIADB_CLIENT_LIBS} ${ENGINE_WRITE_LIBS} ${GTEST_LIBRARIES} processor dbbc)
-    gtest_discover_tests(column_scan_filter_tests TEST_PREFIX columnstore:)
+    gtest_add_tests(TARGET column_scan_filter_tests TEST_PREFIX columnstore:)
 
     add_executable(simd_processors simd_processors.cpp)
     target_link_libraries(simd_processors ${ENGINE_LDFLAGS} ${MARIADB_CLIENT_LIBS} ${ENGINE_WRITE_LIBS} ${GTEST_LIBRARIES} processor dbbc)
-    gtest_discover_tests(simd_processors TEST_PREFIX columnstore:)
+    gtest_add_tests(TARGET simd_processors TEST_PREFIX columnstore:)
 
     # Comment this out b/c FairThreadPoolRemove segfaults in containers. Moreover this code isn't
     # in production yet.
     # add_executable(fair_threadpool_test fair_threadpool.cpp)
     # target_link_libraries(fair_threadpool_test ${ENGINE_LDFLAGS} ${MARIADB_CLIENT_LIBS} ${ENGINE_WRITE_LIBS} ${GTEST_LIBRARIES} processor dbbc)
-    # gtest_discover_tests(fair_threadpool_test TEST_PREFIX columnstore:)
+    # gtest_add_tests(TARGET fair_threadpool_test TEST_PREFIX columnstore:)
 
     # CPPUNIT TESTS
     add_executable(we_shared_components_tests shared_components_tests.cpp)


### PR DESCRIPTION
    Despite we have another number of tests in result, they all still run
    gtests_add_test cannot parse TYPED_TEST_SUITE one by one and run them
    in one bunch