### PR TITLE
MCOL-5385: Delete RowGroup::setData and make Pointer ctor explicit

### DIFF
--- a/dbcon/joblist/crossenginestep.cpp
+++ b/dbcon/joblist/crossenginestep.cpp
@@ -442,7 +442,7 @@ void CrossEngineStep::execute()
       Row rowFe1;                       // row for fe evaluation
       fRowGroupFe1.initRow(&rowFe1, true);
       rgDataFe1.reset(new uint8_t[rowFe1.getSize()]);
-      rowFe1.setData(rgDataFe1.get());
+      rowFe1.setData(rowgroup::Row::Pointer(rgDataFe1.get()));
 
       while ((rowIn = mysql->nextRow()) && !cancelled())
       {
@@ -493,7 +493,7 @@ void CrossEngineStep::execute()
       Row rowFe3;                       // row for fe evaluation
       fRowGroupOut.initRow(&rowFe3, true);
       rgDataFe3.reset(new uint8_t[rowFe3.getSize()]);
-      rowFe3.setData(rgDataFe3.get());
+      rowFe3.setData(rowgroup::Row::Pointer(rgDataFe3.get()));
 
       while ((rowIn = mysql->nextRow()) && !cancelled())
       {
@@ -514,13 +514,13 @@ void CrossEngineStep::execute()
       Row rowFe1;                       // row for fe1 evaluation
       fRowGroupFe1.initRow(&rowFe1, true);
       rgDataFe1.reset(new uint8_t[rowFe1.getSize()]);
-      rowFe1.setData(rgDataFe1.get());
+      rowFe1.setData(rowgroup::Row::Pointer(rgDataFe1.get()));
 
       shared_array<uint8_t> rgDataFe3;  // functions in select clause
       Row rowFe3;                       // row for fe3 evaluation
       fRowGroupOut.initRow(&rowFe3, true);
       rgDataFe3.reset(new uint8_t[rowFe3.getSize()]);
-      rowFe3.setData(rgDataFe3.get());
+      rowFe3.setData(rowgroup::Row::Pointer(rgDataFe3.get()));
 
       while ((rowIn = mysql->nextRow()) && !cancelled())
       {

--- a/dbcon/joblist/diskjoinstep.cpp
+++ b/dbcon/joblist/diskjoinstep.cpp
@@ -382,7 +382,7 @@ void DiskJoinStep::joinFcn()
 
   baseRowMem.reset(new uint8_t[baseRow.getSize()]);
   baseRow.setData(rowgroup::Row::Pointer(baseRowMem.get()));
-  joinMatches.push_back(vector<Row::Pointer>());
+  joinMatches.emplace_back(vector<Row::Pointer>());
   smallRG.initRow(&smallRowTemplates[0]);
   joiners.resize(1);
 

--- a/dbcon/joblist/diskjoinstep.cpp
+++ b/dbcon/joblist/diskjoinstep.cpp
@@ -372,7 +372,7 @@ void DiskJoinStep::joinFcn()
   {
     joinFERG.initRow(&l_joinFERow, true);
     joinFEMem.reset(new uint8_t[l_joinFERow.getSize()]);
-    l_joinFERow.setData(joinFEMem.get());
+    l_joinFERow.setData(rowgroup::Row::Pointer(joinFEMem.get()));
   }
 
   outputRG.initRow(&l_outputRow);
@@ -381,7 +381,7 @@ void DiskJoinStep::joinFcn()
   largeRG.initRow(&l_largeRow);
 
   baseRowMem.reset(new uint8_t[baseRow.getSize()]);
-  baseRow.setData(baseRowMem.get());
+  baseRow.setData(rowgroup::Row::Pointer(baseRowMem.get()));
   joinMatches.push_back(vector<Row::Pointer>());
   smallRG.initRow(&smallRowTemplates[0]);
   joiners.resize(1);
@@ -400,7 +400,7 @@ void DiskJoinStep::joinFcn()
   l_smallRG.initRow(&smallNullRow, true);
   smallNullMem.reset(new boost::scoped_array<uint8_t>[1]);
   smallNullMem[0].reset(new uint8_t[smallNullRow.getSize()]);
-  smallNullRow.setData(smallNullMem[0].get());
+  smallNullRow.setData(rowgroup::Row::Pointer(smallNullMem[0].get()));
   smallNullRow.initToNull();
 
   try
@@ -461,7 +461,7 @@ void DiskJoinStep::joinFcn()
 
           l_largeRG.initRow(&l_largeRow, true);
           boost::scoped_array<uint8_t> largeNullMem(new uint8_t[l_largeRow.getSize()]);
-          l_largeRow.setData(largeNullMem.get());
+          l_largeRow.setData(rowgroup::Row::Pointer(largeNullMem.get()));
           l_largeRow.initToNull();
 
           in->tupleJoiner->getUnmarkedRows(&unmatched);

--- a/dbcon/joblist/groupconcat.cpp
+++ b/dbcon/joblist/groupconcat.cpp
@@ -322,7 +322,8 @@ void GroupConcatAgUM::initialize()
 
   fGroupConcat->fRowGroup.initRow(&fRow, true);
   fData.reset(new uint8_t[fRow.getSize()]);
-  fRow.setData(fData.get());
+
+  fRow.setData(rowgroup::Row::Pointer(fData.get()));
 }
 
 void GroupConcatAgUM::processRow(const rowgroup::Row& inRow)

--- a/dbcon/joblist/jsonarrayagg.cpp
+++ b/dbcon/joblist/jsonarrayagg.cpp
@@ -315,7 +315,7 @@ void JsonArrayAggregatAgUM::initialize()
 
   fGroupConcat->fRowGroup.initRow(&fRow, true);
   fData.reset(new uint8_t[fRow.getSize()]);
-  fRow.setData(fData.get());
+  fRow.setData(rowgroup::Row::Pointer(fData.get()));
 }
 
 void JsonArrayAggregatAgUM::processRow(const rowgroup::Row& inRow)

--- a/dbcon/joblist/subquerytransformer.cpp
+++ b/dbcon/joblist/subquerytransformer.cpp
@@ -592,7 +592,7 @@ void SimpleScalarTransformer::getScalarResult()
       fRowGroup.initRow(&row);
       fRowGroup.getRow(0, &row);
       fRowData.reset(new uint8_t[fRow.getSize()]);
-      fRow.setData(fRowData.get());
+      fRow.setData(rowgroup::Row::Pointer(fRowData.get()));
       copyRow(row, &fRow);
 
       // For exist filter, stop the query after one or more rows retrieved.

--- a/dbcon/joblist/tuple-bps.cpp
+++ b/dbcon/joblist/tuple-bps.cpp
@@ -199,7 +199,7 @@ TupleBPS::JoinLocalData::JoinLocalData(TupleBPS* pTupleBPS, RowGroup& primRowGro
     local_primRG.initRow(&largeSideRow);
     local_outputRG.initRow(&joinedBaseRow, true);
     joinedBaseRowData.reset(new uint8_t[joinedBaseRow.getSize()]);
-    joinedBaseRow.setData(joinedBaseRowData.get());
+    joinedBaseRow.setData(rowgroup::Row::Pointer(joinedBaseRowData.get()));
     joinedBaseRow.initToNull();
     largeMapping = makeMapping(local_primRG, local_outputRG);
 
@@ -222,7 +222,7 @@ TupleBPS::JoinLocalData::JoinLocalData(TupleBPS* pTupleBPS, RowGroup& primRowGro
       joinFERG.initRow(&joinFERow, true);
       joinFERowData.reset(new uint8_t[joinFERow.getSize()]);
       memset(joinFERowData.get(), 0, joinFERow.getSize());
-      joinFERow.setData(joinFERowData.get());
+      joinFERow.setData(rowgroup::Row::Pointer(joinFERowData.get()));
       fergMappings[smallSideCount] = makeMapping(local_primRG, joinFERG);
     }
 
@@ -230,13 +230,13 @@ TupleBPS::JoinLocalData::JoinLocalData(TupleBPS* pTupleBPS, RowGroup& primRowGro
     {
       joinerMatchesRGs[i].initRow(&(smallNulls[i]), true);
       smallNullMemory[i].reset(new uint8_t[smallNulls[i].getSize()]);
-      smallNulls[i].setData(smallNullMemory[i].get());
+      smallNulls[i].setData(rowgroup::Row::Pointer(smallNullMemory[i].get()));
       smallNulls[i].initToNull();
     }
 
     local_primRG.initRow(&largeNull, true);
     largeNullMemory.reset(new uint8_t[largeNull.getSize()]);
-    largeNull.setData(largeNullMemory.get());
+    largeNull.setData(rowgroup::Row::Pointer(largeNullMemory.get()));
     largeNull.initToNull();
   }
 }
@@ -568,7 +568,7 @@ TupleBPS::TupleBPS(const pColScanStep& rhs, const JobInfo& jobInfo) : BatchPrimi
       std::ostringstream oss;
       oss << "Error getting AUX column OID for table " << tableName.toString();
       throw runtime_error(oss.str());
-    }    
+    }
 
     if (fOidAux > 3000)
     {

--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -5371,7 +5371,7 @@ void TupleAggregateStep::threadedAggregateRowGroups(uint32_t threadID)
               {
                 multiDist->subAggregators()[j]->getOutputRowGroup()->initRow(&distRow[j], true);
                 distRowData[j].reset(new uint8_t[distRow[j].getSize()]);
-                distRow[j].setData(distRowData[j].get());
+                distRow[j].setData(rowgroup::Row::Pointer(distRowData[j].get()));
                 hashLens.push_back(multiDist->subAggregators()[j]->aggMapKeyLength());
               }
             }

