### PR TITLE
Revert "This commit fixes an incorrect predicate in the if condition (#2608)"

### DIFF
--- a/writeengine/server/we_dmlcommandproc.cpp
+++ b/writeengine/server/we_dmlcommandproc.cpp
@@ -2424,7 +2424,7 @@ uint8_t WE_DMLCommandProc::processBatchInsertHwm(messageqcpp::ByteStream& bs, st
         if ((aIt->partNum > aExtentInfo.fPartition) ||
             ((aIt->partNum == aExtentInfo.fPartition) && (aIt->segNum > aExtentInfo.fSegment)) ||
             ((aIt->partNum == aExtentInfo.fPartition) && (aIt->segNum == aExtentInfo.fSegment) &&
-             (aIt->hwm > aExtentInfo.fLocalHwm)))
+             (aIt->segNum > aExtentInfo.fLocalHwm)))
         {
           aExtentInfo.fPartition = aIt->partNum;
           aExtentInfo.fDbRoot = aIt->dbRoot;


### PR DESCRIPTION
This reverts commit f4e3022fbdecc25a22ae6eaf072e462aa6695f35.

The commit apparently caused MCOL-5318 and MCOL-5319 which involve the internal ColumnStore batch insert mechanism passing through the SQL layer. The code block involved in this change is a predicate checking for the HWM extent in WriteEngineServer at the end of the batch insert. This is done in WE_DMLCommandProc::processBatchInsertHwm(). The original predicate check in this function for the HWM extent is restored until further investigation.