### PR TITLE
[MCOL-5061] Fix wrong `join id` assignment for the views.

### DIFF
--- a/dbcon/joblist/jlf_common.h
+++ b/dbcon/joblist/jlf_common.h
@@ -199,6 +199,7 @@ struct JobInfo
    , limitStart(0)
    , limitCount(-1)
    , joinNum(0)
+   , joinNumInView(0)
    , subLevel(0)
    , subNum(0)
    , subId(0)
@@ -292,6 +293,8 @@ struct JobInfo
   // mixed outer join
   std::map<int, uint64_t> tableSize;
   int64_t joinNum;
+  // MCOL-5061, MCOL-334.
+  int64_t joinNumInView;
 
   // for subquery
   boost::shared_ptr<int> subCount;  // # of subqueries in the query statement
@@ -367,9 +370,9 @@ struct JobInfo
 
   PrimitiveServerThreadPools primitiveServerThreadPools;
   // Represents a `join edges` and `join id` to be restored in `join order` part.
-  std::map<std::pair<uint32_t, uint32_t>, uint32_t> joinEdgesToRestore;
+  std::map<std::pair<uint32_t, uint32_t>, int64_t> joinEdgesToRestore;
   // Represents a pair of `table` to be on a large side and weight associated with that table.
-  std::unordered_map<uint32_t, uint32_t> tablesForLargeSide;
+  std::unordered_map<uint32_t, int64_t> tablesForLargeSide;
 
  private:
   // defaults okay

--- a/dbcon/joblist/jlf_execplantojoblist.cpp
+++ b/dbcon/joblist/jlf_execplantojoblist.cpp
@@ -1166,7 +1166,9 @@ const JobStepVector doJoin(SimpleColumn* sc1, SimpleColumn* sc2, JobInfo& jobInf
   // MCOL-334 joins in views need to have higher priority than SEMI/ANTI
   if (!view1.empty() && view1 == view2)
   {
-    thj->joinId(-1);
+    // MCOL-5061. We could have a filters to be associated with a specific join id, therefore we cannot have
+    // the same join id for different `TupleHashJoin` steps.
+    thj->joinId(std::numeric_limits<int64_t>::min() + (++jobInfo.joinNumInView));
   }
   else
   {

--- a/mysql-test/columnstore/basic/r/mcs63_crossengine_views.result
+++ b/mysql-test/columnstore/basic/r/mcs63_crossengine_views.result
@@ -63,13 +63,13 @@ select `mcs63_db`.`t1`.`t1_int` AS `t1_int`,`mcs63_db`.`t1`.`t1_char` AS `t1_cha
 SELECT * FROM v4;
 t1_int	t1_char	t2_int	t2_char
 1	aaa	1	hhh
-3	ccc	3	iii
-5	eee	5	jjj
-7	gggg	7	llll
 NULL	NULL	NULL	NULL
 2	bbb	NULL	NULL
+3	ccc	NULL	NULL
 4	ddd	NULL	NULL
+5	eee	NULL	NULL
 6	fff	NULL	NULL
+7	gggg	NULL	NULL
 CREATE VIEW v5 AS SELECT * FROM t1 RIGHT JOIN t2 ON t1.t1_int = t2.t2_int;
 SELECT VIEW_DEFINITION FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_NAME='v5' AND TABLE_SCHEMA='mcs63_db';
 VIEW_DEFINITION
@@ -105,10 +105,10 @@ select `mcs63_db`.`t1`.`t1_int` AS `t1_int`,`mcs63_db`.`t1`.`t1_char` AS `t1_cha
 SELECT * FROM v7;
 t1_int	t1_char	t2_int	t2_char
 NULL	NULL	NULL	NULL
-1	aaa	1	hhh
-3	ccc	3	iii
+NULL	NULL	1	hhh
+NULL	NULL	3	iii
 5	eee	5	jjj
-7	gggg	7	llll
+NULL	NULL	7	llll
 NULL	NULL	9	kkkk
 NULL	NULL	11	mm
 NULL	NULL	13	n

--- a/mysql-test/columnstore/bugfixes/mcol-5061.result
+++ b/mysql-test/columnstore/bugfixes/mcol-5061.result
@@ -1,0 +1,20 @@
+DROP DATABASE IF EXISTS mcol_5061;
+CREATE DATABASE mcol_5061;
+USE mcol_5061;
+create table t1 (a int, b int) engine=columnstore;
+create table t2 (a int, b int) engine=columnstore;
+insert into t1 values (1, 3), (2, 3), (3, 4);
+insert into t2 values (1, 2), (2, 4), (4, 5);
+select t1.a as a, t1.b as b, t2.a as c, t2.b as d, t2_1.a as e, t2_1.b as f from t1 left join t2 on (t1.a = t2.a and t2.a > 1) left join t2 as t2_1 on (t1.b = t2_1.b and t2_1.a > 1);
+a	b	c	d	e	f
+1	3	NULL	NULL	NULL	NULL
+2	3	2	4	NULL	NULL
+3	4	NULL	NULL	2	4
+create or replace view view_test as
+select t1.a as a, t1.b as b, t2.a as c, t2.b as d, t2_1.a as e, t2_1.b as f from t1 left join t2 on (t1.a = t2.a and t2.a > 1) left join t2 as t2_1 on (t1.b = t2_1.b and t2_1.a > 1);
+select * from view_test;
+a	b	c	d	e	f
+1	3	NULL	NULL	NULL	NULL
+2	3	2	4	NULL	NULL
+3	4	NULL	NULL	2	4
+DROP DATABASE mcol_5061;

--- a/mysql-test/columnstore/bugfixes/mcol-5061.test
+++ b/mysql-test/columnstore/bugfixes/mcol-5061.test
@@ -1,0 +1,26 @@
+#
+# Test based on Jira MCOL-5061
+# Reduced customer test case.
+#
+
+--source ../include/have_columnstore.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol_5061;
+--enable_warnings
+
+CREATE DATABASE mcol_5061;
+USE mcol_5061;
+
+create table t1 (a int, b int) engine=columnstore;
+create table t2 (a int, b int) engine=columnstore;
+
+insert into t1 values (1, 3), (2, 3), (3, 4);
+insert into t2 values (1, 2), (2, 4), (4, 5);
+select t1.a as a, t1.b as b, t2.a as c, t2.b as d, t2_1.a as e, t2_1.b as f from t1 left join t2 on (t1.a = t2.a and t2.a > 1) left join t2 as t2_1 on (t1.b = t2_1.b and t2_1.a > 1);
+
+create or replace view view_test as
+select t1.a as a, t1.b as b, t2.a as c, t2.b as d, t2_1.a as e, t2_1.b as f from t1 left join t2 on (t1.a = t2.a and t2.a > 1) left join t2 as t2_1 on (t1.b = t2_1.b and t2_1.a > 1);
+select * from view_test;
+
+DROP DATABASE mcol_5061;


### PR DESCRIPTION
This patch fixes a wrong `join id` assignment for `TupleHashJoinStep` in a view.
After MCOL-334 CS assigns a '-1' as `join id` for `TupleHashJoinStep` in a view, and
in this case we cannot apply a filter for specific `Join step`, which is associated with `join id`
for 2 reasons:
1. Filters for all `TupleHashJoinSteps` associated with the same `join id`, which is '-1'.
2. When CS creates a `joinIdIndexMap` it eliminates all `join ids` which a less or equal 0.

This patch also fixes some tests for the view, which were generated wrong results.