### PR TITLE
MCOL-5311 Add timezone to jobList in subquerytransformer

### DIFF
--- a/dbcon/joblist/jlf_common.h
+++ b/dbcon/joblist/jlf_common.h
@@ -210,6 +210,7 @@ struct JobInfo
    , stringScanThreshold(1)
    , wfqLimitStart(0)
    , wfqLimitCount(-1)
+   , timeZone(0)
   {
   }
   ResourceManager* rm;

--- a/dbcon/joblist/subquerytransformer.cpp
+++ b/dbcon/joblist/subquerytransformer.cpp
@@ -109,6 +109,8 @@ SJSTEP& SubQueryTransformer::makeSubQueryStep(execplan::CalpontSelectExecutionPl
   fSubJobInfo->stringTableThreshold = fOutJobInfo->stringTableThreshold;
   fSubJobInfo->localQuery = fOutJobInfo->localQuery;
   fSubJobInfo->uuid = fOutJobInfo->uuid;
+  fSubJobInfo->timeZone = fOutJobInfo->timeZone;
+
   fOutJobInfo->jobListPtr->addSubqueryJobList(fSubJobList);
 
   fSubJobInfo->smallSideLimit = fOutJobInfo->smallSideLimit;


### PR DESCRIPTION
TimeZone was uninitialized in this scenario and led to undefined behavior.