### PR TITLE
Dlee mtr disable warnings

### DIFF
--- a/mysql-test/columnstore/basic/r/mcol641-delete.result
+++ b/mysql-test/columnstore/basic/r/mcol641-delete.result
@@ -2,17 +2,9 @@ DROP DATABASE IF EXISTS mcol641_delete_db;
 CREATE DATABASE mcol641_delete_db;
 USE mcol641_delete_db;
 DROP PROCEDURE IF EXISTS signedinsertproc;
-Warnings:
-Note	1305	PROCEDURE mcol641_delete_db.signedinsertproc does not exist
 DROP PROCEDURE IF EXISTS signeddeleteproc;
-Warnings:
-Note	1305	PROCEDURE mcol641_delete_db.signeddeleteproc does not exist
 DROP PROCEDURE IF EXISTS unsignedinsertproc;
-Warnings:
-Note	1305	PROCEDURE mcol641_delete_db.unsignedinsertproc does not exist
 DROP PROCEDURE IF EXISTS unsigneddeleteproc;
-Warnings:
-Note	1305	PROCEDURE mcol641_delete_db.unsigneddeleteproc does not exist
 CREATE PROCEDURE signedinsertproc ()
 BEGIN
 INSERT INTO cs1 VALUES (125, 125);
@@ -89,23 +81,11 @@ DELETE FROM cs5;
 DELETE FROM cs6;
 END//
 DROP TABLE IF EXISTS cs1;
-Warnings:
-Note	1051	Unknown table 'mcol641_delete_db.cs1'
 DROP TABLE IF EXISTS cs2;
-Warnings:
-Note	1051	Unknown table 'mcol641_delete_db.cs2'
 DROP TABLE IF EXISTS cs3;
-Warnings:
-Note	1051	Unknown table 'mcol641_delete_db.cs3'
 DROP TABLE IF EXISTS cs4;
-Warnings:
-Note	1051	Unknown table 'mcol641_delete_db.cs4'
 DROP TABLE IF EXISTS cs5;
-Warnings:
-Note	1051	Unknown table 'mcol641_delete_db.cs5'
 DROP TABLE IF EXISTS cs6;
-Warnings:
-Note	1051	Unknown table 'mcol641_delete_db.cs6'
 CREATE TABLE cs1 (d1 DECIMAL(38), d2 DECIMAL(19)) ENGINE=columnstore;
 CREATE TABLE cs2 (d1 DECIMAL(38,10), d2 DECIMAL(19,10)) ENGINE=columnstore;
 CREATE TABLE cs3 (d1 DECIMAL(38,38), d2 DECIMAL(19,19)) ENGINE=columnstore;

--- a/mysql-test/columnstore/basic/r/mcol641-update.result
+++ b/mysql-test/columnstore/basic/r/mcol641-update.result
@@ -2,17 +2,9 @@ DROP DATABASE IF EXISTS mcol641_update_db;
 CREATE DATABASE mcol641_update_db;
 USE mcol641_update_db;
 DROP PROCEDURE IF EXISTS signedinsertproc;
-Warnings:
-Note	1305	PROCEDURE mcol641_update_db.signedinsertproc does not exist
 DROP PROCEDURE IF EXISTS signeddeleteproc;
-Warnings:
-Note	1305	PROCEDURE mcol641_update_db.signeddeleteproc does not exist
 DROP PROCEDURE IF EXISTS unsignedinsertproc;
-Warnings:
-Note	1305	PROCEDURE mcol641_update_db.unsignedinsertproc does not exist
 DROP PROCEDURE IF EXISTS unsigneddeleteproc;
-Warnings:
-Note	1305	PROCEDURE mcol641_update_db.unsigneddeleteproc does not exist
 CREATE PROCEDURE signedinsertproc ()
 BEGIN
 INSERT INTO cs1 VALUES (125, 125);
@@ -89,23 +81,11 @@ DELETE FROM cs5;
 DELETE FROM cs6;
 END//
 DROP TABLE IF EXISTS cs1;
-Warnings:
-Note	1051	Unknown table 'mcol641_update_db.cs1'
 DROP TABLE IF EXISTS cs2;
-Warnings:
-Note	1051	Unknown table 'mcol641_update_db.cs2'
 DROP TABLE IF EXISTS cs3;
-Warnings:
-Note	1051	Unknown table 'mcol641_update_db.cs3'
 DROP TABLE IF EXISTS cs4;
-Warnings:
-Note	1051	Unknown table 'mcol641_update_db.cs4'
 DROP TABLE IF EXISTS cs5;
-Warnings:
-Note	1051	Unknown table 'mcol641_update_db.cs5'
 DROP TABLE IF EXISTS cs6;
-Warnings:
-Note	1051	Unknown table 'mcol641_update_db.cs6'
 CREATE TABLE cs1 (d1 DECIMAL(38), d2 DECIMAL(19)) ENGINE=columnstore;
 CREATE TABLE cs2 (d1 DECIMAL(38,10), d2 DECIMAL(19,10)) ENGINE=columnstore;
 CREATE TABLE cs3 (d1 DECIMAL(38,38), d2 DECIMAL(19,19)) ENGINE=columnstore;

--- a/mysql-test/columnstore/basic/r/unsigned_bug5712.result
+++ b/mysql-test/columnstore/basic/r/unsigned_bug5712.result
@@ -2,8 +2,6 @@ DROP DATABASE IF EXISTS unsigned_bug5712_db;
 CREATE DATABASE unsigned_bug5712_db;
 USE unsigned_bug5712_db;
 DROP TABLE IF EXISTS bug5712;
-Warnings:
-Note	1051	Unknown table 'unsigned_bug5712_db.bug5712'
 CREATE TABLE bug5712 (`time_tk` INT(11) UNSIGNED NOT NULL) ENGINE=Columnstore DEFAULT CHARSET=latin1;
 INSERT INTO bug5712 VALUES 
 (2013113023),

--- a/mysql-test/columnstore/basic/t/mcol641-delete.test
+++ b/mysql-test/columnstore/basic/t/mcol641-delete.test
@@ -335,3 +335,4 @@ DROP PROCEDURE IF EXISTS unsignedinsertproc;
 DROP PROCEDURE IF EXISTS unsigneddeleteproc;
 DROP DATABASE mcol641_delete_db;
 --enable_warnings
+

--- a/mysql-test/columnstore/basic/t/mcol641-delete.test
+++ b/mysql-test/columnstore/basic/t/mcol641-delete.test
@@ -7,10 +7,12 @@ DROP DATABASE IF EXISTS mcol641_delete_db;
 CREATE DATABASE mcol641_delete_db;
 USE mcol641_delete_db;
 
+--disable_warnings
 DROP PROCEDURE IF EXISTS signedinsertproc;
 DROP PROCEDURE IF EXISTS signeddeleteproc;
 DROP PROCEDURE IF EXISTS unsignedinsertproc;
 DROP PROCEDURE IF EXISTS unsigneddeleteproc;
+--enable_warnings
 
 DELIMITER //;
 
@@ -99,12 +101,14 @@ CREATE PROCEDURE unsigneddeleteproc ()
 
 DELIMITER ;//
 
+--disable_warnings
 DROP TABLE IF EXISTS cs1;
 DROP TABLE IF EXISTS cs2;
 DROP TABLE IF EXISTS cs3;
 DROP TABLE IF EXISTS cs4;
 DROP TABLE IF EXISTS cs5;
 DROP TABLE IF EXISTS cs6;
+--enable_warnings
 
 CREATE TABLE cs1 (d1 DECIMAL(38), d2 DECIMAL(19)) ENGINE=columnstore;
 CREATE TABLE cs2 (d1 DECIMAL(38,10), d2 DECIMAL(19,10)) ENGINE=columnstore;
@@ -324,8 +328,10 @@ SELECT "unsignedtest10", d1, d2 FROM cs6;
 # Deletes with functions and expressions in the WHERE clause
 
 # Clean UP
+--disable_warnings
 DROP PROCEDURE IF EXISTS signedinsertproc;
 DROP PROCEDURE IF EXISTS signeddeleteproc;
 DROP PROCEDURE IF EXISTS unsignedinsertproc;
 DROP PROCEDURE IF EXISTS unsigneddeleteproc;
 DROP DATABASE mcol641_delete_db;
+--enable_warnings

--- a/mysql-test/columnstore/basic/t/mcol641-update.test
+++ b/mysql-test/columnstore/basic/t/mcol641-update.test
@@ -7,10 +7,12 @@ DROP DATABASE IF EXISTS mcol641_update_db;
 CREATE DATABASE mcol641_update_db;
 USE mcol641_update_db;
 
+--disable_warnings
 DROP PROCEDURE IF EXISTS signedinsertproc;
 DROP PROCEDURE IF EXISTS signeddeleteproc;
 DROP PROCEDURE IF EXISTS unsignedinsertproc;
 DROP PROCEDURE IF EXISTS unsigneddeleteproc;
+--enable_warnings
 
 DELIMITER //;
 
@@ -99,12 +101,14 @@ CREATE PROCEDURE unsigneddeleteproc ()
 
 DELIMITER ;//
 
+--disable_warnings
 DROP TABLE IF EXISTS cs1;
 DROP TABLE IF EXISTS cs2;
 DROP TABLE IF EXISTS cs3;
 DROP TABLE IF EXISTS cs4;
 DROP TABLE IF EXISTS cs5;
 DROP TABLE IF EXISTS cs6;
+--enable_warnings
 
 CREATE TABLE cs1 (d1 DECIMAL(38), d2 DECIMAL(19)) ENGINE=columnstore;
 CREATE TABLE cs2 (d1 DECIMAL(38,10), d2 DECIMAL(19,10)) ENGINE=columnstore;
@@ -350,8 +354,11 @@ SELECT "unsignedtest10a", d1, d2 FROM cs6;
 # Updates with functions and expressions in the WHERE clause
 
 # Clean UP
+--disable_warnings
 DROP PROCEDURE IF EXISTS signedinsertproc;
 DROP PROCEDURE IF EXISTS signeddeleteproc;
 DROP PROCEDURE IF EXISTS unsignedinsertproc;
 DROP PROCEDURE IF EXISTS unsigneddeleteproc;
 DROP DATABASE mcol641_update_db;
+--enable_warnings
+#

--- a/mysql-test/columnstore/basic/t/mcs13_alter_table_negative.test
+++ b/mysql-test/columnstore/basic/t/mcs13_alter_table_negative.test
@@ -69,4 +69,8 @@ SELECT * FROM mcs13_db1.t1;
 disconnect addconroot1;
 disconnect addconroot2;
 
+--disable_warnings
 DROP DATABASE mcs13_db1;
+--enable_warnings
+#
+

--- a/mysql-test/columnstore/basic/t/mcs14_truncate_table.test
+++ b/mysql-test/columnstore/basic/t/mcs14_truncate_table.test
@@ -87,4 +87,7 @@ SELECT count(*) FROM t2;
 disconnect addconroot1;
 disconnect addconroot2;
 
+--disable_warnings
 DROP DATABASE mcs14_db1;
+--enable_warnings
+#

--- a/mysql-test/columnstore/basic/t/mcs31_update_table_negative.test
+++ b/mysql-test/columnstore/basic/t/mcs31_update_table_negative.test
@@ -40,4 +40,7 @@ SELECT * FROm t1 ORDER BY a;
 SELECT * FROm t2 ORDER BY a;
 
 # Clean up
+--disable_warnings
 DROP DATABASE IF EXISTS mcs31_db1;
+--enable_warnings
+#

--- a/mysql-test/columnstore/basic/t/mcs89_drop_table_restrict.test
+++ b/mysql-test/columnstore/basic/t/mcs89_drop_table_restrict.test
@@ -27,4 +27,8 @@ DROP TABLE t1;
 DROP TABLE t1 RESTRICT;
 
 # Clean up
+--disable_warnings
 DROP DATABASE IF EXISTS mcs89_db;
+--enable_warnings
+#
+

--- a/mysql-test/columnstore/basic/t/unsigned_bug5712.test
+++ b/mysql-test/columnstore/basic/t/unsigned_bug5712.test
@@ -7,7 +7,9 @@ DROP DATABASE IF EXISTS unsigned_bug5712_db;
 CREATE DATABASE unsigned_bug5712_db;
 USE unsigned_bug5712_db;
 
+--disable_warnings
 DROP TABLE IF EXISTS bug5712;
+--enable_warnings
 CREATE TABLE bug5712 (`time_tk` INT(11) UNSIGNED NOT NULL) ENGINE=Columnstore DEFAULT CHARSET=latin1;
 
 INSERT INTO bug5712 VALUES 
@@ -25,4 +27,6 @@ SELECT RIGHT(time_tk,6) AS time_tk_right FROM bug5712;
 DROP TABLE IF EXISTS bug5712;
 
 # Clean UP
+--disable_warnings
 DROP DATABASE unsigned_bug5712_db;
+--enable_warnings

--- a/mysql-test/columnstore/bugfixes/mcol-3721.result
+++ b/mysql-test/columnstore/bugfixes/mcol-3721.result
@@ -6,8 +6,6 @@ SELECT @cs_conn := @@character_set_connection;
 latin1
 SET character_set_connection=latin1;
 DROP TABLE IF EXISTS test_collate;
-Warnings:
-Note	1051	Unknown table 'mcol_3721.test_collate'
 CREATE TABLE test_collate (a INT, b INT) ENGINE=columnstore;
 INSERT INTO test_collate VALUES (1,2), (2,4);
 SELECT a, b FROM test_collate ORDER BY a COLLATE latin1_german2_ci;
@@ -43,9 +41,6 @@ DESCRIBE t1;
 Field	Type	Null	Key	Default	Extra
 col1	char(10)	YES		NULL	
 DROP TABLE IF EXISTS t1;
-DROP TABLE IF EXISTS t1;
-Warnings:
-Note	1051	Unknown table 'mcol_3721.t1'
 CREATE TABLE t1 (col1 CHAR(10) CHARACTER SET utf8 COLLATE utf8_unicode_ci) ENGINE=columnstore;
 INSERT INTO t1 VALUES ('a'), ('1'), ('-1');
 SELECT col1 FROM t1;

--- a/mysql-test/columnstore/bugfixes/mcol-3721.test
+++ b/mysql-test/columnstore/bugfixes/mcol-3721.test
@@ -14,14 +14,19 @@ SELECT @cs_conn := @@character_set_connection;
 SET character_set_connection=latin1;
 
 # Test COLLATE in ORDER BY
+--disable_warnings
 DROP TABLE IF EXISTS test_collate;
+--enable_warnings
 CREATE TABLE test_collate (a INT, b INT) ENGINE=columnstore;
 INSERT INTO test_collate VALUES (1,2), (2,4);
 SELECT a, b FROM test_collate ORDER BY a COLLATE latin1_german2_ci;
 SHOW WARNINGS;
 SELECT a, b FROM test_collate ORDER BY a COLLATE latin1_german2_ci DESC;
 SHOW WARNINGS;
+
+--disable_warnings
 DROP TABLE IF EXISTS test_collate;
+--enable_warnings
 
 # Test COLLATE in table definition and column definition
 DROP TABLE IF EXISTS t1;
@@ -29,14 +34,22 @@ CREATE TABLE t1 (col1 CHAR(10)) CHARSET latin1 COLLATE latin1_bin ENGINE=columns
 INSERT INTO t1 VALUES ('a'), ('1'), ('-1');
 SELECT col1 FROM t1;
 DESCRIBE t1;
-DROP TABLE IF EXISTS t1;
 
+--disable_warnings
 DROP TABLE IF EXISTS t1;
+--enable_warnings
+
 CREATE TABLE t1 (col1 CHAR(10) CHARACTER SET utf8 COLLATE utf8_unicode_ci) ENGINE=columnstore;
 INSERT INTO t1 VALUES ('a'), ('1'), ('-1');
 SELECT col1 FROM t1;
 DESCRIBE t1;
-DROP TABLE IF EXISTS t1;
 
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+--enable_warnings
+
+--disable_warnings
 DROP DATABASE `mcol_3721`;
+--enable_warnings
+
 SET character_set_connection=@cs_conn;

--- a/mysql-test/columnstore/devregression/r/mcs7012_regression_bug2788.result
+++ b/mysql-test/columnstore/devregression/r/mcs7012_regression_bug2788.result
@@ -1,6 +1,4 @@
 USE tpch1;
 drop table if exists foo;
-Warnings:
-Note	1051	Unknown table 'tpch1.foo'
 create table foo (col1 int(11) null default null) engine=columnstore;
 drop table foo;

--- a/mysql-test/columnstore/devregression/r/mcs7015_regression_bug2835.result
+++ b/mysql-test/columnstore/devregression/r/mcs7015_regression_bug2835.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug2835;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug2835'
 create table bug2835 (c1 int, c2 varchar(6), c3 varchar(20), c4 datetime)engine=columnstore;
 insert into bug2835 values (1, 'one', 'one', '2010-01-01'), (2, 'two', 'two', '2010-02-02'), (null, null, null, null);
 select c1, c2, c3, ifnull(c1,"z"), ifnull(c2,''), ifnull(c3,''), ifnull(c4,'') from bug2835;

--- a/mysql-test/columnstore/devregression/r/mcs7017_regression_bug2845.result
+++ b/mysql-test/columnstore/devregression/r/mcs7017_regression_bug2845.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug2845;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug2845'
 create table bug2845(c1 int, c2 varchar(7), c3 varchar(30))engine=columnstore;
 insert into bug2845 values (1, 'A\'s', 'Joe\'s');
 select * from bug2845;

--- a/mysql-test/columnstore/devregression/r/mcs7018_regression_bug2873.result
+++ b/mysql-test/columnstore/devregression/r/mcs7018_regression_bug2873.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug2873;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug2873'
 create table bug2873(id int, logtime int, filename varchar(20))engine=columnstore;
 insert into bug2873 values 
 (1, unix_timestamp('2010-05-23 10:00:10'), 'Cam1.jpg'),

--- a/mysql-test/columnstore/devregression/r/mcs7019_regression_bug2876.result
+++ b/mysql-test/columnstore/devregression/r/mcs7019_regression_bug2876.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug2876;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug2876'
 create table bug2876(c1 int, c2 varchar(117))engine=columnstore;
 insert into bug2876 values (1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3), (3, 1), (3, 2), (3, 3);
 insert into bug2876 values (1, null), (2, null), (3, null), (null, 1), (null, 2), (null, 3), (null, null);

--- a/mysql-test/columnstore/devregression/r/mcs7026_regression_bug2915.result
+++ b/mysql-test/columnstore/devregression/r/mcs7026_regression_bug2915.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists tbl1;
-Warnings:
-Note	1051	Unknown table 'tpch1.tbl1'
 drop table if exists tbl2;
-Warnings:
-Note	1051	Unknown table 'tpch1.tbl2'
 create table tbl1 (c1 char(1), c2 char(255))engine=columnstore;
 create table tbl2 (c1 char(1), c2 char(255))engine=columnstore;
 insert into tbl1 values (1, 1), (2, 2), (3, 3), (4, 4), (null, null);

--- a/mysql-test/columnstore/devregression/r/mcs7035_regression_bug2976.result
+++ b/mysql-test/columnstore/devregression/r/mcs7035_regression_bug2976.result
@@ -1,13 +1,6 @@
 USE tpch1;
-/*
-* Bug 2976.  Lost connection with from clause subselect against MyISAM tables in an InfiniDB instance.
-*/
 drop table if exists a;
-Warnings:
-Note	1051	Unknown table 'tpch1.a'
 drop table if exists b;
-Warnings:
-Note	1051	Unknown table 'tpch1.b'
 create table a (c1 int)engine=myisam;
 create table b (c2 int)engine=myisam;
 insert into a values (1), (2);
@@ -20,18 +13,9 @@ c1	c2
 2	2
 drop table a;
 drop table b;
-/*
-* Skinit example. 
-*/
 drop table if exists shipamounts;
-Warnings:
-Note	1051	Unknown table 'tpch1.shipamounts'
 drop table if exists ship1;
-Warnings:
-Note	1051	Unknown table 'tpch1.ship1'
 drop table if exists ship2;
