### PR TITLE
MCOL-5306 Re-read the config (Columnstore.xml) file if it was updated.

### DIFF
--- a/utils/configcpp/configcpp.h
+++ b/utils/configcpp/configcpp.h
@@ -248,6 +248,11 @@ class Config
   time_t fMtime;
   mutable boost::recursive_mutex fLock;
   XMLParser fParser;
+
+  /** @brief Re-read the config file if it was updated
+   *
+   */
+  void checkAndReloadConfig();
 };
 
 }  // namespace config


### PR DESCRIPTION
The existing implementation of Config::makeConfig() factory method was returning a possibly stale config to the caller, without checking if the config file was updated since the last read. This bug triggered a scenario as described in MCOL-5306 where after a failover in an MCS cluster, the controllernode coordinates changed in the config file after failover and the existing mariadbd process was still using the old controllernode coordinates. This lead to failed network connection between mariadbd and the new controllernode.

The change in this fix, however, is more generic and not just limited to this above scenario.