### PR TITLE
Add threshold for eqFilter in p_Dictionary of pp

### DIFF
--- a/dbcon/joblist/dictstep-jl.cpp
+++ b/dbcon/joblist/dictstep-jl.cpp
@@ -49,14 +49,16 @@ DictStepJL::DictStepJL(const pDictionaryStep& dict)
 
   hasEqFilter = dict.hasEqualityFilter;
 
-  if (hasEqFilter)
+  if (hasEqFilter && dict.eqFilter.size()> USEEQFILTERTHRESHOLD)
   {
     eqOp = dict.tmpCOP;
     eqFilter = dict.eqFilter;
   }
   else
+  {
+    hasEqFilter=false;
     filterString = dict.fFilterString;
-
+  }
   filterCount = dict.fFilterCount;
   charsetNumber = dict.fColType.charsetNumber;
 }

--- a/dbcon/joblist/primitivestep.h
+++ b/dbcon/joblist/primitivestep.h
@@ -544,6 +544,7 @@ class pColScanStep : public JobStep
 /** @brief class pDictionaryStep
  *
  */
+#define USEEQFILTERTHRESHOLD 6
 class pDictionaryStep : public JobStep
 {
  public:

--- a/primitives/primproc/dictstep.cpp
+++ b/primitives/primproc/dictstep.cpp
@@ -346,8 +346,6 @@ void DictStep::_execute()
     newRidList[i].pos = i;
   }
 
-  sort(&newRidList[0], &newRidList[bpp->ridCount], TokenSorter());
-
   tmpResultCounter = 0;
   i = 0;
 


### PR DESCRIPTION
For Eq comparasions in p_Dictionary function of pp,the way uses hashmap is faster than for loop,but when the filtercount is less than a magic number N,the for loop method is faster.And I have simply found that N is 6,but it is just an estimate.
![image](https://user-images.githubusercontent.com/74389817/186296661-91d10d3d-7154-426b-afa4-54077aa0a211.png).Accroding to this micro benchmark.The time complexity of for loop is O(n).We can find that when filtercount is 3,the time for loop method is half of eqFilter. So when filtercount is less than 6,the way uses for loop benefits a lop to performance.
