### PR TITLE
MDEV-25080 Add dummy support for UNION pushdown in the MCS 6.x plugin.

### DIFF
--- a/dbcon/mysql/ha_mcs.cpp
+++ b/dbcon/mysql/ha_mcs.cpp
@@ -45,7 +45,7 @@ group_by_handler* create_columnstore_group_by_handler(THD* thd, Query* query);
 
 derived_handler* create_columnstore_derived_handler(THD* thd, TABLE_LIST* derived);
 
-select_handler* create_columnstore_select_handler(THD* thd, SELECT_LEX* sel);
+select_handler* create_columnstore_select_handler(THD* thd, SELECT_LEX* sel, SELECT_LEX_UNIT* sel_unit);
 
 /* Variables for example share methods */
 

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -8622,7 +8622,7 @@ int cs_get_derived_plan(ha_columnstore_derived_handler* handler, THD* thd, SCSEP
 
 int cs_get_select_plan(ha_columnstore_select_handler* handler, THD* thd, SCSEP& csep, gp_walk_info& gwi)
 {
-  SELECT_LEX& select_lex = *handler->select;
+  SELECT_LEX& select_lex = *handler->select_lex;
 
   if (select_lex.where)
   {


### PR DESCRIPTION
MCS 6.x does not support full/partial pushdown of UNIONs in outer select as implemented in MDEV-25080. This patch makes the bare minimum changes to the MCS 6.x plugin interface to make mariadb community server 10.11 compile with MCS 6.x.