### PR TITLE
Adding automation for benchmarks.

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+usage() {
+  cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") branch lua_script [-h] [-d data.tbl] [-s 1000000]
+
+A script to run benchmark(for now) to compare the pefromanceo of min/max
+calculation on develop and provided branch. Runs the provided .lua script using sysbench.
+
+Available options:
+
+-h, --help      Print this help and exit
+-d, --data      Data for table that will be given to cpimport; if no name provided it will be generated.
+-s, --size      Size of the dataset to generate
+EOF
+  exit
+}
+
+SCRIPT_LOCATION=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+MDB_SOURCE_PATH=$(realpath $SCRIPT_LOCATION/../../..)
+DATA="data.tbl"
+
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+  if [ -f $DATA ]
+     then
+         sudo rm $DATA
+  fi
+}
+
+die() {
+  local msg=$1
+  local code=${2-1} # default exit status 1
+  echo "$msg"
+  exit "$code"
+}
+
+parse_params() {
+
+  args=("$@")
+  # check required params and arguments
+  [[ ${#args[@]} -eq 0 ]] && die "Missing script arguments"
+
+  BRANCH="$1"
+
+  if [ $BRANCH == "--help" ] || [ $BRANCH == "-h" ]
+     then
+         usage
+  fi
+
+  [[ ${#args[@]} < 2 ]] && die "Missing script arguments"
+
+  SCRIPT="$2"
+  RANGE=1000000
+
+  while :; do
+    case "${1-}" in
+    -d | --data) DATA="${2-}"
+                 shift
+                 ;;
+    -s | --size) RANGE="${2-}"
+                 shift
+                 ;;
+    -?*) die "Unknown option: $1" ;;
+    *) break ;;
+    esac
+    shift
+  done
+
+  return 0
+}
+
+parse_params "$@"
+cd $MDB_SOURCE_PATH/columnstore/columnstore/benchmarks
+seq 1 $RANGE > "$DATA"
+
+git checkout $BRANCH
+sudo $MDB_SOURCE_PATH/columnstore/columnstore/build/bootstrap_mcs.sh -t RelWithDebInfo
+echo "Build done; benchmarking $BRANCH now"
+#Prepare should only create the table, we will fill it with cpimport
+sysbench $SCRIPT \
+        --mysql-socket=/run/mysqld/mysqld.sock \
+        --db-driver=mysql \
+        --mysql-db=test \
+        prepare
+
+sudo cpimport test t1 "$DATA"
+
+sysbench $SCRIPT \
+        --mysql-socket=/run/mysqld/mysqld.sock \
+        --db-driver=mysql \
+        --mysql-db=test \
+        --time=30 run | tail -n +12 > "${BRANCH}_bench.txt"
+
+git checkout develop
+sudo $MDB_SOURCE_PATH/columnstore/columnstore/build/bootstrap_mcs.sh -t RelWithDebInfo
+echo "Build done; benchmarking develop now"
+sysbench $SCRIPT \
+        --mysql-socket=/run/mysqld/mysqld.sock \
+        --db-driver=mysql \
+        --mysql-db=test \
+        prepare
+
+sudo cpimport test t1 "$DATA"
+
+sysbench $SCRIPT \
+        --mysql-socket=/run/mysqld/mysqld.sock \
+        --db-driver=mysql \
+        --mysql-db=test \
+        --time=30 run | tail -n +12 > develop_bench.txt
+
+sysbench $SCRIPT --mysql-socket=/run/mysqld/mysqld.sock \
+        --db-driver=mysql \
+        --mysql-db=test \
+        cleanup
+
+python3 parse_bench.py "$BRANCH" "${BRANCH}_bench.txt" "develop_bench.txt"

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -106,6 +106,7 @@ fi
 git checkout $BRANCH
 sudo $MDB_SOURCE_PATH/columnstore/columnstore/build/bootstrap_mcs.sh -t RelWithDebInfo
 echo "Build done; benchmarking $BRANCH now"
+git checkout with_benchmarks
 #Prepare should only create the table, we will fill it with cpimport
 sysbench $SCRIPT \
         --mysql-socket=/run/mysqld/mysqld.sock \
@@ -124,6 +125,7 @@ sysbench $SCRIPT \
 git checkout develop
 sudo $MDB_SOURCE_PATH/columnstore/columnstore/build/bootstrap_mcs.sh -t RelWithDebInfo
 echo "Build done; benchmarking develop now"
+git checkout with_benchmarks
 sysbench $SCRIPT \
         --mysql-socket=/run/mysqld/mysqld.sock \
         --db-driver=mysql \

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -1,40 +1,11 @@
 #!/usr/bin/env bash
 
-set -Eeuo pipefail
+set -Eeo pipefail
 
 
-
-trap cleanup SIGINT SIGTERM ERR EXIT
 
 SCRIPT_LOCATION=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 MDB_SOURCE_PATH=$(realpath $SCRIPT_LOCATION/../../..)
-
-BRANCH="$1"
-SCRIPT="$2"
-DATA="$3"
-TABLE="t1"
-export TABLE
-
-cleanup() {
-  trap - SIGINT SIGTERM ERR EXIT
-  if [ -f $DATA ]
-     then
-         sudo rm $DATA
-  fi
-  if [ -f "${BRANCH}_bench.txt" ]
-     then
-         sudo rm "${BRANCH}_bench.txt"
-  fi
-  if [ -f "develop_bench.txt" ]
-     then
-         sudo rm "develop_bench.txt"
-  fi
-  sysbench $SCRIPT --mysql-socket=/run/mysqld/mysqld.sock \
-        --db-driver=mysql \
-        --mysql-db=test \
-        cleanup > /dev/null
-  unset TABLE
-}
 
 
 source $MDB_SOURCE_PATH/columnstore/columnstore/build/utils.sh
@@ -44,14 +15,33 @@ if [ "$EUID" -ne 0 ]
     exit 1
 fi
 
-message "Usage: $(basename "${BASH_SOURCE[0]}") branch lua_script data [-h] [-t t1]
-
-A script to run benchmark(for now) to compare the pefromanceo of min/max
-calculation on develop and provided branch. Runs the provided .lua script using sysbench.
+message "A script to run benchmark(for now) to compare the pefromanceo of min/max
+calculation for two provided branches. Runs the provided .lua script using sysbench.
 "
-optparse.define short=t long=table desc="Name of the test table" variable=TABLE
+optparse.define short=a long=branch1 desc="Branch1 to compare" variable=BRANCH1 default="develop"
+optparse.define short=b long=branch2 desc="Branch2 to compare" variable=BRANCH2
+optparse.define short=s long=script-bench desc="Lua benchmark script" variable=SCRIPT
+optparse.define short=g long=gen desc="Data generator for the test table(to be used by cpimport)" variable=GEN
+optparse.define short=n long=name desc="Name of the test table" variable=TABLE default="t1"
+optparse.define short=t long=time desc="Time (in seconds) to run the benchmark" variable=TIME default=120
 
 source $( optparse.build )
+
+export TABLE
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+  sysbench $SCRIPT --mysql-socket=/run/mysqld/mysqld.sock \
+        --db-driver=mysql \
+        --mysql-db=test \
+        cleanup > /dev/null
+  if [ -f "$DATA" ] ; then
+    sudo rm "$DATA"
+  fi
+  unset TABLE
+}
+
 
 die() {
   local msg=$1
@@ -60,11 +50,15 @@ die() {
   exit "$code"
 }
 
+
 cd $MDB_SOURCE_PATH/columnstore/columnstore/benchmarks
 
-git checkout $BRANCH
+DATA=$(sudo mktemp -p /var)
+eval ./$GEN > "$DATA"
+
+git checkout $BRANCH1
 sudo $MDB_SOURCE_PATH/columnstore/columnstore/build/bootstrap_mcs.sh -t RelWithDebInfo
-echo "Build done; benchmarking $BRANCH now"
+echo "Build done; benchmarking $BRANCH1 now"
 git checkout with_benchmarks
 #Prepare should only create the table, we will fill it with cpimport
 sysbench $SCRIPT \
@@ -75,15 +69,15 @@ sysbench $SCRIPT \
 
 sudo cpimport test "$TABLE" "$DATA"
 
-sysbench $SCRIPT \
+BRANCH1_DATA=$(sysbench $SCRIPT \
         --mysql-socket=/run/mysqld/mysqld.sock \
         --db-driver=mysql \
         --mysql-db=test \
-        --time=120 run | tail -n +12 > "${BRANCH}_bench.txt"
+        --time=$TIME run | tail -n +12)
 
-git checkout develop
+git checkout $BRANCH2
 sudo $MDB_SOURCE_PATH/columnstore/columnstore/build/bootstrap_mcs.sh -t RelWithDebInfo
-echo "Build done; benchmarking develop now"
+echo "Build done; benchmarking $BRANCH2 now"
 git checkout with_benchmarks
 sysbench $SCRIPT \
         --mysql-socket=/run/mysqld/mysqld.sock \
@@ -93,10 +87,10 @@ sysbench $SCRIPT \
 
 sudo cpimport test "$TABLE" "$DATA"
 
-sysbench $SCRIPT \
+BRANCH2_DATA=$(sysbench $SCRIPT \
         --mysql-socket=/run/mysqld/mysqld.sock \
         --db-driver=mysql \
         --mysql-db=test \
-        --time=120 run | tail -n +12 > develop_bench.txt
+        --time=$TIME run | tail -n +12)
 
-python3 parse_bench.py "$BRANCH" "${BRANCH}_bench.txt" "develop_bench.txt"
+python3 parse_bench.py "$BRANCH2" "$BRANCH1" "$BRANCH2_DATA" "$BRANCH1_DATA" "$TIME"

--- a/benchmarks/bench_report.lua
+++ b/benchmarks/bench_report.lua
@@ -1,0 +1,49 @@
+function sysbench.report_json(stat)
+   if not gobj then
+      io.write('[\n')
+      -- hack to print the closing bracket when the Lua state of the reporting
+      -- thread is closed
+      gobj = newproxy(true)
+      getmetatable(gobj).__gc = function () io.write('\n]\n') end
+   else
+      io.write(',\n')
+   end
+
+   local seconds = stat.time_interval
+   io.write(([[
+  {
+    "time": %4.0f,
+    "threads": %u,
+    "transactions": %u,
+    "queries": {
+       "total": %u,
+       "reads": %u,
+       "writes": %u,
+       "other": %u
+    },
+    "tps": %4.2f,
+    "qps": {
+      "total": %4.2f,
+      "reads": %4.2f,
+      "writes": %4.2f,
+      "other": %4.2f
+    },
+    "latency": %4.2f,
+    "errors": %4.2f,
+    "reconnects": %4.2f
+  }]]):format(
+            stat.time_total,
+            stat.threads_running,
+            stat.events,
+            stat.reads + stat.writes + stat.other,
+            stat.reads, stat.writes, stat.other,
+            stat.events / seconds,
+            (stat.reads + stat.writes + stat.other) / seconds,
+            stat.reads / seconds,
+            stat.writes / seconds,
+            stat.other / seconds,
+            stat.latency_pct * 1000,
+            stat.errors / seconds,
+            stat.reconnects / seconds
+   ))
+end

--- a/benchmarks/chargen.sh
+++ b/benchmarks/chargen.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+for (( VAR=1; VAR<=1000; VAR++ ))
+do
+    shuf -er -n3  {A..Z} {a..z} | tr -d '\n'
+    echo
+done

--- a/benchmarks/numgen.sh
+++ b/benchmarks/numgen.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+seq 1 100000000

--- a/benchmarks/parse_bench.py
+++ b/benchmarks/parse_bench.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+branch_name = sys.argv[1]
+data_branch = []
+data_develop = []
+time_spent = 30
+
+with open(sys.argv[2],'r') as jf1:
+    data_branch = json.load(jf1)
+
+with open(sys.argv[3],'r') as jf2:
+    data_develop = json.load(jf2)
+
+time = '''Time spent: {time}'''.format(time = time_spent)
+
+comparison = '''Queries made:
+for {name}
+  -- {reads1} reads ({reads1ps} per second)
+  -- {writes1} writes ({writes1ps} per second)
+  -- {other1} other ({other1ps} per second)
+  -- {total1} in total ({total1ps} per second)
+for develop
+  -- {reads2} reads ({reads2ps} per second)
+  -- {writes2} writes ({writes2ps} per second)
+  -- {other2} other ({other2ps} per second)
+  -- {total2} in total ({total2ps} per second)
+'''.format(name = branch_name,
+           reads1 = data_branch[0]["queries"]["reads"],
+           writes1 = data_branch[0]["queries"]["writes"],
+           other1 = data_branch[0]["queries"]["other"],
+           total1 = data_branch[0]["queries"]["total"],
+           reads2 = data_develop[0]["queries"]["reads"],
+           writes2 = data_develop[0]["queries"]["writes"],
+           other2 = data_develop[0]["queries"]["other"],
+           total2 = data_develop[0]["queries"]["total"],
+           reads1ps = data_branch[0]["qps"]["reads"],
+           writes1ps = data_branch[0]["qps"]["writes"],
+           other1ps = data_branch[0]["qps"]["other"],
+           total1ps = data_branch[0]["qps"]["total"],
+           reads2ps = data_develop[0]["qps"]["reads"],
+           writes2ps = data_develop[0]["qps"]["writes"],
+           other2ps = data_develop[0]["qps"]["other"],
+           total2ps = data_develop[0]["qps"]["total"],)
+
+relation = ""
+if data_branch[0]["qps"]["total"] >= data_develop[0]["qps"]["total"]:
+    relation = '''The speed increase (total / total) is {inc}
+               '''.format(inc = data_branch[0]["qps"]["total"]/data_develop[0]["qps"]["total"])
+else:
+    relation = '''The speed decrease (total / total) is {inc}
+               '''.format(inc = data_develop[0]["qps"]["total"]/data_branch[0]["qps"]["total"])
+
+print(time)
+print(comparison)
+print(relation)

--- a/benchmarks/parse_bench.py
+++ b/benchmarks/parse_bench.py
@@ -3,31 +3,27 @@
 import json
 import sys
 
-branch_name = sys.argv[1]
-data_branch = []
-data_develop = []
-time_spent = 30
+branch1_name = sys.argv[1]
+branch2_name = sys.argv[2]
+data_branch = json.loads(sys.argv[3])
+data_develop = json.loads(sys.argv[4])
+time_spent = 120
 
-with open(sys.argv[2],'r') as jf1:
-    data_branch = json.load(jf1)
-
-with open(sys.argv[3],'r') as jf2:
-    data_develop = json.load(jf2)
-
-time = '''Time spent: {time}'''.format(time = time_spent)
+time = '''Time spent: {time}'''.format(time = sys.argv[5])
 
 comparison = '''Queries made:
-for {name}
+for {name1}
   -- {reads1} reads ({reads1ps} per second)
   -- {writes1} writes ({writes1ps} per second)
   -- {other1} other ({other1ps} per second)
   -- {total1} in total ({total1ps} per second)
-for develop
+for {name2}
   -- {reads2} reads ({reads2ps} per second)
   -- {writes2} writes ({writes2ps} per second)
   -- {other2} other ({other2ps} per second)
   -- {total2} in total ({total2ps} per second)
-'''.format(name = branch_name,
+'''.format(name1 = branch1_name,
+           name2 = branch2_name,
            reads1 = data_branch[0]["queries"]["reads"],
            writes1 = data_branch[0]["queries"]["writes"],
            other1 = data_branch[0]["queries"]["other"],

--- a/benchmarks/select_bench.lua
+++ b/benchmarks/select_bench.lua
@@ -7,7 +7,7 @@ function prepare ()
 end
 
 function cleanup()
-  db_query("drop table if exists" .. os.getenv("TABLE") ..)
+  db_query("drop table if exists " .. os.getenv("TABLE"))
 end
 
 function help()

--- a/benchmarks/select_bench.lua
+++ b/benchmarks/select_bench.lua
@@ -2,12 +2,12 @@ require("bench_report")
 
 function prepare ()
   local i
-  print("creating table test.t1 ...")
-  db_query("create table t1 (c1 int)engine=columnstore")
+  print("creating table...")
+  db_query("create table if not exists " .. os.getenv("TABLE") .. " (c1 int)engine=columnstore")
 end
 
 function cleanup()
-  db_query("drop table t1")
+  db_query("drop table if exists" .. os.getenv("TABLE") ..)
 end
 
 function help()
@@ -22,7 +22,7 @@ function thread_done(thread_id)
 end
 
 function event(thread_id)
-  db_query("select c1 from t1 where c1 = 5 or c1 = 10")
+  db_query("select c1 from " .. os.getenv("TABLE") .. " where c1 = 5 or c1 = 10")
 end
 
 sysbench.hooks.report_intermediate = sysbench.report_json

--- a/benchmarks/select_bench.lua
+++ b/benchmarks/select_bench.lua
@@ -1,0 +1,29 @@
+require("bench_report")
+
+function prepare ()
+  local i
+  print("creating table test.t1 ...")
+  db_query("create table t1 (c1 int)engine=columnstore")
+end
+
+function cleanup()
+  db_query("drop table t1")
+end
+
+function help()
+  print("sysbench Lua demo; no special command line options available")
+end
+
+function thread_init(thread_id)
+end
+
+function thread_done(thread_id)
+  db_disconnect()
+end
+
+function event(thread_id)
+  db_query("select c1 from t1 where c1 = 5 or c1 = 10")
+end
+
+sysbench.hooks.report_intermediate = sysbench.report_json
+sysbench.hooks.report_cumulative = sysbench.report_json

--- a/benchmarks/select_text_bench.lua
+++ b/benchmarks/select_text_bench.lua
@@ -1,0 +1,29 @@
+require("bench_report")
+
+function prepare ()
+  local i
+  print("creating table...")
+  db_query("create table if not exists " .. os.getenv("TABLE") .. " (c1 varchar(3))engine=columnstore")
+end
+
+function cleanup()
+  db_query("drop table if exists " .. os.getenv("TABLE"))
+end
+
+function help()
+  print("sysbench Lua demo; no special command line options available")
+end
+
+function thread_init(thread_id)
+end
+
+function thread_done(thread_id)
+  db_disconnect()
+end
+
+function event(thread_id)
+  db_query("select c1 from " .. os.getenv("TABLE") .. " where c1 = 'aaa' or c1 = 'ccc'")
+end
+
+sysbench.hooks.report_intermediate = sysbench.report_json
+sysbench.hooks.report_cumulative = sysbench.report_json


### PR DESCRIPTION
Consists of 4 files:
 -- `bench.sh` is the main script to run a benchmark.
 -- `bench_report.lua` is a formatter for sysbench and needs to be `require`d in every sysbench script
 -- `parse_bench.py` is formatter for output. Not done in bash because it parses json output of sysbench.
 -- `select_bench.lua` is my benchmark for `vect_min_max` branch.