### PR TITLE
This patch forces char to be signed b default at all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ ELSE()
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a")
 ENDIF()
 
+# There is an inconsistency b/w default char signedness at ARM and x86.
+# This flag explicitly sets char as signed.
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char")
+
 UNSET(CMAKE_CXX_STANDARD)
 SET(CMAKE_CXX_EXTENSIONS FALSE)
 SET(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)


### PR DESCRIPTION
ARM and x86 differ in their default char signedness, namely x86's
char is signed and ARM's char is not. This difference breaks at least
breaks calShowPartitionByValue() udf.