--- a/dbcon/joblist/tupleconstantstep.cpp
+++ b/dbcon/joblist/tupleconstantstep.cpp
@@ -180,7 +180,7 @@ void TupleConstantStep::constructContanstRow(const JobInfo& jobInfo)
 {
   // construct a row with only the constant values
   fConstRowData.reset(new uint8_t[fRowConst.getSize()]);
-  fRowConst.setData(fConstRowData.get());
+  fRowConst.setData(rowgroup::Row::Pointer(fConstRowData.get()));
   fRowConst.initToNull();  // make sure every col is init'd to something, because later we copy the whole row
   const vector<CalpontSystemCatalog::ColDataType>& types = fRowGroupOut.getColTypes();
 

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -1377,7 +1377,7 @@ void TupleHashJoinStep::startJoinThreads()
     Row smallRow;
     smallRGs[i].initRow(&smallRow, true);
     smallNullMemory[i].reset(new uint8_t[smallRow.getSize()]);
-    smallRow.setData(smallNullMemory[i].get());
+    smallRow.setData(rowgroup::Row::Pointer(smallNullMemory[i].get()));
     smallRow.initToNull();
   }
 
@@ -1427,12 +1427,12 @@ void TupleHashJoinStep::finishSmallOuterJoin()
   {
     smallRGs[i].initRow(&smallRowTemplates[i]);
     smallRGs[i].initRow(&smallNullRows[i], true);
-    smallNullRows[i].setData(smallNullMemory[i].get());
+    smallNullRows[i].setData(rowgroup::Row::Pointer(smallNullMemory[i].get()));
   }
 
   largeRG.initRow(&largeNullRow, true);
   largeNullMemory.reset(new uint8_t[largeNullRow.getSize()]);
