### PR TITLE
Add missing includes

### DIFF
--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -18,6 +18,7 @@
    MA 02110-1301, USA. */
 
 #pragma once
+#include <bitset>
 #include <string>
 #include <stdint.h>
 #ifdef _MSC_VER

--- a/storage-manager/src/MetadataFile.cpp
+++ b/storage-manager/src/MetadataFile.cpp
@@ -19,6 +19,7 @@
  * MetadataFile.cpp
  */
 #include "MetadataFile.h"
+#include <set>
 #include <boost/filesystem.hpp>
 #define BOOST_SPIRIT_THREADSAFE
 #include <boost/property_tree/ptree.hpp>

--- a/storage-manager/src/S3Storage.h
+++ b/storage-manager/src/S3Storage.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <deque>
 #include <string>
 #include <map>
 #include "CloudStorage.h"

--- a/tools/passwd/secrets.cpp
+++ b/tools/passwd/secrets.cpp
@@ -12,6 +12,8 @@
  */
 #include "secrets.h"
 
+#include <array>
+#include <cstdint>
 #include <cctype>
 #include <fstream>
 #include <pwd.h>

--- a/utils/cloudio/SocketPool.h
+++ b/utils/cloudio/SocketPool.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <deque>
+
 #include <boost/utility.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition_variable.hpp>


### PR DESCRIPTION
These seem to have all fallen out of a recent Boost update to 1.81 which dropped some internal includes. All of these uses within columnstore relied on these transitive includes, so explicitly include what we need to fix build.

Signed-off-by: Sam James <sam@gentoo.org>