### PR TITLE
MCOL-1170 Fix ANALYZE to not error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,7 @@ build/Testing/
 tests/*\[1\]_tests.cmake
 tests/*\[1\]_include.cmake
 .boost
+*.vtg
+*.vtg-back
+'*.vtg-Stashed changes'
+


### PR DESCRIPTION
Analyze needs to be completed differently than a normal query. In server, when an ANALYZE is seen, it calls init_scan() immediatly followed by end_scan(). This leaves the sqlfrontendsession (ExeMgr) in a state where it expects to return rows. This patch fixes end_scan to clean this up via reads and writes to get everything back in synch.

ANALYZE should display the number of rows to be displayed if the query were run normally. We have that information available, but no way to return it. A modification to server side to ask for that in the handler is required.

This patch also includes a beautification of sqlfrontsessionthread.cpp since it looked bad. The important change is at line 774 if (!swallowRows)
which short circuits the actual return of data