### PR TITLE
MCOL-5302: Fix brm-save to prevent overwrites Extent Map files multiple times with shared(non-S3) storage setup.

### DIFF
--- a/oam/install_scripts/mcs-loadbrm.py.in
+++ b/oam/install_scripts/mcs-loadbrm.py.in
@@ -311,7 +311,7 @@ if __name__ == '__main__':
 
     if s3_enabled:
         # start SM using systemd
-        if use_systemd is True:
+        if use_systemd:
             cmd = 'systemctl start mcs-storagemanager'
             try:
                 subprocess.check_call(cmd, shell=True)
@@ -398,7 +398,6 @@ if __name__ == '__main__':
                                 'Cmapi is not running on primary node. '
                                 'Skip loading metafiles.'
                             )
-
             except Exception as exc:
                 logging.error(
                     'Failed to detect primary or load BRM data from',

--- a/oam/install_scripts/mcs-savebrm.py.in
+++ b/oam/install_scripts/mcs-savebrm.py.in
@@ -211,27 +211,7 @@ if __name__ == '__main__':
         'ObjectStorage', 'service', fallback='LocalStorage'
     )
 
-    is_primary = False
-
-    # For multi-node with local storage or default installations
-    multi_with_local_storage = (
-        storage.lower() != 's3' and master_addr != LOCALHOST
-    )
-    if multi_with_local_storage or master_addr == LOCALHOST:
-        # This might be not a primary in a multi-node cluster but we are safe
-        # to save BRM locally
-        is_primary = True
-        if multi_with_local_storage:
-            logging.info(
-                'Detected a multi-node installation with a local-storage.'
-            )
-        else:
-            logging.info('Detected a single-node installation.')
-    else:
-        has_requests = False
-        is_primary = is_node_primary(config_root)
-
-    if is_primary is True:
+    if is_node_primary(config_root):
         try:
             retcode = subprocess.check_call(SAVEBRM, shell=True)
         except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
- [fix] oam/install_scripts/mcs-savebrm.py.in , now everytime using method to detect primary node
- [fix] condition style in oam/install_scripts/mcs-loadbrm.py.in