### PR TITLE
Build instructions, bootstrap script unit tests option and openSuse support removed

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks:          'clang-diagnostic-*,clang-analyzer-*'
+FormatStyle:     google

--- a/BUILD.md
+++ b/BUILD.md
@@ -2,35 +2,27 @@
 
 Since MCS is not meant to be built independently outside outside of MariaDB server, we should checkout the [server](https://github.com/MariaDB/server) code first.
 
-You can clone from github with
+Install git with your distro package manager
 
+You can now clone from github with
 	git clone git@github.com:MariaDB/server.git
 
 or if you are not a github user,
-
 	git clone https://github.com/MariaDB/server.git
-
-The MCS engine repo has a number of develop-X branches where X is a number and it equals with the last number of MariaDB server major release, e.g develop-6 must be used with 10.6 of the server. There is single exception, namely develop branch of the engine must be compile with a current develop version of the server.
-
-	git checkout -b 10.6 origin/10.6
 
 MariaDB server contains many git submodules that need to be checked out with,
 
 	git submodule update --init --recursive --depth=1
 
-This would be automatically done when you excute cmake, but consider we are focus MCS here, so dependencies of MCS should be installed first.
+Then we should checkout Columnstore branch we want to build and install
 
-## Build Prerequisites
-
-The list of Debian or RPM packages dependencies can be installed with:
-
-	./install-deps.sh
-
+	cd server/storage/columnstore/columnstore
+	git checkout <columnstore-branch-you-want-to-build>
+	git config --global --add safe.directory `pwd`
 ## Building phase
 
-After the dependencies had been installed, just follow the normal building instrutions to build, MCS will be compiled along with mariadbd.
+But for development convenience, we supply a script to build, install and run Mariadb server in MCS repo.
 
-But for development convenience, we supply a script to build and run Mariadb server in MCS repo.
+	sudo -E build/bootstrap_mcs.sh
 
-	# TODO
-	
+Ubuntu:20.04/22.04, CentOS:7, Debian:10/11, RockyLinux:8 are supported with this script

--- a/build/bootstrap_mcs.sh
+++ b/build/bootstrap_mcs.sh
@@ -5,12 +5,10 @@
 # - the script is to be run under root.
 
 
-
 SCRIPT_LOCATION=$(dirname "$0")
 MDB_SOURCE_PATH=$(realpath $SCRIPT_LOCATION/../../../..)
 
 source $SCRIPT_LOCATION/utils.sh
-
 
 if [ "$EUID" -ne 0 ]
     then error "Please run script as root to install MariaDb to system paths"
@@ -20,7 +18,7 @@ fi
 message "Building Mariadb Server from $color_yellow$MDB_SOURCE_PATH$color_normal"
 
 BUILD_TYPE_OPTIONS=("Debug" "RelWithDebInfo")
-DISTRO_OPTIONS=("Ubuntu" "CentOS" "Debian" "openSUSE" "Rocky")
+DISTRO_OPTIONS=("Ubuntu" "CentOS" "Debian" "Rocky")
 BRANCHES=($(git branch --list --no-color| grep "[^* ]+" -Eo))
 
 optparse.define short=t long=build-type desc="Build Type: ${BUILD_TYPE_OPTIONS[*]}" variable=MCS_BUILD_TYPE
@@ -28,6 +26,7 @@ optparse.define short=d long=distro desc="Choouse your OS: ${DISTRO_OPTIONS[*]}"
 optparse.define short=s long=skip-deps desc="Skip install dependences" variable=SKIP_DEPS default=false value=true
 optparse.define short=C long=force-cmake-reconfig desc="Force cmake reconfigure" variable=FORCE_CMAKE_CONFIG default=false value=true
 optparse.define short=S long=skip-columnstore-submodules desc="Skip columnstore submodules initialization" variable=SKIP_SUBMODULES default=false value=true
+optparse.define short=u long=skip-unit-tests desc="Skip UnitTests" variable=SKIP_UNIT_TESTS default=false value=true
 optparse.define short=b long=branch desc="Choouse git branch ('none' for menu)" variable=BRANCH
 
 source $( optparse.build )
@@ -73,17 +72,20 @@ install_deps()
 {
     message "Installing deps"
     if [[ $OS = 'Ubuntu' || $OS = 'Debian' ]]; then
-        sudo apt-get -y update
+        apt-get -y update
         apt-get -y install build-essential automake libboost-all-dev bison cmake \
         libncurses5-dev libaio-dev libsystemd-dev libpcre2-dev \
         libperl-dev libssl-dev libxml2-dev libkrb5-dev flex libpam-dev git \
-        libsnappy-dev libcurl4-openssl-dev libgtest-dev libcppunit-dev googletest libsnappy-dev libjemalloc-dev
+        libsnappy-dev libcurl4-openssl-dev libgtest-dev libcppunit-dev googletest libsnappy-dev libjemalloc-dev \
+        liblz-dev liblzo2-dev liblzma-dev liblz4-dev libbz2-dev
+
     elif [[ $OS = 'CentOS' || $OS = 'Rocky' ]]; then
         yum -y install epel-release \
         && yum -y groupinstall "Development Tools" \
 	&& yum config-manager --set-enabled powertools \
         && yum -y install bison ncurses-devel readline-devel perl-devel openssl-devel libxml2-devel gperf libaio-devel libevent-devel tree wget pam-devel snappy-devel libicu \
-        && yum -y install vim wget strace ltrace gdb  rsyslog net-tools openssh-server expect boost perl-DBI libicu boost-devel initscripts jemalloc-devel libcurl-devel gtest-devel cppunit-devel systemd-devel
+        && yum -y install vim wget strace ltrace gdb  rsyslog net-tools openssh-server expect boost perl-DBI libicu boost-devel initscripts jemalloc-devel libcurl-devel gtest-devel cppunit-devel systemd-devel \        && yum -y install lzo-devel xz-devel lz4-devel bzip2-devel
+
         if [[ "$OS_VERSION" == "7" ]]; then
             yum -y install cmake3
             CMAKE_BIN_NAME=cmake3
@@ -93,12 +95,6 @@ install_deps()
         if [ $OS = 'Rocky' ]; then
 	    yum install -y checkpolicy
         fi
-    elif [ $OS = 'openSUSE' ]; then
-        zypper install -y bison ncurses-devel readline-devel libopenssl-devel cmake libxml2-devel gperf libaio-devel libevent-devel python-devel ruby-devel tree wget pam-devel snappy-devel libicu-devel \
-        && zypper install -y libboost_system-devel libboost_filesystem-devel libboost_thread-devel libboost_regex-devel libboost_date_time-devel libboost_chrono-devel libboost_atomic-devel \
-        && zypper install -y vim wget strace ltrace gdb  rsyslog net-tools expect perl-DBI libicu boost-devel jemalloc-devel libcurl-devel liblz4-devel lz4 \
-        && zypper install -y gcc gcc-c++ git automake libtool gtest cppunit-devel pcre2-devel systemd-devel libaio-devel snappy-devel cracklib-devel policycoreutils-devel ncurses-devel \
-        && zypper install -y make flex libcurl-devel  automake libtool rpm-build lsof iproute pam-devel perl-DBI expect createrepo
     fi
 }
 
@@ -205,7 +201,6 @@ build()
     cd -
 }
 
