### PR TITLE
[MCOL-5265] Change boost:shared_ptr to std::shared_ptr.

### DIFF
--- a/dbcon/joblist/batchprimitiveprocessor-jl.cpp
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.cpp
@@ -1362,7 +1362,7 @@ void BatchPrimitiveProcessorJL::destroyBPP(ByteStream& bs) const
   bs << uniqueID;
 }
 
-void BatchPrimitiveProcessorJL::useJoiners(const vector<boost::shared_ptr<joiner::TupleJoiner> >& j)
+void BatchPrimitiveProcessorJL::useJoiners(const vector<std::shared_ptr<joiner::TupleJoiner> >& j)
 {
   pos = 0;
   joinerNum = 0;

--- a/dbcon/joblist/batchprimitiveprocessor-jl.h
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.h
@@ -209,7 +209,7 @@ class BatchPrimitiveProcessorJL
   void setJoinedRowGroup(const rowgroup::RowGroup& rg);
 
   /* Tuple hashjoin */
-  void useJoiners(const std::vector<boost::shared_ptr<joiner::TupleJoiner> >&);
+  void useJoiners(const std::vector<std::shared_ptr<joiner::TupleJoiner> >&);
   bool nextTupleJoinerMsg(messageqcpp::ByteStream&);
   // 	void setSmallSideKeyColumn(uint32_t col);
 
@@ -348,7 +348,7 @@ class BatchPrimitiveProcessorJL
   rowgroup::RowGroup aggregateRGPM;
 
   /* UM portion of the PM join alg */
-  std::vector<boost::shared_ptr<joiner::TupleJoiner> > tJoiners;
+  std::vector<std::shared_ptr<joiner::TupleJoiner> > tJoiners;
   std::vector<rowgroup::RowGroup> smallSideRGs;
   rowgroup::RowGroup largeSideRG;
   std::vector<std::vector<uint32_t> > smallSideKeys;

--- a/dbcon/joblist/diskjoinstep.cpp
+++ b/dbcon/joblist/diskjoinstep.cpp
@@ -360,7 +360,7 @@ void DiskJoinStep::joinFcn()
   Row l_joinFERow, l_outputRow, baseRow;
   vector<vector<Row::Pointer> > joinMatches;
   boost::shared_array<Row> smallRowTemplates(new Row[1]);
-  vector<boost::shared_ptr<TupleJoiner> > joiners;
+  vector<std::shared_ptr<TupleJoiner>> joiners;
   boost::shared_array<boost::shared_array<int> > colMappings, fergMappings;
   boost::scoped_array<boost::scoped_array<uint8_t> > smallNullMem;
   boost::scoped_array<uint8_t> joinFEMem;

--- a/dbcon/joblist/diskjoinstep.h
+++ b/dbcon/joblist/diskjoinstep.h
@@ -55,7 +55,7 @@ class DiskJoinStep : public JobStep
   boost::shared_ptr<funcexp::FuncExpWrapper> fe;
   bool typeless;
   JoinType joinType;
-  boost::shared_ptr<joiner::TupleJoiner> joiner;  // the same instance THJS uses
+  std::shared_ptr<joiner::TupleJoiner> joiner;  // the same instance THJS uses
 
   /* main thread, started by JobStep::run() */
   void mainRunner();
@@ -106,7 +106,7 @@ class DiskJoinStep : public JobStep
   /* Builder structs */
   struct BuilderOutput
   {
-    boost::shared_ptr<joiner::TupleJoiner> tupleJoiner;
+    std::shared_ptr<joiner::TupleJoiner> tupleJoiner;
     std::vector<rowgroup::RGData> smallData;
     uint64_t partitionID;
     joiner::JoinPartition* jp;

--- a/dbcon/joblist/primitivestep.h
+++ b/dbcon/joblist/primitivestep.h
@@ -1101,8 +1101,8 @@ class TupleBPS : public BatchPrimitive, public TupleDeliveryStep
   {
     return uniqueID;
   }
-  void useJoiner(boost::shared_ptr<joiner::TupleJoiner>);
-  void useJoiners(const std::vector<boost::shared_ptr<joiner::TupleJoiner>>&);
+  void useJoiner(std::shared_ptr<joiner::TupleJoiner>);
+  void useJoiners(const std::vector<std::shared_ptr<joiner::TupleJoiner>>&);
   bool wasStepRun() const
   {
     return fRunExecuted;
@@ -1298,7 +1298,7 @@ class TupleBPS : public BatchPrimitive, public TupleDeliveryStep
   void serializeJoiner();
   void serializeJoiner(uint32_t connectionNumber);
 
-  std::vector<boost::shared_ptr<joiner::TupleJoiner>> tjoiners;
+  std::vector<std::shared_ptr<joiner::TupleJoiner>> tjoiners;
   bool doJoin, hasPMJoin, hasUMJoin;
   std::vector<rowgroup::RowGroup> joinerMatchesRGs;  // parses the small-side matches from joiner
 
@@ -1361,7 +1361,7 @@ class TupleBPS : public BatchPrimitive, public TupleDeliveryStep
     JoinLocalData(TupleBPS* pTupleBPS, rowgroup::RowGroup& primRowGroup, rowgroup::RowGroup& outputRowGroup,
                   boost::shared_ptr<funcexp::FuncExpWrapper>& fe2, rowgroup::RowGroup& fe2Output,
                   std::vector<rowgroup::RowGroup>& joinerMatchesRGs, rowgroup::RowGroup& joinFERG,
-                  std::vector<boost::shared_ptr<joiner::TupleJoiner>>& tjoiners, uint32_t smallSideCount,
+                  std::vector<std::shared_ptr<joiner::TupleJoiner>>& tjoiners, uint32_t smallSideCount,
                   bool doJoin);
 
     friend class TupleBPS;
@@ -1385,7 +1385,7 @@ class TupleBPS : public BatchPrimitive, public TupleDeliveryStep
     rowgroup::RowGroup fe2Output;
     std::vector<rowgroup::RowGroup> joinerMatchesRGs;
     rowgroup::RowGroup joinFERG;
-    std::vector<boost::shared_ptr<joiner::TupleJoiner>> tjoiners;
+    std::vector<std::shared_ptr<joiner::TupleJoiner>> tjoiners;
 
     uint32_t smallSideCount;
     bool doJoin;

--- a/dbcon/joblist/tuple-bps.cpp
+++ b/dbcon/joblist/tuple-bps.cpp
@@ -161,7 +161,7 @@ TupleBPS::JoinLocalData::JoinLocalData(TupleBPS* pTupleBPS, RowGroup& primRowGro
                                        rowgroup::RowGroup& fe2Output,
                                        std::vector<rowgroup::RowGroup>& joinerMatchesRGs,
                                        rowgroup::RowGroup& joinFERG,
-                                       std::vector<boost::shared_ptr<joiner::TupleJoiner>>& tjoiners,
+                                       std::vector<std::shared_ptr<joiner::TupleJoiner>>& tjoiners,
                                        uint32_t smallSideCount, bool doJoin)
  : tbps(pTupleBPS)
  , local_primRG(primRowGroup)
@@ -2915,14 +2915,14 @@ uint64_t TupleBPS::getFBO(uint64_t lbid)
   throw logic_error("TupleBPS: didn't find the FBO?");
 }
 
-void TupleBPS::useJoiner(boost::shared_ptr<joiner::TupleJoiner> tj)
+void TupleBPS::useJoiner(std::shared_ptr<joiner::TupleJoiner> tj)
 {
-  vector<boost::shared_ptr<joiner::TupleJoiner>> v;
+  vector<std::shared_ptr<joiner::TupleJoiner>> v;
   v.push_back(tj);
   useJoiners(v);
 }
 
-void TupleBPS::useJoiners(const vector<boost::shared_ptr<joiner::TupleJoiner>>& joiners)
+void TupleBPS::useJoiners(const vector<std::shared_ptr<joiner::TupleJoiner>>& joiners)
 {
   uint32_t i;
 

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -214,7 +214,7 @@ void TupleHashJoinStep::join()
 // the threads inserting into Joiner.
 void TupleHashJoinStep::trackMem(uint index)
 {
-  boost::shared_ptr<TupleJoiner> joiner = joiners[index];
+  auto joiner = joiners[index];
   ssize_t memBefore = 0, memAfter = 0;
   bool gotMem;
 
@@ -268,7 +268,7 @@ void TupleHashJoinStep::startSmallRunners(uint index)
   utils::setThreadName("HJSStartSmall");
   string extendedInfo;
   JoinType jt;
-  boost::shared_ptr<TupleJoiner> joiner;
+  std::shared_ptr<TupleJoiner> joiner;
 
   jt = joinTypes[index];
   extendedInfo += toString();
@@ -391,7 +391,7 @@ void TupleHashJoinStep::smallRunnerFcn(uint32_t index, uint threadID, uint64_t* 
   RowGroupDL* smallDL;
   uint32_t smallIt;
   RowGroup smallRG;
-  boost::shared_ptr<TupleJoiner> joiner = joiners[index];
+  auto joiner = joiners[index];
 
   smallDL = smallDLs[index];
   smallIt = smallIts[index];
@@ -1708,7 +1708,7 @@ void TupleHashJoinStep::joinOneRG(
     Row& joinFERow, Row& joinedRow, Row& baseRow, vector<vector<Row::Pointer> >& joinMatches,
     shared_array<Row>& smallRowTemplates, RowGroupDL* outputDL,
     // disk-join support vars.  This param list is insane; refactor attempt would be nice at some point.
-    vector<boost::shared_ptr<joiner::TupleJoiner> >* tjoiners,
+    vector<std::shared_ptr<joiner::TupleJoiner> >* tjoiners,
     boost::shared_array<boost::shared_array<int> >* rgMappings,
     boost::shared_array<boost::shared_array<int> >* feMappings,
     boost::scoped_array<boost::scoped_array<uint8_t> >* smallNullMem)

--- a/dbcon/joblist/tuplehashjoin.h
+++ b/dbcon/joblist/tuplehashjoin.h
@@ -442,13 +442,13 @@ class TupleHashJoinStep : public JobStep, public TupleDeliveryStep
 
   struct JoinerSorter
   {
-    inline bool operator()(const boost::shared_ptr<joiner::TupleJoiner>& j1,
-                           const boost::shared_ptr<joiner::TupleJoiner>& j2) const
+    inline bool operator()(const std::shared_ptr<joiner::TupleJoiner>& j1,
+                           const std::shared_ptr<joiner::TupleJoiner>& j2) const
     {
       return *j1 < *j2;
     }
   };
-  std::vector<boost::shared_ptr<joiner::TupleJoiner> > joiners;
+  std::vector<std::shared_ptr<joiner::TupleJoiner> > joiners;
   boost::scoped_array<std::vector<rowgroup::RGData> > rgData;
   TupleBPS* largeBPS;
   rowgroup::RowGroup largeRG, outputRG;
@@ -551,7 +551,7 @@ class TupleHashJoinStep : public JobStep, public TupleDeliveryStep
                  rowgroup::Row& joinedRow, rowgroup::Row& baseRow,
                  std::vector<std::vector<rowgroup::Row::Pointer> >& joinMatches,
                  boost::shared_array<rowgroup::Row>& smallRowTemplates, RowGroupDL* outputDL,
-                 std::vector<boost::shared_ptr<joiner::TupleJoiner> >* joiners = NULL,
+                 std::vector<std::shared_ptr<joiner::TupleJoiner> >* joiners = NULL,
                  boost::shared_array<boost::shared_array<int> >* rgMappings = NULL,
                  boost::shared_array<boost::shared_array<int> >* feMappings = NULL,
                  boost::scoped_array<boost::scoped_array<uint8_t> >* smallNullMem = NULL);
@@ -631,8 +631,8 @@ class TupleHashJoinStep : public JobStep, public TupleDeliveryStep
   bool ownsOutputDL;
 
   void segregateJoiners();
-  std::vector<boost::shared_ptr<joiner::TupleJoiner> > tbpsJoiners;
-  std::vector<boost::shared_ptr<joiner::TupleJoiner> > djsJoiners;
+  std::vector<std::shared_ptr<joiner::TupleJoiner> > tbpsJoiners;
+  std::vector<std::shared_ptr<joiner::TupleJoiner> > djsJoiners;
   std::vector<int> djsJoinerMap;
   boost::scoped_array<ssize_t> memUsedByEachJoin;
   boost::mutex djsLock;

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -1819,9 +1819,9 @@ void TupleJoiner::clearData()
   finished = false;
 }
 
-boost::shared_ptr<TupleJoiner> TupleJoiner::copyForDiskJoin()
+std::shared_ptr<TupleJoiner> TupleJoiner::copyForDiskJoin()
 {
-  boost::shared_ptr<TupleJoiner> ret(new TupleJoiner());
+  std::shared_ptr<TupleJoiner> ret(new TupleJoiner());
 
   ret->smallRG = smallRG;
   ret->largeRG = largeRG;

--- a/utils/joiner/tuplejoiner.h
+++ b/utils/joiner/tuplejoiner.h
@@ -460,7 +460,7 @@ class TupleJoiner
   }
   // Disk-based join support
   void clearData();
-  boost::shared_ptr<TupleJoiner> copyForDiskJoin();
+  std::shared_ptr<TupleJoiner> copyForDiskJoin();
   bool isFinished()
   {
     return finished;


### PR DESCRIPTION
This is attempt to make some part of the code more stable. For some reason we can get a spurious nullptr for boost::shared_ptr which cause an assert and abort.