### PR TITLE
Docker defaults character_set_database=utf8mb3, which would cause an …

### DIFF
--- a/mysql-test/columnstore/include/regression_create_wide_tables.inc
+++ b/mysql-test/columnstore/include/regression_create_wide_tables.inc
@@ -53,7 +53,7 @@ c47 varchar(1000),
 c48 varchar(1000),
 c49 varchar(1000),
 c50 varchar(1000)
-)engine=columnstore;
+)engine=columnstore DEFAULT CHARSET=latin1;
 
 create table wide2 (
 id int(11)       ,
@@ -78,4 +78,4 @@ c18 varchar(2000),
 c19 varchar(4000),
 c20 varchar(4000),
 c_temp varchar(16)
-)engine=columnstore;
+)engine=columnstore DEFAULT CHARSET=latin1;


### PR DESCRIPTION
The 'setup' test suite failed on docker containers because the 'character_set_database' variable is set to 'utf8mb3'.  It returns an ER_TOO_BIG_ROWSIZE error when creating wide tables.  Forcing latin1 for wide tables would help to avoid this error.