-
 check_user_and_group()
 {
     if [ -z "$(grep mysql /etc/passwd)" ]; then
@@ -217,6 +212,18 @@ check_user_and_group()
         GroupID = `awk -F: '{uid[$3]=1}END{for(x=100; x<=999; x++) {if(uid[x] != ""){}else{print x; exit;}}}' /etc/group`
         message "Adding group mysql with id $GroupID"
         groupadd -g GroupID mysql
+    fi
+}
+
+run_unit_tests()
+{
+    if [[ $SKIP_UNIT_TESTS = true ]] ; then
+        warn "Skipping unittests"
+    else
+        message "Running unittests"
+        cd $MDB_SOURCE_PATH
+        ctest . -R columnstore: -j $(nproc)
+        cd -
     fi
 }
 
@@ -289,7 +296,6 @@ socket=/run/mysqld/mysqld.sock" > /etc/my.cnf.d/socket.cnf'
     chmod 777 /var/log/mariadb/columnstore
 }
 
-
 select_branch
 
 if [[ $SKIP_DEPS = false ]] ; then
@@ -299,6 +305,7 @@ fi
 stop_service
 clean_old_installation
 build
+run_unit_tests
 install
 start_service
 message "$color_green FINISHED $color_normal"


### PR DESCRIPTION
- Build instructions updated
- .clang-tidy initial
- bootstrap script openSUSE support removed, compression library install added
force running unittests on build, with option to skip it