-  largeNullRow.setData(largeNullMemory.get());
+  largeNullRow.setData(rowgroup::Row::Pointer(largeNullMemory.get()));
   largeNullRow.initToNull();
 
   joinedData.reinit(l_outputRG);
@@ -1529,14 +1529,14 @@ void TupleHashJoinStep::joinRunnerFcn(uint32_t threadID)
   local_outputRG.initRow(&joinedRow);
   local_outputRG.initRow(&baseRow, true);
   baseRowData.reset(new uint8_t[baseRow.getSize()]);
-  baseRow.setData(baseRowData.get());
+  baseRow.setData(rowgroup::Row::Pointer(baseRowData.get()));
 
   if (hasJoinFE)
   {
     local_joinFERG = joinFilterRG;
     local_joinFERG.initRow(&joinFERow, true);
     joinFERowData.reset(new uint8_t[joinFERow.getSize()]);
-    joinFERow.setData(joinFERowData.get());
+    joinFERow.setData(rowgroup::Row::Pointer(joinFERowData.get()));
   }
 
   if (fe2)

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -996,7 +996,7 @@ void BatchPrimitiveProcessor::initProcessor()
       {
         joinFERG->initRow(&joinFERow, true);
         joinFERowData.reset(new uint8_t[joinFERow.getSize()]);
-        joinFERow.setData(joinFERowData.get());
+        joinFERow.setData(rowgroup::Row::Pointer(joinFERowData.get()));
         joinFEMappings.reset(new shared_array<int>[joinerCount + 1]);
 
         for (i = 0; i < joinerCount; i++)
@@ -1058,7 +1058,7 @@ void BatchPrimitiveProcessor::initProcessor()
         smallSideRGs[i].initRow(&smallRows[i], true);
 
       baseJRowMem.reset(new uint8_t[baseJRow.getSize()]);
-      baseJRow.setData(baseJRowMem.get());
+      baseJRow.setData(rowgroup::Row::Pointer(baseJRowMem.get()));
       gjrgMappings.reset(new shared_array<int>[joinerCount + 1]);
 
       for (i = 0; i < joinerCount; i++)

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -574,7 +574,7 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
           return;
 
         for (; range.first != range.second; ++range.first)
-          matches->push_back(range.first->second);
+          matches->push_back(rowgroup::Row::Pointer(range.first->second));
       }
     }
     else
