### PR TITLE
MCOL-5162 This patch allows for an automatic upgrade of syscat tables via dbbuilder.

### DIFF
--- a/tools/dbbuilder/systemcatalog.h
+++ b/tools/dbbuilder/systemcatalog.h
@@ -23,12 +23,19 @@
 #pragma once
 
 #include "writeengine.h"
+#include <unordered_map>
+#include <utility>
+
+using OidTypeT = std::pair<execplan::CalpontSystemCatalog::ColDataType, int>;
 
 class SystemCatalog
 {
  public:
   void build();
   void remove();
+  int upgrade(const std::unordered_map<int, std::pair<int, bool>>&,
+              std::unordered_map<int, OidTypeT>,
+              std::unordered_map<int, std::string>);
 
  private:
   WriteEngine::WriteEngineWrapper fWriteEngine;


### PR DESCRIPTION
We have added a new function, SystemCatalog::upgrade(), which will
create a new column in the database and fill it with default values.
It uses a reference column to fill the column, which is passed as a
std::unordered_map<key, value> value to SystemCatalog::upgrade()
function, where key is the target column which needs to be created.
In addition, we pass additional std::unordered_map's to
SystemCatalog::upgrade() containing information such as the datatypes
and colwidths of the target and reference columns, as well as the
default value which will be used to fill the target column.