-Warnings:
-Note	1051	Unknown table 'tpch1.ship2'
 CREATE TABLE `shipamounts` (
 `OrderNum` varchar(50) DEFAULT NULL,
 `OrderLine` int(11) DEFAULT NULL,
@@ -99,27 +83,12 @@ OrderNum	OrderLine	ShippingAmount	ShippingOrderAmount	ShippingTotalAmount	Shippi
 drop table if exists shipamounts;
 drop table if exists ship1;
 drop table if exists ship2;
-/*
-* Lurn India example.
-*/
 drop table if exists users;
-Warnings:
-Note	1051	Unknown table 'tpch1.users'
 drop table if exists user_login_log;
-Warnings:
-Note	1051	Unknown table 'tpch1.user_login_log'
 drop table if exists user_groups;
-Warnings:
-Note	1051	Unknown table 'tpch1.user_groups'
 drop table if exists user_types;
-Warnings:
-Note	1051	Unknown table 'tpch1.user_types'
 drop table if exists system;
-Warnings:
-Note	1051	Unknown table 'tpch1.system'
 drop table if exists user_system;
-Warnings:
-Note	1051	Unknown table 'tpch1.user_system'
 create table users(
 id int,
 users_id int, 

--- a/mysql-test/columnstore/devregression/r/mcs7039_regression_bug3007.result
+++ b/mysql-test/columnstore/devregression/r/mcs7039_regression_bug3007.result
@@ -1,8 +1,6 @@
 USE tpch1;
 create database if not exists bug3007;
 drop table if exists bug3007.bug;
-Warnings:
-Note	1051	Unknown table 'bug3007.bug'
 create table bug3007.bug(c1 int)engine=columnstore;
 insert into bug3007.bug values (1), (2);
 select * from bug3007.bug;

--- a/mysql-test/columnstore/devregression/r/mcs7040_regression_bug3012.result
+++ b/mysql-test/columnstore/devregression/r/mcs7040_regression_bug3012.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3012;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3012'
 create table bug3012 (anz int, mx varchar(20)) engine=columnstore;
 insert into bug3012 values (1,'hotmail.com'), (2,'hotmail.com'), (3,'foo.com'),
 (4,'www.1and1.net'), (5,'1and1.com');

--- a/mysql-test/columnstore/devregression/r/mcs7042_regression_bug3021.result
+++ b/mysql-test/columnstore/devregression/r/mcs7042_regression_bug3021.result
@@ -4,8 +4,6 @@ select @xxx;
 @xxx
 2010-02-01
 drop table if exists bug3021;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3021'
 create table bug3021(c1 date)engine=columnstore;
 insert into bug3021 values ('2001-01-01');
 update bug3021 set c1=@xxx;

--- a/mysql-test/columnstore/devregression/r/mcs7044_regression_bug3025.result
+++ b/mysql-test/columnstore/devregression/r/mcs7044_regression_bug3025.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3025;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3025'
 create table bug3025(value integer(5)) engine=Columnstore;
 insert into bug3025 values (1), (1001), (24), (2123), (null), (123), (888), (8421), (231), (-100), (null);
 select value, IF(value<=1000,'<=1000', '>1000') 

--- a/mysql-test/columnstore/devregression/r/mcs7045_regression_bug3051.result
+++ b/mysql-test/columnstore/devregression/r/mcs7045_regression_bug3051.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3051;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3051'
 CREATE TABLE `bug3051` (
 `c1` int(11) DEFAULT NULL,
 `c2` varchar(17) DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7050_regression_bug3137.result
+++ b/mysql-test/columnstore/devregression/r/mcs7050_regression_bug3137.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3137;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3137'
 CREATE TABLE `bug3137` (
 `id` INTEGER DEFAULT NULL,
 `value` INTEGER DEFAULT NULL

--- a/mysql-test/columnstore/devregression/r/mcs7055_regression_bug3203.result
+++ b/mysql-test/columnstore/devregression/r/mcs7055_regression_bug3203.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3203;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3203'
 create table bug3203 (c1 varchar(20))engine=columnstore;
 select * from bug3203 where c1 = 'x';
 c1

--- a/mysql-test/columnstore/devregression/r/mcs7056_regression_bug3229.result
+++ b/mysql-test/columnstore/devregression/r/mcs7056_regression_bug3229.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists testnulldate;
-Warnings:
-Note	1051	Unknown table 'tpch1.testnulldate'
 create table testnulldate (id int, time_stamp datetime) engine=columnstore;
 insert into testnulldate values (1, '2010-11-08 17:46:44');
 insert into testnulldate values (2, null);

--- a/mysql-test/columnstore/devregression/r/mcs7057_regression_bug3258.result
+++ b/mysql-test/columnstore/devregression/r/mcs7057_regression_bug3258.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists var_between;
-Warnings:
-Note	1051	Unknown table 'tpch1.var_between'
 create table var_between (c1 varchar(10), c2 char(7)) engine=columnstore;
 insert into var_between values ('099', '099');
 insert into var_between values ('9', '9');
@@ -20,7 +18,6 @@ q3	9	9
 q3	1	1
 select 'q4', var_between.* from var_between where substr(c2,1,1) not  between '0' and '9';
 q4	c1	c2
-drop table var_between;
 select 'q5', count(*) from orders where substr(o_comment, 1, 1) between 'a' and 'f';
 q5	count(*)
 q5	388241
@@ -36,3 +33,4 @@ q8	165747
 select 'q9', count(*) from orders where substr(o_totalprice, 2, 3)  not between '200' and '300';
 q9	count(*)
 q9	1334253
+drop table var_between;

--- a/mysql-test/columnstore/devregression/r/mcs7059_regression_bug3267.result
+++ b/mysql-test/columnstore/devregression/r/mcs7059_regression_bug3267.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3267;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3267'
 create table bug3267 (c1 decimal(12, 6), c2 float) engine=columnstore;
 insert into bug3267 values (5.240620, 5.24062e+06), (7.240620, 7.24062e+06), (9.940620, 9.94062e+06), (5.240620, 5.24062), (-4.44, -4.44), (-8.87, -8.87);
 select floor(c1), ceil(c1), c1 from bug3267;

--- a/mysql-test/columnstore/devregression/r/mcs7060_regression_bug3270.result
+++ b/mysql-test/columnstore/devregression/r/mcs7060_regression_bug3270.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3270;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3270'
 create table bug3270 (c1 decimal(12, 6), c2 float) engine=columnstore;
 insert into bug3270 
 values	(5.240620, 5.24062e+06), (7.240620, 7.24062e+06), (9.940620, 9.94062e+06), (5.240620, 5.24062), (5.240720, 5.240720), 

--- a/mysql-test/columnstore/devregression/r/mcs7061_regression_bug3272.result
+++ b/mysql-test/columnstore/devregression/r/mcs7061_regression_bug3272.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3272;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3272'
 create table bug3272 (c1 float, c2 char(12)) engine=columnstore;
 insert into bug3272 values (5.24062, '5.24062'), (7.24062, '7.24062'), (9.94062, '9.94062');
 insert into bug3272 values (-5.24062, '-5.24062'), (-7.24062, '-7.24062'), (-9.94062, '-9.94062');

--- a/mysql-test/columnstore/devregression/r/mcs7062_regression_bug3274.result
+++ b/mysql-test/columnstore/devregression/r/mcs7062_regression_bug3274.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3274;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3274'
 create table bug3274(d2 decimal(4,2), f float);
 insert into bug3274 values (43.34, 43.345), (13.54, 13.545);
 select d2, count(*) from bug3274 group by 1 order by 1;

--- a/mysql-test/columnstore/devregression/r/mcs7065_regression_bug3292.result
+++ b/mysql-test/columnstore/devregression/r/mcs7065_regression_bug3292.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3292;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3292'
 create table bug3292 (c1 double, c2 float, c3 char(12)) engine=columnstore;
 insert into bug3292 values 
 (5.24062, 5.24062, '5.24062'),

--- a/mysql-test/columnstore/devregression/r/mcs7066_regression_bug3295.result
+++ b/mysql-test/columnstore/devregression/r/mcs7066_regression_bug3295.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists visit;
-Warnings:
-Note	1051	Unknown table 'tpch1.visit'
 drop table if exists client;
-Warnings:
-Note	1051	Unknown table 'tpch1.client'
 create table visit (id_client integer,nb_event integer,update_date datetime, visit_date datetime) engine=columnstore;
 create table client (id_client integer,id_event integer,event_date datetime) engine=columnstore;
 insert into visit values (1,0,NULL,"2010-09-08");

--- a/mysql-test/columnstore/devregression/r/mcs7067_regression_bug3312.result
+++ b/mysql-test/columnstore/devregression/r/mcs7067_regression_bug3312.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists user_prop_by_game;
-Warnings:
-Note	1051	Unknown table 'tpch1.user_prop_by_game'
 drop table if exists visit;
-Warnings:
-Note	1051	Unknown table 'tpch1.visit'
 create table user_prop_by_game(cl_id int, last_visit_date date)engine=columnstore;
 create table visit(cl_id int, visit_date date)engine=columnstore;
 insert into user_prop_by_game values (1, now()), (2, now());

--- a/mysql-test/columnstore/devregression/r/mcs7068_regression_bug3314.result
+++ b/mysql-test/columnstore/devregression/r/mcs7068_regression_bug3314.result
@@ -1,13 +1,7 @@
 USE tpch1;
 drop table if exists paa;
-Warnings:
-Note	1051	Unknown table 'tpch1.paa'
 drop table if exists dates;
-Warnings:
-Note	1051	Unknown table 'tpch1.dates'
 drop table if exists t;
-Warnings:
-Note	1051	Unknown table 'tpch1.t'
 create table paa (
 p_id int,
 a_id int,

--- a/mysql-test/columnstore/devregression/r/mcs7070_regression_bug3333.result
+++ b/mysql-test/columnstore/devregression/r/mcs7070_regression_bug3333.result
@@ -1,7 +1,5 @@
 USE ssb1;
 drop table if exists datetest;
-Warnings:
-Note	1051	Unknown table 'ssb1.datetest'
 create table if not exists datetest (rowid int, c1 varchar(20), c2 bigint) engine=columnstore;
 insert into datetest values (1, "1990-10-20", 19901121), (2, "1997-01-01 10:00:05", 19970201000000), (3, "0705", 0805), (4, "20120230", 20120230),(5, "20110229", 20110229),(6, "9905", 9905),(7, "20011010888888", 20031010888888),(8, "20011011124455", 20011010122233);
 select 'q1', rowid, c1, c2, cast(c1 as date), cast(c2 as date) from datetest where c2 <> 0805 order by rowid;
@@ -171,7 +169,6 @@ q17	5	20110229	20110229	838:59:59.999999	00:00:00
 q17	6	9905	9905	NULL	NULL
 q17	7	20011010888888	20031010888888	NULL	NULL
 q17	8	20011011124455	20011010122233	12:44:55.000000	12:22:33
-drop table if exists datetest;
 select 'q18', year(lo_orderdate), month(lo_orderdate), count(*) from ssb1.lineorder group by 1, 2, 3 order by 1, 2, 3;
 q18	year(lo_orderdate)	month(lo_orderdate)	count(*)
 q18	1992	1	77440
@@ -254,3 +251,4 @@ q18	1998	5	77725
 q18	1998	6	74584
 q18	1998	7	77744
 q18	1998	8	4783
+drop table if exists datetest;

--- a/mysql-test/columnstore/devregression/r/mcs7076_regression_bug3398.result
+++ b/mysql-test/columnstore/devregression/r/mcs7076_regression_bug3398.result
@@ -1,10 +1,6 @@
 USE tpch1;
 DROP TABLE IF EXISTS bug3398_1;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3398_1'
 DROP TABLE IF EXISTS bug3398_2;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3398_2'
 CREATE TABLE bug3398_1 (lid int, name char(10)) engine=columnstore;
 INSERT INTO bug3398_1 (lid, name) VALUES (1, 'YES'), (2, 'NO');
 CREATE TABLE bug3398_2 (  id int, gid int, lid int, dt date) engine=columnstore;

--- a/mysql-test/columnstore/devregression/r/mcs7077_regression_bug3414.result
+++ b/mysql-test/columnstore/devregression/r/mcs7077_regression_bug3414.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists qa_cast;
-Warnings:
-Note	1051	Unknown table 'tpch1.qa_cast'
 create table qa_cast ( s1 varchar(20), qaint1 int, qadouble double) engine=columnstore;
 insert into qa_cast values ('123456789',123456789, 1234);
 insert into qa_cast values ('123.45',123456789, 123.45);

--- a/mysql-test/columnstore/devregression/r/mcs7078_regression_bug3436.result
+++ b/mysql-test/columnstore/devregression/r/mcs7078_regression_bug3436.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists bug3436a;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3436a'
 drop table if exists bug3436b;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3436b'
 create table bug3436a (i int, j int, c1 tinyint, c2 decimal(2,1), c3 decimal(4,0), c4 decimal(4,2), c5 float, c6 double) engine=columnstore;
 insert into bug3436a values (1, 1, 1, 1.1, 9991, 99.1, 1.1, 1.1), (1, 1, 2, 2.2, 9992, 99.2, 2.2, 2.2), (2, 2, 1, 1.1, 9993, 99.3, 1.1, 1.1), (2, 2, 2, 2.2, 9994, 99.4, 2.2, 2.2), (1, 1, 127, 9.1, 9995, 99.5, 127.1, 127.1), (1, 2, 100, 9.2, 9996, 99.6, 100.2, 100.2);
 create table bug3436b (k int) engine=columnstore;

--- a/mysql-test/columnstore/devregression/r/mcs7079_regression_bug3442.result
+++ b/mysql-test/columnstore/devregression/r/mcs7079_regression_bug3442.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists optest;
-Warnings:
-Note	1051	Unknown table 'tpch1.optest'
 create table optest (id int, c1 date, c2 decimal(4,2), c3 date) engine=columnstore;
 insert into optest values (0, '2011-01-27', null, '1999-08-25'), (1, null, null, null), (2, '2001-01-05', 2.34, null), (3, null, null, '2001-05-03');
 select * from optest where (year(c1) = 2011 or c2 = 2.34) or month(c3) = 1;
@@ -70,8 +68,6 @@ id	c1	c2	c3
 0	2011-01-27	NULL	1999-08-25
 3	NULL	NULL	2001-05-03
 drop table if exists bug3442b;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3442b'
 create table bug3442b (
 idx int,
 i1 int,

--- a/mysql-test/columnstore/devregression/r/mcs7087_regression_bug3488.result
+++ b/mysql-test/columnstore/devregression/r/mcs7087_regression_bug3488.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3488;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3488'
 create table bug3488 (c1 bigint, c2 decimal(18,2), c3 float, c4 double, c5 char(120), c6 varchar(120)) engine=columnstore;
 insert into bug3488 values
 (1, 1.1, 1.1, 1.1, '1.1', '1.1'),

--- a/mysql-test/columnstore/devregression/r/mcs7089_regression_bug3496.result
+++ b/mysql-test/columnstore/devregression/r/mcs7089_regression_bug3496.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3496;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3496'
 create table `bug3496` (`c1` int(11) default null,`c2` char(6) default null, `c3` char(11) default null) engine=columnstore;
 insert into bug3496 values
 (1, 'abc', 'abc'),

--- a/mysql-test/columnstore/devregression/r/mcs7090_regression_bug3497.result
+++ b/mysql-test/columnstore/devregression/r/mcs7090_regression_bug3497.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists bug3497a;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3497a'
 drop table if exists bug3497b;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3497b'
 CREATE TABLE bug3497a (col1 int, col2 varchar(10)) engine=columnstore;
 INSERT INTO bug3497a VALUES(1,'trudy');
 INSERT INTO bug3497a VALUES(2,'peter');

--- a/mysql-test/columnstore/devregression/r/mcs7097_regression_bug3524.result
+++ b/mysql-test/columnstore/devregression/r/mcs7097_regression_bug3524.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists a1;
-Warnings:
-Note	1051	Unknown table 'tpch1.a1'
 drop table if exists a2;
-Warnings:
-Note	1051	Unknown table 'tpch1.a2'
 create table a1 (c1 int, c2 int)engine=columnstore;
 create table a2 (c1 int, c2 int)engine=columnstore;
 insert into a1 values (1, 1),(2,2),(3,null),(null,3),(null,null);

--- a/mysql-test/columnstore/devregression/r/mcs7098_regression_bug3532.result
+++ b/mysql-test/columnstore/devregression/r/mcs7098_regression_bug3532.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3532;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3532'
 create table `bug3532` (`c1` char(1) default null, `c2` int(11) default null) engine=columnstore;
 insert into bug3532 values (1,1), (0,0), (1,12), (1,-1), (null, null);
 select round(c1,c1) from bug3532 where c1 = 1;

--- a/mysql-test/columnstore/devregression/r/mcs7100_regression_bug3563.result
+++ b/mysql-test/columnstore/devregression/r/mcs7100_regression_bug3563.result
@@ -1,13 +1,7 @@
 USE tpch1;
 drop table if exists qatabledecimal2byte;
-Warnings:
-Note	1051	Unknown table 'tpch1.qatabledecimal2byte'
 drop table if exists qatabledecimal4byte;
-Warnings:
-Note	1051	Unknown table 'tpch1.qatabledecimal4byte'
 drop table if exists qatabletinyint;
-Warnings:
-Note	1051	Unknown table 'tpch1.qatabletinyint'
 create table qatabledecimal2byte (col1 decimal(1), col2 decimal(4), col3 decimal(4,2)) engine=columnstore;
 create table qatabledecimal4byte (col1 decimal(5), col2 decimal(9), col3 decimal(9,2)) engine=columnstore;
 create table qatabletinyint (col numeric(2,0)) engine=columnstore;

--- a/mysql-test/columnstore/devregression/r/mcs7101_regression_bug3565.result
+++ b/mysql-test/columnstore/devregression/r/mcs7101_regression_bug3565.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3565;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3565'
 create table bug3565(c1 tinyint)engine=columnstore;
 insert into bug3565 (select 0 from orders limit 270000);
 alter table bug3565 add column c2 bigint;

--- a/mysql-test/columnstore/devregression/r/mcs7103_regression_bug3582.result
+++ b/mysql-test/columnstore/devregression/r/mcs7103_regression_bug3582.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3582;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3582'
 create table bug3582 (c1 decimal(4,2), c2 char(4), c3 varchar(15)) engine=columnstore;
 insert into bug3582 values (4.00,'a','b');
 select * from bug3582;

--- a/mysql-test/columnstore/devregression/r/mcs7106_regression_bug3669.result
+++ b/mysql-test/columnstore/devregression/r/mcs7106_regression_bug3669.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists stringtest;
-Warnings:
-Note	1051	Unknown table 'tpch1.stringtest'
 create table stringtest (c1 char(10), c2 varchar(10), c3 varchar(6))engine=columnstore;
 insert into stringtest values ('abc','cde','abc'), ('cde','abc','cde');
 select * from stringtest where c1='abc' or c2='abc';

--- a/mysql-test/columnstore/devregression/r/mcs7107_regression_bug3670_negative.result
+++ b/mysql-test/columnstore/devregression/r/mcs7107_regression_bug3670_negative.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists month;
-Warnings:
-Note	1051	Unknown table 'tpch1.month'
 create table month(id int, month varchar(20), season varchar(6))engine=columnstore;
 insert into month values (1, 'Jan', 'Winter');
 SELECT  *,

--- a/mysql-test/columnstore/devregression/r/mcs7109_regression_bug3680.result
+++ b/mysql-test/columnstore/devregression/r/mcs7109_regression_bug3680.result
@@ -1,19 +1,9 @@
 USE tpch1;
 drop table if exists pts_agg_url_report;
-Warnings:
-Note	1051	Unknown table 'tpch1.pts_agg_url_report'
 drop table if exists pts_dim_publisher;
-Warnings:
-Note	1051	Unknown table 'tpch1.pts_dim_publisher'
 drop table if exists pts_dim_subsite;
-Warnings:
-Note	1051	Unknown table 'tpch1.pts_dim_subsite'
 drop table if exists pts_meta_ad;
-Warnings:
-Note	1051	Unknown table 'tpch1.pts_meta_ad'
 drop table if exists pts_meta_campaign;
-Warnings:
-Note	1051	Unknown table 'tpch1.pts_meta_campaign'
 CREATE TABLE `pts_agg_url_report` (
 `agg_date` date DEFAULT NULL,
 `client_id` varchar(32) DEFAULT NULL,
@@ -56,7 +46,7 @@ CREATE TABLE `pts_meta_ad` (
 `dimension` varchar(7) DEFAULT NULL,
 `dimensionName` varchar(250) DEFAULT NULL
 ) engine=columnstore;
-cREATE TABLE `pts_meta_campaign` (
+CREATE TABLE `pts_meta_campaign` (
 `clientId` varchar(32) DEFAULT NULL,
 `externalClientId` int(11) DEFAULT NULL,
 `id` varchar(32) DEFAULT NULL,
@@ -91,14 +81,8 @@ drop table pts_dim_subsite;
 drop table pts_meta_ad;
 drop table pts_meta_campaign;
 drop table if exists marketing_conversions;
-Warnings:
-Note	1051	Unknown table 'tpch1.marketing_conversions'
 drop table if exists marketing_events;
-Warnings:
-Note	1051	Unknown table 'tpch1.marketing_events'
 drop table if exists marketing_leads;
-Warnings:
-Note	1051	Unknown table 'tpch1.marketing_leads'
 CREATE TABLE `marketing_conversions` (
 `pkMarketingConversionID` int(10) DEFAULT NULL,
 `CreatedOn` datetime DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7111_regression_bug3706.result
+++ b/mysql-test/columnstore/devregression/r/mcs7111_regression_bug3706.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists t1;
-Warnings:
-Note	1051	Unknown table 'tpch1.t1'
 create table t1(f1 varchar(5)) engine=columnstore;
 insert into t1(f1) select if(max(f1) is null, '2000',max(f1)+1) from t1;
 select * from t1 order by 1;

--- a/mysql-test/columnstore/devregression/r/mcs7112_regression_bug3708.result
+++ b/mysql-test/columnstore/devregression/r/mcs7112_regression_bug3708.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists looooooooooooooooooooooooooooooooooooooooong_tb_name;
-Warnings:
-Note	1051	Unknown table 'tpch1.looooooooooooooooooooooooooooooooooooooooong_tb_name'
 create table looooooooooooooooooooooooooooooooooooooooong_tb_name (looooooooooooooooooooooooooooooooooooooooong_col_name int)engine=columnstore;
 insert into looooooooooooooooooooooooooooooooooooooooong_tb_name values (10);
 select looooooooooooooooooooooooooooooooooooooooong_col_name from looooooooooooooooooooooooooooooooooooooooong_tb_name 

--- a/mysql-test/columnstore/devregression/r/mcs7113_regression_bug3719.result
+++ b/mysql-test/columnstore/devregression/r/mcs7113_regression_bug3719.result
@@ -2,11 +2,7 @@ USE tpch1;
 create database if not exists geo;
 use geo;
 drop table if exists `geo_tag_values`;
-Warnings:
-Note	1051	Unknown table 'geo.geo_tag_values'
 drop table if exists `geo_tags`;
-Warnings:
-Note	1051	Unknown table 'geo.geo_tags'
 CREATE TABLE `geo_tag_values` (
 `id` int(11) DEFAULT NULL,
 `value` varchar(255) DEFAULT NULL,
@@ -23,29 +19,13 @@ CREATE TABLE `geo_tags` (
 create database if not exists pbkt;
 use pbkt;
 drop table if exists `areas`;
-Warnings:
-Note	1051	Unknown table 'pbkt.areas'
 drop table if exists `bigsumplus`;
-Warnings:
-Note	1051	Unknown table 'pbkt.bigsumplus'
 drop table if exists `dim_date`;
-Warnings:
-Note	1051	Unknown table 'pbkt.dim_date'
 drop table if exists `sizes`;
-Warnings:
-Note	1051	Unknown table 'pbkt.sizes'
 drop table if exists `tag_values`;
-Warnings:
-Note	1051	Unknown table 'pbkt.tag_values'
 drop view if exists `tag_values_geo_country`;
-Warnings:
-Note	4092	Unknown VIEW: 'pbkt.tag_values_geo_country'
 drop view if exists `tag_values_geo_region`;
-Warnings:
-Note	4092	Unknown VIEW: 'pbkt.tag_values_geo_region'
 drop view if exists `tag_values_ptype`;
-Warnings:
-Note	4092	Unknown VIEW: 'pbkt.tag_values_ptype'
 CREATE TABLE `areas` (
 `id` int(11) DEFAULT NULL,
 `name` varchar(255) DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7121_regression_bug3783.result
+++ b/mysql-test/columnstore/devregression/r/mcs7121_regression_bug3783.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3783;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3783'
 set max_length_for_sort_data = 8192;
 create table bug3783 (id int, name varchar(1000))engine=columnstore;
 insert into bug3783 values (1,'yionfsdayfeiwajg'),(2,'gretsuyhejkstj jkete');

--- a/mysql-test/columnstore/devregression/r/mcs7123_regression_bug3792_negative.result
+++ b/mysql-test/columnstore/devregression/r/mcs7123_regression_bug3792_negative.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3792;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3792'
 create table bug3792 (c1 int, c2 datetime) engine=columnstore;
 insert into bug3792 values (1, '9999-12-31 23:59:59');
 insert into bug3792 values (2, '1000-01-01 00:00:00');

--- a/mysql-test/columnstore/devregression/r/mcs7124_regression_bug3798.result
+++ b/mysql-test/columnstore/devregression/r/mcs7124_regression_bug3798.result
@@ -13,8 +13,6 @@ cidx	CDOUBLE	CAST(CDOUBLE AS DECIMAL(9))
 10	1.797693231e108	999999999
 11	0	0
 drop table if exists bug3798;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3798'
 create table bug3798 (c1 float) engine=columnstore;
 insert into bug3798 values (1234567), (1.2345678);
 select c1, cast(c1 as decimal(9,2)), cast(c1 as decimal(14,12)) from bug3798;

--- a/mysql-test/columnstore/devregression/r/mcs7126_regression_bug3853.result
+++ b/mysql-test/columnstore/devregression/r/mcs7126_regression_bug3853.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists dw_entradas_fact;
-Warnings:
-Note	1051	Unknown table 'tpch1.dw_entradas_fact'
 drop table if exists dw_entradas_fact_1;
-Warnings:
-Note	1051	Unknown table 'tpch1.dw_entradas_fact_1'
 create table dw_entradas_fact (fecha date) engine=columnstore;
 create table dw_entradas_fact_1 (fecha date) engine=columnstore;
 insert into dw_entradas_fact values ('2010-01-01'), ('2010-02-02'), ('2010-02-27'), ('2010-03-01');
@@ -92,8 +88,6 @@ FROM DW_ENTRADAS_FACT_1
 WHERE FECHA BETWEEN '2010-02-01' and '2010-02-28')) AS TY;
 NORMAL	OFERTA
 1	1
-drop table if exists dw_entradas_fact;
-drop table if exists dw_entradas_fact_1;
 select * from region where 2=2 union select n_regionkey, n_nationkey, n_name from nation where 0=1;
 r_regionkey	r_name	r_comment
 0	AFRICA	lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
@@ -101,3 +95,5 @@ r_regionkey	r_name	r_comment
 2	ASIA	ges. thinly even pinto beans ca
 3	EUROPE	ly final courts cajole furiously final excuse
 4	MIDDLE EAST	uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
+drop table if exists dw_entradas_fact;
+drop table if exists dw_entradas_fact_1;

--- a/mysql-test/columnstore/devregression/r/mcs7129_regression_bug3932.result
+++ b/mysql-test/columnstore/devregression/r/mcs7129_regression_bug3932.result
@@ -1,16 +1,8 @@
 USE tpch1;
 drop table if exists qa_nation;
-Warnings:
-Note	1051	Unknown table 'tpch1.qa_nation'
 drop table if exists qa_customer;
-Warnings:
-Note	1051	Unknown table 'tpch1.qa_customer'
 drop table if exists qa_region;
-Warnings:
-Note	1051	Unknown table 'tpch1.qa_region'
 drop table if exists qa_orders;
-Warnings:
-Note	1051	Unknown table 'tpch1.qa_orders'
 create table qa_nation (n_id int, n_name char(20), regionid int) engine=columnstore;
 create table qa_customer (c_id int, c_custname char(20), nationid int) engine=columnstore;
 create table qa_region (r_id int, r_name char(20)) engine=columnstore;

--- a/mysql-test/columnstore/devregression/r/mcs7131_regression_bug3948.result
+++ b/mysql-test/columnstore/devregression/r/mcs7131_regression_bug3948.result
@@ -1,16 +1,8 @@
 USE tpch1;
 drop table if exists fct_summary_transactional_snapshot;
-Warnings:
-Note	1051	Unknown table 'tpch1.fct_summary_transactional_snapshot'
 drop table if exists dim_c_bridge_duration;
-Warnings:
-Note	1051	Unknown table 'tpch1.dim_c_bridge_duration'
 drop table if exists fct_macro_payment_details;
-Warnings:
-Note	1051	Unknown table 'tpch1.fct_macro_payment_details'
 drop table if exists dim_c_calendar;
-Warnings:
-Note	1051	Unknown table 'tpch1.dim_c_calendar'
 CREATE TABLE `fct_macro_payment_details` (
 `TRANSACTION_DW_ID` bigint(20) DEFAULT NULL,
 `TRANSACTION_ID` varchar(255) DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7132_regression_bug3952.result
+++ b/mysql-test/columnstore/devregression/r/mcs7132_regression_bug3952.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug3952;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3952'
 create table bug3952 (id int, name varchar(25));
 insert into bug3952 values (1,'aaa'),(2,'bbb');
 select * from bug3952 n1, (select * from bug3952)n2 where n1.id=n2.id;

--- a/mysql-test/columnstore/devregression/r/mcs7135_regression_bug3998.result
+++ b/mysql-test/columnstore/devregression/r/mcs7135_regression_bug3998.result
@@ -1,16 +1,8 @@
 USE tpch1;
 drop table if exists bug3998a;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3998a'
 drop table if exists bug3998b;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3998b'
 drop table if exists bug3998c;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3998c'
 drop table if exists bug3998d;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug3998d'
 create table bug3998a (c1 int, c2 int) engine=columnstore;
 insert into bug3998a values (0,0), (1,1), (2,1), (3, 1), (null,1), (null, null);
 select * from bug3998a;

--- a/mysql-test/columnstore/devregression/r/mcs7136_regression_bug4027.result
+++ b/mysql-test/columnstore/devregression/r/mcs7136_regression_bug4027.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists product;
-Warnings:
-Note	1051	Unknown table 'tpch1.product'
 drop table if exists product_tag;
-Warnings:
-Note	1051	Unknown table 'tpch1.product_tag'
 create table product_tag (product_id bigint)engine=columnstore;
 CREATE TABLE `product` (
 `product_id` bigint(20) DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7143_regression_bug4346.result
+++ b/mysql-test/columnstore/devregression/r/mcs7143_regression_bug4346.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists dim_day;
-Warnings:
-Note	1051	Unknown table 'tpch1.dim_day'
 CREATE TABLE `dim_day` (
 `dayId` SMALLINT(5) DEFAULT NULL,
 `displayDate` DATE DEFAULT NULL

--- a/mysql-test/columnstore/devregression/r/mcs7144_regression_bug4359.result
+++ b/mysql-test/columnstore/devregression/r/mcs7144_regression_bug4359.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug4359;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug4359'
 CREATE TABLE bug4359 (
 sdate datetime DEFAULT NULL,
 edate datetime DEFAULT NULL

--- a/mysql-test/columnstore/devregression/r/mcs7146_regression_bug4386.result
+++ b/mysql-test/columnstore/devregression/r/mcs7146_regression_bug4386.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists dim_date;
-Warnings:
-Note	1051	Unknown table 'tpch1.dim_date'
 create table dim_date ( companycode integer, FinancialQuarterID integer,
 FinancialQuarter integer, FinancialYear integer ) engine=columnstore;
 insert into dim_date values (1,1,2,1);

--- a/mysql-test/columnstore/devregression/r/mcs7149_regression_bug4394.result
+++ b/mysql-test/columnstore/devregression/r/mcs7149_regression_bug4394.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug4394;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug4394'
 create table bug4394(c1 datetime) engine=columnstore;
 insert into bug4394 values('1000-01-01 00:00:00');
 select * from bug4394;

--- a/mysql-test/columnstore/devregression/r/mcs7150_regression_bug4422.result
+++ b/mysql-test/columnstore/devregression/r/mcs7150_regression_bug4422.result
@@ -1,19 +1,9 @@
 USE tpch1;
 drop table if exists bigsumplus;
-Warnings:
-Note	1051	Unknown table 'tpch1.bigsumplus'
 drop table if exists areas;
-Warnings:
-Note	1051	Unknown table 'tpch1.areas'
 drop table if exists geo_tag_values;
-Warnings:
-Note	1051	Unknown table 'tpch1.geo_tag_values'
 drop table if exists geo_tags;
-Warnings:
-Note	1051	Unknown table 'tpch1.geo_tags'
 drop view if exists tag_values_geo_country;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.tag_values_geo_country'
 create table if not exists
 `bigsumplus` (
 `served` bigint(20) DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7151_regression_bug4431.result
+++ b/mysql-test/columnstore/devregression/r/mcs7151_regression_bug4431.result
@@ -1,13 +1,7 @@
 USE tpch1;
 drop table if exists bug4431_1;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug4431_1'
 drop table if exists bug4431_2;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug4431_2'
 drop table if exists bug4431_3;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug4431_3'
 create table bug4431_1 (date int, col2 date) engine=columnstore;
 create table bug4431_2 (`date` int, col2 date) engine=columnstore;
 create table bug4431_3 (col2 date) engine=columnstore;

--- a/mysql-test/columnstore/devregression/r/mcs7158_regression_bug4767.result
+++ b/mysql-test/columnstore/devregression/r/mcs7158_regression_bug4767.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists cat;
-Warnings:
-Note	1051	Unknown table 'tpch1.cat'
 drop table if exists dog;
-Warnings:
-Note	1051	Unknown table 'tpch1.dog'
 create table cat(id int, f float, d double)engine=columnstore;
 create table dog(id int, f float, d double)engine=columnstore;
 insert into cat values

--- a/mysql-test/columnstore/devregression/r/mcs7166_regression_bug5099.result
+++ b/mysql-test/columnstore/devregression/r/mcs7166_regression_bug5099.result
@@ -1,7 +1,5 @@
 USE tpch1;
 DROP TABLE if exists bug5099;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug5099'
 CREATE TABLE `bug5099` (`col1` datetime DEFAULT NULL, `col2` datetime DEFAULT NULL ) ENGINE=Columnstore;
 insert into bug5099 (col1, col2) values ('2012-09-24 11:00:01', '2012-09-24 11:00:00');
 insert into bug5099 (col1, col2) values ('2012-09-24 11:01:00', '2012-09-24 11:02:00');

--- a/mysql-test/columnstore/devregression/r/mcs7168_regression_bug5173.result
+++ b/mysql-test/columnstore/devregression/r/mcs7168_regression_bug5173.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists qadefaulttest;
-Warnings:
-Note	1051	Unknown table 'tpch1.qadefaulttest'
 create table qadefaulttest (cidx int) engine=columnstore;
 ALTER TABLE qadefaulttest ADD column MYDOUBLE2 DOUBLE not null DEFAULT -88.88;
 insert into qadefaulttest values (1, -88.88);

--- a/mysql-test/columnstore/devregression/r/mcs7171_regression_bug5229.result
+++ b/mysql-test/columnstore/devregression/r/mcs7171_regression_bug5229.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists uriage_inf;
-Warnings:
-Note	1051	Unknown table 'tpch1.uriage_inf'
 create table uriage_inf(eigyo_shimei varchar(20),uriage numeric) engine=columnstore default charset=utf8;
 insert into uriage_inf values('SMITH',1000);
 insert into uriage_inf values('ALLEN',2000);
@@ -9,8 +7,6 @@ insert into uriage_inf values('JONES',3000);
 insert into uriage_inf values('SMITH',4000);
 insert into uriage_inf values('BLAKE',5000);
 drop table if exists uriage_my;
-Warnings:
-Note	1051	Unknown table 'tpch1.uriage_my'
 create table uriage_my (eigyo_shimei varchar(20),uriage numeric) engine=myisam default charset=utf8;
 insert into uriage_my values('SMITH',1000);
 insert into uriage_my values('ALLEN',2000);

--- a/mysql-test/columnstore/devregression/r/mcs7172_regression_bug5230.result
+++ b/mysql-test/columnstore/devregression/r/mcs7172_regression_bug5230.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists region1;
-Warnings:
-Note	1051	Unknown table 'tpch1.region1'
 create table  region1
 (
 r_regionkey int,

--- a/mysql-test/columnstore/devregression/r/mcs7174_regression_bug5286.result
+++ b/mysql-test/columnstore/devregression/r/mcs7174_regression_bug5286.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists test;
-Warnings:
-Note	1051	Unknown table 'tpch1.test'
 drop view if exists test_v;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.test_v'
 create table test (test1 numeric,test2 varchar(20)) engine=columnstore;
 create view test_v as select * from test;
 insert into test values (1,'data1');

--- a/mysql-test/columnstore/devregression/r/mcs7175_regression_bug5289.result
+++ b/mysql-test/columnstore/devregression/r/mcs7175_regression_bug5289.result
@@ -1,13 +1,7 @@
 USE tpch1;
 drop table if exists bug5289a;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug5289a'
 drop table if exists bug5289b;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug5289b'
 drop view if exists bug5289b_v;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.bug5289b_v'
 create table bug5289a(
 a decimal(10,0),
 b varchar(30)) 
@@ -32,5 +26,3 @@ q3	2
 drop table if exists bug5289a;
 drop table if exists bug5289b;
 drop view if exists bug5289b_v;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.bug5289b_v'

--- a/mysql-test/columnstore/devregression/r/mcs7177_regression_bug5319.result
+++ b/mysql-test/columnstore/devregression/r/mcs7177_regression_bug5319.result
@@ -1,7 +1,5 @@
 USE tpch1;
 DROP TABLE IF EXISTS bug5319_a;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug5319_a'
 CREATE TABLE `bug5319_a` (
 `col1` int(11) DEFAULT NULL,
 `col2` int(11) DEFAULT NULL
@@ -9,8 +7,6 @@ CREATE TABLE `bug5319_a` (
 insert into bug5319_a values (1,2);
 insert into bug5319_a values (1,2);
 DROP TABLE IF EXISTS bug5319_b;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug5319_b'
 CREATE TABLE `bug5319_b` (
 `col1` int(11) DEFAULT NULL,
 `col2` int(11) DEFAULT NULL
@@ -19,8 +15,6 @@ insert into bug5319_b values (1,2);
 insert into bug5319_b values (1,3);
 insert into bug5319_b values (1,4);
 DROP VIEW IF EXISTS view_bug5319_b;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.view_bug5319_b'
 create view view_bug5319_b as select bug5319_b.col1 AS col1, bug5319_b.col2 AS col2,sum(bug5319_b.col2) AS
 kensyu_gk_total from bug5319_b group by bug5319_b.col1,bug5319_b.col2;
 Select bug5319_a.col1,bv.col2 from bug5319_a left join view_bug5319_b bv on (bug5319_a.col1 = bv.col1) order by 1, 2 ;

--- a/mysql-test/columnstore/devregression/r/mcs7181_regression_bug5448.result
+++ b/mysql-test/columnstore/devregression/r/mcs7181_regression_bug5448.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug5448;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug5448'
 create table bug5448 (mst_date datetime) engine=columnstore;
 insert into bug5448 values ('2013-03-01');
 insert into bug5448 values ('2012-03-01');

--- a/mysql-test/columnstore/devregression/r/mcs7182_regression_bug5687.result
+++ b/mysql-test/columnstore/devregression/r/mcs7182_regression_bug5687.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug5687;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug5687'
 create table bug5687(col1 datetime DEFAULT NULL) engine=columnstore;
 insert into bug5687 (col1) values ("2012-01-24 11:00:01");
 insert into bug5687 (col1) values ("1812-02-24 11:10:01");

--- a/mysql-test/columnstore/devregression/r/mcs7183_regression_bug5712.result
+++ b/mysql-test/columnstore/devregression/r/mcs7183_regression_bug5712.result
@@ -1,7 +1,5 @@
 USE tpch1;
 DROP TABLE IF EXISTS bug5712;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug5712'
 CREATE TABLE bug5712 (`time_tk` INT(11) UNSIGNED NOT NULL) ENGINE=Columnstore DEFAULT CHARSET=latin1;
 INSERT INTO bug5712 VALUES 
 (2013113023),

--- a/mysql-test/columnstore/devregression/r/mcs7185_regression_bug5764b.result
+++ b/mysql-test/columnstore/devregression/r/mcs7185_regression_bug5764b.result
@@ -1,16 +1,8 @@
 USE tpch1;
 drop view if exists vwBug;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.vwbug'
 drop view if exists vwBug2;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.vwbug2'
 drop view if exists vwBug3;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.vwbug3'
 drop view if exists vwBug4;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.vwbug4'
 create view vwBug as 
 select sub1.c1 s1c1, sub1.c2 s1c2, sub2.c1 s2c1, sub2.c2 s2c2, sub3.c1 s3c1, sub3.c2 s3c2
 from sub1 

--- a/mysql-test/columnstore/devregression/r/mcs7186_regression_bug5764.result
+++ b/mysql-test/columnstore/devregression/r/mcs7186_regression_bug5764.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists mk_calendar;
-Warnings:
-Note	1051	Unknown table 'tpch1.mk_calendar'
 CREATE TABLE if not exists `mk_calendar` (
 `nengetsu_yyyymmdd` date DEFAULT NULL,
 `shukei_dd` varchar(6) DEFAULT NULL,
@@ -14,8 +12,6 @@ insert into mk_calendar values
 ('2009-04-01', 1, 200904),
 ('2009-04-02', 2, 200904);
 drop table if exists mk_kishu_gaibu;
-Warnings:
-Note	1051	Unknown table 'tpch1.mk_kishu_gaibu'
 CREATE TABLE if not exists `mk_kishu_gaibu` (
 `Jyohokei_Denwa_Shurui` varchar(100) DEFAULT NULL,
 `Shuryoku_Hanbai_Kishu_Key` varchar(100) DEFAULT NULL
@@ -29,8 +25,6 @@ insert into mk_kishu_gaibu values
 ('A1', '508G'),                                           
 ('GT', 'HD60');
 drop table if exists mk_kishubetsu_report2;
-Warnings:
-Note	1051	Unknown table 'tpch1.mk_kishubetsu_report2'
 CREATE TABLE if not exists `mk_kishubetsu_report2` (
 `KEYNO` int(10) DEFAULT NULL
 ) ENGINE=Columnstore DEFAULT CHARSET=utf8;
@@ -46,8 +40,6 @@ insert into mk_kishubetsu_report2 values
 (1000009),
 (6000001);
 drop table if exists mk_organization;
-Warnings:
-Note	1051	Unknown table 'tpch1.mk_organization'
 CREATE TABLE if not exists `mk_organization` (
 `Tokatsuten_Code` varchar(30) DEFAULT NULL,
 `Kyoten_Code` varchar(30) DEFAULT NULL
@@ -64,8 +56,6 @@ insert into mk_organization values
 ('EK21', '017'),  
 ('NESM', '021');
 drop table if exists mk_shuryoku_hanbai_kishu;
-Warnings:
-Note	1051	Unknown table 'tpch1.mk_shuryoku_hanbai_kishu'
 CREATE TABLE if not exists `mk_shuryoku_hanbai_kishu` (
 `catalog_nengetsu` varchar(6) DEFAULT NULL,
 `kata_shiki` varchar(20) DEFAULT NULL
@@ -79,8 +69,6 @@ insert into mk_shuryoku_hanbai_kishu values
 (200905, 'S002'),
 (200905, 'BUGS');
 drop table if exists ts_kishubetsu_hibetsu_pfmtst;
-Warnings:
-Note	1051	Unknown table 'tpch1.ts_kishubetsu_hibetsu_pfmtst'
 CREATE TABLE if not exists `ts_kishubetsu_hibetsu_pfmtst` (
 `keijyo_yyyymm` int(6) DEFAULT NULL,
 `keijyo_dd` varchar(6) DEFAULT '@',
@@ -99,8 +87,6 @@ insert into ts_kishubetsu_hibetsu_pfmtst values
 (200904, 3, 'K554', 'M18', 'GT', 1000004),
 (200904, 4, 'K554', '021', 'ZZ', 3333333);
 drop view if exists v_kyotenbetsu_kishubetsu_hibetsu_base;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.v_kyotenbetsu_kishubetsu_hibetsu_base'
 CREATE VIEW `v_kyotenbetsu_kishubetsu_hibetsu_base`
 AS
 (
@@ -128,8 +114,6 @@ AND (`trn`.`kyoten_code` = `mst_org`.`Kyoten_Code`)
 )
 );
 drop view if exists v_kyotenbetsu_kishubetsu_hibetsu;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.v_kyotenbetsu_kishubetsu_hibetsu'
 CREATE VIEW `v_kyotenbetsu_kishubetsu_hibetsu`
 AS
 (

--- a/mysql-test/columnstore/devregression/r/mcs7187_regression_bug5777.result
+++ b/mysql-test/columnstore/devregression/r/mcs7187_regression_bug5777.result
@@ -1,7 +1,5 @@
 USE tpch1;
 DROP TABLE IF EXISTS query_class_metrics_float;
-Warnings:
-Note	1051	Unknown table 'tpch1.query_class_metrics_float'
 CREATE TABLE `query_class_metrics_float` (
 `agent_id` bigint(20) DEFAULT NULL,
 `start_ts` datetime DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7190_regression_bug5932.result
+++ b/mysql-test/columnstore/devregression/r/mcs7190_regression_bug5932.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists bug5932;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug5932'
 create table bug5932(c1 int)engine=columnstore;
 insert into bug5932 select 1 from lineitem;
 insert into bug5932 values (2);

--- a/mysql-test/columnstore/devregression/r/mcs7193_regression_bug6113.result
+++ b/mysql-test/columnstore/devregression/r/mcs7193_regression_bug6113.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists t;
-Warnings:
-Note	1051	Unknown table 'tpch1.t'
 create table t(a bigint, b varchar(10)) engine=columnstore;
 insert into t values (1, 'hi');
 insert into t values (1, 'hello');
@@ -14,8 +12,6 @@ a	b	rnum
 2	bye	1
 2	good night	2
 drop view if exists v;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.v'
 create view v as select * from t;
 select v.*, row_number() over (partition by a order by b) as rnum from v;
 a	b	rnum

--- a/mysql-test/columnstore/devregression/r/mcs7195_regression_bug6134.result
+++ b/mysql-test/columnstore/devregression/r/mcs7195_regression_bug6134.result
@@ -1,15 +1,9 @@
 USE tpch1;
 drop table if exists bug6134;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug6134'
 create table bug6134 (a integer) engine=Columnstore;
 drop table if exists bug6134u;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug6134u'
 create table bug6134u (b integer, c varchar(20)) engine=Columnstore;
 drop view if exists bug6134vv;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.bug6134vv'
 create or replace view bug6134vv as select distinct * from bug6134 t
 inner join bug6134u u on t.a = u.b;
 insert into bug6134 values (1);

--- a/mysql-test/columnstore/devregression/r/mcs7196_regression_bug752.result
+++ b/mysql-test/columnstore/devregression/r/mcs7196_regression_bug752.result
@@ -1,10 +1,6 @@
 USE tpch1;
 DROP TABLE if exists `source`;
-Warnings:
-Note	1051	Unknown table 'tpch1.source'
 DROP TABLE if exists `dest`;
-Warnings:
-Note	1051	Unknown table 'tpch1.dest'
 CREATE TABLE `source` (
 `datum` date NOT NULL,
 `datum_hour` datetime NOT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7198_regression_MCOL-1246.result
+++ b/mysql-test/columnstore/devregression/r/mcs7198_regression_MCOL-1246.result
@@ -1,13 +1,7 @@
 USE tpch1;
 drop table if exists mcol1246a;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol1246a'
 drop table if exists mcol1246b;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol1246b'
 drop table if exists mcol1246c;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol1246c'
 create table mcol1246a (a int, b varchar(7)) engine=columnstore;
 create table mcol1246b (a int, b varchar(20)) engine=columnstore;
 create table mcol1246c (a int, b text) engine=columnstore;

--- a/mysql-test/columnstore/devregression/r/mcs7199_regression_MCOL-128.result
+++ b/mysql-test/columnstore/devregression/r/mcs7199_regression_MCOL-128.result
@@ -1,7 +1,5 @@
 USE tpch1;
 DROP TABLE IF EXISTS mcol128;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol128'
 CREATE TABLE mcol128 (a int, b varchar(50));
 INSERT INTO mcol128 VALUES (1, 'hello'),(2, 'world');
 SELECT * FROM mcol128;
@@ -19,8 +17,6 @@ a	b
 1	hello
 2	world
 DROP TABLE IF EXISTS mcol128_clone;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol128_clone'
 CREATE TABLE mcol128_clone ENGINE=Columnstore AS SELECT * FROM mcol128;
 SELECT * FROM mcol128_clone;
 a	b

--- a/mysql-test/columnstore/devregression/r/mcs7200_regression_MCOL-1403.result
+++ b/mysql-test/columnstore/devregression/r/mcs7200_regression_MCOL-1403.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists mcol1403a;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol1403a'
 drop table if exists mcol1403b;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol1403b'
 create table mcol1403a (a int, b varchar(4)) engine=columnstore;
 create table mcol1403b (a int, b char(20), c varchar(20)) engine=columnstore;
 insert into mcol1403a values (1, 'ABC ');

--- a/mysql-test/columnstore/devregression/r/mcs7201_regression_MCOL-1531.result
+++ b/mysql-test/columnstore/devregression/r/mcs7201_regression_MCOL-1531.result
@@ -1,10 +1,6 @@
 USE tpch1;
 DROP TABLE IF EXISTS cs1;
-Warnings:
-Note	1051	Unknown table 'tpch1.cs1'
 DROP TABLE IF EXISTS cs2;
-Warnings:
-Note	1051	Unknown table 'tpch1.cs2'
 CREATE TABLE `cs1` (
 `t` varchar(2) DEFAULT NULL,
 `i` int(11) DEFAULT NULL

--- a/mysql-test/columnstore/devregression/r/mcs7203_regression_MCOL-1559.result
+++ b/mysql-test/columnstore/devregression/r/mcs7203_regression_MCOL-1559.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists mcol1559;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol1559'
 create table mcol1559 (c7nospace char(7), c7space char(7), c20nospace char(20), c20space char(20), vcnospace varchar(20), vcspace varchar(20)) engine=columnstore;
 insert into mcol1559 values ("ABC", "ABC ", "ABC12345678910", "ABC12345678910 ", "ABC", "ABC ");
 select * from mcol1559 where c7nospace = "ABC";

--- a/mysql-test/columnstore/devregression/r/mcs7204_regression_MCOL-163.result
+++ b/mysql-test/columnstore/devregression/r/mcs7204_regression_MCOL-163.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists test.mcol163;
-Warnings:
-Note	1051	Unknown table 'test.mcol163'
 create table test.mcol163 (a int, b double, c double precision) engine=columnstore;
 insert into test.mcol163 values (1,1.1,1.1);
 select * from test.mcol163;

--- a/mysql-test/columnstore/devregression/r/mcs7206_regression_MCOL-1676.result
+++ b/mysql-test/columnstore/devregression/r/mcs7206_regression_MCOL-1676.result
@@ -1,7 +1,5 @@
 USE tpch1;
 DROP TABLE IF EXISTS query_class_metrics_float;
-Warnings:
-Note	1051	Unknown table 'tpch1.query_class_metrics_float'
 CREATE TABLE `query_class_metrics_float` (
 `agent_id` bigint(20) DEFAULT NULL,
 `start_ts` datetime DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7207_regression_MCOL-1829.result
+++ b/mysql-test/columnstore/devregression/r/mcs7207_regression_MCOL-1829.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists `football_teams`;
-Warnings:
-Note	1051	Unknown table 'tpch1.football_teams'
 CREATE TABLE `football_teams` (
 `num` int(11) DEFAULT NULL,
 `name` varchar(32) DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7208_regression_MCOL-1989.result
+++ b/mysql-test/columnstore/devregression/r/mcs7208_regression_MCOL-1989.result
@@ -1,22 +1,10 @@
 USE tpch1;
 DROP VIEW IF EXISTS vv2;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.vv2'
 DROP VIEW IF EXISTS vv1;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.vv1'
 DROP TABLE IF EXISTS vt1;
-Warnings:
-Note	1051	Unknown table 'tpch1.vt1'
 DROP TABLE IF EXISTS vt2;
-Warnings:
-Note	1051	Unknown table 'tpch1.vt2'
 DROP TABLE IF EXISTS vt3;
-Warnings:
-Note	1051	Unknown table 'tpch1.vt3'
 DROP TABLE IF EXISTS vt4;
-Warnings:
-Note	1051	Unknown table 'tpch1.vt4'
 CREATE TABLE `vt1` (
 `num_sample_id` int(11) DEFAULT NULL,
 `sample_id` varchar(32) DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7209_regression_MCOL-2050.result
+++ b/mysql-test/columnstore/devregression/r/mcs7209_regression_MCOL-2050.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists `football_teams`;
-Warnings:
-Note	1051	Unknown table 'tpch1.football_teams'
 CREATE TABLE `football_teams` (
 `num` int(11) DEFAULT NULL,
 `name` varchar(32) DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7211_regression_MCOL-2096.result
+++ b/mysql-test/columnstore/devregression/r/mcs7211_regression_MCOL-2096.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists t;
-Warnings:
-Note	1051	Unknown table 'tpch1.t'
 create table t(a int, b int) engine=columnstore;
 insert into t(a,b) values(1,4),(2,3),(3,2),(4,1);
 select

--- a/mysql-test/columnstore/devregression/r/mcs7213_regression_MCOL-2225.result
+++ b/mysql-test/columnstore/devregression/r/mcs7213_regression_MCOL-2225.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists mcol2225i;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol2225i'
 drop table if exists mcol2225c;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol2225c'
 CREATE USER IF NOT EXISTS'cejuser'@'localhost' IDENTIFIED BY 'Vagrant1!0000001';
 GRANT ALL PRIVILEGES ON *.* TO 'cejuser'@'localhost';
 FLUSH PRIVILEGES;

--- a/mysql-test/columnstore/devregression/r/mcs7214_regression_MCOL-2267.result
+++ b/mysql-test/columnstore/devregression/r/mcs7214_regression_MCOL-2267.result
@@ -1,10 +1,6 @@
 USE tpch1;
 DROP TABLE IF EXISTS `MCOL-2267a`;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol-2267a'
 DROP TABLE IF EXISTS `MCOL-2267b`;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol-2267b'
 CREATE TABLE `MCOL-2267a` (
 `thing1` varchar(32) DEFAULT NULL,
 `my_id` varchar(8) DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7215_regression_MCOL-3267.result
+++ b/mysql-test/columnstore/devregression/r/mcs7215_regression_MCOL-3267.result
@@ -1,10 +1,6 @@
 USE tpch1;
 DROP TABLE IF EXISTS t1;
-Warnings:
-Note	1051	Unknown table 'tpch1.t1'
 DROP TABLE IF EXISTS t2;
-Warnings:
-Note	1051	Unknown table 'tpch1.t2'
 CREATE TABLE t1 (a bigint, b bigint)engine=columnstore;
 CREATE TABLE  t2 (a bigint, b bigint)engine=columnstore;
 INSERT INTO t1 VALUES (5,5),(4,4),(3,3);
@@ -25,3 +21,5 @@ a	b
 4	4
 5	5
 5	5
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;

--- a/mysql-test/columnstore/devregression/r/mcs7216_regression_MCOL-3304.result
+++ b/mysql-test/columnstore/devregression/r/mcs7216_regression_MCOL-3304.result
@@ -1,7 +1,5 @@
 USE tpch1;
 DROP TABLE IF EXISTS `MCOL3304`;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol3304'
 CREATE TABLE `MCOL3304` (
 `c` decimal(5,2) DEFAULT NULL
 ) ENGINE=columnstore;

--- a/mysql-test/columnstore/devregression/r/mcs7217_regression_MCOL-3317.result
+++ b/mysql-test/columnstore/devregression/r/mcs7217_regression_MCOL-3317.result
@@ -1,7 +1,5 @@
 USE tpch1;
 DROP TABLE IF EXISTS `mcol-498`;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol-498'
 CREATE TABLE `mcol-498` (i BIGINT) ENGINE=columnstore;
 INSERT INTO `mcol-498` VALUES (42),(6);
 DELETE FROM `mcol-498` WHERE i = 42;

--- a/mysql-test/columnstore/devregression/r/mcs7219_regression_MCOL-3395.result
+++ b/mysql-test/columnstore/devregression/r/mcs7219_regression_MCOL-3395.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists mcol3395;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol3395'
 create table mcol3395 (c1 char(10), c2 varchar(10), c3 varchar(6))engine=columnstore;
 insert into mcol3395 values ('abc','cde','abc'), ('cde','abc','cde');
 select * from mcol3395 where c2='abc';

--- a/mysql-test/columnstore/devregression/r/mcs7220_regression_MCOL-3423.result
+++ b/mysql-test/columnstore/devregression/r/mcs7220_regression_MCOL-3423.result
@@ -1,7 +1,5 @@
 USE tpch1;
 DROP TABLE IF EXISTS tc;
-Warnings:
-Note	1051	Unknown table 'tpch1.tc'
 CREATE TABLE `tc` (
 `id` int(11) NOT NULL,
 `cid` int(11) DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7221_regression_MCOL-3434.result
+++ b/mysql-test/columnstore/devregression/r/mcs7221_regression_MCOL-3434.result
@@ -1,10 +1,6 @@
 USE tpch1;
 DROP TABLE IF EXISTS MCOL3434CS;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol3434cs'
 DROP TABLE IF EXISTS MCOL3434INNO;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol3434inno'
 CREATE TABLE `MCOL3434INNO` (`id` int(11) NOT NULL AUTO_INCREMENT, 
 `cid` int(11) DEFAULT NULL, 
 `d` datetime DEFAULT NULL, 

--- a/mysql-test/columnstore/devregression/r/mcs7222_regression_MCOL-3448.result
+++ b/mysql-test/columnstore/devregression/r/mcs7222_regression_MCOL-3448.result
@@ -1,7 +1,5 @@
 USE tpch1;
 DROP TABLE IF EXISTS dim_date;
-Warnings:
-Note	1051	Unknown table 'tpch1.dim_date'
 create table dim_date(semaine varchar(10), date_jour date, val int) engine=columnstore;
 insert into dim_date values 
 ('2019-S08','2019-02-18',1),

--- a/mysql-test/columnstore/devregression/r/mcs7223_regression_MCOL-3485.result
+++ b/mysql-test/columnstore/devregression/r/mcs7223_regression_MCOL-3485.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists t;
-Warnings:
-Note	1051	Unknown table 'tpch1.t'
 create table t(a int, b varchar(10), c decimal(7,2)) engine=columnstore;
 insert into t(a,b,c) values (1,'x',10),(2,'x',11), (3, 'x', 12), (1,'y',12),(2,'y',11), (3, 'y', 10);
 select a as bu, 

--- a/mysql-test/columnstore/devregression/r/mcs7225_regression_MCOL-3721.result
+++ b/mysql-test/columnstore/devregression/r/mcs7225_regression_MCOL-3721.result
@@ -1,7 +1,5 @@
 USE tpch1;
 DROP TABLE IF EXISTS test_collate;
-Warnings:
-Note	1051	Unknown table 'tpch1.test_collate'
 CREATE TABLE test_collate (a INT, b INT) ENGINE=columnstore;
 INSERT INTO test_collate VALUES (1,2), (2,4);
 SELECT a, b FROM test_collate ORDER BY a COLLATE latin1_german2_ci;
@@ -35,9 +33,6 @@ DESCRIBE t1;
 Field	Type	Null	Key	Default	Extra
 col1	char(10)	YES		NULL	
 DROP TABLE IF EXISTS t1;
-DROP TABLE IF EXISTS t1;
-Warnings:
-Note	1051	Unknown table 'tpch1.t1'
 CREATE TABLE t1 (col1 CHAR(10) CHARACTER SET utf8 COLLATE utf8_unicode_ci) ENGINE=columnstore;
 INSERT INTO t1 VALUES ('a'), ('1'), ('-1');
 SELECT col1 FROM t1;

--- a/mysql-test/columnstore/devregression/r/mcs7226_regression_MCOL_3747.result
+++ b/mysql-test/columnstore/devregression/r/mcs7226_regression_MCOL_3747.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists cs1;
-Warnings:
-Note	1051	Unknown table 'tpch1.cs1'
 create table cs1(key_ bigint) engine=columnstore;
 insert into cs1 values (42),(43),(45),(666),(777),(333);
 select key_, count(*) from cs1 where key_ in (select * from (select key_ from cs1 group by key_ order by key_ limit 2) a1) group by key_ order by 1;

--- a/mysql-test/columnstore/devregression/r/mcs7228_regression_MCOL-3813.result
+++ b/mysql-test/columnstore/devregression/r/mcs7228_regression_MCOL-3813.result
@@ -1,19 +1,8 @@
 USE tpch1;
-/* FROM MCOL-1349 
-Note: Adding this because code that directly involved this bug was modified
-Other regression involved is working_tpch1_compareLogOnly/misc/bug5764.sql*/
 drop table if exists t3813_1;
-Warnings:
-Note	1051	Unknown table 'tpch1.t3813_1'
 drop table if exists t3813_2;
-Warnings:
-Note	1051	Unknown table 'tpch1.t3813_2'
 drop table if exists t3813_3;
-Warnings:
-Note	1051	Unknown table 'tpch1.t3813_3'
 drop table if exists t3813_4;
-Warnings:
-Note	1051	Unknown table 'tpch1.t3813_4'
 create table t3813_1
 (id int
 )ENGINE=COLUMNSTORE DEFAULT CHARSET=UTF8MB4;
@@ -34,27 +23,20 @@ insert into t3813_1(id) values(1);
 insert into t3813_2(id2, snapshot_date) values(1,'2020-05-09');
 insert into t3813_3(id3, from_date, to_date) values(1,'2020-05-09'-interval 1 day, '2020-05-09'+interval 2 day);
 insert into t3813_4(id4, category) values(1, 'cat-1');
-/*PREPARATION END*/
-/*THE PROBLEM: The SELECT itself below runs properly, but calling it from view the 1815 error is thrown*/
 select * from t3813_1 t3813_1
 LEFT JOIN t3813_4 t3813_4 ON (t3813_1.id = t3813_4.id4) 
 LEFT JOIN t3813_2 t3813_2 ON (t3813_1.id = t3813_2.id2) 
 LEFT JOIN t3813_3 t3813_3 ON (t3813_2.id2 = t3813_3.id3 AND t3813_2.snapshot_date BETWEEN t3813_3.from_date AND t3813_3.to_date);
 id	id4	category	id2	snapshot_date	id3	from_date	to_date
 1	1	cat-1	1	2020-05-09	1	2020-05-08	2020-05-11
-/*Creating VIEW based on the SELECT above*/
 create or replace view view_test as
 select * from t3813_1 t3813_1
 LEFT JOIN t3813_4 t3813_4 ON (t3813_1.id = t3813_4.id4)
 LEFT JOIN t3813_2 t3813_2 ON (t3813_1.id = t3813_2.id2) 
 LEFT JOIN t3813_3 t3813_3 ON (t3813_2.id2 = t3813_3.id3 AND t3813_2.snapshot_date BETWEEN t3813_3.from_date AND t3813_3.to_date);
-/*SELECT from the VIEW throws the error: Error Code: 1815. Internal error: On clause filter involving a table not directly involved in the outer join is currently not supported.*/
 select * from view_test;
 id	id4	category	id2	snapshot_date	id3	from_date	to_date
 1	1	cat-1	1	2020-05-09	1	2020-05-08	2020-05-11
-/*Notes*/
-/*If I remove either the 1st or the 3rd LEFT JOINs from the VIEW definition, the SELECT * from VIEW will work. (I cannot remove the 2nd LEFT JOIN since the 3rd is based on that one)*/
-/*Replacing COLUMNSTORE engine to INNODB the view the SELECT * from VIEW will work, but if one of the tables is COLUMNSTORE the error will thrown*/
 drop table if exists t3813_1;
 drop table if exists t3813_2;
 drop table if exists t3813_3;

--- a/mysql-test/columnstore/devregression/r/mcs7229_regression_MCOL-3839.result
+++ b/mysql-test/columnstore/devregression/r/mcs7229_regression_MCOL-3839.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists test_wf_count_with_constants;
-Warnings:
-Note	1051	Unknown table 'tpch1.test_wf_count_with_constants'
 create table test_wf_count_with_constants (t1 int) engine=columnstore;
 insert into test_wf_count_with_constants values (1);
 select count(null) over () from test_wf_count_with_constants;

--- a/mysql-test/columnstore/devregression/r/mcs7233_regression_MCOL-477.result
+++ b/mysql-test/columnstore/devregression/r/mcs7233_regression_MCOL-477.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists test.mcol477;
-Warnings:
-Note	1051	Unknown table 'test.mcol477'
 create table test.mcol477 (a int, b int) engine=columnstore comment='autoincrement=a,9';
 insert into test.mcol477 set b=1;
 select * from test.mcol477;

--- a/mysql-test/columnstore/devregression/r/mcs7236_regression_MCOL-736.result
+++ b/mysql-test/columnstore/devregression/r/mcs7236_regression_MCOL-736.result
@@ -1,7 +1,5 @@
 USE tpch1;
 DROP TABLE IF EXISTS MCOL_736;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol_736'
 CREATE TABLE `MCOL_736` (
 `code` varchar(255) NOT NULL
 ) ENGINE=InnoDB;

--- a/mysql-test/columnstore/devregression/r/mcs7237_regression_MCOL-812.result
+++ b/mysql-test/columnstore/devregression/r/mcs7237_regression_MCOL-812.result
@@ -1,10 +1,6 @@
 USE tpch1;
 DROP TABLE IF EXISTS test.mcol812a;
-Warnings:
-Note	1051	Unknown table 'test.mcol812a'
 DROP TABLE IF EXISTS test.mcol812b;
-Warnings:
-Note	1051	Unknown table 'test.mcol812b'
 CREATE USER IF NOT EXISTS'cejuser'@'localhost' IDENTIFIED BY 'Vagrant1!0000001';
 GRANT ALL PRIVILEGES ON *.* TO 'cejuser'@'localhost';
 FLUSH PRIVILEGES;

--- a/mysql-test/columnstore/devregression/r/mcs7238_regression_MCOL-830.result
+++ b/mysql-test/columnstore/devregression/r/mcs7238_regression_MCOL-830.result
@@ -1,10 +1,6 @@
 USE tpch1;
 DROP TABLE IF EXISTS test.mcol830a;
-Warnings:
-Note	1051	Unknown table 'test.mcol830a'
 DROP TABLE IF EXISTS test.mcol830b;
-Warnings:
-Note	1051	Unknown table 'test.mcol830b'
 CREATE TABLE test.mcol830a (
 `c1` int(11) DEFAULT NULL,
 `c2` varchar(64) DEFAULT NULL

--- a/mysql-test/columnstore/devregression/r/mcs7239_regression_MCOL-979.result
+++ b/mysql-test/columnstore/devregression/r/mcs7239_regression_MCOL-979.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists mcol979;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol979'
 create table mcol979 (a int, b double, c CHAR(1), d CHAR(2), e CHAR(3), f CHAR(4), g CHAR(8),
 h CHAR(16), m VARCHAR(32)) engine=columnstore;
 insert into mcol979 values (1,1.1,'a','ab','abc','abcd','abcdefgh','abcdefghijklmnop','abcdefghijklmnopqrstuvwxyz123456');

--- a/mysql-test/columnstore/devregression/r/mcs7245_regression_bug2977.result
+++ b/mysql-test/columnstore/devregression/r/mcs7245_regression_bug2977.result
@@ -1,13 +1,7 @@
 USE tpch1;
 drop table if exists `shipamounts`;
-Warnings:
-Note	1051	Unknown table 'tpch1.shipamounts'
 drop table if exists `ship1`;
-Warnings:
-Note	1051	Unknown table 'tpch1.ship1'
 drop table if exists `ship2`;
-Warnings:
-Note	1051	Unknown table 'tpch1.ship2'
 CREATE TABLE `shipamounts` (
 `OrderNum` varchar(50) DEFAULT NULL,
 `OrderLine` int(11) DEFAULT NULL,

--- a/mysql-test/columnstore/devregression/r/mcs7247_regression_bug3038b.result
+++ b/mysql-test/columnstore/devregression/r/mcs7247_regression_bug3038b.result
@@ -1,12 +1,6 @@
 USE tpch1;
-/* Test case from Radek at CognitiveMatch - customer who bought based on us adding the multi-value in clause feature. */
-/* First test using IDB tables. */
 drop table if exists agg_fact_pageview;
-Warnings:
-Note	1051	Unknown table 'tpch1.agg_fact_pageview'
 drop table if exists dim_date;
-Warnings:
-Note	1051	Unknown table 'tpch1.dim_date'
 create table AGG_FACT_PAGEVIEW
 (
 server_day_date         date ,

--- a/mysql-test/columnstore/devregression/r/mcs7248_regression_bug3038c.result
+++ b/mysql-test/columnstore/devregression/r/mcs7248_regression_bug3038c.result
@@ -1,12 +1,6 @@
 USE tpch1;
-/* Test case from Radek at CognitiveMatch - customer who bought based on us adding the multi-value in clause feature. */
-/* Second test using myisam tables. */
 drop table if exists agg_fact_pageview;
-Warnings:
-Note	1051	Unknown table 'tpch1.agg_fact_pageview'
 drop table if exists dim_date;
-Warnings:
-Note	1051	Unknown table 'tpch1.dim_date'
 create table AGG_FACT_PAGEVIEW
 (
 server_day_date         date ,

--- a/mysql-test/columnstore/devregression/r/mcs7250_regression_bug4594.result
+++ b/mysql-test/columnstore/devregression/r/mcs7250_regression_bug4594.result
@@ -4,8 +4,6 @@ select substr(@x, length(@x)-6, 10);
 substr(@x, length(@x)-6, 10)
 Enabled
 drop table if exists bug4594;
-Warnings:
-Note	1051	Unknown table 'tpch1.bug4594'
 create table if not exists bug4594(c1 char(5))engine=columnstore;
 insert into bug4594 values ('abc'), ('def');
 select * from bug4594;

--- a/mysql-test/columnstore/devregression/r/mcs7251_regression_bug5315.result
+++ b/mysql-test/columnstore/devregression/r/mcs7251_regression_bug5315.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists trow;
-Warnings:
-Note	1051	Unknown table 'tpch1.trow'
 create table trow(col1 int, col2 int) engine=columnstore;
 insert into trow values(1,2),(3,4);
 select * from trow;

--- a/mysql-test/columnstore/devregression/r/mcs7252_regression_MCOL-669.result
+++ b/mysql-test/columnstore/devregression/r/mcs7252_regression_MCOL-669.result
@@ -1,10 +1,6 @@
 USE tpch1;
 drop table if exists MCOL_669_a;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol_669_a'
 drop table if exists MCOL_669_B;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol_669_b'
 CREATE TABLE MCOL_669_a (a int, b text) engine=columnstore;
 CREATE TABLE MCOL_669_b (a int, b text) engine=columnstore;
 INSERT INTO MCOL_669_a VALUES (1, REPEAT('MariaDB ', 7500));

--- a/mysql-test/columnstore/devregression/r/mcs7253_regression_MCOL-670.result
+++ b/mysql-test/columnstore/devregression/r/mcs7253_regression_MCOL-670.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists MCOL_670;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol_670'
 CREATE TABLE MCOL_670 (a int, b text) engine=columnstore;
 INSERT INTO MCOL_670 VALUES (1, REPEAT('MariaDB ', 7500));
 INSERT INTO MCOL_670 VALUES (2, REPEAT('MariaDB ', 7500));

--- a/mysql-test/columnstore/devregression/r/mcs7254_regression_MCOL-671.result
+++ b/mysql-test/columnstore/devregression/r/mcs7254_regression_MCOL-671.result
@@ -1,7 +1,5 @@
 USE tpch1;
 drop table if exists MCOL_671;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol_671'
 CREATE TABLE MCOL_671 (a int, b text) engine=columnstore;
 INSERT INTO MCOL_671 VALUES (1, REPEAT('MariaDB ', 7500));
 SELECT a, length(b) FROM MCOL_671 WHERE b > 'K';

--- a/mysql-test/columnstore/devregression/r/mcs7521_storedProcedures_sp.result
+++ b/mysql-test/columnstore/devregression/r/mcs7521_storedProcedures_sp.result
@@ -1,22 +1,10 @@
 USE tpch1;
 drop procedure if exists sp_simple_select;
-Warnings:
-Note	1305	PROCEDURE tpch1.sp_simple_select does not exist
 drop procedure if exists sp_simple_variable;
-Warnings:
-Note	1305	PROCEDURE tpch1.sp_simple_variable does not exist
 drop procedure if exists sp_simple_variables;
-Warnings:
-Note	1305	PROCEDURE tpch1.sp_simple_variables does not exist
 drop procedure if exists sp_complex_variable;
-Warnings:
-Note	1305	PROCEDURE tpch1.sp_complex_variable does not exist
 drop procedure if exists proc1;
-Warnings:
-Note	1305	PROCEDURE tpch1.proc1 does not exist
 DROP TABLE IF EXISTS t1;
-Warnings:
-Note	1051	Unknown table 'tpch1.t1'
 Create Procedure sp_simple_select( )
 begin
 select * from part where p_partkey < 5;

--- a/mysql-test/columnstore/devregression/r/mcs7523_partitionOptimization_aCreateViews.result
+++ b/mysql-test/columnstore/devregression/r/mcs7523_partitionOptimization_aCreateViews.result
@@ -1,28 +1,12 @@
 USE tpch1;
 drop view if exists v_nation;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.v_nation'
 drop view if exists v_region;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.v_region'
 drop view if exists v_customer;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.v_customer'
 drop view if exists v_orders;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.v_orders'
 drop view if exists v_supplier;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.v_supplier'
 drop view if exists v_partsupp;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.v_partsupp'
 drop view if exists v_part;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.v_part'
 drop view if exists v_lineitem;
-Warnings:
-Note	4092	Unknown VIEW: 'tpch1.v_lineitem'
 create view v_nation as select * from nation where n_nationkey > 10 union all select * from nation where n_nationkey <= 10;
 create view v_region as select * from region where r_regionkey > 3 union all select * from region where r_regionkey <= 3;
 create view v_customer as select * from customer union all select * from customer where c_custkey=0;
@@ -32,32 +16,14 @@ create view v_partsupp as select * from partsupp union all select * from partsup
 create view v_part as select * from part union all select * from part where p_partkey=0;
 create view v_lineitem as select * from lineitem union all select * from lineitem where l_orderkey=0;
 drop procedure if exists ordersColumnsTouched;
-Warnings:
-Note	1305	PROCEDURE tpch1.ordersColumnsTouched does not exist
 drop procedure if exists lineitemColumnsTouched;
-Warnings:
-Note	1305	PROCEDURE tpch1.lineitemColumnsTouched does not exist
 drop procedure if exists customerColumnsTouched;
-Warnings:
-Note	1305	PROCEDURE tpch1.customerColumnsTouched does not exist
 drop procedure if exists supplierColumnsTouched;
-Warnings:
-Note	1305	PROCEDURE tpch1.supplierColumnsTouched does not exist
 drop procedure if exists partColumnsTouched;
-Warnings:
-Note	1305	PROCEDURE tpch1.partColumnsTouched does not exist
 drop procedure if exists partsuppColumnsTouched;
-Warnings:
-Note	1305	PROCEDURE tpch1.partsuppColumnsTouched does not exist
 drop procedure if exists regionColumnsTouched;
-Warnings:
-Note	1305	PROCEDURE tpch1.regionColumnsTouched does not exist
 drop procedure if exists nationColumnsTouched;
-Warnings:
-Note	1305	PROCEDURE tpch1.nationColumnsTouched does not exist
 drop procedure if exists eliminatedBlocksGE;
-Warnings:
-Note	1305	PROCEDURE tpch1.eliminatedBlocksGE does not exist
 create procedure ordersColumnsTouched (in trace varchar(10000)) BEGIN
 select locate('o_orderkey', trace) > 0 as o_orderkey_accessed;
 select locate('o_custkey', trace) > 0 as o_custkey_accessed;

--- a/mysql-test/columnstore/devregression/r/mcs7525_MCOL-829.result
+++ b/mysql-test/columnstore/devregression/r/mcs7525_MCOL-829.result
@@ -1,13 +1,7 @@
 USE tpch1;
 drop table if exists mcol829a;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol829a'
 drop table if exists mcol829b;
-Warnings:
-Note	1051	Unknown table 'tpch1.mcol829b'
 drop procedure if exists mcol829;
-Warnings:
-Note	1305	PROCEDURE tpch1.mcol829 does not exist
 create table mcol829a (a int, b int) engine=columnstore;
 create table mcol829b (a int, b int) engine=columnstore;
 insert into mcol829a values (1,1),(2,2),(3,3);

--- a/mysql-test/columnstore/devregression/r/mcs7635_q212.result
+++ b/mysql-test/columnstore/devregression/r/mcs7635_q212.result
@@ -1,13 +1,9 @@
 USE tpch1;
 drop database if exists test023_cs3;
-Warnings:
-Note	1008	Can't drop database 'test023_cs3'; database doesn't exist
 create database test023_cs3;
 use test023_cs3;
 SET SESSION sql_mode = 'ANSI_QUOTES';
 drop table if exists "test023_cs3"."cs3";
-Warnings:
-Note	1051	Unknown table 'test023_cs3.cs3'
 create table "test023_cs3"."cs3"(i int, t text) engine=columnstore;
 insert into "test023_cs3"."cs3" values (1,'Lorem ipsum dolor sit amet, consectetur adipiscing elit,'),(7,'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'),(8,'Ut enim ad minim veniam,'),(9,'quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'),(10,'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore e');
 select * from "test023_cs3"."cs3";

--- a/mysql-test/columnstore/devregression/r/mcs7636_q213.result
+++ b/mysql-test/columnstore/devregression/r/mcs7636_q213.result
@@ -1,16 +1,10 @@
 USE tpch1;
 drop database if exists test023_cs3;
-Warnings:
-Note	1008	Can't drop database 'test023_cs3'; database doesn't exist
 drop database if exists test023_cs2;
-Warnings:
-Note	1008	Can't drop database 'test023_cs2'; database doesn't exist
 create database test023_cs3;
 create database test023_cs2;
 use test023_cs2;
 drop table if exists `test023_cs3`.`cs3`;
-Warnings:
-Note	1051	Unknown table 'test023_cs3.cs3'
 create table `test023_cs3`.`cs3`(i int, t text) engine=columnstore;
 insert into `test023_cs3`.`cs3` values (1,'Lorem ipsum dolor sit amet, consectetur adipiscing elit,'),(7,'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'),(8,'Ut enim ad minim veniam,'),(9,'quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'),(10,'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore e');
 select * from `test023_cs3`.`cs3`;

--- a/mysql-test/columnstore/devregression/t/mcs7012_regression_bug2788.test
+++ b/mysql-test/columnstore/devregression/t/mcs7012_regression_bug2788.test
@@ -8,8 +8,11 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists foo;
+--enable_warnings
 create table foo (col1 int(11) null default null) engine=columnstore;
+--disable_warnings
 drop table foo;
+--enable_warnings
 #
-

--- a/mysql-test/columnstore/devregression/t/mcs7015_regression_bug2835.test
+++ b/mysql-test/columnstore/devregression/t/mcs7015_regression_bug2835.test
@@ -8,11 +8,13 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug2835;
+--enable_warnings
 create table bug2835 (c1 int, c2 varchar(6), c3 varchar(20), c4 datetime)engine=columnstore;
 insert into bug2835 values (1, 'one', 'one', '2010-01-01'), (2, 'two', 'two', '2010-02-02'), (null, null, null, null);
 select c1, c2, c3, ifnull(c1,"z"), ifnull(c2,''), ifnull(c3,''), ifnull(c4,'') from bug2835;
+--disable_warnings
 drop table bug2835;
-
+--enable_warnings
 #
-

--- a/mysql-test/columnstore/devregression/t/mcs7017_regression_bug2845.test
+++ b/mysql-test/columnstore/devregression/t/mcs7017_regression_bug2845.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug2845;
+--enable_warnings
 create table bug2845(c1 int, c2 varchar(7), c3 varchar(30))engine=columnstore;
 insert into bug2845 values (1, 'A\'s', 'Joe\'s');
 select * from bug2845;
@@ -16,7 +18,8 @@ update bug2845 set c2='Bubba\'s', c3='Uncle Julio\'s';
 select * from bug2845;
 delete from bug2845;
 select count(*) from bug2845;
+--disable_warnings
 drop table bug2845;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7018_regression_bug2873.test
+++ b/mysql-test/columnstore/devregression/t/mcs7018_regression_bug2873.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug2873;
+--enable_warnings
 create table bug2873(id int, logtime int, filename varchar(20))engine=columnstore;
 insert into bug2873 values 
 	(1, unix_timestamp('2010-05-23 10:00:10'), 'Cam1.jpg'),
@@ -32,6 +34,8 @@ select if(filename rlike '^Cam1.jpg$',filename ,'no') datei from bug2873 limit 1
 select if(filename rlike '^Cam1.jpg$',filename ,'no') datei from bug2873;
 select if(filename rlike '^Cam1.jpg$',filename ,'no') datei from bug2873 where if(filename rlike '^Cam1.jpg$',filename ,'no')='no' limit 1;
 
+--disable_warnings
 drop table bug2873;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7019_regression_bug2876.test
+++ b/mysql-test/columnstore/devregression/t/mcs7019_regression_bug2876.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug2876;
+--enable_warnings
 create table bug2876(c1 int, c2 varchar(117))engine=columnstore;
 insert into bug2876 values (1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3), (3, 1), (3, 2), (3, 3);
 insert into bug2876 values (1, null), (2, null), (3, null), (null, 1), (null, 2), (null, 3), (null, null);
@@ -20,6 +22,8 @@ select * from bug2876 where c1 <= c2 order by 1, 2;
 select * from bug2876 where c1 >= c2 order by 1, 2;
 delete from bug2876 where c1 = c2;
 select * from bug2876 order by 1, 2;
+--disable_warnings
 drop table bug2876;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7026_regression_bug2915.test
+++ b/mysql-test/columnstore/devregression/t/mcs7026_regression_bug2915.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists tbl1;
 drop table if exists tbl2;
+--enable_warnings
 
 create table tbl1 (c1 char(1), c2 char(255))engine=columnstore;
 create table tbl2 (c1 char(1), c2 char(255))engine=columnstore;
@@ -32,7 +34,9 @@ select count(*) from tbl1 right join tbl2 on tbl1.c1 = tbl2.c2;
 select count(*) from tbl1 right join tbl2 on tbl1.c2 = tbl2.c1;
 select count(*) from tbl1 right join tbl2 on tbl1.c2 = tbl2.c2;
 
+--disable_warnings
 drop table tbl1;
 drop table tbl2;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7035_regression_bug2976.test
+++ b/mysql-test/columnstore/devregression/t/mcs7035_regression_bug2976.test
@@ -8,14 +8,15 @@
 #
 USE tpch1;
 #
-/*
-* Bug 2976.  Lost connection with from clause subselect against MyISAM tables in an InfiniDB instance.
-*/
+#
+# Bug 2976.  Lost connection with from clause subselect against MyISAM tables in an InfiniDB instance.
+#
 
 --disable_warnings
 drop table if exists a;
---disable_warnings
 drop table if exists b;
+--enable_warnings
+
 create table a (c1 int)engine=myisam;
 create table b (c2 int)engine=myisam;
 insert into a values (1), (2);
@@ -25,9 +26,10 @@ select * from a, (select * from b) x;
 drop table a; 
 drop table b;
 --enable_warnings
-/*
-* Skinit example. 
-*/
+
+#
+# Skinit example. 
+#
 --disable_warnings
 drop table if exists shipamounts;
 drop table if exists ship1;
@@ -105,9 +107,9 @@ drop table if exists shipamounts;
 drop table if exists ship1;
 drop table if exists ship2;
 --enable_warnings
-/*
-* Lurn India example.
-*/
+#
+# Lurn India example.
+#
 --disable_warnings
 drop table if exists users;
 drop table if exists user_login_log;

--- a/mysql-test/columnstore/devregression/t/mcs7035_regression_bug2976.test
+++ b/mysql-test/columnstore/devregression/t/mcs7035_regression_bug2976.test
@@ -12,22 +12,27 @@ USE tpch1;
 * Bug 2976.  Lost connection with from clause subselect against MyISAM tables in an InfiniDB instance.
 */
 
+--disable_warnings
 drop table if exists a;
+--disable_warnings
 drop table if exists b;
 create table a (c1 int)engine=myisam;
 create table b (c2 int)engine=myisam;
 insert into a values (1), (2);
 insert into b values (1), (2);
 select * from a, (select * from b) x;
+--disable_warnings
 drop table a; 
 drop table b;
-
+--enable_warnings
 /*
 * Skinit example. 
 */
+--disable_warnings
 drop table if exists shipamounts;
 drop table if exists ship1;
 drop table if exists ship2;
+--enable_warnings
 
 CREATE TABLE `shipamounts` (
   `OrderNum` varchar(50) DEFAULT NULL,
@@ -95,19 +100,22 @@ SELECT s.OrderNum, s.OrderLine, s.ShippingAmount, s.ShippingOrderAmount,
          FROM ship2 GROUP BY OrderNum
      ) AS total ON s.OrderNum = total.OrderNum;
 
+--disable_warnings
 drop table if exists shipamounts;
 drop table if exists ship1;
 drop table if exists ship2;
-
+--enable_warnings
 /*
 * Lurn India example.
 */
+--disable_warnings
 drop table if exists users;
 drop table if exists user_login_log;
 drop table if exists user_groups;
 drop table if exists user_types;
 drop table if exists system;
 drop table if exists user_system;
+--enable_warnings
 
 create table users(
 	id int,
@@ -183,11 +191,13 @@ AND u.status IN ('active')
 AND ug.start_date BETWEEN '2010-06-01' AND '2010-06-30'
 ORDER BY DATE(ug.start_date) DESC, u.users_id DESC;
 
+--disable_warnings
 drop table if exists users;
 drop table if exists user_login_log;
 drop table if exists user_groups;
 drop table if exists user_types;
 drop table if exists system;
 drop table if exists user_system;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7039_regression_bug3007.test
+++ b/mysql-test/columnstore/devregression/t/mcs7039_regression_bug3007.test
@@ -8,14 +8,20 @@
 #
 USE tpch1;
 #
+--disable_warnings
 create database if not exists bug3007;
 drop table if exists bug3007.bug;
+--enable_warnings
+
 create table bug3007.bug(c1 int)engine=columnstore;
 insert into bug3007.bug values (1), (2);
 select * from bug3007.bug;
 update bug3007.bug set c1=99;
 delete from bug3007.bug;
+
+--disable_warnings
 drop table if exists bug3007.bug;
 drop database if exists bug3007;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7040_regression_bug3012.test
+++ b/mysql-test/columnstore/devregression/t/mcs7040_regression_bug3012.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3012;
+--enable_warnings
+
 create table bug3012 (anz int, mx varchar(20)) engine=columnstore;
 insert into bug3012 values (1,'hotmail.com'), (2,'hotmail.com'), (3,'foo.com'),
 (4,'www.1and1.net'), (5,'1and1.com');
@@ -17,6 +20,8 @@ select * from bug3012;
 SELECT * FROM bug3012 WHERE (mx RLIKE 'hotmail' OR mx RLIKE '1and1');
 SELECT * FROM bug3012 WHERE (mx RLIKE '1and1' OR mx RLIKE 'hotmail');
 
+--disable_warnings
 drop table if exists bug3012;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7042_regression_bug3021.test
+++ b/mysql-test/columnstore/devregression/t/mcs7042_regression_bug3021.test
@@ -11,13 +11,19 @@ USE tpch1;
 select date('2010-02-01') into @xxx;
 select @xxx;
 
+--disable_warnings
 drop table if exists bug3021;
+--enable_warnings
+
 create table bug3021(c1 date)engine=columnstore;
 insert into bug3021 values ('2001-01-01');
 update bug3021 set c1=@xxx;
 select * from bug3021;
 update bug3021 set c1=date('2010-11-14');
 select * from bug3021;
+
+--disable_warnings
 drop table bug3021;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7043_regression_bug3024.test
+++ b/mysql-test/columnstore/devregression/t/mcs7043_regression_bug3024.test
@@ -12,12 +12,17 @@ select * from nation where n_nationkey=@value;
 set @value=5;
 select * from nation where n_nationkey=@value;
 
+--disable_warnings
 create table if not exists bug3024 (c1 int) engine=columnstore;
+--enable_warnings
 insert into bug3024 values (1), (2);
 update bug3024 set c1=3 where c1=@value;
 set @value=2;
 update bug3024 set c1=3 where c1=@value;
 select * from bug3024;
+
+--disable_warnings
 drop table if exists bug3024;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7044_regression_bug3025.test
+++ b/mysql-test/columnstore/devregression/t/mcs7044_regression_bug3025.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3025;
+--enable_warnings
 
 create table bug3025(value integer(5)) engine=Columnstore;
 insert into bug3025 values (1), (1001), (24), (2123), (null), (123), (888), (8421), (231), (-100), (null);
@@ -37,7 +39,8 @@ order by 1, 2;
 
 select IF(value<=1000,'<=1000', '>1000') a, isnull(IF(value<=1000,'<=1000', '>1000')) b from bug3025 group by 1,2 order by 2,1;
 
-
+--disable_warnings
 drop table if exists bug3025;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7045_regression_bug3051.test
+++ b/mysql-test/columnstore/devregression/t/mcs7045_regression_bug3051.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3051;
+--enable_warnings
+
 CREATE TABLE `bug3051` (
   `c1` int(11) DEFAULT NULL,
   `c2` varchar(17) DEFAULT NULL,
@@ -32,5 +35,8 @@ alter table bug3051 drop column c7;
 alter table bug3051 add column c7 datetime;
 select count(*) from bug3051;
 update bug3051 set c7=now();
+
+--disable_warnings
 drop table bug3051;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7050_regression_bug3137.test
+++ b/mysql-test/columnstore/devregression/t/mcs7050_regression_bug3137.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3137;
+--enable_warnings
 
 CREATE TABLE `bug3137` (
   `id` INTEGER DEFAULT NULL,
@@ -26,8 +28,8 @@ select * from bug3137 where (value = 1 OR 1 = 1);
 select * from bug3137 where id >= 0 and (value = 1 or 1 = -1);
 select n_nationkey from nation where n_nationkey <=5 and (n_nationkey=2 or 1=-1);
 
+--disable_warnings
 drop table if exists bug3137;
-
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7055_regression_bug3203.test
+++ b/mysql-test/columnstore/devregression/t/mcs7055_regression_bug3203.test
@@ -8,9 +8,15 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3203;
+--enable_warnings
+
 create table bug3203 (c1 varchar(20))engine=columnstore;
 select * from bug3203 where c1 = 'x';
+
+--disable_warnings
 drop table if exists bug3203;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7056_regression_bug3229.test
+++ b/mysql-test/columnstore/devregression/t/mcs7056_regression_bug3229.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists testnulldate;
+--enable_warnings
+
 create table testnulldate (id int, time_stamp datetime) engine=columnstore;
  
 insert into testnulldate values (1, '2010-11-08 17:46:44');
@@ -44,7 +47,8 @@ select
   case when `time_stamp` is null then 'N/A' end as `Test1`
 from testnulldate;
  
+--disable_warnings
 drop table if exists testnulldate;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7057_regression_bug3258.test
+++ b/mysql-test/columnstore/devregression/t/mcs7057_regression_bug3258.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists var_between;
+--enable_warnings
+
 create table var_between (c1 varchar(10), c2 char(7)) engine=columnstore;
 insert into var_between values ('099', '099');
 insert into var_between values ('9', '9');
@@ -17,12 +20,13 @@ select 'q1', var_between.* from var_between where substr(c1,1,1) between '0' and
 select 'q2', var_between.* from var_between where substr(c1,1,1) not  between '0' and '9';
 select 'q3', var_between.* from var_between where substr(c2,1,1) between '0' and '9';
 select 'q4', var_between.* from var_between where substr(c2,1,1) not  between '0' and '9';
-drop table var_between;
-
 select 'q5', count(*) from orders where substr(o_comment, 1, 1) between 'a' and 'f';
 select 'q6', count(*) from orders where substr(o_orderpriority, 1, 1) between '2' and '3';
 select 'q7', count(*) from orders where substr(o_orderpriority, 1, 1) not between '2' and '3';
 select 'q8', count(*) from orders where substr(o_totalprice, 2, 3)  between '200' and '300';
 select 'q9', count(*) from orders where substr(o_totalprice, 2, 3)  not between '200' and '300';
 #
-
+--disable_warnings
+drop table var_between;
+--enable_warnings
+#

--- a/mysql-test/columnstore/devregression/t/mcs7059_regression_bug3267.test
+++ b/mysql-test/columnstore/devregression/t/mcs7059_regression_bug3267.test
@@ -8,11 +8,17 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3267;
+--enable_warnings
+
 create table bug3267 (c1 decimal(12, 6), c2 float) engine=columnstore;
 insert into bug3267 values (5.240620, 5.24062e+06), (7.240620, 7.24062e+06), (9.940620, 9.94062e+06), (5.240620, 5.24062), (-4.44, -4.44), (-8.87, -8.87);
 select floor(c1), ceil(c1), c1 from bug3267;
 select floor(c2), ceil(c2), c2 from bug3267;
+
+--disable_warnings
 drop table if exists bug3267;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7060_regression_bug3270.test
+++ b/mysql-test/columnstore/devregression/t/mcs7060_regression_bug3270.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3270;
+--enable_warnings
+
 create table bug3270 (c1 decimal(12, 6), c2 float) engine=columnstore;
 insert into bug3270 
 values	(5.240620, 5.24062e+06), (7.240620, 7.24062e+06), (9.940620, 9.94062e+06), (5.240620, 5.24062), (5.240720, 5.240720), 
@@ -23,6 +26,8 @@ select truncate(c1, 0), truncate(c1, 1), truncate(c1, 2) from bug3270 order by 1
 select truncate(c2, 0), truncate(c2, 1), truncate(c2, 2) from bug3270 order by 1,2,3;
 
 select truncate(c2 ,2), count(*) from bug3270 group by 1 order by 1, 2;
+--disable_warnings
 drop table if exists bug3270;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7061_regression_bug3272.test
+++ b/mysql-test/columnstore/devregression/t/mcs7061_regression_bug3272.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3272;
+--enable_warnings
+
 create table bug3272 (c1 float, c2 char(12)) engine=columnstore;
 
 insert into bug3272 values (5.24062, '5.24062'), (7.24062, '7.24062'), (9.94062, '9.94062');
@@ -21,6 +24,8 @@ select cast(c1 as decimal(0,0)) floattype, cast(c2 as decimal(0,0)) chartype fro
 select cast(c1 as signed) floattype, cast(c2 as signed) chartype from bug3272 order by 1, 2;
 select cast(cast(c1 as decimal(4,2)) as signed) decimaltype, cast(c2 as signed) chartype from bug3272 order by 1, 2;
 
+--disable_warnings
 drop table if exists bug3272;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7062_regression_bug3274.test
+++ b/mysql-test/columnstore/devregression/t/mcs7062_regression_bug3274.test
@@ -8,14 +8,19 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3274;
+--enable_warnings
+
 create table bug3274(d2 decimal(4,2), f float);
 insert into bug3274 values (43.34, 43.345), (13.54, 13.545);
 select d2, count(*) from bug3274 group by 1 order by 1;
 select f, count(*) from bug3274 group by 1 order by 1;
 select * from (select d2, count(*) from bug3274 group by 1 order by 1) a;
 select * from (select f, count(*) from bug3274 group by 1 order by 1) a;
-drop table if exists bug3274;
 
+--disable_warnings
+drop table if exists bug3274;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7065_regression_bug3292.test
+++ b/mysql-test/columnstore/devregression/t/mcs7065_regression_bug3292.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3292;
+--enable_warnings
+
 create table bug3292 (c1 double, c2 float, c3 char(12)) engine=columnstore;
 insert into bug3292 values 
 	(5.24062, 5.24062, '5.24062'),
@@ -40,6 +43,8 @@ select c1, format(c1, 5), format(c2,2), format(c3,2) from bug3292;
 select c1, format(c1, 6), format(c2,6), format(c3,6) from bug3292;
 select c1, format(c1, -1), format(c2,-1), format(c3,-1) from bug3292;
 
+--disable_warnings
 drop table if exists bug3292;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7066_regression_bug3295.test
+++ b/mysql-test/columnstore/devregression/t/mcs7066_regression_bug3295.test
@@ -8,8 +8,11 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists visit;
 drop table if exists client;
+--enable_warnings
+
 create table visit (id_client integer,nb_event integer,update_date datetime, visit_date datetime) engine=columnstore;
 create table client (id_client integer,id_event integer,event_date datetime) engine=columnstore;
 
@@ -80,7 +83,9 @@ WHERE
 V.visit_date ="2010-09-08"
 AND V.id_client = Res.id_client order by 1, 2, 3;
 
+--disable_warnings
 drop table if exists visit;
 drop table if exists client;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7067_regression_bug3312.test
+++ b/mysql-test/columnstore/devregression/t/mcs7067_regression_bug3312.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists user_prop_by_game;
 drop table if exists visit;
+--enable_warnings
 
 create table user_prop_by_game(cl_id int, last_visit_date date)engine=columnstore;
 create table visit(cl_id int, visit_date date)engine=columnstore;
@@ -24,7 +26,9 @@ UPBG.cl_id = sub.cl_id;
 
 select * from user_prop_by_game;
 
+--disable_warnings
 drop table if exists user_prop_by_game;
 drop table if exists visit;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7068_regression_bug3314.test
+++ b/mysql-test/columnstore/devregression/t/mcs7068_regression_bug3314.test
@@ -8,9 +8,11 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists paa;
 drop table if exists dates;
 drop table if exists t;
+--enable_warnings
 
 create table paa (
     p_id int,
@@ -61,8 +63,10 @@ left outer join (select t.date_id, t.p_id, a_id,
        and p.date_id = tx.date_id)
 order by 1, 2, 3;
 
+--disable_warnings
 drop table if exists paa;
 drop table if exists dates;
 drop table if exists t;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7070_regression_bug3333.test
+++ b/mysql-test/columnstore/devregression/t/mcs7070_regression_bug3333.test
@@ -8,8 +8,11 @@
 #
 USE ssb1;
 #
+--disable_warnings
 drop table if exists datetest;
 create table if not exists datetest (rowid int, c1 varchar(20), c2 bigint) engine=columnstore;
+--enable_warnings
+
 insert into datetest values (1, "1990-10-20", 19901121), (2, "1997-01-01 10:00:05", 19970201000000), (3, "0705", 0805), (4, "20120230", 20120230),(5, "20110229", 20110229),(6, "9905", 9905),(7, "20011010888888", 20031010888888),(8, "20011011124455", 20011010122233);
 select 'q1', rowid, c1, c2, cast(c1 as date), cast(c2 as date) from datetest where c2 <> 0805 order by rowid;
 select 'q1b', rowid, c1, c2, cast(c1 as date), substr(cast(c2 as date), 6, 5) from datetest where c2 = 0805 order by rowid;
@@ -36,7 +39,10 @@ select 'q15', rowid, c1, c2, year(c1), year(c2) from datetest where c2 <> 0805 o
 select 'q16', rowid, c1, c2, month(c1), month(c2) from datetest order by 1,2;
 select 'q17', rowid, c1, c2, time(c1), time(c2) from datetest order by 1,2;
 
-drop table if exists datetest;
 select 'q18', year(lo_orderdate), month(lo_orderdate), count(*) from ssb1.lineorder group by 1, 2, 3 order by 1, 2, 3;
+
+--disable_warnings
+drop table if exists datetest;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7076_regression_bug3398.test
+++ b/mysql-test/columnstore/devregression/t/mcs7076_regression_bug3398.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS bug3398_1;
 DROP TABLE IF EXISTS bug3398_2;
+--enable_warnings
 
 CREATE TABLE bug3398_1 (lid int, name char(10)) engine=columnstore;
 INSERT INTO bug3398_1 (lid, name) VALUES (1, 'YES'), (2, 'NO');
@@ -23,7 +25,9 @@ SELECT DISTINCT tt.gid AS lgid, (SELECT bug3398_1.name FROM bug3398_1, bug3398_2
 
 SELECT DISTINCT bug3398_2.gid AS lgid, (SELECT bug3398_1.name FROM bug3398_1, bug3398_2 WHERE bug3398_1.lid  = bug3398_2.lid AND bug3398_2.gid = lgid and bug3398_1.name > 'NO' ORDER BY bug3398_2.dt) as clid FROM bug3398_2 ORDER BY 1;
 
+--disable_warnings
 DROP TABLE bug3398_1;
 DROP TABLE bug3398_2;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7077_regression_bug3414.test
+++ b/mysql-test/columnstore/devregression/t/mcs7077_regression_bug3414.test
@@ -8,16 +8,19 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists qa_cast;
+--enable_warnings
+
 create table qa_cast ( s1 varchar(20), qaint1 int, qadouble double) engine=columnstore;
 insert into qa_cast values ('123456789',123456789, 1234);
 insert into qa_cast values ('123.45',123456789, 123.45);
 insert into qa_cast values ('abc',123456789, 1.5);
 insert into qa_cast values ('0.001',123456789, 0.001);
 select s1, qaint1, mod(s1, 10), mod(qaint1, 10), mod(qadouble, 10)  from qa_cast;
+
+--disable_warnings
 drop table qa_cast;
-
-
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7078_regression_bug3436.test
+++ b/mysql-test/columnstore/devregression/t/mcs7078_regression_bug3436.test
@@ -8,8 +8,11 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3436a;
 drop table if exists bug3436b;
+--enable_warnings
+
 create table bug3436a (i int, j int, c1 tinyint, c2 decimal(2,1), c3 decimal(4,0), c4 decimal(4,2), c5 float, c6 double) engine=columnstore;
 insert into bug3436a values (1, 1, 1, 1.1, 9991, 99.1, 1.1, 1.1), (1, 1, 2, 2.2, 9992, 99.2, 2.2, 2.2), (2, 2, 1, 1.1, 9993, 99.3, 1.1, 1.1), (2, 2, 2, 2.2, 9994, 99.4, 2.2, 2.2), (1, 1, 127, 9.1, 9995, 99.5, 127.1, 127.1), (1, 2, 100, 9.2, 9996, 99.6, 100.2, 100.2);
 
@@ -29,8 +32,9 @@ select s/d from (select k, stddev(c4) s, count(distinct j) d from bug3436a join 
 select s/d from (select k, stddev(c5) s, count(distinct j) d from bug3436a join bug3436b on i=k group by 1) a order by 1;
 select s/d from (select k, stddev(c6) s, count(distinct j) d from bug3436a join bug3436b on i=k group by 1) a order by 1;
 
+--disable_warnings
 drop table bug3436a;
 drop table bug3436b;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7079_regression_bug3442.test
+++ b/mysql-test/columnstore/devregression/t/mcs7079_regression_bug3442.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists optest;
+--enable_warnings
+
 create table optest (id int, c1 date, c2 decimal(4,2), c3 date) engine=columnstore;
 insert into optest values (0, '2011-01-27', null, '1999-08-25'), (1, null, null, null), (2, '2001-01-05', 2.34, null), (3, null, null, '2001-05-03');
 select * from optest where (year(c1) = 2011 or c2 = 2.34) or month(c3) = 1;
@@ -27,7 +30,9 @@ select * from optest where (null or year(ifnull(c1, c3)) > 2000 and isnull(c2)) 
 select * from optest where ((null or year(ifnull(c1, c3)) > 2000) and isnull(c2)) or ( (c3 is not null or null) and null);
 select * from optest where (null or c2+1 between 0 and 4 or isnull(c2)) and ( c3 is not null or null);
 
+--disable_warnings
 drop table if exists bug3442b;
+--enable_warnings
 
 create table bug3442b (
 idx int,
@@ -89,8 +94,10 @@ bi2 < 4;
 select 'q10', idx from bug3442b where hour(dtm1)=9 or i1 = 2 or i2 = 5 or f2 is null or f1 > 6 or year(dtm2)= 2012 or 
 vc1 = 9 or bi2 = 4;
 
+--disable_warnings
 drop table bug3442b;
 drop table optest;
+--enable_warnings
 
 select count(*) from nation where n_nationkey < 3 OR NULL;
 

--- a/mysql-test/columnstore/devregression/t/mcs7085_regression_bug3483.test
+++ b/mysql-test/columnstore/devregression/t/mcs7085_regression_bug3483.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3483;
+--enable_warnings
+
 create table bug3483 (c1 bigint, c2 decimal(18,2), c3 float, c4 double, c5 char(120), c6 varchar(120)) engine=columnstore;
 insert into bug3483 values
 (1, 1.1, 1.1, 1.1, '1.1', '1.1'),
@@ -30,7 +33,8 @@ select c4, ceil(c4), ceiling(c4), floor(c4) from bug3483;
 select c5, ceil(c5), ceiling(c5), floor(c5), truncate(c5, 2) from bug3483;
 select c6, ceil(c6), ceiling(c6), floor(c6), truncate(c6, 2) from bug3483;
 
+--disable_warnings
 drop table bug3483;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7087_regression_bug3488.test
+++ b/mysql-test/columnstore/devregression/t/mcs7087_regression_bug3488.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3488;
+--enable_warnings
+
 create table bug3488 (c1 bigint, c2 decimal(18,2), c3 float, c4 double, c5 char(120), c6 varchar(120)) engine=columnstore;
 insert into bug3488 values
 (1, 1.1, 1.1, 1.1, '1.1', '1.1'),
@@ -36,7 +39,8 @@ select c4, format(c4, -2), format(c4, 0), format(c4, 2) from (select * from bug3
 select c5, format(c5, -2), format(c5, 0), format(c5, 2) from (select * from bug3488) sub;
 select c6, format(c6, -2), format(c6, 0), format(c6, 2) from (select * from bug3488) sub;
 
+--disable_warnings
 drop table bug3488;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7089_regression_bug3496.test
+++ b/mysql-test/columnstore/devregression/t/mcs7089_regression_bug3496.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3496;
+--enable_warnings
+
 create table `bug3496` (`c1` int(11) default null,`c2` char(6) default null, `c3` char(11) default null) engine=columnstore;
 insert into bug3496 values
 (1, 'abc', 'abc'),
@@ -115,7 +118,8 @@ select c1, c3 from bug3496 where c3 like '%_%';
 select c1, c3 from bug3496 where c3 like 'a_%';
 select c1, c3 from bug3496 where c3 like 'a(b)|(c)%';
 
+--disable_warnings
 drop table bug3496;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7090_regression_bug3497.test
+++ b/mysql-test/columnstore/devregression/t/mcs7090_regression_bug3497.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3497a;
 drop table if exists bug3497b;
+--enable_warnings
 
 CREATE TABLE bug3497a (col1 int, col2 varchar(10)) engine=columnstore; 
 INSERT INTO bug3497a VALUES(1,'trudy'); 
@@ -45,7 +47,9 @@ SELECT a.col1,a.col2,b.col2,b.col3 FROM bug3497b b RIGHT JOIN bug3497a a ON
 a.col1=b.col1 WHERE b.col1 IN (1,5,9) AND b.col2=(SELECT MAX(col2) FROM bug3497b b2
 WHERE b2.col1=b.col1) order by 1, 2;
 
+--disable_warnings
 drop table if exists bug3497a;
 drop table if exists bug3497b;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7093_regression_bug3518_negative.test
+++ b/mysql-test/columnstore/devregression/t/mcs7093_regression_bug3518_negative.test
@@ -102,6 +102,8 @@ select b.cidx from qa_dict_join_1 a, qa_dict_join_2 b where   a.CBIGINT = b.CBIG
 select a.cidx, b.cidx from qa_dict_join_1 a, qa_dict_join_2 b where   a.CBIGINT = b.CBIGINT order by abs(a.cidx), abs(b.cidx);
 select abs(a.cidx), b.cidx from qa_dict_join_1 a, qa_dict_join_2 b where   a.CBIGINT = b.CBIGINT order by a.cidx, b.cidx;
 #
+--disable_warnings
 drop table if exists qa_dict_join_1;
 drop table if exists qa_dict_join_2;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7097_regression_bug3524.test
+++ b/mysql-test/columnstore/devregression/t/mcs7097_regression_bug3524.test
@@ -8,8 +8,11 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists a1;
 drop table if exists a2;
+--enable_warnings
+
 create table a1 (c1 int, c2 int)engine=columnstore;
 create table a2 (c1 int, c2 int)engine=columnstore;
 insert into a1 values (1, 1),(2,2),(3,null),(null,3),(null,null);
@@ -28,10 +31,10 @@ select * from a1 where c1 not in (select c2 from a2 where a1.c2>a2.c2);
 select * from a1 where c1 not in (select 1 from a2 where a1.c1=a2.c1);
 select count(*) from a1 where c1 not in (select c2 from a2 where a1.c2=a2.c2);
 select count(*) from a1 where not exists (select c2 from a2 where a1.c2=a2.c2 and a1.c1=a2.c1);
+
+--disable_warnings
 drop table a1;
 drop table a2;
-
-
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7098_regression_bug3532.test
+++ b/mysql-test/columnstore/devregression/t/mcs7098_regression_bug3532.test
@@ -8,11 +8,16 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3532;
+--enable_warnings
+
 create table `bug3532` (`c1` char(1) default null, `c2` int(11) default null) engine=columnstore;
 insert into bug3532 values (1,1), (0,0), (1,12), (1,-1), (null, null);
 select round(c1,c1) from bug3532 where c1 = 1;
-drop table bug3532;
 
+--disable_warnings
+drop table bug3532;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7100_regression_bug3563.test
+++ b/mysql-test/columnstore/devregression/t/mcs7100_regression_bug3563.test
@@ -8,9 +8,12 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists qatabledecimal2byte;
 drop table if exists qatabledecimal4byte;
 drop table if exists qatabletinyint;
+--enable_warnings
+
 create table qatabledecimal2byte (col1 decimal(1), col2 decimal(4), col3 decimal(4,2)) engine=columnstore;
 create table qatabledecimal4byte (col1 decimal(5), col2 decimal(9), col3 decimal(9,2)) engine=columnstore;
 create table qatabletinyint (col numeric(2,0)) engine=columnstore;
@@ -38,12 +41,11 @@ insert into qatabletinyint values (99);
 select * from qatabledecimal2byte;
 select * from qatabledecimal4byte;
 select * from qatabletinyint;
+
+--disable_warnings
 drop table if exists qatabledecimal2byte;
 drop table if exists qatabledecimal4byte;
 drop table if exists qatabletinyint;
-
-
-
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7101_regression_bug3565.test
+++ b/mysql-test/columnstore/devregression/t/mcs7101_regression_bug3565.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3565;
+--enable_warnings
 
 #-- Create a table with a tinyint.
 create table bug3565(c1 tinyint)engine=columnstore;
@@ -22,6 +24,8 @@ select count(c1) from bug3565;
 select count(c2) from bug3565;
 select count(c3) from bug3565;
 
+--disable_warnings
 drop table if exists bug3565;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7103_regression_bug3582.test
+++ b/mysql-test/columnstore/devregression/t/mcs7103_regression_bug3582.test
@@ -8,13 +8,19 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3582;
+--enable_warnings
+
 create table bug3582 (c1 decimal(4,2), c2 char(4), c3 varchar(15)) engine=columnstore;
 insert into bug3582 values (4.00,'a','b');
 select * from bug3582;
 select *, round(c1,1), round(c1,10) from bug3582;
 update bug3582 set c2=round(c1,1), c3=round(c1,10);
 select *, round(c1,1), round(c1,10) from bug3582;
+
+--disable_warnings
 drop table if exists bug3582;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7106_regression_bug3669.test
+++ b/mysql-test/columnstore/devregression/t/mcs7106_regression_bug3669.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists stringtest;
+--enable_warnings
+
 create table stringtest (c1 char(10), c2 varchar(10), c3 varchar(6))engine=columnstore;
 insert into stringtest values ('abc','cde','abc'), ('cde','abc','cde');
 select * from stringtest where c1='abc' or c2='abc';
@@ -17,6 +20,9 @@ select * from stringtest where c2='abc  ';
 select * from stringtest where c1='abc ' or c2='abc  ';
 select * from stringtest where c1 = 'abc' or c3='cde  ';
 select concat('abc ', c2), concat('cde ', c3) from stringtest;
+
+--disable_warnings
 drop table stringtest;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7107_regression_bug3670_negative.test
+++ b/mysql-test/columnstore/devregression/t/mcs7107_regression_bug3670_negative.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists month;
+--enable_warnings
+
 create table month(id int, month varchar(20), season varchar(6))engine=columnstore;
 insert into month values (1, 'Jan', 'Winter');
 SELECT  *,
@@ -28,6 +31,9 @@ AND (@_season := season) IS NOT NULL;
 
 SELECT  * FROM    ( SELECT  m.* FROM   
  ( SELECT  @_season is NULL a) vars, month m where a=m.id ORDER BY season, id ) mo;
+
+--disable_warnings
 drop table month;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7109_regression_bug3680.test
+++ b/mysql-test/columnstore/devregression/t/mcs7109_regression_bug3680.test
@@ -8,11 +8,13 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists pts_agg_url_report;
 drop table if exists pts_dim_publisher;
 drop table if exists pts_dim_subsite;
 drop table if exists pts_meta_ad;
 drop table if exists pts_meta_campaign;
+--enable_warnings
 
 CREATE TABLE `pts_agg_url_report` (
   `agg_date` date DEFAULT NULL,
@@ -60,7 +62,7 @@ CREATE TABLE `pts_meta_ad` (
   `dimensionName` varchar(250) DEFAULT NULL
 ) engine=columnstore;
 
-cREATE TABLE `pts_meta_campaign` (
+CREATE TABLE `pts_meta_campaign` (
   `clientId` varchar(32) DEFAULT NULL,
   `externalClientId` int(11) DEFAULT NULL,
   `id` varchar(32) DEFAULT NULL,
@@ -90,6 +92,7 @@ pts_meta_campaign pmc on pmc.id = s.cid
   where cid is not null order by agg_date,pmc.displayname,publisher,pds.subsite,pma.dimensionname
 ;
 
+--disable_warnings
 drop table pts_agg_url_report;
 drop table pts_dim_publisher;
 drop table pts_dim_subsite;
@@ -99,6 +102,7 @@ drop table pts_meta_campaign;
 drop table if exists marketing_conversions;
 drop table if exists marketing_events;
 drop table if exists marketing_leads;
+--enable_warnings
 
 CREATE TABLE `marketing_conversions` (
   `pkMarketingConversionID` int(10) DEFAULT NULL,
@@ -184,8 +188,10 @@ marketing_conversions  where createdon > '2011-01-01' and newuser = 1 and
 productid = 'Business-2010' group by xdate ) bus  on bus.xdate=ml.xdate group
 by ml.xdate order by ml.xdate;
 
+--disable_warnings
 drop table marketing_conversions;
 drop table marketing_events;
 drop table marketing_leads;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7110_regression_bug3682.test
+++ b/mysql-test/columnstore/devregression/t/mcs7110_regression_bug3682.test
@@ -66,4 +66,7 @@ insert into bug3682 values
 ('2011-01-29 23:46:13');
 select date(c1), count(*) from bug3682 group by 1 order by 1;
 #
+--disable_warnings
 drop table if exists bug3682;
+--enable_warnings
+#

--- a/mysql-test/columnstore/devregression/t/mcs7111_regression_bug3706.test
+++ b/mysql-test/columnstore/devregression/t/mcs7111_regression_bug3706.test
@@ -8,12 +8,18 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists t1;
+--enable_warnings
+
 create table t1(f1 varchar(5)) engine=columnstore;
 insert into t1(f1) select if(max(f1) is null, '2000',max(f1)+1) from t1;
 select * from t1 order by 1;
 insert into t1(f1) select if(max(f1) is null, '2000',max(f1)+1) from t1;
 select * from t1 order by 1;
+
+--disable_warnings
 drop table t1;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7112_regression_bug3708.test
+++ b/mysql-test/columnstore/devregression/t/mcs7112_regression_bug3708.test
@@ -8,12 +8,18 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists looooooooooooooooooooooooooooooooooooooooong_tb_name;
+--enable_warnings
+
 create table looooooooooooooooooooooooooooooooooooooooong_tb_name (looooooooooooooooooooooooooooooooooooooooong_col_name int)engine=columnstore;
 insert into looooooooooooooooooooooooooooooooooooooooong_tb_name values (10);
 select looooooooooooooooooooooooooooooooooooooooong_col_name from looooooooooooooooooooooooooooooooooooooooong_tb_name 
 order by isnull(looooooooooooooooooooooooooooooooooooooooong_col_name);
 select concat('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', looooooooooooooooooooooooooooooooooooooooong_col_name) from looooooooooooooooooooooooooooooooooooooooong_tb_name;
+
+--disable_warnings
 drop table looooooooooooooooooooooooooooooooooooooooong_tb_name;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7113_regression_bug3719.test
+++ b/mysql-test/columnstore/devregression/t/mcs7113_regression_bug3719.test
@@ -8,11 +8,15 @@
 #
 USE tpch1;
 #
+--disable_warnings
 create database if not exists geo;
+--enable_warnings
 use geo;
 
+--disable_warnings
 drop table if exists `geo_tag_values`;
 drop table if exists `geo_tags`;
+--enable_warnings
 
 CREATE TABLE `geo_tag_values` (
   `id` int(11) DEFAULT NULL,
@@ -29,8 +33,12 @@ CREATE TABLE `geo_tags` (
   `lock_version` int(11) DEFAULT NULL
 ) engine=columnstore;
 
+--disable_warnings
 create database if not exists pbkt;
+--enable_warnings
+
 use pbkt;
+--disable_warnings
 drop table if exists `areas`;
 drop table if exists `bigsumplus`;
 drop table if exists `dim_date`;
@@ -39,6 +47,7 @@ drop table if exists `tag_values`;
 drop view if exists `tag_values_geo_country`;
 drop view if exists `tag_values_geo_region`;
 drop view if exists `tag_values_ptype`;
+--enable_warnings
 
 CREATE TABLE `areas` (
   `id` int(11) DEFAULT NULL,
@@ -279,9 +288,13 @@ select `tag_values_ptype`.value from (select * from tag_values_ptype) t1, tag_va
 where tag_values_ptype.id = t1.id;
 
 use geo;
+--disable_warnings
 drop table `geo_tag_values`;
 drop table `geo_tags`;
+--enable_warnings
+
 use pbkt;
+--disable_warnings
 drop table `areas`;
 drop table `bigsumplus`;
 drop table `dim_date`;
@@ -292,7 +305,6 @@ drop view `tag_values_geo_region`;
 drop view `tag_values_ptype`;
 drop database geo;
 drop database pbkt;
-
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7121_regression_bug3783.test
+++ b/mysql-test/columnstore/devregression/t/mcs7121_regression_bug3783.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3783;
+--enable_warnings
+
 set max_length_for_sort_data = 8192;
 create table bug3783 (id int, name varchar(1000))engine=columnstore;
 insert into bug3783 values (1,'yionfsdayfeiwajg'),(2,'gretsuyhejkstj jkete');
@@ -16,7 +19,9 @@ select id, hex(name) from bug3783 order by 1,2;
 select id, group_concat(name) from bug3783 group by 1 order by 1;
 select id, min(repeat(name,3)) from bug3783 group by 1 order by 1;
 select id, repeat(name,3) from bug3783 order by 1,2;
-drop table bug3783;
 
+--disable_warnings
+drop table bug3783;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7123_regression_bug3792_negative.test
+++ b/mysql-test/columnstore/devregression/t/mcs7123_regression_bug3792_negative.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3792;
+--enable_warnings
 
 create table bug3792 (c1 int, c2 datetime) engine=columnstore;
 insert into bug3792 values (1, '9999-12-31 23:59:59');
@@ -23,6 +25,8 @@ select c1, c2, subtime(c2, '2:0:0') x from bug3792 where c1 = 1;
 select c1, c2, subtime(c2, '2:0:0') x from bug3792 where c1 = 2;
 select c1, c2, subtime(c2, '2:0:0') x from bug3792 where c1 = 3;
 
+--disable_warnings
 drop table bug3792;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7124_regression_bug3798.test
+++ b/mysql-test/columnstore/devregression/t/mcs7124_regression_bug3798.test
@@ -9,11 +9,16 @@
 USE tpch1;
 #
 select cidx, CDOUBLE, CAST(CDOUBLE AS DECIMAL(9)) from datatypetestm order by cidx;
+--disable_warnings
 drop table if exists bug3798;
+--enable_warnings
+
 create table bug3798 (c1 float) engine=columnstore;
 insert into bug3798 values (1234567), (1.2345678);
 select c1, cast(c1 as decimal(9,2)), cast(c1 as decimal(14,12)) from bug3798;
-drop table bug3798;
 
+--disable_warnings
+drop table bug3798;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7126_regression_bug3853.test
+++ b/mysql-test/columnstore/devregression/t/mcs7126_regression_bug3853.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists dw_entradas_fact;
 drop table if exists dw_entradas_fact_1;
+--enable_warnings
 
 create table dw_entradas_fact (fecha date) engine=columnstore;
 create table dw_entradas_fact_1 (fecha date) engine=columnstore;
@@ -91,11 +93,11 @@ union
           FROM DW_ENTRADAS_FACT_1
          WHERE FECHA BETWEEN '2010-02-01' and '2010-02-28')) AS TY;         
 
-
-drop table if exists dw_entradas_fact;
-drop table if exists dw_entradas_fact_1;
-
 select * from region where 2=2 union select n_regionkey, n_nationkey, n_name from nation where 0=1;
 
+--disable_warnings
+drop table if exists dw_entradas_fact;
+drop table if exists dw_entradas_fact_1;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7129_regression_bug3932.test
+++ b/mysql-test/columnstore/devregression/t/mcs7129_regression_bug3932.test
@@ -8,11 +8,12 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists qa_nation;
 drop table if exists qa_customer;
 drop table if exists qa_region;
 drop table if exists qa_orders;
-
+--enable_warnings
 
 create table qa_nation (n_id int, n_name char(20), regionid int) engine=columnstore;
 create table qa_customer (c_id int, c_custname char(20), nationid int) engine=columnstore;
@@ -23,7 +24,6 @@ insert into qa_region values (1, 'ASIA'), (2, 'AMERICA'), (3, 'EUROPE');
 insert into qa_nation values (1, 'UNITED STATES', 2), (2, 'CANADA', 2), (3, 'JAPAN', 1), (4, 'CHINA', 1), (5, 'GERMANY', 3), (6, 'ITALY', 3);
 insert into qa_customer values (1, 'Cust_US', 1), (2, 'Cust_Japan', 3), (3, 'Cust_Italy', 6);
 insert into qa_orders values (1, 'Order_US#1', 1), (2, 'Order_US#2', 1), (3, 'Order_Japan#1', 2);
-
 
 select n.n_name, c.c_custname
 from qa_nation n 
@@ -55,10 +55,6 @@ from qa_nation n
 	left outer join qa_customer c on n.n_id = c.nationid
 where n.n_id in (select n2.n_id from qa_nation n2, qa_region r1 where n2.regionid = r1.r_id) group by n.n_name order by n.n_name;
 
-
-
-
-
 select r.r_name, n.n_name, c.c_custname
 from qa_region r 
 	join qa_nation n on r.r_id = n.regionid 
@@ -95,11 +91,6 @@ from qa_region r
 	left outer join qa_customer c on n.n_id = c.nationid
 where n.n_id in (select n2.n_id from qa_nation n2, qa_region r1 where n2.regionid = r1.r_id and r1.r_name = 'AMERICA') order by r.r_name, n.n_name;
 
-
-
-
-
-
 select r.r_name, n.n_name, c.c_custname
 from qa_region r 
 	join qa_nation n on r.r_id = n.regionid 
@@ -135,10 +126,6 @@ from qa_region r
 	join qa_nation n on r.r_id = n.regionid 
 	left outer join qa_customer c on n.n_id = c.nationid
 where r.r_id in (select r1.r_id from qa_nation n2, qa_region r1 where n2.regionid = r1.r_id and n2.n_name = 'UNITED STATES') order by r.r_name, n.n_name;
-
-
-
-
 
 select r.r_name, n.n_name, c.c_custname, o.o_name
 from qa_region r 
@@ -182,9 +169,6 @@ from qa_region r
 	left outer join qa_orders o on c.c_id = o.custid
 where n.n_id in (select n2.n_id from qa_nation n2, qa_region r1 where n2.regionid = r1.r_id and r1.r_name = 'AMERICA') order by r.r_name, n.n_name, o.o_name;
 
-
-
-
 select r.r_name, n.n_name, c.c_custname, o.o_name
 from qa_region r 
 	join qa_nation n on r.r_id = n.regionid 
@@ -227,10 +211,6 @@ from qa_region r
 	left outer join qa_orders o on c.c_id = o.custid
 where r.r_id in (select r1.r_id from qa_nation n2, qa_region r1 where n2.regionid = r1.r_id and n2.n_name = 'UNITED STATES') order by r.r_name, n.n_name, o.o_name;
 
-
-
-
-
 select r.r_name, n.n_name, c.c_custname, o.o_name
 from qa_region r 
 	join qa_nation n on r.r_id = n.regionid 
@@ -272,10 +252,6 @@ from qa_region r
 	join qa_customer c on n.n_id = c.nationid 
 	left outer join qa_orders o on c.c_id = o.custid
 where r.r_id in (select r1.r_id from qa_nation n2, qa_region r1 where n2.regionid = r1.r_id and n2.n_name = 'UNITED STATES') order by r.r_name, n.n_name, o.o_name;
-
-
-
-
 
 select r.r_name, n.n_name, c.c_custname, o.o_name
 from qa_region r 
@@ -340,13 +316,11 @@ from qa_region r
 	left outer join qa_orders o on c.c_id = o.custid
 where c.c_id in (select c1.c_id from qa_customer c1 where c1.c_custname = 'Cust_Italy') order by r.r_name, n.n_name;
 
-
-
-
+--disable_warnings
 drop table if exists qa_nation;
 drop table if exists qa_customer;
 drop table if exists qa_region;
 drop table if exists qa_orders;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7131_regression_bug3948.test
+++ b/mysql-test/columnstore/devregression/t/mcs7131_regression_bug3948.test
@@ -8,10 +8,12 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists fct_summary_transactional_snapshot;
 drop table if exists dim_c_bridge_duration;
 drop table if exists fct_macro_payment_details;
 drop table if exists dim_c_calendar;
+--enable_warnings
 
 CREATE TABLE `fct_macro_payment_details` (
   `TRANSACTION_DW_ID` bigint(20) DEFAULT NULL,
@@ -196,11 +198,11 @@ ON b.PeriodDesc = d.PeriodDesc ;
 )b
 ON b.PeriodDesc= d.PeriodDesc;
 
+--disable_warnings
 drop table fct_summary_transactional_snapshot;
 drop table dim_c_bridge_duration;
 drop table fct_macro_payment_details;
 drop table dim_c_calendar;
-
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7132_regression_bug3952.test
+++ b/mysql-test/columnstore/devregression/t/mcs7132_regression_bug3952.test
@@ -8,10 +8,16 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3952;
+--enable_warnings
+
 create table bug3952 (id int, name varchar(25));
 insert into bug3952 values (1,'aaa'),(2,'bbb');
 select * from bug3952 n1, (select * from bug3952)n2 where n1.id=n2.id;
+
+--disable_warnings
 drop table bug3952;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7135_regression_bug3998.test
+++ b/mysql-test/columnstore/devregression/t/mcs7135_regression_bug3998.test
@@ -8,10 +8,12 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug3998a;
 drop table if exists bug3998b;
 drop table if exists bug3998c;
 drop table if exists bug3998d;
+--enable_warnings
 
 create table bug3998a (c1 int, c2 int) engine=columnstore;
 insert into bug3998a values (0,0), (1,1), (2,1), (3, 1), (null,1), (null, null);
@@ -38,10 +40,12 @@ select * from bug3998b;
 update bug3998c right join bug3998d on bug3998c.c1 = bug3998d.c1 set bug3998c.c1=9;
 select * from bug3998c;
 
+--disable_warnings
 drop table if exists bug3998a;
 drop table if exists bug3998b;
 drop table if exists bug3998c;
 drop table if exists bug3998d;
+--enable_warnings
 
 create table bug3998a (c1 int, c2 int) engine=columnstore;
 insert into bug3998a values (0,0), (1,1), (2,1), (3, 1), (null,1), (null, null);
@@ -68,9 +72,11 @@ select * from bug3998b;
 delete c from bug3998c c right join bug3998d d on c.c1 = d.c1;
 select * from bug3998c;
 
+--disable_warnings
 drop table if exists bug3998a;
 drop table if exists bug3998b;
 drop table if exists bug3998c;
 drop table if exists bug3998d;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7136_regression_bug4027.test
+++ b/mysql-test/columnstore/devregression/t/mcs7136_regression_bug4027.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists product;
 drop table if exists product_tag;
+--enable_warnings
 
 create table product_tag (product_id bigint)engine=columnstore;
 
@@ -34,8 +36,10 @@ set brand=p.product_id, price=555, modified_dtm='2011-12-15 15:15:30',
 short_description=concat(short_description,modified_by);
 
 select * from product;
+
+--disable_warnings
 drop table product;
 drop table product_tag;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7139_regression_bug4074.test
+++ b/mysql-test/columnstore/devregression/t/mcs7139_regression_bug4074.test
@@ -32,5 +32,7 @@ select 'q5', birthdate, age, id, col8 from bug3657 where col8=6;
 select calflushcache();
 select 'q6', birthdate, age, id, col8 from bug3657 where col8=2;
 #
+--disable_warnings
 drop table if exists bug3657;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7143_regression_bug4346.test
+++ b/mysql-test/columnstore/devregression/t/mcs7143_regression_bug4346.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists dim_day;
+--enable_warnings
+
 CREATE TABLE `dim_day` (
   `dayId` SMALLINT(5) DEFAULT NULL,
   `displayDate` DATE DEFAULT NULL
@@ -17,5 +20,9 @@ INSERT INTO dim_day (dayId, displayDate) VALUES (1,'2012-01-01') ,
 (2,'2012-02-01');
 SELECT STR_TO_DATE(CONCAT(YEARWEEK(displayDate,2),'-01'),'%X%V-%w')
 FROM dim_day;
-drop table dim_day;#
+
+--disable_warnings
+drop table dim_day;
+--enable_warnings
+#
 

--- a/mysql-test/columnstore/devregression/t/mcs7144_regression_bug4359.test
+++ b/mysql-test/columnstore/devregression/t/mcs7144_regression_bug4359.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug4359;
+--enable_warnings
 
 CREATE TABLE bug4359 (
   sdate datetime DEFAULT NULL,
@@ -21,7 +23,8 @@ insert into bug4359 values ('2009-01-05 13:30:00','2009-01-05 14:00:00');
 select timediff(edate,sdate) from bug4359;
 select time_to_sec(timediff(edate,sdate)) from bug4359;
 
+--disable_warnings
 drop table bug4359;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7145_regression_bug4373.test
+++ b/mysql-test/columnstore/devregression/t/mcs7145_regression_bug4373.test
@@ -8,9 +8,15 @@
 #
 USE tpch1;
 #
+--enable_warnings
 create table if not exists mkr (c1 int, select_b int) engine=columnstore;
+--enable_warnings
+
 insert into mkr (c1, select_b) (select n_nationkey, n_regionkey from nation);
 select * from mkr;
+
+--disable_warnings
 drop table mkr;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7146_regression_bug4386.test
+++ b/mysql-test/columnstore/devregression/t/mcs7146_regression_bug4386.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists dim_date;
+--enable_warnings
+
 create table dim_date ( companycode integer, FinancialQuarterID integer,
 FinancialQuarter integer, FinancialYear integer ) engine=columnstore;
 insert into dim_date values (1,1,2,1);
@@ -19,7 +22,9 @@ select count(*)     from dim_date x_varDate      where      FinancialQuarterID B
 x_varDate.FinancialQuarter <=               3       THEN          ((x_varDate.FinancialYear  - 1) * 10)          +
 (1 + x_varDate.FinancialQuarter)       ELSE          (x_varDate.FinancialYear * 10)          +
 (x_varDate.FinancialQuarter - 3)         END       AND x_varDate.FinancialQuarterID;
-drop table dim_date;
 
+--disable_warnings
+drop table dim_date;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7147_regression_bug4388.test
+++ b/mysql-test/columnstore/devregression/t/mcs7147_regression_bug4388.test
@@ -99,6 +99,10 @@ insert into t3 values
 
 select * from (select a,b from t1 union select a,b from t2 union select a,b from t3) tu order by a,b;
 
+--disable_warnings
 drop table t1;
 drop table t2;
 drop table t3;
+--enable_warnings
+#
+

--- a/mysql-test/columnstore/devregression/t/mcs7148_regression_bug4391.test
+++ b/mysql-test/columnstore/devregression/t/mcs7148_regression_bug4391.test
@@ -18,5 +18,7 @@ insert into bug4391 (c2) values (1);
 insert into bug4391 (c2) values (2),(3);
 select * from bug4391;
 #
+--disable_warnings
 drop table if exists bug4391;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7149_regression_bug4394.test
+++ b/mysql-test/columnstore/devregression/t/mcs7149_regression_bug4394.test
@@ -10,10 +10,16 @@ USE tpch1;
 #
 # Prior to bug 4629, this was a negative test case.  The year range was expanded from 1000 on the low end to the year 0 on the low end with the bug.
 
+--disable_warnings
 drop table if exists bug4394;
+--enable_warnings
+
 create table bug4394(c1 datetime) engine=columnstore;
 insert into bug4394 values('1000-01-01 00:00:00'); 
 select * from bug4394;
+
+--disable_warnings
 drop table bug4394;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7150_regression_bug4422.test
+++ b/mysql-test/columnstore/devregression/t/mcs7150_regression_bug4422.test
@@ -8,12 +8,13 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bigsumplus;
 drop table if exists areas;
 drop table if exists geo_tag_values;
 drop table if exists geo_tags;
 drop view if exists tag_values_geo_country;
-
+--enable_warnings
 
 create table if not exists
 `bigsumplus` (
@@ -119,12 +120,12 @@ select g.name,g.country,g.served from (select b.area as name,gc.value as country
 bigsumplus b join tag_values_geo_country gc on b.geo_country=gc.id join areas a on b.area=a.id where 
 cdate='2012-05-15' group by b.area,gc.value) g where g.served <= 3;
 
-
+--disable_warnings
 drop table bigsumplus;
 drop table areas;
 drop table geo_tag_values;
 drop table geo_tags;
 drop view tag_values_geo_country;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7151_regression_bug4431.test
+++ b/mysql-test/columnstore/devregression/t/mcs7151_regression_bug4431.test
@@ -8,21 +8,26 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug4431_1;
 drop table if exists bug4431_2;
 drop table if exists bug4431_3;
+--enable_warnings
 
 create table bug4431_1 (date int, col2 date) engine=columnstore;
 create table bug4431_2 (`date` int, col2 date) engine=columnstore;
 create table bug4431_3 (col2 date) engine=columnstore;
 alter table bug4431_3 add column date int;
-alter table bug4431_3 drop column date;
+alter table bug4431_3 --disable_warnings
+drop column date;
 
 insert into bug4431_1 values (1, '2012-06-06'),(2, '2012-06-06'),(3, '2012-06-06'),(4, '2012-06-06');
 select * from bug4431_1;
 
+--disable_warnings
 drop table bug4431_1;
 drop table bug4431_2;
 drop table bug4431_3;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7151_regression_bug4431.test
+++ b/mysql-test/columnstore/devregression/t/mcs7151_regression_bug4431.test
@@ -18,8 +18,7 @@ create table bug4431_1 (date int, col2 date) engine=columnstore;
 create table bug4431_2 (`date` int, col2 date) engine=columnstore;
 create table bug4431_3 (col2 date) engine=columnstore;
 alter table bug4431_3 add column date int;
-alter table bug4431_3 --disable_warnings
-drop column date;
+alter table bug4431_3 drop column date;
 
 insert into bug4431_1 values (1, '2012-06-06'),(2, '2012-06-06'),(3, '2012-06-06'),(4, '2012-06-06');
 select * from bug4431_1;

--- a/mysql-test/columnstore/devregression/t/mcs7152_regression_bug4457.test
+++ b/mysql-test/columnstore/devregression/t/mcs7152_regression_bug4457.test
@@ -137,8 +137,10 @@ SET C.pef_ind_trc_CEN06_date_partid = D.pepf_int_date_trc_partid_date,
 C.pef_id_fonctionnel_tournee = D.pepf_id_fonctionnel_tournee
 WHERE C.pef_env_id_env= D.pef_env_id_env;
 
+--disable_warnings
 drop table poc_enveloppe_fact;
 drop table poc_enveloppe_partid_fact;
 drop table poc_tmp_calc_indic;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7153_regression_bug4488.test
+++ b/mysql-test/columnstore/devregression/t/mcs7153_regression_bug4488.test
@@ -33,8 +33,9 @@ homemcc, COUNT(*) AS gtot, count(distinct imei) as ugtot FROM `sessions`  WHERE
 appname='WP Exchange Activation Tracking OBA QA' AND DATE(stime)>='2012-05-28'
 GROUP BY devname, homemcc, appversion, applang;
 
+--disable_warnings
 drop table `sessions`;
 drop table myfil;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7154_regression_bug4509.test
+++ b/mysql-test/columnstore/devregression/t/mcs7154_regression_bug4509.test
@@ -29,7 +29,10 @@ insert into bug4509 values (1,2),(2,3),(3,4);
 insert into bug4509_myisam values (1,2),(2,4),(3,4);
 select * from bug4509 join bug4509_myisam using (id);
 select * from bug4509_myisam join bug4509 using (c1, id);
+
+--disable_warnings
 drop table bug4509;
 drop table bug4509_myisam;
+--enable_warnings
 #
 DROP USER 'cejuser'@'localhost';

--- a/mysql-test/columnstore/devregression/t/mcs7155_regression_bug4543.test
+++ b/mysql-test/columnstore/devregression/t/mcs7155_regression_bug4543.test
@@ -51,5 +51,7 @@ select date_stamp, sum(adjusted_imp)
 #
 select count(*) from bug4543 where dart_ad_id >= 1;
 #
+--disable_warnings
 drop table if exists bug4543;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7158_regression_bug4767.test
+++ b/mysql-test/columnstore/devregression/t/mcs7158_regression_bug4767.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists cat;
 drop table if exists dog;
+--enable_warnings
 
 create table cat(id int, f float, d double)engine=columnstore;
 create table dog(id int, f float, d double)engine=columnstore;
@@ -37,7 +39,9 @@ select 'q4', cat.* from cat;
 
 select 'q5', cat.id, dog.id from cat join dog on cat.f = dog.f and cat.d = dog.d;
 
+--disable_warnings
 drop table cat;
 drop table dog; 
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7161_regression_bug4947.test
+++ b/mysql-test/columnstore/devregression/t/mcs7161_regression_bug4947.test
@@ -92,5 +92,7 @@ select 12, count(o_orderpriority) from orders2;
 
 select count(distinct o_orderkey) from orders2;
 #
+--disable_warnings
 drop table if exists orders2;
+--enable_warnings
 

--- a/mysql-test/columnstore/devregression/t/mcs7162_regression_bug5044.test
+++ b/mysql-test/columnstore/devregression/t/mcs7162_regression_bug5044.test
@@ -8,11 +8,17 @@
 #
 USE tpch1;
 #
+--disable_warnings
 create table if not exists casetest (id int, c1 int, c2 int, c3 int) engine=columnstore;
+--enable_warnings
+
 insert into casetest values (1, 1, 1, 1), (2, null, null, null), (3, 1, 1, null), (4, 1, null, null);
 select id, case when c1 is not null and c2 is not null and c3 is not null then 'A' when c1 is not null and c2 is 
 not null and c3 is null then 'B' when c1 is not null and c2 is null and c3 is not null then 'C' when c1 is not null 
 and c2 is null and c3 is null then 'D' end case_func from casetest;
+
+--disable_warnings
 drop table casetest;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7164_regression_bug5096.test
+++ b/mysql-test/columnstore/devregression/t/mcs7164_regression_bug5096.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 create table if not exists bug5096 (id int, c1 int)engine=columnstore;
+--enable_warnings
+
 insert into bug5096 values (1,1),(2,2),(3,3),(4,4);
 set autocommit=0;
 update bug5096 set id = 10 limit 2;
@@ -27,7 +30,9 @@ select * from bug5096 limit 10;
 rollback;
 delete from bug5096 limit 2;
 select * from bug5096;
-drop table bug5096;
 
+--disable_warnings
+drop table bug5096;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7166_regression_bug5099.test
+++ b/mysql-test/columnstore/devregression/t/mcs7166_regression_bug5099.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE if exists bug5099;
+--enable_warnings
+
 CREATE TABLE `bug5099` (`col1` datetime DEFAULT NULL, `col2` datetime DEFAULT NULL ) ENGINE=Columnstore;
 insert into bug5099 (col1, col2) values ('2012-09-24 11:00:01', '2012-09-24 11:00:00');
 insert into bug5099 (col1, col2) values ('2012-09-24 11:01:00', '2012-09-24 11:02:00');
@@ -21,7 +24,8 @@ insert into bug5099 (col1, col2) values ('2012-01-24 12:00:00', '2012-01-29 11:0
 insert into bug5099 (col1, col2) values ('2012-09-29 12:00:00', '2012-01-24 11:00:00');
 select col1,col2,timediff(col1, col2),time_to_sec(timediff(col1, col2) ) from bug5099;
 
+--disable_warnings
 drop table if exists bug5099;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7168_regression_bug5173.test
+++ b/mysql-test/columnstore/devregression/t/mcs7168_regression_bug5173.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists qadefaulttest;
+--enable_warnings
+
 create table qadefaulttest (cidx int) engine=columnstore;
 ALTER TABLE qadefaulttest ADD column MYDOUBLE2 DOUBLE not null DEFAULT -88.88;
 insert into qadefaulttest values (1, -88.88);
@@ -17,5 +20,8 @@ ALTER TABLE qadefaulttest ADD column MYFLOAT3 FLOAT not null DEFAULT -88.88;
 select * from qadefaulttest;
 ALTER TABLE qadefaulttest ADD column MYDECIMAL2 DECIMAL(4,2) not null DEFAULT -88.88;
 select * from qadefaulttest;
-drop table qadefaulttest;#
 
+--disable_warnings
+drop table qadefaulttest;#
+--enable_warnings
+#

--- a/mysql-test/columnstore/devregression/t/mcs7169_regression_bug5176.test
+++ b/mysql-test/columnstore/devregression/t/mcs7169_regression_bug5176.test
@@ -9,7 +9,10 @@
 USE tpch1;
 #
 set @@sql_select_limit=4;
+--disable_warnings
 create table if not exists bug5054(id int)engine=columnstore; 
+--enable_warnings
+
 insert into bug5054 values (1),(2),(3),(4),(5),(6),(7),(8); 
 update bug5054 set id=4 where id>5; 
 select * from bug5054 order by 1; 
@@ -20,9 +23,9 @@ select count(*) from bug5054 order by 1;
 insert into bug5054 select * from bug5054;
 select * from bug5054 order by 1;
 select count(*) from bug5054;
+
+--disable_warnings
 drop table bug5054;
-
-
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7170_regression_bug5228.test
+++ b/mysql-test/columnstore/devregression/t/mcs7170_regression_bug5228.test
@@ -34,8 +34,6 @@ ORDER BY
 T1.`eigyo_shimei`,
 (CASE (T1.`eigyo_shimei`)  WHEN 'SMITH' THEN 1 WHEN 'ALLEN' THEN 2 WHEN 'JONES' THEN 3 ELSE 4 END); 
 
-
-
 SELECT
 T1.`eigyo_shimei`,
 (CASE (T1.eigyo_shimei)  WHEN 'SMITH' THEN 1 WHEN 'ALLEN' THEN 2 WHEN 'JONES' THEN 3 ELSE 4 END),
@@ -47,7 +45,6 @@ T1.`eigyo_shimei`,
 ORDER BY
 T1.`eigyo_shimei`,
 (CASE (T1.`eigyo_shimei`)  WHEN 'SMITH' THEN 1 WHEN 'ALLEN' THEN 2 WHEN 'JONES' THEN 3 ELSE 4 END);
-
 
 SELECT
 T1.`eigyo_shimei`,
@@ -61,7 +58,6 @@ ORDER BY
 T1.`eigyo_shimei`,
 (CASE (T1.`eigyo_shimei`)  WHEN 'SMITH' THEN 1 WHEN 'ALLEN' THEN 2 WHEN 'JONES' THEN 3 ELSE 4 END);
 
-
 SELECT
 T1.`eigyo_shimei`,
 (CASE (T1.`eigyo_shimei`)  WHEN 'SMITH' THEN 1 WHEN 'ALLEN' THEN 2 WHEN 'JONES' THEN 3 ELSE 4 END),
@@ -73,7 +69,6 @@ T1.`eigyo_shimei`,
 ORDER BY
 T1.`eigyo_shimei`,
 (CASE (T1.`eigyo_shimei`)  WHEN 'SMITH' THEN 1 WHEN 'ALLEN' THEN 2 WHEN 'JONES' THEN 3 ELSE 4 END);
-
 
 SELECT
 T1.`eigyo_shimei`,
@@ -87,7 +82,6 @@ ORDER BY
 T1.`eigyo_shimei`,
 (CASE (T1.`eigyo_shimei`)  WHEN 'SMITH' THEN 1 WHEN 'ALLEN' THEN 2 WHEN 'JONES' THEN 3 ELSE 4 END);
 
-
 SELECT
 T1.`eigyo_shimei`,
 (CASE (T1.eigyo_shimei)  WHEN 'SMITH' THEN 1 WHEN 'ALLEN' THEN 2 WHEN 'JONES' THEN 3 ELSE 4 END) number,
@@ -100,6 +94,8 @@ ORDER BY
 T1.`eigyo_shimei`,
 (CASE (T1.`eigyo_shimei`)  WHEN 'SMITH' THEN 1 WHEN 'ALLEN' THEN 2 WHEN 'JONES' THEN 3 ELSE 4 END);
 
+--disable_warnings
 drop table uriage_inf;
 drop table uriage_my;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7171_regression_bug5229.test
+++ b/mysql-test/columnstore/devregression/t/mcs7171_regression_bug5229.test
@@ -8,13 +8,17 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists uriage_inf;
+--enable_warnings
 
 create table uriage_inf(eigyo_shimei varchar(20),uriage numeric) engine=columnstore default charset=utf8;
 
 insert into uriage_inf values('SMITH',1000); insert into uriage_inf values('ALLEN',2000); insert into uriage_inf values('JONES',3000); insert into uriage_inf values('SMITH',4000); insert into uriage_inf values('BLAKE',5000);
 
+--disable_warnings
 drop table if exists uriage_my;
+--enable_warnings
 
 create table uriage_my (eigyo_shimei varchar(20),uriage numeric) engine=myisam default charset=utf8;
 
@@ -61,6 +65,8 @@ GROUP BY
 ORDER BY
  T1.`eigyo_shimei`;
 
+--disable_warnings
 drop table uriage_inf;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7172_regression_bug5230.test
+++ b/mysql-test/columnstore/devregression/t/mcs7172_regression_bug5230.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists region1;
+--enable_warnings
+
 create table  region1
    (
     r_regionkey int,
@@ -23,7 +26,9 @@ start transaction;
 insert into region1 select * from tpch1.region;
 commit;
 select * from region1;
-drop table region1;
 
+--disable_warnings
+drop table region1;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7174_regression_bug5286.test
+++ b/mysql-test/columnstore/devregression/t/mcs7174_regression_bug5286.test
@@ -8,8 +8,11 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists test;
 drop view if exists test_v;
+--enable_warnings
+
 create table test (test1 numeric,test2 varchar(20)) engine=columnstore; 
 create view test_v as select * from test;
 insert into test values (1,'data1');
@@ -19,7 +22,10 @@ insert into test values (3,'data3');
 select T.test1,T.test2 from test_v T;
 select T.test1,T.test2 from test_v t;
 select T.test1 from (select * from test_v)T;
+
+--disable_warnings
 drop table test;
 drop view test_v;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7175_regression_bug5289.test
+++ b/mysql-test/columnstore/devregression/t/mcs7175_regression_bug5289.test
@@ -8,9 +8,11 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug5289a;
 drop table if exists bug5289b;
 drop view if exists bug5289b_v;
+--enable_warnings
 
 create table bug5289a(
 a decimal(10,0),
@@ -32,8 +34,10 @@ select 'q1', count(*) from bug5289a a,bug5289_v b where a.a = b.a;
 select 'q2', count(*) from bug5289a a left join bug5289_v b on (a.a = b.a);
 select 'q3', count(*) from bug5289a a, bug5289b b where a.a = cast(b.a as decimal(10,0));
 
+--disable_warnings
 drop table if exists bug5289a;
 drop table if exists bug5289b;
 drop view if exists bug5289b_v;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7177_regression_bug5319.test
+++ b/mysql-test/columnstore/devregression/t/mcs7177_regression_bug5319.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS bug5319_a;
+--enable_warnings
+
 CREATE TABLE `bug5319_a` (
   `col1` int(11) DEFAULT NULL,
   `col2` int(11) DEFAULT NULL
@@ -16,7 +19,10 @@ CREATE TABLE `bug5319_a` (
 insert into bug5319_a values (1,2);
 insert into bug5319_a values (1,2);
 
+--disable_warnings
 DROP TABLE IF EXISTS bug5319_b;
+--enable_warnings
+
 CREATE TABLE `bug5319_b` (
   `col1` int(11) DEFAULT NULL,
   `col2` int(11) DEFAULT NULL
@@ -25,15 +31,20 @@ insert into bug5319_b values (1,2);
 insert into bug5319_b values (1,3);
 insert into bug5319_b values (1,4);
 
+--disable_warnings
 DROP VIEW IF EXISTS view_bug5319_b;
+--enable_warnings
+
 create view view_bug5319_b as select bug5319_b.col1 AS col1, bug5319_b.col2 AS col2,sum(bug5319_b.col2) AS
 kensyu_gk_total from bug5319_b group by bug5319_b.col1,bug5319_b.col2;
 Select bug5319_a.col1,bv.col2 from bug5319_a left join view_bug5319_b bv on (bug5319_a.col1 = bv.col1) order by 1, 2 ;
 Select bug5319_a.col1,bv.col2 from bug5319_a join view_bug5319_b bv on (bug5319_a.col1 = bv.col1) order by 1, 2;
 Select bug5319_a.col1,bv.col2 from bug5319_a right join view_bug5319_b bv on (bug5319_a.col1 = bv.col1) order by 1, 2;
+
+--disable_warnings
 DROP TABLE bug5319_a;
 DROP TABLE bug5319_b;
 DROP VIEW view_bug5319_b;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7181_regression_bug5448.test
+++ b/mysql-test/columnstore/devregression/t/mcs7181_regression_bug5448.test
@@ -8,6 +8,7 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug5448;
 
 create table bug5448 (mst_date datetime) engine=columnstore; 
@@ -17,6 +18,7 @@ insert into bug5448 values ('2012-03-01');
 
 select mst_date, date_add(date(mst_date), interval - 30 day) from bug5448;
 
+--disable_warnings
 drop table if exists bug5448;
 
 #

--- a/mysql-test/columnstore/devregression/t/mcs7182_regression_bug5687.test
+++ b/mysql-test/columnstore/devregression/t/mcs7182_regression_bug5687.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug5687;
+--enable_warnings
 
 create table bug5687(col1 datetime DEFAULT NULL) engine=columnstore;
 insert into bug5687 (col1) values ("2012-01-24 11:00:01");
@@ -22,6 +24,8 @@ insert into bug5687 (col1) values ("2052-08-24 11:00:31");
 insert into bug5687 (col1) values ("3002-09-24 11:00:41");
 select TIMESTAMPADD(SECOND, 25284748647, col1) from bug5687;
 
+--disable_warnings
 drop table if exists bug5687;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7183_regression_bug5712.test
+++ b/mysql-test/columnstore/devregression/t/mcs7183_regression_bug5712.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS bug5712;
+--enable_warnings
+
 CREATE TABLE bug5712 (`time_tk` INT(11) UNSIGNED NOT NULL) ENGINE=Columnstore DEFAULT CHARSET=latin1;
 
 INSERT INTO bug5712 VALUES 
@@ -23,5 +26,8 @@ INSERT INTO bug5712 VALUES
 SELECT LEFT(time_tk,6) AS time_tk_left FROM bug5712;
 SELECT RIGHT(time_tk,6) AS time_tk_right FROM bug5712;
 
-DROP TABLE IF EXISTS bug5712;#
+--disable_warnings
+DROP TABLE IF EXISTS bug5712;
+--enable_warnings
+#
 

--- a/mysql-test/columnstore/devregression/t/mcs7184_regression_bug5715.test
+++ b/mysql-test/columnstore/devregression/t/mcs7184_regression_bug5715.test
@@ -42,6 +42,8 @@ select col1*4.00040040003599959959996 from bug2437;
 
 select (count(*)/72143371)*100,(6001215/72143371)*100,(count(*)*100)/72143371,(6001215*100)/72143371 from lineitem;
 #
+--disable_warnings
 drop table `p2_loaded_uh_p_xml_fsc_2x_for_agg_201310_valid_sess`;
 drop table bug2437;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7185_regression_bug5764b.test
+++ b/mysql-test/columnstore/devregression/t/mcs7185_regression_bug5764b.test
@@ -8,10 +8,12 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop view if exists vwBug;
 drop view if exists vwBug2;
 drop view if exists vwBug3;
 drop view if exists vwBug4;
+--enable_warnings
 
 create view vwBug as 
 select sub1.c1 s1c1, sub1.c2 s1c2, sub2.c1 s2c1, sub2.c2 s2c2, sub3.c1 s3c1, sub3.c2 s3c2
@@ -38,10 +40,11 @@ select 'q9', vwBug.s1c1, vwBug2.s1c1 from vwBug right join vwBug2 on (vwBug.s1c1
 create view vwBug4 as (select * from vwBug3 where s1c1 in (select s1c2 from vwBug2 where s1c1 in (select s1c1 from vwBug)));
 select 'q10', vwBug4.s1c1, vwBug4.s1c2, count(*) from vwBug4 group by 1, 2, 3 order by 1, 2, 3;
 
-
+--disable_warnings
 drop view vwBug;
 drop view vwBug2;
 drop view vwBug3;
 drop view vwBug4;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7186_regression_bug5764.test
+++ b/mysql-test/columnstore/devregression/t/mcs7186_regression_bug5764.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists mk_calendar;
+--enable_warnings
+
  CREATE TABLE if not exists `mk_calendar` (
   `nengetsu_yyyymmdd` date DEFAULT NULL,
   `shukei_dd` varchar(6) DEFAULT NULL,
@@ -23,7 +26,10 @@ insert into mk_calendar values
 ('2009-04-01', 1, 200904),
 ('2009-04-02', 2, 200904);
 
+--disable_warnings
 drop table if exists mk_kishu_gaibu;
+--enable_warnings
+
 CREATE TABLE if not exists `mk_kishu_gaibu` (
   `Jyohokei_Denwa_Shurui` varchar(100) DEFAULT NULL,
   `Shuryoku_Hanbai_Kishu_Key` varchar(100) DEFAULT NULL
@@ -39,7 +45,10 @@ insert into mk_kishu_gaibu values
 ('A1', '508G'),                                           
 ('GT', 'HD60');                                           
 
+--disable_warnings
 drop table if exists mk_kishubetsu_report2;
+--enable_warnings
+
  CREATE TABLE if not exists `mk_kishubetsu_report2` (
   `KEYNO` int(10) DEFAULT NULL
 ) ENGINE=Columnstore DEFAULT CHARSET=utf8;
@@ -56,7 +65,10 @@ insert into mk_kishubetsu_report2 values
 (1000009),
 (6000001);
 
+--disable_warnings
 drop table if exists mk_organization;
+--enable_warnings
+
  CREATE TABLE if not exists `mk_organization` (
   `Tokatsuten_Code` varchar(30) DEFAULT NULL,
   `Kyoten_Code` varchar(30) DEFAULT NULL
@@ -74,7 +86,10 @@ insert into mk_organization values
 ('EK21', '017'),  
 ('NESM', '021');
 
+--disable_warnings
 drop table if exists mk_shuryoku_hanbai_kishu;
+--enable_warnings
+
  CREATE TABLE if not exists `mk_shuryoku_hanbai_kishu` (
   `catalog_nengetsu` varchar(6) DEFAULT NULL,
   `kata_shiki` varchar(20) DEFAULT NULL
@@ -89,7 +104,10 @@ insert into mk_shuryoku_hanbai_kishu values
 (200905, 'S002'),
 (200905, 'BUGS');
 
+--disable_warnings
 drop table if exists ts_kishubetsu_hibetsu_pfmtst;
+--enable_warnings
+
 CREATE TABLE if not exists `ts_kishubetsu_hibetsu_pfmtst` (
   `keijyo_yyyymm` int(6) DEFAULT NULL,
   `keijyo_dd` varchar(6) DEFAULT '@',
@@ -109,7 +127,10 @@ insert into ts_kishubetsu_hibetsu_pfmtst values
 (200904, 3, 'K554', 'M18', 'GT', 1000004),
 (200904, 4, 'K554', '021', 'ZZ', 3333333);
 
+--disable_warnings
 drop view if exists v_kyotenbetsu_kishubetsu_hibetsu_base;
+--enable_warnings
+
 CREATE VIEW `v_kyotenbetsu_kishubetsu_hibetsu_base`
 AS
 (
@@ -137,7 +158,10 @@ AS
 			)
 		);
 
+--disable_warnings
 drop view if exists v_kyotenbetsu_kishubetsu_hibetsu;
+--enable_warnings
+
 CREATE VIEW `v_kyotenbetsu_kishubetsu_hibetsu`
 AS
 (
@@ -153,10 +177,6 @@ AS
 			)
 		);
 
-
-
-
-
 select count(*) count1
 from
 (
@@ -170,6 +190,7 @@ from (
 
 select count(*) count2 from v_kyotenbetsu_kishubetsu_hibetsu;
 
+--disable_warnings
 drop table if exists mk_calendar;
 drop table if exists mk_kishu_gaibu;
 drop table if exists mk_kishubetsu_report2;
@@ -178,6 +199,6 @@ drop table if exists mk_shuryoku_hanbai_kishu;
 drop table if exists ts_kishubetsu_hibetsu_pfmtst;
 drop view if exists v_kyotenbetsu_kishubetsu_hibetsu_base;
 drop view if exists v_kyotenbetsu_kishubetsu_hibetsu;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7187_regression_bug5777.test
+++ b/mysql-test/columnstore/devregression/t/mcs7187_regression_bug5777.test
@@ -9,6 +9,7 @@
 USE tpch1;
 #
 
+--disable_warnings
 DROP TABLE IF EXISTS query_class_metrics_float;
 
 #
@@ -39,5 +40,6 @@ SELECT start_ts, Query_time_sum,FIRST_VALUE(Query_time_sum) OVER(order by start_
 SELECT start_ts, Query_time_sum,LAST_VALUE(Query_time_sum) OVER(order by start_ts) prev_sum  from query_class_metrics_float where agent_id=1 and query_class=1563 limit 50;
 SELECT start_ts, Query_time_sum,NTH_VALUE(Query_time_sum, 3) OVER(order by start_ts) prev_sum  from query_class_metrics_float where agent_id=1 and query_class=1563 limit 50;
 #
+--disable_warnings
 DROP TABLE query_class_metrics_float;
 

--- a/mysql-test/columnstore/devregression/t/mcs7190_regression_bug5932.test
+++ b/mysql-test/columnstore/devregression/t/mcs7190_regression_bug5932.test
@@ -8,6 +8,7 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug5932;
 
 create table bug5932(c1 int)engine=columnstore;
@@ -25,6 +26,7 @@ select * from bug5932 where c1=2;
 
 select distinct c1 from bug5932 order by 1;
 
+--disable_warnings
 drop table if exists bug5932;
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7192_regression_bug6065.test
+++ b/mysql-test/columnstore/devregression/t/mcs7192_regression_bug6065.test
@@ -9,6 +9,7 @@
 USE tpch1;
 #
 --disable_warnings
+--disable_warnings
 DROP TABLE IF EXISTS `pv_facts`;
 --enable_warnings
 #
@@ -348,5 +349,6 @@ count(*) over (partition by visit_id ) as pvs,
 from pv_facts
 where visit_id='U1mQdAoBCjUAAHbgZcsAAABS') a;
 #
+--disable_warnings
 DROP TABLE `pv_facts`;
 #

--- a/mysql-test/columnstore/devregression/t/mcs7193_regression_bug6113.test
+++ b/mysql-test/columnstore/devregression/t/mcs7193_regression_bug6113.test
@@ -8,6 +8,7 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists t;
 create table t(a bigint, b varchar(10)) engine=columnstore;
  
@@ -17,13 +18,16 @@ insert into t values (2, 'bye');
 insert into t values (2, 'good night');
  
 select t.*, row_number() over (partition by a order by b) as rnum from t;
+--disable_warnings
 drop view if exists v;
 create view v as select * from t;
  
 select v.*, row_number() over (partition by a order by b) as rnum from v;
 select v.*, min(a) over (partition by a order by b) as rnum from v;
 select rank() over(order by a) from v;
+--disable_warnings
 drop table t;
+--disable_warnings
 drop view v;
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7194_regression_bug6126.test
+++ b/mysql-test/columnstore/devregression/t/mcs7194_regression_bug6126.test
@@ -9,8 +9,11 @@
 USE tpch1;
 #
 --disable_warnings
+--disable_warnings
 DROP TABLE IF EXISTS `fact_radius_sessions`;
+--disable_warnings
 DROP TABLE IF EXISTS `dim_traffic_class`;
+--disable_warnings
 DROP TABLE IF EXISTS `dim_age_band_marketing_list`;
 --enable_warnings
 
@@ -93,8 +96,11 @@ GROUP BY
     s.venue_visit_id,
     s.registered_at_venue;
 #
+--disable_warnings
 DROP TABLE `fact_radius_sessions`;
+--disable_warnings
 DROP TABLE `dim_traffic_class`;
+--disable_warnings
 DROP TABLE `dim_age_band_marketing_list`;
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7195_regression_bug6134.test
+++ b/mysql-test/columnstore/devregression/t/mcs7195_regression_bug6134.test
@@ -8,10 +8,13 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists bug6134;
 create table bug6134 (a integer) engine=Columnstore;
+--disable_warnings
 drop table if exists bug6134u;
 create table bug6134u (b integer, c varchar(20)) engine=Columnstore;
+--disable_warnings
 drop view if exists bug6134vv;
 create or replace view bug6134vv as select distinct * from bug6134 t
 inner join bug6134u u on t.a = u.b;
@@ -27,8 +30,11 @@ insert into bug6134u values (2, 1);
 insert into bug6134u values (2, 2);
  
 select * from bug6134vv order by 1, 2, 3;
+--disable_warnings
 drop table bug6134;
+--disable_warnings
 drop table bug6134u;
+--disable_warnings
 drop view bug6134vv;
 select count(*) from (select distinct n_regionkey, n_nationkey from nation)a order by 1;
 select count(*) from (select * from region union select distinct r_regionkey, r_regionkey, r_regionkey from region)a order by 1;

--- a/mysql-test/columnstore/devregression/t/mcs7196_regression_bug752.test
+++ b/mysql-test/columnstore/devregression/t/mcs7196_regression_bug752.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE if exists `source`;
+--disable_warnings
 DROP TABLE if exists `dest`;
 
 CREATE TABLE `source` (
@@ -60,7 +62,9 @@ INSERT INTO source VALUES(
 INSERT INTO dest SELECT * FROM source;
 select * from dest;
 
+--disable_warnings
 drop table source;
+--disable_warnings
 drop table dest;
 
 #

--- a/mysql-test/columnstore/devregression/t/mcs7198_regression_MCOL-1246.test
+++ b/mysql-test/columnstore/devregression/t/mcs7198_regression_MCOL-1246.test
@@ -9,9 +9,12 @@
 USE tpch1;
 #
 #-- Support SQL-92 matching for spaces
+--disable_warnings
 drop table if exists mcol1246a;
 drop table if exists mcol1246b;
 drop table if exists mcol1246c;
+--enable_warnings
+
 #-- varchar(7) for extent elimination check
 create table mcol1246a (a int, b varchar(7)) engine=columnstore;
 create table mcol1246b (a int, b varchar(20)) engine=columnstore;
@@ -37,8 +40,10 @@ select * from mcol1246a where b LIKE 'ABC';
 select * from mcol1246b where b LIKE 'ABC';
 select * from mcol1246c where b LIKE 'ABC';
 
+--disable_warnings
 drop table mcol1246a;
 drop table mcol1246b;
 drop table mcol1246c;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7199_regression_MCOL-128.test
+++ b/mysql-test/columnstore/devregression/t/mcs7199_regression_MCOL-128.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS mcol128;
+--enable_warnings
+
 CREATE TABLE mcol128 (a int, b varchar(50));
 INSERT INTO mcol128 VALUES (1, 'hello'),(2, 'world');
 SELECT * FROM mcol128;
@@ -16,10 +19,17 @@ ALTER TABLE mcol128 ENGINE=Columnstore;
 SELECT * FROM mcol128;
 ALTER TABLE mcol128 ENGINE=InnoDB;
 SELECT * FROM mcol128;
+
+--disable_warnings
 DROP TABLE IF EXISTS mcol128_clone;
+--enable_warnings
+
 CREATE TABLE mcol128_clone ENGINE=Columnstore AS SELECT * FROM mcol128;
 SELECT * FROM mcol128_clone;
+
+--disable_warnings
 DROP TABLE mcol128_clone;
 DROP TABLE mcol128;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7200_regression_MCOL-1403.test
+++ b/mysql-test/columnstore/devregression/t/mcs7200_regression_MCOL-1403.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists mcol1403a;
 drop table if exists mcol1403b;
+--enable_warnings
 
 create table mcol1403a (a int, b varchar(4)) engine=columnstore;
 create table mcol1403b (a int, b char(20), c varchar(20)) engine=columnstore;
@@ -26,7 +28,9 @@ select * from mcol1403b where lower(c) like 'majestic12 ';
 select concat(b, '#') from mcol1403b where b like '% ';
 select concat(c, '#') from mcol1403b where c like '% ';
 
+--disable_warnings
 drop table mcol1403a;
 drop table mcol1403b;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7201_regression_MCOL-1531.test
+++ b/mysql-test/columnstore/devregression/t/mcs7201_regression_MCOL-1531.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS cs1;
 DROP TABLE IF EXISTS cs2;
+--enable_warnings
 
 CREATE TABLE `cs1` (
   `t` varchar(2) DEFAULT NULL,
@@ -24,7 +26,9 @@ insert into cs1 values (NULL, 2);
 
 select * from cs1 inner join cs2 on (cs1.t = case cs2.t when NULL then 'MO' else cs2.t end);
 
+--disable_warnings
 DROP TABLE IF EXISTS cs1;
 DROP TABLE IF EXISTS cs2;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7202_regression_MCOL-1535.test
+++ b/mysql-test/columnstore/devregression/t/mcs7202_regression_MCOL-1535.test
@@ -27,6 +27,8 @@ collation('AAA'),
 (case nm when 'AAA' then 1 else 0 end) as nmchk2
 from t2;
 
+--disable_warnings
 drop table t2;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7203_regression_MCOL-1559.test
+++ b/mysql-test/columnstore/devregression/t/mcs7203_regression_MCOL-1559.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists mcol1559;
+--enable_warnings
+
 create table mcol1559 (c7nospace char(7), c7space char(7), c20nospace char(20), c20space char(20), vcnospace varchar(20), vcspace varchar(20)) engine=columnstore;
 
 insert into mcol1559 values ("ABC", "ABC ", "ABC12345678910", "ABC12345678910 ", "ABC", "ABC ");
@@ -38,7 +41,8 @@ select * from mcol1559 where c7nospace LIKE "ABC ";
 select * from mcol1559 where c20nospace LIKE "ABC12345678910 ";
 select * from mcol1559 where vcnospace LIKE "ABC ";
 
+--disable_warnings
 drop table if exists mcol1559;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7204_regression_MCOL-163.test
+++ b/mysql-test/columnstore/devregression/t/mcs7204_regression_MCOL-163.test
@@ -8,10 +8,16 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists test.mcol163;
+--enable_warnings
+
 create table test.mcol163 (a int, b double, c double precision) engine=columnstore;
 insert into test.mcol163 values (1,1.1,1.1);
 select * from test.mcol163;
+
+--disable_warnings
 drop table test.mcol163;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7205_regression_MCOL-1662.test
+++ b/mysql-test/columnstore/devregression/t/mcs7205_regression_MCOL-1662.test
@@ -10,8 +10,12 @@ USE tpch1;
 #
 #-- Run an insert...select without cpimport followed by update to trigger
 #-- bad cache results due to dictionary version stuck at 0
+
+--disable_warnings
 CREATE TABLE IF NOT EXISTS mcol1662 (a int, b varchar(200)) engine=columnstore;
 CREATE TABLE IF NOT EXISTS mcol1662_source (a int, b varchar(200));
+--enable_warnings
+
 INSERT INTO mcol1662_source VALUES (1, 'hello');
 
 SET columnstore_use_import_for_batchinsert=0;
@@ -23,7 +27,10 @@ UPDATE mcol1662 SET a = 1, b = 'Hello' WHERE a = 1 and b = 'hello';
 SELECT * FROM mcol1662;
 
 SET columnstore_use_import_for_batchinsert=1;
+
+--disable_warnings
 DROP TABLE mcol1662_source;
 DROP TABLE mcol1662;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7206_regression_MCOL-1676.test
+++ b/mysql-test/columnstore/devregression/t/mcs7206_regression_MCOL-1676.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS query_class_metrics_float;
+--enable_warnings
 #
 CREATE TABLE `query_class_metrics_float` (
 `agent_id` bigint(20) DEFAULT NULL,
@@ -31,4 +33,7 @@ INSERT INTO query_class_metrics_float VALUES (1, '2013-06-18 23:45:00', 1563, 0.
 #--Check for Window Function working with FLOAT
 SELECT start_ts, Query_time_sum,round(avg(Query_time_sum) OVER(order by start_ts), 8) prev_sum from query_class_metrics_float where agent_id=1 and query_class=1563 limit 50;
 #
+--disable_warnings
 DROP TABLE query_class_metrics_float;
+--enable_warnings
+#

--- a/mysql-test/columnstore/devregression/t/mcs7207_regression_MCOL-1829.test
+++ b/mysql-test/columnstore/devregression/t/mcs7207_regression_MCOL-1829.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists `football_teams`;
+--enable_warnings
 
 CREATE TABLE `football_teams` (
 `num` int(11) DEFAULT NULL,
@@ -23,6 +25,8 @@ insert into football_teams VALUES (4,'Minnesota',53);
 
 select * from (select distinct num from football_teams order by num limit 3) a;
 
+--disable_warnings
 drop table football_teams;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7208_regression_MCOL-1989.test
+++ b/mysql-test/columnstore/devregression/t/mcs7208_regression_MCOL-1989.test
@@ -8,12 +8,14 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP VIEW IF EXISTS vv2;
 DROP VIEW IF EXISTS vv1;
 DROP TABLE IF EXISTS vt1;
 DROP TABLE IF EXISTS vt2;
 DROP TABLE IF EXISTS vt3;
 DROP TABLE IF EXISTS vt4;
+--enable_warnings
 
 CREATE TABLE `vt1` (
   `num_sample_id` int(11) DEFAULT NULL,
@@ -60,12 +62,13 @@ select `a`.`id` AS `cid`,`a`.`sampid` AS `csample`,`a`.`code` AS `ncode`,`b`.`sa
 #-- Should return no result. Should not error.
 SELECT * from vv2;
 
+--disable_warnings
 DROP VIEW IF EXISTS vv2;
 DROP VIEW IF EXISTS vv1;
 DROP TABLE IF EXISTS vt1;
 DROP TABLE IF EXISTS vt2;
 DROP TABLE IF EXISTS vt3;
 DROP TABLE IF EXISTS vt4;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7209_regression_MCOL-2050.test
+++ b/mysql-test/columnstore/devregression/t/mcs7209_regression_MCOL-2050.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists `football_teams`;
+--enable_warnings
 
 CREATE TABLE `football_teams` (
 `num` int(11) DEFAULT NULL,
@@ -23,6 +25,8 @@ insert into football_teams VALUES (4,'Minnesota',53);
 
 select * from (select  num from football_teams order by num limit 3 offset 2) a;
 
+--disable_warnings
 drop table football_teams;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7210_regression_MCOL-2091.test
+++ b/mysql-test/columnstore/devregression/t/mcs7210_regression_MCOL-2091.test
@@ -15,5 +15,8 @@ drop table if exists t1;
 create table t1 (c1 int, c2 int, c3 int, c4 int)engine=columnstore;
 insert into t1 values (1,2,3,4),(1,2,3,4),(1,2,3,4),(1,2,3,4);
 select  c1,count(distinct c2) as c2,count(distinct c3) as c3, avg_mode(c4) as c4 from t1 group by c1;
+
+--disable_warnings
 drop table if exists t1;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7211_regression_MCOL-2096.test
+++ b/mysql-test/columnstore/devregression/t/mcs7211_regression_MCOL-2096.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists t;
+--enable_warnings
+
 create table t(a int, b int) engine=columnstore;
 insert into t(a,b) values(1,4),(2,3),(3,2),(4,1);
 
@@ -107,8 +110,8 @@ from (
 ) t0
 where a not in (1, 2);
 
-
-
+--disable_warnings
 drop table if exists t;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7212_regression_MCOL-2139.test
+++ b/mysql-test/columnstore/devregression/t/mcs7212_regression_MCOL-2139.test
@@ -21,7 +21,9 @@ update dairy_collection_animal a, (select collection_id from dairy_collection_vi
 select * from dairy_collection_animal;
 select * from dairy_collection_view;
 
+--disable_warnings
 drop table dairy_collection_animal;
 drop view dairy_collection_view;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7213_regression_MCOL-2225.test
+++ b/mysql-test/columnstore/devregression/t/mcs7213_regression_MCOL-2225.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists mcol2225i;
 drop table if exists mcol2225c;
+--enable_warnings
 # -------------------------------------------------------------- #
 # Enable cross engine join
 # Configure user and password in Columnstore.xml file
@@ -28,7 +30,9 @@ FLUSH PRIVILEGES;
 create table mcol2225i (`a 2` int, `b 2` int);
 create table mcol2225c (a int) engine=columnstore;
 select * from mcol2225i join mcol2225c where mcol2225i.`a 2` = mcol2225c.a and mcol2225i.`b 2` = 5;
+--disable_warnings
 drop table mcol2225i;
 drop table mcol2225c;
+--enable_warnings
 #
 DROP USER 'cejuser'@'localhost';

--- a/mysql-test/columnstore/devregression/t/mcs7214_regression_MCOL-2267.test
+++ b/mysql-test/columnstore/devregression/t/mcs7214_regression_MCOL-2267.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS `MCOL-2267a`;
 DROP TABLE IF EXISTS `MCOL-2267b`;
+--enable_warnings
 
 CREATE TABLE `MCOL-2267a` (
 `thing1` varchar(32) DEFAULT NULL,
@@ -69,7 +71,9 @@ from cte3
 left join cte4 on cte3.c1=cte4.c1 
 group by sum3,gc1,matched;
 
+--disable_warnings
 DROP TABLE IF EXISTS `MCOL-2267a`;
 DROP TABLE IF EXISTS `MCOL-2267b`;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7215_regression_MCOL-3267.test
+++ b/mysql-test/columnstore/devregression/t/mcs7215_regression_MCOL-3267.test
@@ -8,8 +8,11 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
+--enable_warnings
+
 CREATE TABLE t1 (a bigint, b bigint)engine=columnstore;
 CREATE TABLE  t2 (a bigint, b bigint)engine=columnstore;
 INSERT INTO t1 VALUES (5,5),(4,4),(3,3);
@@ -18,5 +21,10 @@ INSERT INTO t1 VALUES (5,5),(4,4),(3,3);
 SELECT * FROM ((SELECT a, b FROM t1 ORDER BY b LIMIT 2) UNION ALL (SELECT a, b FROM t2 ORDER BY b LIMIT 2)) as sq3 ORDER BY 1,2;
 SELECT * FROM (select * FROM (SELECT a, b FROM t1 ORDER BY b LIMIT 2) sub1 UNION ALL SELECT * FROM (SELECT a, b FROM t2 ORDER BY b LIMIT 2) sub2 ) as sq3 ORDER BY 1,2;
 SELECT * FROM (select * FROM (SELECT a, b FROM t1 ORDER BY b) sub1 UNION ALL SELECT * FROM (SELECT a, b FROM t2 ORDER BY b) sub2 ) as sq3 ORDER BY 1,2;
+#
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7216_regression_MCOL-3304.test
+++ b/mysql-test/columnstore/devregression/t/mcs7216_regression_MCOL-3304.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS `MCOL3304`;
+--enable_warnings
+
 CREATE TABLE `MCOL3304` (
 `c` decimal(5,2) DEFAULT NULL
 ) ENGINE=columnstore;
@@ -24,7 +27,8 @@ select csum,sum(csum) over(), sum(csum) over w1, sum(csum) over w2 from
 (select sum(c) as csum from`MCOL3304`) t 
 WINDOW `w1` as (),`w2` as (rows between unbounded preceding and current row);
 
+--disable_warnings
 DROP TABLE IF EXISTS `MCOL3304`;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7217_regression_MCOL-3317.test
+++ b/mysql-test/columnstore/devregression/t/mcs7217_regression_MCOL-3317.test
@@ -8,12 +8,18 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS `mcol-498`;
+--enable_warnings
+
 CREATE TABLE `mcol-498` (i BIGINT) ENGINE=columnstore;
 INSERT INTO `mcol-498` VALUES (42),(6);
 DELETE FROM `mcol-498` WHERE i = 42;
 INSERT INTO `mcol-498` VALUES (42);
 SELECT i FROM `mcol-498`;
+
+--disable_warnings
 DROP TABLE `mcol-498`;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7219_regression_MCOL-3395.test
+++ b/mysql-test/columnstore/devregression/t/mcs7219_regression_MCOL-3395.test
@@ -8,10 +8,16 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists mcol3395;
+--enable_warnings
+
 create table mcol3395 (c1 char(10), c2 varchar(10), c3 varchar(6))engine=columnstore;
 insert into mcol3395 values ('abc','cde','abc'), ('cde','abc','cde');
 select * from mcol3395 where c2='abc';
+
+--disable_warnings
 drop table mcol3395;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7220_regression_MCOL-3423.test
+++ b/mysql-test/columnstore/devregression/t/mcs7220_regression_MCOL-3423.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS tc;
+--enable_warnings
+
 CREATE TABLE `tc` (
   `id` int(11) NOT NULL,
   `cid` int(11) DEFAULT NULL,
@@ -35,7 +38,8 @@ select cust, week_d, mpp_sum,
                sum(c) over (partition by cid, week(d)) as mpp_sum  
          from tc where year(d) = '2018') as inside where cust = 0 and week_d = 0;
 
+--disable_warnings
 DROP TABLE IF EXISTS tc;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7221_regression_MCOL-3434.test
+++ b/mysql-test/columnstore/devregression/t/mcs7221_regression_MCOL-3434.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS MCOL3434CS;
 DROP TABLE IF EXISTS MCOL3434INNO;
+--enable_warnings
 
 CREATE TABLE `MCOL3434INNO` (`id` int(11) NOT NULL AUTO_INCREMENT, 
                              `cid` int(11) DEFAULT NULL, 
@@ -104,8 +106,9 @@ select distinct cid, week(d) as week,
                 max(week(d)) over (partition by year(d)) as w_max 
     from MCOL3434CS where year(d) = '2018' order by id;
 
+--disable_warnings
 DROP TABLE IF EXISTS MCOL3434CS;
 DROP TABLE IF EXISTS MCOL3434INNO;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7222_regression_MCOL-3448.test
+++ b/mysql-test/columnstore/devregression/t/mcs7222_regression_MCOL-3448.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS dim_date;
+--enable_warnings
+
 create table dim_date(semaine varchar(10), date_jour date, val int) engine=columnstore;
 
 insert into dim_date values 
@@ -21,7 +24,8 @@ insert into dim_date values
 
 SELECT * FROM dim_date WHERE SEMAINE IN ('2019-S07') OR (SEMAINE,DATE_JOUR) IN ( ('2019-S08','2019-02-18'), ('2019-S08','2019-02-19') ) order by val;
 
+--disable_warnings
 DROP TABLE IF EXISTS dim_date;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7223_regression_MCOL-3485.test
+++ b/mysql-test/columnstore/devregression/t/mcs7223_regression_MCOL-3485.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists t;
+--enable_warnings
+
 create table t(a int, b varchar(10), c decimal(7,2)) engine=columnstore;
 insert into t(a,b,c) values (1,'x',10),(2,'x',11), (3, 'x', 12), (1,'y',12),(2,'y',11), (3, 'y', 10);
  
@@ -56,6 +59,8 @@ from t
 group by bu
 order by 3;
 
+--disable_warnings
 drop table if exists t;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7225_regression_MCOL-3721.test
+++ b/mysql-test/columnstore/devregression/t/mcs7225_regression_MCOL-3721.test
@@ -9,30 +9,42 @@
 USE tpch1;
 #
 #--Test COLLATE in ORDER BY
+--disable_warnings
 DROP TABLE IF EXISTS test_collate;
+--enable_warnings
+
 CREATE TABLE test_collate (a INT, b INT) ENGINE=columnstore;
 INSERT INTO test_collate VALUES (1,2), (2,4);
 SELECT a, b FROM test_collate ORDER BY a COLLATE latin1_german2_ci;
 SHOW WARNINGS;
 SELECT a, b FROM test_collate ORDER BY a COLLATE latin1_german2_ci DESC;
 SHOW WARNINGS;
+
+--disable_warnings
 DROP TABLE IF EXISTS test_collate;
+--enable_warnings
 
 #--Test COLLATE in table definition and column definition
+--disable_warnings
 DROP TABLE IF EXISTS t1;
+--enable_warnings
+
 CREATE TABLE t1 (col1 CHAR(10)) CHARSET latin1 COLLATE latin1_bin ENGINE=columnstore;
 INSERT INTO t1 VALUES ('a'), ('1'), ('-1');
 SELECT col1 FROM t1;
 DESCRIBE t1;
-DROP TABLE IF EXISTS t1;
 
+--disable_warnings
 DROP TABLE IF EXISTS t1;
+--enable_warnings
+
 CREATE TABLE t1 (col1 CHAR(10) CHARACTER SET utf8 COLLATE utf8_unicode_ci) ENGINE=columnstore;
 INSERT INTO t1 VALUES ('a'), ('1'), ('-1');
 SELECT col1 FROM t1;
 DESCRIBE t1;
+
+--disable_warnings
 DROP TABLE IF EXISTS t1;
-
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7226_regression_MCOL_3747.test
+++ b/mysql-test/columnstore/devregression/t/mcs7226_regression_MCOL_3747.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists cs1;
+--enable_warnings
+
 create table cs1(key_ bigint) engine=columnstore;
 insert into cs1 values (42),(43),(45),(666),(777),(333);
  
@@ -16,6 +19,8 @@ select key_, count(*) from cs1 where key_ in (select * from (select key_ from cs
  
 select * from (select key_, count(*) from cs1 where key_ in (select * from (select key_ from cs1 group by key_ order by key_ limit 2) a1) group by key_) a2 order by 1;
 
+--disable_warnings
 drop table cs1;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7227_regression_MCOL-3766.test
+++ b/mysql-test/columnstore/devregression/t/mcs7227_regression_MCOL-3766.test
@@ -11,10 +11,13 @@ USE tpch1;
 --disable_warnings
 DROP TABLE IF EXISTS `MCOL-3766`;
 --enable_warnings
+
 CREATE TABLE `MCOL-3766`(a int) engine=columnstore;
 EXPLAIN SELECT a FROM `MCOL-3766` GROUP BY a HAVING 1 != 1 AND a > 1;
 EXPLAIN SELECT a FROM `MCOL-3766` GROUP BY a HAVING 1 != 1 AND a > 1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS `MCOL-3766`;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7228_regression_MCOL-3813.test
+++ b/mysql-test/columnstore/devregression/t/mcs7228_regression_MCOL-3813.test
@@ -10,9 +10,9 @@ USE tpch1;
 #
 
 
-/* FROM MCOL-1349 
-   Note: Adding this because code that directly involved this bug was modified
-   Other regression involved is working_tpch1_compareLogOnly/misc/bug5764.sql*/
+# FROM MCOL-1349 
+#   Note: Adding this because code that directly involved this bug was modified
+#   Other regression involved is working_tpch1_compareLogOnly/misc/bug5764.sql*/
 
 --disable_warnings
 drop table if exists t3813_1;
@@ -45,27 +45,27 @@ insert into t3813_1(id) values(1);
 insert into t3813_2(id2, snapshot_date) values(1,'2020-05-09');
 insert into t3813_3(id3, from_date, to_date) values(1,'2020-05-09'-interval 1 day, '2020-05-09'+interval 2 day);
 insert into t3813_4(id4, category) values(1, 'cat-1');
-/*PREPARATION END*/
+#/*PREPARATION END*/
 
-/*THE PROBLEM: The SELECT itself below runs properly, but calling it from view the 1815 error is thrown*/
+#/*THE PROBLEM: The SELECT itself below runs properly, but calling it from view the 1815 error is thrown*/
 select * from t3813_1 t3813_1
 LEFT JOIN t3813_4 t3813_4 ON (t3813_1.id = t3813_4.id4) 
 LEFT JOIN t3813_2 t3813_2 ON (t3813_1.id = t3813_2.id2) 
 LEFT JOIN t3813_3 t3813_3 ON (t3813_2.id2 = t3813_3.id3 AND t3813_2.snapshot_date BETWEEN t3813_3.from_date AND t3813_3.to_date);
 
-/*Creating VIEW based on the SELECT above*/
+#/*Creating VIEW based on the SELECT above*/
 create or replace view view_test as
 select * from t3813_1 t3813_1
 LEFT JOIN t3813_4 t3813_4 ON (t3813_1.id = t3813_4.id4)
 LEFT JOIN t3813_2 t3813_2 ON (t3813_1.id = t3813_2.id2) 
 LEFT JOIN t3813_3 t3813_3 ON (t3813_2.id2 = t3813_3.id3 AND t3813_2.snapshot_date BETWEEN t3813_3.from_date AND t3813_3.to_date);
 
-/*SELECT from the VIEW throws the error: Error Code: 1815. Internal error: On clause filter involving a table not directly involved in the outer join is currently not supported.*/
+#/*SELECT from the VIEW throws the error: Error Code: 1815. Internal error: On clause filter involving a table not directly involved in the outer join is currently not supported.*/
 select * from view_test;
 
-/*Notes*/
-/*If I remove either the 1st or the 3rd LEFT JOINs from the VIEW definition, the SELECT * from VIEW will work. (I cannot remove the 2nd LEFT JOIN since the 3rd is based on that one)*/
-/*Replacing COLUMNSTORE engine to INNODB the view the SELECT * from VIEW will work, but if one of the tables is COLUMNSTORE the error will thrown*/
+#/*Notes*/
+#/*If I remove either the 1st or the 3rd LEFT JOINs from the VIEW definition, the SELECT * from VIEW will work. (I cannot remove the 2nd LEFT JOIN since the 3rd is based on that one)*/
+#/*Replacing COLUMNSTORE engine to INNODB the view the SELECT * from VIEW will work, but if one of the tables is COLUMNSTORE the error will thrown*/
 --disable_warnings
 drop table if exists t3813_1;
 drop table if exists t3813_2;

--- a/mysql-test/columnstore/devregression/t/mcs7228_regression_MCOL-3813.test
+++ b/mysql-test/columnstore/devregression/t/mcs7228_regression_MCOL-3813.test
@@ -14,10 +14,12 @@ USE tpch1;
    Note: Adding this because code that directly involved this bug was modified
    Other regression involved is working_tpch1_compareLogOnly/misc/bug5764.sql*/
 
+--disable_warnings
 drop table if exists t3813_1;
 drop table if exists t3813_2;
 drop table if exists t3813_3;
 drop table if exists t3813_4;
+--enable_warnings
 
 create table t3813_1
 (id int
@@ -64,10 +66,11 @@ select * from view_test;
 /*Notes*/
 /*If I remove either the 1st or the 3rd LEFT JOINs from the VIEW definition, the SELECT * from VIEW will work. (I cannot remove the 2nd LEFT JOIN since the 3rd is based on that one)*/
 /*Replacing COLUMNSTORE engine to INNODB the view the SELECT * from VIEW will work, but if one of the tables is COLUMNSTORE the error will thrown*/
+--disable_warnings
 drop table if exists t3813_1;
 drop table if exists t3813_2;
 drop table if exists t3813_3;
 drop table if exists t3813_4;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7229_regression_MCOL-3839.test
+++ b/mysql-test/columnstore/devregression/t/mcs7229_regression_MCOL-3839.test
@@ -8,7 +8,9 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists test_wf_count_with_constants;
+--enable_warnings
 
 create table test_wf_count_with_constants (t1 int) engine=columnstore;
 insert into test_wf_count_with_constants values (1);
@@ -41,7 +43,8 @@ select count(5) over(order by t1 rows between current row and unbounded followin
 select count(*) over(order by t1 rows between current row and unbounded following)  from test_wf_count_with_constants;
 select count(null) over(order by t1 rows between current row and unbounded following)  from test_wf_count_with_constants;
 
+--disable_warnings
 drop table test_wf_count_with_constants;
-
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7230_regression_MCOL-4000.test
+++ b/mysql-test/columnstore/devregression/t/mcs7230_regression_MCOL-4000.test
@@ -117,5 +117,7 @@ INSERT INTO mcol4000(l_comment) VALUES ('mcol4000');
 LOAD DATA LOCAL INFILE '/tmp/mcol4000.txt' INTO TABLE mcol4000 FIELDS TERMINATED BY ',' ENCLOSED BY '"';
 SELECT COUNT(*) FROM mcol4000; #-- should return 7000004
 #
+--disable_warnings
 DROP TABLE mcol4000;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7231_regression_MCOL-4002.test
+++ b/mysql-test/columnstore/devregression/t/mcs7231_regression_MCOL-4002.test
@@ -163,5 +163,7 @@ INSERT INTO mcol4002(l_comment) VALUES ('mcol4002');
 LOAD DATA LOCAL INFILE '/tmp/mcol4002.txt' INTO TABLE mcol4002 FIELDS TERMINATED BY ',' ENCLOSED BY '"';
 SELECT COUNT(*) FROM mcol4002; #-- should return 606
 #
+--disable_warnings
 DROP TABLE mcol4002;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7232_regression_MCOL-4126.test
+++ b/mysql-test/columnstore/devregression/t/mcs7232_regression_MCOL-4126.test
@@ -12,6 +12,7 @@ USE tpch1;
 drop table if exists T4126_1;
 drop table if exists T4126_2;
 --enable_warnings
+
 create table T4126_1 (idx int, col varchar(20)) engine=columnstore;
 create table T4126_2 (idx int, col varchar(20), col2 varchar(20)) engine=columnstore;
 insert into T4126_1 values (3, 'a');
@@ -21,11 +22,16 @@ insert into T4126_2 values (1, 'lamp', 'table lamp');
 select * from T4126_2;
 update T4126_2 set col = "floor lamp" where col = 'lamp';
 
+--disable_warnings
 drop table if exists T4126_1;
 drop table if exists T4126_2;
+--enable_warnings
 
 create table T4126_1 (idx1 int, col1 varchar(20)) engine=columnstore;
 insert into T4126_1 values (3, 'a');
 select * from T4126_1;
+
+--disable_warnings
 drop table if exists T4126_1;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7233_regression_MCOL-477.test
+++ b/mysql-test/columnstore/devregression/t/mcs7233_regression_MCOL-477.test
@@ -8,13 +8,19 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists test.mcol477;
+--enable_warnings
+
 create table test.mcol477 (a int, b int) engine=columnstore comment='autoincrement=a,9';
 insert into test.mcol477 set b=1;
 select * from test.mcol477;
 alter table test.mcol477 comment='autoincrement=25';
 insert into test.mcol477 set b=2;
 select * from test.mcol477;
+
+--disable_warnings
 drop table test.mcol477;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7235_regression_MCOL-657.test
+++ b/mysql-test/columnstore/devregression/t/mcs7235_regression_MCOL-657.test
@@ -8,10 +8,16 @@
 #
 USE tpch1;
 #
+--disable_warnings
 create table if not exists MCOL657 (a int, b int) engine=columnstore;
+--enable_warnings
+
 insert into MCOL657 values (1,1), (2,2), (3,4), (NULL, NULL), (NULL, 2), (3, NULL);
 select * from MCOL657 where a = b OR (a IS NULL AND b IS NULL);
 select * from MCOL657 where a<=>b;
+
+--disable_warnings
 drop table MCOL657;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7236_regression_MCOL-736.test
+++ b/mysql-test/columnstore/devregression/t/mcs7236_regression_MCOL-736.test
@@ -10,7 +10,10 @@ USE tpch1;
 #
 #-- SELECT was triggering implicit commit
 
+--disable_warnings
 DROP TABLE IF EXISTS MCOL_736;
+--enable_warnings
+
 CREATE TABLE `MCOL_736` (
 	`code` varchar(255) NOT NULL
 ) ENGINE=InnoDB;
@@ -22,6 +25,8 @@ ROLLBACK;
 
 #-- Result should be BR and not UK
 SELECT * FROM MCOL_736;
+--disable_warnings
 DROP TABLE MCOL_736;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7237_regression_MCOL-812.test
+++ b/mysql-test/columnstore/devregression/t/mcs7237_regression_MCOL-812.test
@@ -8,8 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 DROP TABLE IF EXISTS test.mcol812a;
 DROP TABLE IF EXISTS test.mcol812b;
+--enable_warnings
 # -------------------------------------------------------------- #
 # Enable cross engine join
 # Configure user and password in Columnstore.xml file
@@ -40,7 +42,9 @@ insert into test.mcol812b values (1);
 select * from test.mcol812b join test.mcol812a on test.mcol812b.a = test.mcol812a.a where test.mcol812a.b='\'';
 select * from test.mcol812b join test.mcol812a on test.mcol812b.a = test.mcol812a.a where test.mcol812a.b='\\';
 
+--disable_warnings
 DROP TABLE test.mcol812a;
 DROP TABLE test.mcol812b;
+--enable_warnings
 #
 DROP USER 'cejuser'@'localhost';

--- a/mysql-test/columnstore/devregression/t/mcs7238_regression_MCOL-830.test
+++ b/mysql-test/columnstore/devregression/t/mcs7238_regression_MCOL-830.test
@@ -9,8 +9,11 @@
 USE tpch1;
 #
 #-- Make sure UTF8 works during cross engine
+--disable_warnings
 DROP TABLE IF EXISTS test.mcol830a;
 DROP TABLE IF EXISTS test.mcol830b;
+--enable_warnings
+
 CREATE TABLE test.mcol830a (
 `c1` int(11) DEFAULT NULL,
 `c2` varchar(64) DEFAULT NULL
@@ -22,7 +25,10 @@ CREATE TABLE test.mcol830b (
 insert into test.mcol830a values(1, 'cs测试');
 insert into test.mcol830b values(2, 'myisam测试');
 select * from test.mcol830a union select * from test.mcol830b order by c1 desc;
+
+--disable_warnings
 DROP TABLE test.mcol830a;
 DROP TABLE test.mcol830b;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7239_regression_MCOL-979.test
+++ b/mysql-test/columnstore/devregression/t/mcs7239_regression_MCOL-979.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists mcol979;
+--enable_warnings
+
 create table mcol979 (a int, b double, c CHAR(1), d CHAR(2), e CHAR(3), f CHAR(4), g CHAR(8),
                       h CHAR(16), m VARCHAR(32)) engine=columnstore;
 
@@ -77,6 +80,8 @@ select lag(b) over (order by g) from mcol979;
 select lag(b) over (order by h) from mcol979;
 select lag(b) over (order by m) from mcol979;
 
+--disable_warnings
 drop table if exists mcol979;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7245_regression_bug2977.test
+++ b/mysql-test/columnstore/devregression/t/mcs7245_regression_bug2977.test
@@ -8,9 +8,12 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists `shipamounts`;
 drop table if exists `ship1`;
 drop table if exists `ship2`;
+--enable_warnings
+
 CREATE TABLE `shipamounts` (
   `OrderNum` varchar(50) DEFAULT NULL,
   `OrderLine` int(11) DEFAULT NULL,
@@ -60,8 +63,10 @@ FROM shipAmounts AS s
 	GROUP BY OrderNum) AS total ON s.OrderNum = total.OrderNum 
 	GROUP BY s.OrderNum,s.OrderLine,3,4,5,6,7,8;
 
+--disable_warnings
 drop table if exists shipamounts;
 drop table if exists ship1;
 drop table if exists ship2;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7247_regression_bug3038b.test
+++ b/mysql-test/columnstore/devregression/t/mcs7247_regression_bug3038b.test
@@ -11,8 +11,10 @@ USE tpch1;
 /* Test case from Radek at CognitiveMatch - customer who bought based on us adding the multi-value in clause feature. */
 
 /* First test using IDB tables. */
+--disable_warnings
 drop table if exists agg_fact_pageview;
 drop table if exists dim_date;
+--enable_warnings
 create table AGG_FACT_PAGEVIEW
 (
         server_day_date         date ,
@@ -517,7 +519,9 @@ order by
   `DIM_DATE`.`day_of_month_number` ASC, ISNULL(`AGG_FACT_PAGEVIEW`.`organisation_name`), `AGG_FACT_PAGEVIEW`.`organisation_name` ASC;
 
 
+--disable_warnings
 drop table if exists agg_fact_pageview;
 drop table if exists dim_date;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7247_regression_bug3038b.test
+++ b/mysql-test/columnstore/devregression/t/mcs7247_regression_bug3038b.test
@@ -8,9 +8,9 @@
 #
 USE tpch1;
 #
-/* Test case from Radek at CognitiveMatch - customer who bought based on us adding the multi-value in clause feature. */
+#/* Test case from Radek at CognitiveMatch - customer who bought based on us adding the multi-value in clause feature. */
 
-/* First test using IDB tables. */
+#/* First test using IDB tables. */
 --disable_warnings
 drop table if exists agg_fact_pageview;
 drop table if exists dim_date;

--- a/mysql-test/columnstore/devregression/t/mcs7248_regression_bug3038c.test
+++ b/mysql-test/columnstore/devregression/t/mcs7248_regression_bug3038c.test
@@ -11,8 +11,10 @@ USE tpch1;
 /* Test case from Radek at CognitiveMatch - customer who bought based on us adding the multi-value in clause feature. */
 
 /* Second test using myisam tables. */
+--disable_warnings
 drop table if exists agg_fact_pageview;
 drop table if exists dim_date;
+--enable_warnings
 create table AGG_FACT_PAGEVIEW
 (
         server_day_date         date ,
@@ -517,7 +519,9 @@ order by
   `DIM_DATE`.`day_of_month_number` ASC, ISNULL(`AGG_FACT_PAGEVIEW`.`organisation_name`), `AGG_FACT_PAGEVIEW`.`organisation_name` ASC;
 
 
+--disable_warnings
 drop table if exists agg_fact_pageview;
 drop table if exists dim_date;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7248_regression_bug3038c.test
+++ b/mysql-test/columnstore/devregression/t/mcs7248_regression_bug3038c.test
@@ -8,9 +8,9 @@
 #
 USE tpch1;
 #
-/* Test case from Radek at CognitiveMatch - customer who bought based on us adding the multi-value in clause feature. */
+#/* Test case from Radek at CognitiveMatch - customer who bought based on us adding the multi-value in clause feature. */
 
-/* Second test using myisam tables. */
+#/* Second test using myisam tables. */
 --disable_warnings
 drop table if exists agg_fact_pageview;
 drop table if exists dim_date;

--- a/mysql-test/columnstore/devregression/t/mcs7250_regression_bug4594.test
+++ b/mysql-test/columnstore/devregression/t/mcs7250_regression_bug4594.test
@@ -14,13 +14,18 @@ select calshowpartitions('tpch1','dtypes','c2') into @x;
 # log regardless of the DBRoot.
 select substr(@x, length(@x)-6, 10);
 
+--disable_warnings
 drop table if exists bug4594;
+--enable_warnings
+
 create table if not exists bug4594(c1 char(5))engine=columnstore;
 insert into bug4594 values ('abc'), ('def');
 select * from bug4594;
 select calshowpartitionsbyvalue('bug4594', 'c1', 'aa', 'zz') into @y;
 select substr(@y, length(@y)-6, 10);
-drop table bug4594;
 
+--disable_warnings
+drop table bug4594;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7251_regression_bug5315.test
+++ b/mysql-test/columnstore/devregression/t/mcs7251_regression_bug5315.test
@@ -8,7 +8,10 @@
 #
 USE tpch1;
 #
+--disable_warnings
 drop table if exists trow;
+--enable_warnings
+
 create table trow(col1 int, col2 int) engine=columnstore;
 insert into trow values(1,2),(3,4);
 select * from trow;
@@ -21,5 +24,9 @@ select * from trow;
 delete from trow;
 delete from trow where col2=20;
 select * from trow;
-drop table trow;#
+
+--disable_warnings
+drop table trow;
+--enable_warnings
+#
 

--- a/mysql-test/columnstore/devregression/t/mcs7252_regression_MCOL-669.test
+++ b/mysql-test/columnstore/devregression/t/mcs7252_regression_MCOL-669.test
@@ -9,8 +9,10 @@
 USE tpch1;
 #
 
+--disable_warnings
 drop table if exists MCOL_669_a;
 drop table if exists MCOL_669_B;
+--enable_warnings
 
 CREATE TABLE MCOL_669_a (a int, b text) engine=columnstore;
 CREATE TABLE MCOL_669_b (a int, b text) engine=columnstore;
@@ -28,7 +30,8 @@ INSERT INTO MCOL_669_b SELECT * FROM MCOL_669_a;
 SELECT a, length(b) FROM MCOL_669_a;
 SELECT a, length(b) FROM MCOL_669_b;
 #
+--disable_warnings
 DROP TABLE MCOL_669_a;
 DROP TABLE MCOL_669_b;
-
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7253_regression_MCOL-670.test
+++ b/mysql-test/columnstore/devregression/t/mcs7253_regression_MCOL-670.test
@@ -7,7 +7,10 @@
 --source ../include/have_columnstore.inc
 #
 USE tpch1;
+--disable_warnings
 drop table if exists MCOL_670;
+--enable_warnings
+
 CREATE TABLE MCOL_670 (a int, b text) engine=columnstore;
 #
 INSERT INTO MCOL_670 VALUES (1, REPEAT('MariaDB ', 7500));
@@ -24,5 +27,8 @@ UPDATE MCOL_670 SET b = 'ColumnStore';
 SELECT a, length(b) FROM MCOL_670;
 UPDATE MCOL_670 SET b = REPEAT('Hello World ', 5000);
 SELECT a, length(b) FROM MCOL_670;
+
+--disable_warnings
 drop table if exists MCOL_670;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7254_regression_MCOL-671.test
+++ b/mysql-test/columnstore/devregression/t/mcs7254_regression_MCOL-671.test
@@ -9,11 +9,16 @@
 USE tpch1;
 #
 
+--disable_warnings
 drop table if exists MCOL_671;
+--enable_warnings
 
 CREATE TABLE MCOL_671 (a int, b text) engine=columnstore;
 INSERT INTO MCOL_671 VALUES (1, REPEAT('MariaDB ', 7500));
 
 SELECT a, length(b) FROM MCOL_671 WHERE b > 'K';
+
+--disable_warnings
 DROP TABLE MCOL_671;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7255_regression_MCOL-673.test
+++ b/mysql-test/columnstore/devregression/t/mcs7255_regression_MCOL-673.test
@@ -29,6 +29,8 @@ INSERT INTO MCOL_673_b SELECT * FROM MCOL_673_a;
 SELECT a, length(b) FROM MCOL_673_a;
 SELECT a, length(b) FROM MCOL_673_b;
 #
+--disable_warnings
 drop table if exists MCOL_673_a;
 drop table if exists MCOL_673_b;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7256_regression_mcol-1188.test
+++ b/mysql-test/columnstore/devregression/t/mcs7256_regression_mcol-1188.test
@@ -131,8 +131,10 @@ select  distinct(i_product_name)
  order by i_product_name
  limit 100;
 #
+--disable_warnings
 drop table if exists cs_item;
 drop table if exists ar_item;
 drop table if exists in_item;
 drop table if exists item;
+--enable_warnings
 #

--- a/mysql-test/columnstore/devregression/t/mcs7521_storedProcedures_sp.test
+++ b/mysql-test/columnstore/devregression/t/mcs7521_storedProcedures_sp.test
@@ -10,12 +10,14 @@
 
 USE tpch1;
 
+--disable_warnings
 drop procedure if exists sp_simple_select;
 drop procedure if exists sp_simple_variable;
 drop procedure if exists sp_simple_variables;
 drop procedure if exists sp_complex_variable;
 drop procedure if exists proc1;
 DROP TABLE IF EXISTS t1;
+--enable_warnings
 
 DELIMITER $$;
 Create Procedure sp_simple_select( )
@@ -62,11 +64,13 @@ call proc1();
 # Should get 'Duplicate column name' error this time
 --error 1060
 call proc1();
-drop table t1;
 
+--disable_warnings
+drop table t1;
 drop procedure sp_simple_select;
 drop procedure sp_simple_variable;
 drop procedure sp_simple_variables;
 drop procedure sp_complex_variable;
 drop procedure proc1;
-
+--enable_warnings
+#

--- a/mysql-test/columnstore/devregression/t/mcs7522_storedProcedures_sp_autoswitch.test
+++ b/mysql-test/columnstore/devregression/t/mcs7522_storedProcedures_sp_autoswitch.test
@@ -11,9 +11,7 @@ USE tpch1;
 
 # Simple SP without args
 DELIMITER $$;
---disable_warnings
 drop procedure if exists sp_simple_select;
---enable_warnings
 
 Create Procedure sp_simple_select( )
 begin
@@ -21,9 +19,7 @@ begin
 end $$
 
 # Simple SP with 1 arg
---disable_warnings
 drop procedure if exists sp_simple_variable;
---enable_warnings
 
 Create Procedure sp_simple_variable(in arg_key int)
 begin
@@ -31,9 +27,7 @@ begin
 end $$
 
 # Simple SP with multiple args
---disable_warnings
 drop procedure if exists sp_simple_variables;
---enable_warnings
 
 Create Procedure sp_simple_variables(in arg_key int, in arg_string varchar(25))
 begin
@@ -41,9 +35,7 @@ begin
 end $$
 
 # Simple SP with cross table select query
---disable_warnings
 drop procedure if exists sp_complex_variable;
---enable_warnings
 
 Create Procedure sp_complex_variable(in arg_key int, in arg_date date)
 begin
@@ -52,9 +44,7 @@ begin
 end $$
 
 # Complex SP. All following SPs will fail vtable mode
---disable_warnings
 drop procedure if exists sp_unstructured_loop;
---enable_warnings
 
 Create Procedure sp_unstructured_loop(in arg_key int)
 begin
@@ -82,9 +72,7 @@ begin
 end$$
 
 
---disable_warnings
 drop procedure if exists sp_repeat_loop;
---enable_warnings
 
 Create Procedure sp_repeat_loop(in arg_key int, in arg_key2 int)
 begin
@@ -114,9 +102,7 @@ begin
     CLOSE cur1;
 end$$
 
---disable_warnings
 drop procedure if exists sp_while_loop;
---enable_warnings
 
 Create Procedure sp_while_loop(in arg_key int, in arg_key2 int)
 begin
@@ -146,9 +132,7 @@ begin
 end$$
 
 # SP with DDL
---disable_warnings
 drop procedure if exists proc1;
---enable_warnings
 
 create procedure proc1()
 begin

--- a/mysql-test/columnstore/devregression/t/mcs7522_storedProcedures_sp_autoswitch.test
+++ b/mysql-test/columnstore/devregression/t/mcs7522_storedProcedures_sp_autoswitch.test
@@ -11,28 +11,40 @@ USE tpch1;
 
 # Simple SP without args
 DELIMITER $$;
+--disable_warnings
 drop procedure if exists sp_simple_select;
+--enable_warnings
+
 Create Procedure sp_simple_select( )
 begin
         select * from part where p_partkey < 5;
 end $$
 
 # Simple SP with 1 arg
+--disable_warnings
 drop procedure if exists sp_simple_variable;
+--enable_warnings
+
 Create Procedure sp_simple_variable(in arg_key int)
 begin
         select * from part where p_partkey <= arg_key;
 end $$
 
 # Simple SP with multiple args
+--disable_warnings
 drop procedure if exists sp_simple_variables;
+--enable_warnings
+
 Create Procedure sp_simple_variables(in arg_key int, in arg_string varchar(25))
 begin
         select * from nation where n_nationkey <= arg_key and n_name > arg_string;
 end $$
 
 # Simple SP with cross table select query
+--disable_warnings
 drop procedure if exists sp_complex_variable;
+--enable_warnings
+
 Create Procedure sp_complex_variable(in arg_key int, in arg_date date)
 begin
         Select * from lineitem, orders where o_custkey < arg_key and
@@ -40,7 +52,10 @@ begin
 end $$
 
 # Complex SP. All following SPs will fail vtable mode
+--disable_warnings
 drop procedure if exists sp_unstructured_loop;
+--enable_warnings
+
 Create Procedure sp_unstructured_loop(in arg_key int)
 begin
         declare v_col1 int;
@@ -67,7 +82,10 @@ begin
 end$$
 
 
+--disable_warnings
 drop procedure if exists sp_repeat_loop;
+--enable_warnings
+
 Create Procedure sp_repeat_loop(in arg_key int, in arg_key2 int)
 begin
    DECLARE done INT DEFAULT 0;
@@ -96,7 +114,10 @@ begin
     CLOSE cur1;
 end$$
 
+--disable_warnings
 drop procedure if exists sp_while_loop;
+--enable_warnings
+
 Create Procedure sp_while_loop(in arg_key int, in arg_key2 int)
 begin
    DECLARE done INT DEFAULT 0;
@@ -125,7 +146,10 @@ begin
 end$$
 
 # SP with DDL
+--disable_warnings
 drop procedure if exists proc1;
+--enable_warnings
+
 create procedure proc1()
 begin
 drop table if exists t1;
@@ -149,6 +173,7 @@ call sp_while_loop(1,2);
 call proc1();
 select @a, @b;
 
+--disable_warnings
 drop procedure sp_simple_select;
 drop procedure sp_simple_variable;
 drop procedure sp_simple_variables;
@@ -157,3 +182,6 @@ drop procedure sp_unstructured_loop;
 drop procedure sp_repeat_loop;
 drop procedure sp_while_loop;
 drop procedure proc1;
+--enable_warnings
+#
+

--- a/mysql-test/columnstore/devregression/t/mcs7523_partitionOptimization_aCreateViews.test
+++ b/mysql-test/columnstore/devregression/t/mcs7523_partitionOptimization_aCreateViews.test
@@ -174,5 +174,6 @@ drop procedure if exists partsuppColumnsTouched;
 drop procedure if exists regionColumnsTouched;
 drop procedure if exists nationColumnsTouched;
 drop procedure if exists eliminatedBlocksGE;
+--enable_warnings
 #
 

--- a/mysql-test/columnstore/devregression/t/mcs7523_partitionOptimization_aCreateViews.test
+++ b/mysql-test/columnstore/devregression/t/mcs7523_partitionOptimization_aCreateViews.test
@@ -10,6 +10,7 @@
 USE tpch1;
 
 
+--disable_warnings
 drop view if exists v_nation;
 drop view if exists v_region;
 drop view if exists v_customer;
@@ -18,7 +19,7 @@ drop view if exists v_supplier;
 drop view if exists v_partsupp;
 drop view if exists v_part;
 drop view if exists v_lineitem;
-
+--enable_warnings
 
 create view v_nation as select * from nation where n_nationkey > 10 union all select * from nation where n_nationkey <= 10;
 create view v_region as select * from region where r_regionkey > 3 union all select * from region where r_regionkey <= 3;
@@ -30,6 +31,7 @@ create view v_part as select * from part union all select * from part where p_pa
 create view v_lineitem as select * from lineitem union all select * from lineitem where l_orderkey=0;
 
 
+--disable_warnings
 drop procedure if exists ordersColumnsTouched;
 drop procedure if exists lineitemColumnsTouched;
 drop procedure if exists customerColumnsTouched;
@@ -39,6 +41,7 @@ drop procedure if exists partsuppColumnsTouched;
 drop procedure if exists regionColumnsTouched;
 drop procedure if exists nationColumnsTouched;
 drop procedure if exists eliminatedBlocksGE;
+--enable_warnings
 
 delimiter //;
 create procedure ordersColumnsTouched (in trace varchar(10000)) BEGIN
@@ -152,6 +155,7 @@ select count(*) as nation_count from nation;
 select count(*) as v_nation_count from v_nation;
 
 # Clean up
+--disable_warnings
 drop view if exists v_nation;
 drop view if exists v_region;
 drop view if exists v_customer;
@@ -160,7 +164,7 @@ drop view if exists v_supplier;
 drop view if exists v_partsupp;
 drop view if exists v_part;
 drop view if exists v_lineitem;
-
+#
 drop procedure if exists ordersColumnsTouched;
 drop procedure if exists lineitemColumnsTouched;
 drop procedure if exists customerColumnsTouched;
@@ -170,4 +174,5 @@ drop procedure if exists partsuppColumnsTouched;
 drop procedure if exists regionColumnsTouched;
 drop procedure if exists nationColumnsTouched;
 drop procedure if exists eliminatedBlocksGE;
+#
 

--- a/mysql-test/columnstore/devregression/t/mcs7524_view_sp.test
+++ b/mysql-test/columnstore/devregression/t/mcs7524_view_sp.test
@@ -20,7 +20,10 @@ begin
 end $$
 
 # Simple SP with 1 arg
+--disable_warnings
 drop procedure if exists sp_simple_variable;
+--enable_warnings
+
 Create Procedure sp_simple_variable(in arg_key int)
 begin
         select * from v_temp where p_partkey <= arg_key;
@@ -29,7 +32,10 @@ DELIMITER ;$$
 
 call sp_simple_select;
 call sp_simple_variable(2);
+--disable_warnings
 drop procedure sp_simple_select;
 drop procedure sp_simple_variable;
 drop view v_temp;
+--enable_warnings
+#
 

--- a/mysql-test/columnstore/devregression/t/mcs7524_view_sp.test
+++ b/mysql-test/columnstore/devregression/t/mcs7524_view_sp.test
@@ -20,9 +20,7 @@ begin
 end $$
 
 # Simple SP with 1 arg
---disable_warnings
 drop procedure if exists sp_simple_variable;
---enable_warnings
 
 Create Procedure sp_simple_variable(in arg_key int)
 begin
@@ -32,6 +30,7 @@ DELIMITER ;$$
 
 call sp_simple_select;
 call sp_simple_variable(2);
+
 --disable_warnings
 drop procedure sp_simple_select;
 drop procedure sp_simple_variable;

--- a/mysql-test/columnstore/devregression/t/mcs7525_MCOL-829.test
+++ b/mysql-test/columnstore/devregression/t/mcs7525_MCOL-829.test
@@ -10,9 +10,12 @@
 USE tpch1;
 
 # Support INSERT...SELECT in stored procedures
+--disable_warnings
 drop table if exists mcol829a;
 drop table if exists mcol829b;
 drop procedure if exists mcol829;
+--enable_warnings
+
 create table mcol829a (a int, b int) engine=columnstore;
 create table mcol829b (a int, b int) engine=columnstore;
 insert into mcol829a values (1,1),(2,2),(3,3);
@@ -22,8 +25,10 @@ delimiter ;//
 call mcol829();
 select * from mcol829b;
 
+--disable_warnings
 drop procedure mcol829;
 drop table mcol829a;
 drop table mcol829b;
-
+--enable_warnings
+#
 

--- a/mysql-test/columnstore/devregression/t/mcs7578_j1.test
+++ b/mysql-test/columnstore/devregression/t/mcs7578_j1.test
@@ -16,4 +16,7 @@ create table j1 (j1_key int)engine=columnstore;
 insert into j1 values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(null);
 
 select * from j1;
+--disable_warnings
 drop table j1;
+--enable_warnings
+#

--- a/mysql-test/columnstore/devregression/t/mcs7579_j11.test
+++ b/mysql-test/columnstore/devregression/t/mcs7579_j11.test
@@ -16,4 +16,7 @@ create table j11 (j11_key int)engine=columnstore;
 insert into j11 values (11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(null);
 
 select * from j11;
+--disable_warnings
 drop table j11;
+--enable_warnings
+#

--- a/mysql-test/columnstore/devregression/t/mcs7580_j16.test
+++ b/mysql-test/columnstore/devregression/t/mcs7580_j16.test
@@ -16,4 +16,7 @@ create table j16 (j16_key int)engine=columnstore;
 insert into j16 values (16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(null);
 
 select * from j16;
+--disable_warnings
 drop table j16;
+--enable_warnings
+#

--- a/mysql-test/columnstore/devregression/t/mcs7581_j6.test
+++ b/mysql-test/columnstore/devregression/t/mcs7581_j6.test
@@ -15,5 +15,7 @@ create table j6 (j6_key int)engine=columnstore;
 insert into j6 values (6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(null);
 
 select * from j6;
-
+--disable_warnings
 drop table j6;
+--enable_warnings
+#

--- a/mysql-test/columnstore/devregression/t/mcs7634_q211.test
+++ b/mysql-test/columnstore/devregression/t/mcs7634_q211.test
@@ -26,4 +26,7 @@ drop table `test023_cs3`.`cs3`;
 --error 1146
 show create table `test023_cs3`.`cs3`;
 use tpch1;
+
+--disable_warnings
 drop database if exists test023_cs3;
+--enable_warnings

--- a/mysql-test/columnstore/devregression/t/mcs7635_q212.test
+++ b/mysql-test/columnstore/devregression/t/mcs7635_q212.test
@@ -9,12 +9,16 @@
 
 USE tpch1;
 
+--disable_warnings
 drop database if exists test023_cs3;
+--enable_warnings
+
 create database test023_cs3;
 use test023_cs3;
 
 SET SESSION sql_mode = 'ANSI_QUOTES';
 
+--disable_warnings
 drop table if exists "test023_cs3"."cs3";
 create table "test023_cs3"."cs3"(i int, t text) engine=columnstore;
 insert into "test023_cs3"."cs3" values (1,'Lorem ipsum dolor sit amet, consectetur adipiscing elit,'),(7,'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'),(8,'Ut enim ad minim veniam,'),(9,'quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'),(10,'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore e');
@@ -28,4 +32,7 @@ drop table "test023_cs3"."cs3";
 --error 1146
 show create table "test023_cs3"."cs3";
 use tpch1;
+--disable_warnings
 drop database if exists test023_cs3;
+--enable_warnings
+#

--- a/mysql-test/columnstore/devregression/t/mcs7636_q213.test
+++ b/mysql-test/columnstore/devregression/t/mcs7636_q213.test
@@ -9,13 +9,19 @@
 
 USE tpch1;
 
+--disable_warnings
 drop database if exists test023_cs3;
 drop database if exists test023_cs2;
+--enable_warnings
+
 create database test023_cs3;
 create database test023_cs2;
 use test023_cs2;
 
+--disable_warnings
 drop table if exists `test023_cs3`.`cs3`;
+--enable_warnings
+
 create table `test023_cs3`.`cs3`(i int, t text) engine=columnstore;
 insert into `test023_cs3`.`cs3` values (1,'Lorem ipsum dolor sit amet, consectetur adipiscing elit,'),(7,'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'),(8,'Ut enim ad minim veniam,'),(9,'quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'),(10,'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore e');
 select * from `test023_cs3`.`cs3`;
@@ -30,5 +36,8 @@ drop table `test023_cs3`.`cs3`;
 --error 1146
 show create table `test023_cs3`.`cs3`;
 use tpch1;
+--disable_warnings
 drop database if exists test023_cs3;
 drop database if exists test023_cs2;
+--enable_warnings
+#

--- a/mysql-test/columnstore/devregression/t/mcs7637_q214.test
+++ b/mysql-test/columnstore/devregression/t/mcs7637_q214.test
@@ -9,6 +9,12 @@
 
 USE tpch1;
 
+--disable_warnings
 CREATE TABLE IF NOT EXISTS mcol2219 (`t (space` int) engine=columnstore;
+--enable_warnings
+
 SELECT column_name FROM information_schema.columnstore_columns WHERE table_name='mcol2219';
+--disable_warnings
 DROP TABLE mcol2219;
+--enable_warnings
+#


### PR DESCRIPTION
Add --disable_warnings and --enable_warnings around "create table if not exist" and "drop table if exist" for setting up and cleaning up test tables.  This change did not apply to test cases are designed to validate the functionality of such two commands.

Reference results have been recorded after making these changes.