@@ -615,7 +615,7 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
       pair<iterator, iterator> range = h[bucket]->equal_range(nullVal);
 
       for (; range.first != range.second; ++range.first)
-        matches->push_back(range.first->second);
+        matches->push_back(rowgroup::Row::Pointer(range.first->second));
     }
     else
     {
@@ -648,7 +648,7 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
 
         for (uint i = 0; i < bucketCount; i++)
           for (it = h[i]->begin(); it != h[i]->end(); ++it)
-            matches->push_back(it->second);
+            matches->push_back(rowgroup::Row::Pointer(it->second));
       }
       else
       {
@@ -747,7 +747,7 @@ void TupleJoiner::doneInserting()
       {
         while (hit == h[bucket]->end())
           hit = h[++bucket]->begin();
-        smallRow.setPointer(hit->second);
+        smallRow.setPointer(rowgroup::Row::Pointer(hit->second));
         ++hit;
       }
       else
@@ -1033,10 +1033,10 @@ void TupleJoiner::getUnmarkedRows(vector<Row::Pointer>* out)
       for (uint i = 0; i < bucketCount; i++)
         for (it = h[i]->begin(); it != h[i]->end(); ++it)
         {
-          smallR.setPointer(it->second);
+          smallR.setPointer(rowgroup::Row::Pointer(it->second));
 
           if (!smallR.isMarked())
-            out->push_back(it->second);
+            out->push_back(rowgroup::Row::Pointer(it->second));
         }
     }
     else

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -574,7 +574,7 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
           return;
 
         for (; range.first != range.second; ++range.first)
-          matches->push_back(rowgroup::Row::Pointer(range.first->second));
+          matches->emplace_back(rowgroup::Row::Pointer(range.first->second));
       }
     }
     else
@@ -615,7 +615,7 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
       pair<iterator, iterator> range = h[bucket]->equal_range(nullVal);
 
       for (; range.first != range.second; ++range.first)
-        matches->push_back(rowgroup::Row::Pointer(range.first->second));
+        matches->emplace_back(rowgroup::Row::Pointer(range.first->second));
     }
     else
     {
@@ -648,7 +648,7 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
 
         for (uint i = 0; i < bucketCount; i++)
           for (it = h[i]->begin(); it != h[i]->end(); ++it)
-            matches->push_back(rowgroup::Row::Pointer(it->second));
+            matches->emplace_back(rowgroup::Row::Pointer(it->second));
       }
       else
       {

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -1036,7 +1036,7 @@ void TupleJoiner::getUnmarkedRows(vector<Row::Pointer>* out)
           smallR.setPointer(rowgroup::Row::Pointer(it->second));
 
           if (!smallR.isMarked())
-            out->push_back(rowgroup::Row::Pointer(it->second));
+            out->emplace_back(rowgroup::Row::Pointer(it->second));
         }
     }
     else

