### PR TITLE
MCOL-5264 This patch replaces boost mutex locks with std analogs

### DIFF
--- a/dbcon/joblist/distributedenginecomm.h
+++ b/dbcon/joblist/distributedenginecomm.h
@@ -32,16 +32,17 @@
 
 #pragma once
 
-#include <ifaddrs.h>
-#include <condition_variable>
-#include <iostream>
-#include <vector>
-#include <queue>
-#include <string>
-#include <map>
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/scoped_array.hpp>
+#include <condition_variable>
+#include <ifaddrs.h>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <queue>
+#include <vector>
 
 #include "bytestream.h"
 #include "primitivemsg.h"
@@ -224,7 +225,7 @@ class DistributedEngineComm
 
  private:
   typedef std::vector<boost::thread*> ReaderList;
-  typedef std::vector<boost::shared_ptr<messageqcpp::MessageQueueClient> > ClientList;
+  typedef std::vector<boost::shared_ptr<messageqcpp::MessageQueueClient>> ClientList;
 
   // A queue of ByteStreams coming in from PrimProc heading for a JobStep
   typedef ThreadSafeQueue<messageqcpp::SBS> StepMsgQueue;
@@ -258,7 +259,7 @@ class DistributedEngineComm
   };
 
   // The mapping of session ids to StepMsgQueueLists
-  typedef std::map<unsigned, boost::shared_ptr<MQE> > MessageQueueMap;
+  typedef std::map<unsigned, boost::shared_ptr<MQE>> MessageQueueMap;
 
   explicit DistributedEngineComm(ResourceManager* rm, bool isExeMgr);
 
@@ -283,8 +284,8 @@ class DistributedEngineComm
   ReaderList fPmReader;       // all the reader threads for the pm servers
   MessageQueueMap
       fSessionMessages;  // place to put messages from the pm server to be returned by the Read method
-  boost::mutex fMlock;   // sessionMessages mutex
-  std::vector<boost::shared_ptr<boost::mutex> > fWlock;  // PrimProc socket write mutexes
+  std::mutex fMlock;     // sessionMessages mutex
+  std::vector<std::shared_ptr<std::mutex>> fWlock;  // PrimProc socket write mutexes
   bool fBusy;
   volatile uint32_t pmCount;
   boost::mutex fOnErrMutex;  // to lock function scope to reset pmconnections under error condition
@@ -295,7 +296,7 @@ class DistributedEngineComm
   boost::mutex eventListenerLock;
 
   ClientList newClients;
-  std::vector<boost::shared_ptr<boost::mutex> > newLocks;
+  std::vector<std::shared_ptr<std::mutex>> newLocks;
 
   bool fIsExeMgr;
 


### PR DESCRIPTION
boost::uniqie_lock dtor calls a fancy unlock logic that throws twice. First if the mutex is 0 and second lock doesn't own the mutex. The first condition failure causes unhandled exception for one of the clients in DEC::writeToClient(). I was unable to find out why Linux can have a 0 mutex and replaced boost::mutex with std::mutex b/c stdlibc++ should be more stable comparing with boost.