### PR TITLE
Add missing stdlib includes

### DIFF
--- a/storage-manager/src/MetadataFile.cpp
+++ b/storage-manager/src/MetadataFile.cpp
@@ -20,6 +20,7 @@
  */
 #include "MetadataFile.h"
 #include <set>
+#include <vector>
 #include <boost/filesystem.hpp>
 #define BOOST_SPIRIT_THREADSAFE
 #ifndef __clang__


### PR DESCRIPTION
Looks that these includes were missing. Either compiler was silently skipping this, or the team is using precompiled header, which I am unaware of. These includes were required to build columnstore with clang from MariaDB root.