### PR TITLE
MCOL-5153 This increases the size of the multiplier in the guarding

### DIFF
--- a/utils/rowgroup/rowstorage.cpp
+++ b/utils/rowgroup/rowstorage.cpp
@@ -1814,7 +1814,10 @@ void RowAggStorage::increaseSize()
   if (fCurData->fSize < maxSize && tryIncreaseInfo())
     return;
 
-  if (fCurData->fSize * 2 < calcMaxSize(fCurData->fMask + 1))
+  constexpr size_t maxMaskMultiplierWoRehashing = 1U << (INIT_INFO_INC - 1);
+  // We don't check for the overflow here b/c it is impractical to has fSize so that multiplication
+  // overflows.
+  if (fCurData->fSize * maxMaskMultiplierWoRehashing < calcMaxSize(fCurData->fMask + 1))
   {
     // something strange happens...
     throw logging::IDBExcept(logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_DISKAGG_ERROR),

--- a/utils/rowgroup/rowstorage.h
+++ b/utils/rowgroup/rowstorage.h
@@ -321,6 +321,8 @@ class RowAggStorage
   {
     RowPosHashStoragePtr fHashes;
     std::unique_ptr<uint8_t[]> fInfo;
+    // This is a power of 2 that controls a potential number of hash buckets
+    // w/o rehashing.
     size_t fSize{0};
     size_t fMask{0};
     size_t fMaxSize{0};


### PR DESCRIPTION
check in RowAggStorage::increaseSize() so that it doesn't throw w/o a
reason