### PR TITLE
patch_out_of_band

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,14 @@ SET (ENGINE_EXEC_LIBS       joblist querystats libmysql_client ${PLUGIN_EXEC_LIB
 SET (PLUGIN_WRITE_LIBS      ddlpackageproc ddlpackage dmlpackageproc dmlpackage writeengine writeengineclient idbdatafile cacheutils)
 SET (ENGINE_WRITE_LIBS      ${PLUGIN_WRITE_LIBS} ${ENGINE_EXEC_LIBS})
 
+IF (NOT INSTALL_LAYOUT)
+    SET (LIBMARIADB_BININC_DIR ${SERVER_BUILD_DIR}/libmariadb/include)
+    SET (LIBMARIADB_SRCINC_DIR ${SERVER_SOURCE_ROOT_DIR}/libmariadb/include)
+ELSE()
+    SET (LIBMARIADB_BININC_DIR ${CMAKE_BINARY_DIR}/libmariadb/include)
+    SET (LIBMARIADB_SRCINC_DIR ${CMAKE_SOURCE_DIR}/libmariadb/include)
+ENDIF()
+
 SET (ENGINE_COMMON_LDFLAGS  "")
 
 IF (SERVER_BUILD_INCLUDE_DIR)

--- a/dbcon/joblist/CMakeLists.txt
+++ b/dbcon/joblist/CMakeLists.txt
@@ -66,8 +66,8 @@ add_definitions(-DMYSQL_SERVICE_THD_TIMEZONE_INCLUDED)
 
 add_library(joblist SHARED ${joblist_LIB_SRCS})
 target_include_directories(joblist BEFORE PUBLIC ${OPENSSL_INCLUDE_DIR}
-  ${CMAKE_BINARY_DIR}/libmariadb/include
-  ${CMAKE_SOURCE_DIR}/libmariadb/include)
+  ${LIBMARIADB_BININC_DIR}
+  ${LIBMARIADB_SRCINC_DIR})
 add_dependencies(joblist loggingcpp)
 
 install(TARGETS joblist DESTINATION ${ENGINE_LIBDIR} COMPONENT columnstore-engine)

--- a/utils/libmysql_client/CMakeLists.txt
+++ b/utils/libmysql_client/CMakeLists.txt
@@ -1,11 +1,6 @@
 include_directories(BEFORE
-    ${CMAKE_BINARY_DIR}/libmariadb/include
-    ${CMAKE_SOURCE_DIR}/libmariadb/include)
-add_definitions(-DMYSQL_SERVICE_THD_TIMEZONE_INCLUDED)
-
-include_directories(BEFORE
-  ${CMAKE_BINARY_DIR}/libmariadb/include
-  ${CMAKE_SOURCE_DIR}/libmariadb/include)
+  ${LIBMARIADB_BININC_DIR}
+  ${LIBMARIADB_SRCINC_DIR})
 add_definitions(-DMYSQL_SERVICE_THD_TIMEZONE_INCLUDED)
 
 include_directories( ${ENGINE_COMMON_INCLUDES} )

--- a/utils/querystats/CMakeLists.txt
+++ b/utils/querystats/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(BEFORE
-  ${CMAKE_BINARY_DIR}/libmariadb/include
-  ${CMAKE_SOURCE_DIR}/libmariadb/include)
+  ${LIBMARIADB_BININC_DIR}
+  ${LIBMARIADB_SRCINC_DIR})
 add_definitions(-DMYSQL_SERVICE_THD_TIMEZONE_INCLUDED)
 
 include_directories( ${ENGINE_COMMON_INCLUDES} )


### PR DESCRIPTION
Some changes made to 10.6-enterprise make a build using the out-of-band method of compiling columnstore not work. Out-of band means the source for the engine is not in the storage subdir of server, but rather in a stand alone directory. This is used by developers for easier develop work. In the case of out-of-band, INSTALL_LAYOUT is false in CMakeLists.txt