### PR TITLE
MCOL-5367 Fix a bug introduced in MCOL-5021 (AUX column implementation).

### DIFF
--- a/writeengine/server/we_dmlcommandproc.cpp
+++ b/writeengine/server/we_dmlcommandproc.cpp
@@ -2457,7 +2457,6 @@ uint8_t WE_DMLCommandProc::processBatchInsertHwm(messageqcpp::ByteStream& bs, st
 
   if (hasAUXCol)
   {
-    idbassert(auxColDBRootExtentInfo.size() == 1);
     colDBRootExtentInfo.insert(colDBRootExtentInfo.end(), auxColDBRootExtentInfo.begin(),
                                auxColDBRootExtentInfo.end());
   }


### PR DESCRIPTION
In the implementation of MCOL-5021, an assert was added in `WE_DMLCommandProc::processBatchInsertHwm()` that assumed the `WriteEngine::TableMetaData` cache is uniform across the cluster. However, this assumption is incorrect.

This bug caused undefined behaviour in ColumnStore resulting in bugs such as MCOL-5367. In MCOL-5367, in a multi-node ColumnStore cluster, an INSERT ... SELECT in a transaction with system variable `columnstore_use_import_for_batchinsert=OFF/ON` did not show inserted records when a SELECT query was issued. Assuming a 3-node cluster setup, DMLProc only sends a given batch of records to be inserted to one of the 3 nodes, and not all nodes. As a result, the `WriteEngine::TableMetaData` cache is only populated for that one node and is not uniform across the cluster, causing the assert to fail.

As a fix, we simply remove this assert as it is redundant and should not have been added in the first place.