### PR TITLE
MCOL-5199 This patch solves the overal performance degradation introd…

### DIFF
--- a/dbcon/mysql/ha_mcs_sysvars.cpp
+++ b/dbcon/mysql/ha_mcs_sysvars.cpp
@@ -39,6 +39,8 @@ static MYSQL_THDVAR_ENUM(compression_type, PLUGIN_VAR_RQCMDARG,
                          "SNAPPY segment files are Snappy compressed (default);"
 #ifdef HAVE_LZ4
                          "LZ4 segment files are LZ4 compressed;",
+# else
+			 ,
 #endif
                          NULL,                              // check
                          NULL,                              // update

--- a/utils/common/collation.h
+++ b/utils/common/collation.h
@@ -183,6 +183,10 @@ class Charset
   {
     return flags_;
   }
+  size_t strnxfrm(uchar* dst, size_t dstlen, uint nweights, const uchar* src, size_t srclen, uint flags)
+  {
+    return mCharset->coll->strnxfrm(mCharset, dst, dstlen, nweights, src, srclen, flags);
+  }
 };
 
 class CollationAwareHasher : public Charset

--- a/utils/common/hasher.h
+++ b/utils/common/hasher.h
@@ -27,8 +27,10 @@
 #ifndef UTILS_HASHER_H
 #define UTILS_HASHER_H
 
+#include <cstddef>
 #include <stdint.h>
 #include <string.h>
+#include <string>
 #include "mcs_basic_types.h"
 
 namespace utils
@@ -202,6 +204,81 @@ class Hasher_r
     seed = fmix(seed);
     return seed;
   }
+};
+
+// This stream hasher was borrowed from RobinHood
+class Hasher64_r
+{
+ public:
+  inline uint64_t operator()(const void* ptr, uint32_t len, uint64_t x = 0ULL)
+  {
+    auto const* const data64 = static_cast<uint64_t const*>(ptr);
+    uint64_t h = seed ^ (len * m);
+
+    std::size_t const n_blocks = len / 8;
+    if (x)
+    {
+      x *= m;
+      x ^= x >> r;
+      x *= m;
+      h ^= x;
+      h *= m;
+    }
+    for (std::size_t i = 0; i < n_blocks; ++i)
+    {
+      uint64_t k;
+      memcpy(&k, data64 + i, sizeof(k));
+
+      k *= m;
+      k ^= k >> r;
+      k *= m;
+
+      h ^= k;
+      h *= m;
+    }
+
+    auto const* const data8 = reinterpret_cast<uint8_t const*>(data64 + n_blocks);
+    switch (len & 7U)
+    {
+      case 7:
+        h ^= static_cast<uint64_t>(data8[6]) << 48U;
+        // FALLTHROUGH
+      case 6:
+        h ^= static_cast<uint64_t>(data8[5]) << 40U;
+        // FALLTHROUGH
+      case 5:
+        h ^= static_cast<uint64_t>(data8[4]) << 32U;
+        // FALLTHROUGH
+      case 4:
+        h ^= static_cast<uint64_t>(data8[3]) << 24U;
+        // FALLTHROUGH
+      case 3:
+        h ^= static_cast<uint64_t>(data8[2]) << 16U;
+        // FALLTHROUGH
+      case 2:
+        h ^= static_cast<uint64_t>(data8[1]) << 8U;
+        // FALLTHROUGH
+      case 1:
+        h ^= static_cast<uint64_t>(data8[0]);
+        h *= m;
+        // FALLTHROUGH
+      default: break;
+    }
+    return h;
+  }
+
+  inline uint64_t finalize(uint64_t h, uint64_t len) const
+  {
+    h ^= h >> r;
+    h *= m;
+    h ^= h >> r;
+    return h;
+  }
+
+ private:
+  static constexpr uint64_t m = 0xc6a4a7935bd1e995ULL;
+  static constexpr uint64_t seed = 0xe17a1465ULL;
+  static constexpr unsigned int r = 47;
 };
 
 class Hasher128


### PR DESCRIPTION
…uced with a new way of char columns hashing

in aggregation code
The patch disables padding that forces hasher to calculate over the whole 2k buffer. This patch also moves hashing code
into the common place where it belongs.