### PR TITLE
 [MCOL-5167] Add support for on clause filter for a table which is not involved in join.

### DIFF
--- a/mysql-test/columnstore/basic/r/mcol-5167.result
+++ b/mysql-test/columnstore/basic/r/mcol-5167.result
@@ -1,0 +1,61 @@
+DROP DATABASE IF EXISTS mcol5167;
+CREATE DATABASE mcol5167;
+USE mcol5167;
+create table t1 (a int, b int) engine=columnstore;
+create table t2 (a int, b int) engine=columnstore;
+create table t3 (a int, b int) engine=columnstore;
+create table t4 (a int, b int) engine=columnstore;
+insert into t1 values (1, 3), (2, 3), (3, 4);
+insert into t2 values (1, 2), (2, 4), (4, 5);
+insert into t3 values (1, 2), (2, 3), (3, 4), (4, 5);
+insert into t4 values (1, 2), (2, 3), (3, 4);
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t1.b = t3.b and t2.a > 1);
+a	b	a	b	a	b
+1	3	1	2	NULL	NULL
+2	3	2	4	2	3
+3	4	NULL	NULL	NULL	NULL
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t2.b = t3.b and t1.a > 1);
+a	b	a	b	a	b
+1	3	1	2	NULL	NULL
+2	3	2	4	3	4
+3	4	NULL	NULL	NULL	NULL
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t2.b = t3.b and t1.a > 1 and t2.a > 1);
+a	b	a	b	a	b
+1	3	1	2	NULL	NULL
+2	3	2	4	3	4
+3	4	NULL	NULL	NULL	NULL
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t2.b = t3.b and t2.a > 1 and t1.a > 1);
+a	b	a	b	a	b
+1	3	1	2	NULL	NULL
+2	3	2	4	3	4
+3	4	NULL	NULL	NULL	NULL
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t1.b = t3.b and t2.a > 3);
+a	b	a	b	a	b
+1	3	1	2	NULL	NULL
+2	3	2	4	NULL	NULL
+3	4	NULL	NULL	NULL	NULL
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t2.b = t3.b and t1.a > 3);
+a	b	a	b	a	b
+1	3	1	2	NULL	NULL
+2	3	2	4	NULL	NULL
+3	4	NULL	NULL	NULL	NULL
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t1.b = t3.b) left join t4 on (t3.a = t4.a and t1.a > 1 and t2.a > 1);
+a	b	a	b	a	b	a	b
+1	3	1	2	2	3	NULL	NULL
+2	3	2	4	2	3	2	3
+3	4	NULL	NULL	3	4	NULL	NULL
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t1.b = t3.b) left join t4 on (t3.a = t4.a and t1.a > 1 and t2.a > 2);
+a	b	a	b	a	b	a	b
+1	3	1	2	2	3	NULL	NULL
+2	3	2	4	2	3	NULL	NULL
+3	4	NULL	NULL	3	4	NULL	NULL
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t1.b = t3.b and t1.a > 1) left join t4 on (t3.a = t4.a and t1.a > 1 and t2.a > 1);
+a	b	a	b	a	b	a	b
+1	3	1	2	NULL	NULL	NULL	NULL
+2	3	2	4	2	3	2	3
+3	4	NULL	NULL	3	4	NULL	NULL
+drop table t1;
+drop table t2;
+drop table t3;
+drop table t4;
+DROP DATABASE mcol5167;

--- a/mysql-test/columnstore/basic/t/mcol-5167.test
+++ b/mysql-test/columnstore/basic/t/mcol-5167.test
@@ -1,0 +1,37 @@
+
+#-- source ../include/have_columnstore.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol5167;
+--enable_warnings
+
+CREATE DATABASE mcol5167;
+
+USE mcol5167;
+
+create table t1 (a int, b int) engine=columnstore;
+create table t2 (a int, b int) engine=columnstore;
+create table t3 (a int, b int) engine=columnstore;
+create table t4 (a int, b int) engine=columnstore;
+
+insert into t1 values (1, 3), (2, 3), (3, 4);
+insert into t2 values (1, 2), (2, 4), (4, 5);
+insert into t3 values (1, 2), (2, 3), (3, 4), (4, 5);
+insert into t4 values (1, 2), (2, 3), (3, 4);
+
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t1.b = t3.b and t2.a > 1);
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t2.b = t3.b and t1.a > 1);
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t2.b = t3.b and t1.a > 1 and t2.a > 1);
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t2.b = t3.b and t2.a > 1 and t1.a > 1);
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t1.b = t3.b and t2.a > 3);
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t2.b = t3.b and t1.a > 3);
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t1.b = t3.b) left join t4 on (t3.a = t4.a and t1.a > 1 and t2.a > 1);
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t1.b = t3.b) left join t4 on (t3.a = t4.a and t1.a > 1 and t2.a > 2);
+select * from t1 left join t2 on (t1.a = t2.a) left join t3 on (t1.b = t3.b and t1.a > 1) left join t4 on (t3.a = t4.a and t1.a > 1 and t2.a > 1);
+
+drop table t1;
+drop table t2;
+drop table t3;
+drop table t4;
+
+DROP DATABASE mcol5167;


### PR DESCRIPTION
This patch adds support for on clause filter for a table which is not involved in particular join
by disabling an `merge optimization` for those particular cases.
The `merge optimization` is optimization when CS
tries to create a one BPP join with one `large side` table and multiple `small sides` tables, in this
case we cannot apply a FE filter if this filter requires a columns from `small side` table which is not
involved in particular join.