### PR TITLE
Generate published package URL as part of new pipeline step

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -117,6 +117,8 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
   local brancht = if (branch == '**') then '' else branch + '-',
   local result = std.strReplace(std.strReplace(platform, ':', ''), '/', '-'),
 
+  local publish_pkg_url = "https://cspkg.s3.amazonaws.com/index.html?prefix=" + branchp + event + "/${DRONE_BUILD_NUMBER}/" + server + "/" + arch + "/" + result + "/",
+
   local container_tags = if (event == 'cron') then [brancht + std.strReplace(event, '_', '-') + '${DRONE_BUILD_NUMBER}', brancht] else [brancht + std.strReplace(event, '_', '-') + '${DRONE_BUILD_NUMBER}'],
   local container_version = branchp + event + '/${DRONE_BUILD_NUMBER}/' + server + '/' + arch,
 
@@ -632,7 +634,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
              name: 'publish pkg url',
              image: 'alpine/git',
              commands: [
-               "echo -e '\\e]8;;https://cspkg.s3.amazonaws.com/index.html?prefix=" + branchp + event + "/${DRONE_BUILD_NUMBER}/" + server + "/" + arch + "/" + result + "/\\e\\\\https://cspkg.s3.amazonaws.com/index.html?prefix=" + branchp + event + "/${DRONE_BUILD_NUMBER}/" + server + "/" + arch + "/" + result + "\\e]8;;\\e\\\\'"
+               "echo -e '\\e]8;;" + publish_pkg_url + "\\e\\\\" + publish_pkg_url + "\\e]8;;\\e\\\\'"
              ]
            }
         ] +

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -632,6 +632,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
          [
           {
              name: 'publish pkg url',
+             depends_on: ['publish pkg'],
              image: 'alpine/git',
              commands: [
                "echo -e '\\e]8;;" + publish_pkg_url + "\\e\\\\" + publish_pkg_url + "\\e]8;;\\e\\\\'"

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -627,6 +627,15 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
            },
          ] +
          [pipeline.publish()] +
+         [
+          {
+             name: 'publish pkg url',
+             image: 'alpine/git',
+             commands: [
+               "echo -e '\\e]8;;https://cspkg.s3.amazonaws.com/index.html?prefix=" + branchp + event + "/${DRONE_BUILD_NUMBER}/" + server + "/" + arch + "/" + result + "/\\e\\\\https://cspkg.s3.amazonaws.com/index.html?prefix=" + branchp + event + "/${DRONE_BUILD_NUMBER}/" + server + "/" + arch + "/" + result + "\\e]8;;\\e\\\\'"
+             ]
+           }
+        ] +
          (if (event == 'cron') then [pipeline.publish('pkg latest', 'latest')] else []) +
          [pipeline.smoke] +
          [pipeline.smokelog] +


### PR DESCRIPTION
Hi @mariadb-LeonidFedorov, sorry for the delay on this one.

I'm marking this one as a draft because I have not had a chance to yet test this. I did some digging with regards to getting clickable URL's somewhere in the pipeline output, and using ANSI escape codes for links is the closest I've found. However, I've read conflicting information about whether or not this'll work when run under Drone CI.

There's some information in the thread here <https://community.harness.io/t/add-custom-links-to-build-page/10087/3>

I'd like to test this locally, but that involves setting up a drone instance and I haven't found the time yet to do so.
I'd appreciate any thoughts. Note that there's duplication of the expression there but I'm more curious to know if it even works. It can get moved up to a variable.

I'd appreciate your thoughts