### PR TITLE
MCOL-5180 Check CPU vector instructions set in installer and PrimProc on start

### DIFF
--- a/build/preInstall_storage_engine.sh
+++ b/build/preInstall_storage_engine.sh
@@ -1,6 +1,7 @@
 
 if [ -z $(cat /proc/cpuinfo | grep -E 'sse4_2|neon|asimd' | head -c1) ]; then
-    echo "No support found for sse4 or neon simd instructions; aborting"
+    echo "error: this machine CPU lacks of support for Intel SSE4.2 or ARM Advanced SIMD instructions.
+Columnstore requires one of this instruction sets, installation aborted"
     exit 1
 fi
 

--- a/build/preInstall_storage_engine.sh
+++ b/build/preInstall_storage_engine.sh
@@ -1,4 +1,9 @@
 
+if [ -z $(cat /proc/cpuinfo | grep -E 'sse4_2|neon|asimd' | head -c1) ]; then
+    echo "No support found for sse4 or neon simd instructions; aborting"
+    exit 1
+fi
+
 if [ "$1" == "2" ]; then
     /bin/cp -f /etc/columnstore/storagemanager.cnf /etc/columnstore/storagemanager.cnf.rpmsave > /dev/null 2>&1
     columnstore-pre-uninstall

--- a/debian/mariadb-plugin-columnstore.preinst
+++ b/debian/mariadb-plugin-columnstore.preinst
@@ -5,6 +5,7 @@ set -e
 # Check for sse4.2 or neon support
 
 if [ -z $(cat /proc/cpuinfo | grep -E 'sse4_2|neon|asimd' | head -c1) ]; then
-    echo "No support found for sse4 or neon simd instructions; aborting"
+    echo "error: this machine CPU lacks of support for Intel SSE4.2 or ARM Advanced SIMD instructions.
+Columnstore requires one of this instruction sets, installation aborted"
     exit 1
 fi

--- a/debian/mariadb-plugin-columnstore.preinst
+++ b/debian/mariadb-plugin-columnstore.preinst
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Check for sse4.2 or neon support
+
+if [ -z $(cat /proc/cpuinfo | grep -E 'sse4_2|neon|asimd' | head -c1) ]; then
+    echo "No support found for sse4 or neon simd instructions; aborting"
+    exit 1
+fi

--- a/primitives/primproc/archcheck.h
+++ b/primitives/primproc/archcheck.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 InfiniDB, Inc.
+/* Copyright (C) 2022 MariaDB Corporation
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License
@@ -26,32 +26,41 @@
 
 namespace archcheck
 {
+
+enum class arcitecture
+{
+   DEFAULT = 0,
+   SSE4_2 = 1,
+   ASIMD = 2,
+   UNKNOWN = -1
+};
+
 #if defined(__x86_64__)
-__attribute__((target("default")))
-int checkArchitecture()
+__attribute__ ((target ("default")))
+arcitecture checkArchitecture()
 {
   // The default version.
-  return 1;
+  return arcitecture::DEFAULT;
 }
 
 __attribute__ ((target ("sse4.2")))
-int checkArchitecture ()
+arcitecture checkArchitecture ()
 {
   // version for SSE4.2
-  return 2;
+  return arcitecture::SSE4_2;
 }
 #elif defined(__aarch64__)
-int checkArchitecture()
+arcitecture checkArchitecture()
 {
   // version for arm
   if ((getauxval(AT_HWCAP) & HWCAP_ASIMD) != 0)
-    return 2;
-  return 1;
+    return arcitecture::ASIMD;
+  return arcitecture::DEFAULT;
 }
 #else
-int checkArchitecture()
+arcitecture checkArchitecture()
 {
-  return -1;
+  return arcitecture::UNKNOWN;
 }
 #endif
 }

--- a/primitives/primproc/archcheck.h
+++ b/primitives/primproc/archcheck.h
@@ -1,0 +1,57 @@
+/* Copyright (C) 2014 InfiniDB, Inc.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+   MA 02110-1301, USA. */
+
+#pragma once
+
+#include <iostream>
+
+#ifdef __aarch64__
+#include <sys/auxv.h>
+#include <asm/hwcap.h>
+#endif
+
+namespace archcheck
+{
+#if defined(__x86_64__)
+__attribute__((target("default")))
+int checkArchitecture()
+{
+  // The default version.
+  return 1;
+}
+
+__attribute__ ((target ("sse4.2")))
+int checkArchitecture ()
+{
+  // version for SSE4.2
+  return 2;
+}
+#elif defined(__aarch64__)
+int checkArchitecture()
+{
+  // version for arm
+  if ((getauxval(AT_HWCAP) & HWCAP_ASIMD) != 0)
+    return 2;
+  return 1;
+}
+#else
+int checkArchitecture()
+{
+  return -1;
+}
+#endif
+}

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -59,6 +59,9 @@ using namespace logging;
 #include "umsocketselector.h"
 using namespace primitiveprocessor;
 
+#include "archcheck.h"
+using namespace archcheck;
+
 #include "liboamcpp.h"
 using namespace oam;
 
@@ -735,6 +738,10 @@ int ServicePrimProc::Child()
 
 int main(int argc, char** argv)
 {
+  if (checkArchitecture() != 2) {
+    std::cerr << "Unsupported CPU architecture. ARM Advanced SIMD or x86_64 SSE4.2 required; aborting. \n";
+    return 1;
+  }
   Opt opt(argc, argv);
 
   // Set locale language

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -738,7 +738,8 @@ int ServicePrimProc::Child()
 
 int main(int argc, char** argv)
 {
-  if (checkArchitecture() != arcitecture::SSE4_2 && checkArchitecture() != arcitecture::ASIMD) {
+  if (checkArchitecture() != arcitecture::SSE4_2 || checkArchitecture() != arcitecture::ASIMD)
+  {
     std::cerr << "Unsupported CPU architecture. ARM Advanced SIMD or x86_64 SSE4.2 required; aborting. \n";
     return 1;
   }

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -738,7 +738,7 @@ int ServicePrimProc::Child()
 
 int main(int argc, char** argv)
 {
-  if (checkArchitecture() != arcitecture::SSE4_2 || checkArchitecture() != arcitecture::ASIMD)
+  if (checkArchitecture() != arcitecture::SSE4_2 && checkArchitecture() != arcitecture::ASIMD)
   {
     std::cerr << "Unsupported CPU architecture. ARM Advanced SIMD or x86_64 SSE4.2 required; aborting. \n";
     return 1;

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -738,7 +738,7 @@ int ServicePrimProc::Child()
 
 int main(int argc, char** argv)
 {
-  if (checkArchitecture() != 2) {
+  if (checkArchitecture() != arcitecture::SSE4_2 && checkArchitecture() != arcitecture::ASIMD) {
     std::cerr << "Unsupported CPU architecture. ARM Advanced SIMD or x86_64 SSE4.2 required; aborting. \n";
     return 1;
   }


### PR DESCRIPTION
Adding various checks for simd architecture support.