--- a/utils/rowgroup/rowaggregation.cpp
+++ b/utils/rowgroup/rowaggregation.cpp
@@ -696,7 +696,7 @@ void RowAggregation::initialize()
   // Keep a copy of the null row to initialize new map entries.
   fRowGroupOut->initRow(&fNullRow, true);
   fNullRowData.reset(new uint8_t[fNullRow.getSize()]);
-  fNullRow.setData(fNullRowData.get());
+  fNullRow.setData(rowgroup::Row::Pointer(fNullRowData.get()));
   copyRow(fRow, &fNullRow);
 
   // Lazy approach w/o a mapping b/w fFunctionCols idx and fRGContextColl idx
@@ -4685,7 +4685,7 @@ void RowAggregationSubDistinct::setInputOutput(const RowGroup& pRowGroupIn, RowG
   // initialize the aggregate row
   fRowGroupOut->initRow(&fDistRow, true);
   fDistRowData.reset(new uint8_t[fDistRow.getSize()]);
-  fDistRow.setData(fDistRowData.get());
+  fDistRow.setData(rowgroup::Row::Pointer(fDistRowData.get()));
 }
 
 //------------------------------------------------------------------------------

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -338,7 +338,6 @@ class Row
   {
     inline Pointer() = default;
 
-    // Pointer(uint8_t*) implicitly makes old code compatible with the string table impl;
     explicit inline Pointer(uint8_t* d) : data(d)
     {
     }
@@ -360,8 +359,7 @@ class Row
   Row& operator=(const Row&);
   bool operator==(const Row&) const;
 
-  // void setData(uint8_t *rowData, StringStore *ss);
-  inline void setData(const Pointer&);  // convenience fcn, can go away
+  inline void setData(const Pointer&);
   inline uint8_t* getData() const;
 
   inline void setPointer(const Pointer&);

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -339,7 +339,7 @@ class Row
     inline Pointer() = default;
 
     // Pointer(uint8_t*) implicitly makes old code compatible with the string table impl;
-    inline Pointer(uint8_t* d) : data(d)
+    explicit inline Pointer(uint8_t* d) : data(d)
     {
     }
     inline Pointer(uint8_t* d, StringStore* s) : data(d), strings(s)
@@ -1484,7 +1484,6 @@ class RowGroup : public messageqcpp::Serializeable
   inline uint32_t getRowSizeWithStrings() const;
   inline uint64_t getBaseRid() const;
   void setData(RGData* rgd);
-  inline void setData(uint8_t* d);
   inline uint8_t* getData() const;
   inline RGData* getRGData() const;
 
@@ -1678,14 +1677,6 @@ inline void RowGroup::getRow(uint32_t rowNum, Row* r) const
   r->data = &(data[headerSize + (rowNum * r->getSize())]);
   r->strings = strings;
   r->userDataStore = rgData->userDataStore.get();
-}
-
-inline void RowGroup::setData(uint8_t* d)
-{
-  data = d;
-  strings = nullptr;
-  rgData = nullptr;
-  setUseStringTable(false);
 }
 
 inline void RowGroup::setData(RGData* rgd)


### PR DESCRIPTION
We have a proxy class 
```
class Row
{
 public:
  struct Pointer
  {
    inline Pointer() = default;

    // Pointer(uint8_t*) implicitly makes old code compatible with the string table impl;
    inline Pointer(uint8_t* d) : data(d)
    {
    }
    inline Pointer(uint8_t* d, StringStore* s) : data(d), strings(s)
    {
    }
    inline Pointer(uint8_t* d, StringStore* s, UserDataStore* u) : data(d), strings(s), userDataStore(u)
    {
    }
    uint8_t* data = nullptr;
    StringStore* strings = nullptr;
    UserDataStore* userDataStore = nullptr;
  };
```
Note, first ctor is not explicit, and doesn't respect anything about ```StringStore```
when using ```Row::setData``` on pure byte memory, all the ```StringStore``` does not work

This PR removes ugly ```RowGroup::setData``` and makes Pointer ctor explicit, to highlight all the places we need to inspect
