### PR TITLE
Remove boost shared array

### DIFF
--- a/dbcon/execplan/sessionmanager.cpp
+++ b/dbcon/execplan/sessionmanager.cpp
@@ -119,7 +119,7 @@ const TxnID SessionManager::getTxnID(const SID session)
   return ret;
 }
 
-boost::shared_array<SIDTIDEntry> SessionManager::SIDTIDMap(int& len)
+std::shared_ptr<SIDTIDEntry[]> SessionManager::SIDTIDMap(int& len)
 {
   // is this cast valid?
   return dbrm.SIDTIDMap(len);
@@ -150,7 +150,7 @@ bool SessionManager::checkActiveTransaction(const SID sessionId, bool& bIsDbrmUp
   bIsDbrmUp = true;
   int arrayLenth = 0;
   bool ret = false;
-  boost::shared_array<SIDTIDEntry> sIDTIDMap;
+  std::shared_ptr<SIDTIDEntry[]> sIDTIDMap;
 
   sIDTIDMap = SIDTIDMap(arrayLenth);
 
@@ -178,7 +178,7 @@ bool SessionManager::isTransactionActive(const SID sessionId, bool& bIsDbrmUp)
   bIsDbrmUp = true;
   int arrayLenth = 0;
   bool ret = false;
-  boost::shared_array<SIDTIDEntry> sIDTIDMap;
+  std::shared_ptr<SIDTIDEntry[]> sIDTIDMap;
 
   sIDTIDMap = SIDTIDMap(arrayLenth);
 

--- a/dbcon/execplan/sessionmanager.h
+++ b/dbcon/execplan/sessionmanager.h
@@ -28,7 +28,6 @@
 
 #include "calpontsystemcatalog.h"
 #include "brm.h"
-#include "boost/shared_array.hpp"
 
 namespace execplan
 {
@@ -174,7 +173,7 @@ class SessionManager
    * @return A pointer to the array.  Note: The caller is responsible for
    * deallocating it.  Use delete[].
    */
-  boost::shared_array<BRM::SIDTIDEntry> SIDTIDMap(int& len);
+  std::shared_ptr<BRM::SIDTIDEntry[]> SIDTIDMap(int& len);
 
   /** @brief Returns a unique uint32_t.  It eventually wraps around, but who cares.
    *

--- a/dbcon/joblist/batchprimitiveprocessor-jl.cpp
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.cpp
@@ -873,7 +873,7 @@ void BatchPrimitiveProcessorJL::getRowGroupData(ByteStream& in, vector<RGData>* 
 
     if (!pmSendsFinalResult() || pmSendsMatchesAnyway)
     {
-      boost::shared_array<vector<uint32_t> > joinResults;
+      std::shared_ptr<vector<uint32_t>[]> joinResults;
       uint32_t i, j;
 
       if (pmSendsMatchesAnyway)
@@ -920,7 +920,6 @@ void BatchPrimitiveProcessorJL::getRowGroupData(ByteStream& in, vector<RGData>* 
   idbassert(in.length() == 0);
 }
 
-// boost::shared_array<uint8_t>
 RGData BatchPrimitiveProcessorJL::getErrorRowGroupData(uint16_t error) const
 {
   RGData ret;

--- a/dbcon/joblist/batchprimitiveprocessor-jl.h
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.h
@@ -184,8 +184,7 @@ class BatchPrimitiveProcessorJL
     return status;
   }
   void runErrorBPP(messageqcpp::ByteStream&);
-  //	uint32_t getErrorTableBand(uint16_t error, messageqcpp::ByteStream *out);
-  //	boost::shared_array<uint8_t> getErrorRowGroupData(uint16_t error) const;
+
   rowgroup::RGData getErrorRowGroupData(uint16_t error) const;
 
   // @bug 1098

--- a/dbcon/joblist/crossenginestep.cpp
+++ b/dbcon/joblist/crossenginestep.cpp
@@ -408,7 +408,6 @@ void CrossEngineStep::execute()
     int num_fields = mysql->getFieldCount();
 
     char** rowIn;  // input
-    // shared_array<uint8_t> rgDataDelivered;      // output
     RGData rgDataDelivered;
     fRowGroupAdded.initRow(&fRowDelivered);
     // use getDataSize() i/o getMaxDataSize() to make sure there are 8192 rows.
@@ -438,7 +437,7 @@ void CrossEngineStep::execute()
 
     else if (doFE1 && !doFE3)  // FE in WHERE clause only
     {
-      shared_array<uint8_t> rgDataFe1;  // functions in where clause
+      std::shared_ptr<uint8_t[]> rgDataFe1;  // functions in where clause
       Row rowFe1;                       // row for fe evaluation
       fRowGroupFe1.initRow(&rowFe1, true);
       rgDataFe1.reset(new uint8_t[rowFe1.getSize()]);
@@ -489,7 +488,7 @@ void CrossEngineStep::execute()
 
     else if (!doFE1 && doFE3)  // FE in SELECT clause only
     {
-      shared_array<uint8_t> rgDataFe3;  // functions in select clause
+      std::shared_ptr<uint8_t[]> rgDataFe3;  // functions in select clause
       Row rowFe3;                       // row for fe evaluation
       fRowGroupOut.initRow(&rowFe3, true);
       rgDataFe3.reset(new uint8_t[rowFe3.getSize()]);
@@ -510,13 +509,13 @@ void CrossEngineStep::execute()
 
     else  // FE in SELECT clause, FE join and WHERE clause
     {
-      shared_array<uint8_t> rgDataFe1;  // functions in where clause
+      std::shared_ptr<uint8_t[]> rgDataFe1;  // functions in where clause
       Row rowFe1;                       // row for fe1 evaluation
       fRowGroupFe1.initRow(&rowFe1, true);
       rgDataFe1.reset(new uint8_t[rowFe1.getSize()]);
       rowFe1.setData(rowgroup::Row::Pointer(rgDataFe1.get()));
 
-      shared_array<uint8_t> rgDataFe3;  // functions in select clause
+      std::shared_ptr<uint8_t[]> rgDataFe3;  // functions in select clause
       Row rowFe3;                       // row for fe3 evaluation
       fRowGroupOut.initRow(&rowFe3, true);
       rgDataFe3.reset(new uint8_t[rowFe3.getSize()]);
@@ -708,7 +707,6 @@ const RowGroup& CrossEngineStep::getDeliveredRowGroup() const
 
 uint32_t CrossEngineStep::nextBand(messageqcpp::ByteStream& bs)
 {
-  // shared_array<uint8_t> rgDataOut;
   RGData rgDataOut;
   bool more = false;
   uint32_t rowCount = 0;

--- a/dbcon/joblist/crossenginestep.cpp
+++ b/dbcon/joblist/crossenginestep.cpp
@@ -27,7 +27,7 @@
 using namespace std;
 
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/uuid/uuid_io.hpp>
 using namespace boost;
 

--- a/dbcon/joblist/crossenginestep.h
+++ b/dbcon/joblist/crossenginestep.h
@@ -178,7 +178,7 @@ class CrossEngineStep : public BatchPrimitive, public TupleDeliveryStep
   virtual std::string makeQuery();
   virtual void setField(int, const char*, unsigned long, MYSQL_FIELD*, rowgroup::Row&);
   inline void addRow(rowgroup::RGData&);
-  // inline  void addRow(boost::shared_array<uint8_t>&);
+
   template <typename T>
   T convertValueNum(const char*, const execplan::CalpontSystemCatalog::ColType&);
   virtual void formatMiniStats();
@@ -238,8 +238,8 @@ class CrossEngineStep : public BatchPrimitive, public TupleDeliveryStep
   std::map<uint32_t, uint32_t> fColumnMap;  // projected key position (k->p)
   uint64_t fColumnCount;
   boost::scoped_array<int> fFe1Column;
-  boost::shared_array<int> fFeMapping1;
-  boost::shared_array<int> fFeMapping3;
+  std::shared_ptr<int[]> fFeMapping1;
+  std::shared_ptr<int[]> fFeMapping3;
   rowgroup::RowGroup fRowGroupFe1;
   rowgroup::RowGroup fRowGroupFe3;
 

--- a/dbcon/joblist/diskjoinstep.cpp
+++ b/dbcon/joblist/diskjoinstep.cpp
@@ -359,9 +359,9 @@ void DiskJoinStep::joinFcn()
   Row l_largeRow;
   Row l_joinFERow, l_outputRow, baseRow;
   vector<vector<Row::Pointer> > joinMatches;
-  boost::shared_array<Row> smallRowTemplates(new Row[1]);
+  std::shared_ptr<Row[]> smallRowTemplates(new Row[1]);
   vector<std::shared_ptr<TupleJoiner>> joiners;
-  boost::shared_array<boost::shared_array<int> > colMappings, fergMappings;
+  std::shared_ptr<std::shared_ptr<int[]>[]> colMappings, fergMappings;
   boost::scoped_array<boost::scoped_array<uint8_t> > smallNullMem;
   boost::scoped_array<uint8_t> joinFEMem;
   Row smallNullRow;
@@ -386,13 +386,13 @@ void DiskJoinStep::joinFcn()
   smallRG.initRow(&smallRowTemplates[0]);
   joiners.resize(1);
 
-  colMappings.reset(new boost::shared_array<int>[2]);
+  colMappings.reset(new std::shared_ptr<int[]>[2]);
   colMappings[0] = SOMapping;
   colMappings[1] = LOMapping;
 
   if (fe)
   {
-    fergMappings.reset(new boost::shared_array<int>[2]);
+    fergMappings.reset(new std::shared_ptr<int[]>[2]);
     fergMappings[0] = SjoinFEMapping;
     fergMappings[1] = LjoinFEMapping;
   }

--- a/dbcon/joblist/diskjoinstep.h
+++ b/dbcon/joblist/diskjoinstep.h
@@ -50,7 +50,7 @@ class DiskJoinStep : public JobStep
   boost::shared_ptr<RowGroupDL> largeDL, outputDL;
   RowGroupDL* smallDL;
 
-  boost::shared_array<int> LOMapping, SOMapping, SjoinFEMapping, LjoinFEMapping;
+  std::shared_ptr<int[]> LOMapping, SOMapping, SjoinFEMapping, LjoinFEMapping;
   TupleHashJoinStep* thjs;
   boost::shared_ptr<funcexp::FuncExpWrapper> fe;
   bool typeless;

--- a/dbcon/joblist/elementtype.h
+++ b/dbcon/joblist/elementtype.h
@@ -26,7 +26,7 @@
 #include <utility>
 #include <string>
 #include <stdexcept>
-#include <boost/shared_array.hpp>
+
 #include <stdint.h>
 #include <rowgroup.h>
 

--- a/dbcon/joblist/expressionstep.cpp
+++ b/dbcon/joblist/expressionstep.cpp
@@ -24,7 +24,7 @@
 using namespace std;
 
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 using namespace boost;
 
 #include "messagequeue.h"

--- a/dbcon/joblist/groupconcat.cpp
+++ b/dbcon/joblist/groupconcat.cpp
@@ -25,8 +25,6 @@
 using namespace std;
 
 
-using namespace boost;
-
 #include "errorids.h"
 #include "exceptclasses.h"
 using namespace logging;
@@ -273,10 +271,10 @@ void GroupConcatInfo::mapColumns(const RowGroup& projRG)
   }
 }
 
-shared_array<int> GroupConcatInfo::makeMapping(const RowGroup& in, const RowGroup& out)
+std::shared_ptr<int[]> GroupConcatInfo::makeMapping(const RowGroup& in, const RowGroup& out)
 {
   // For some reason using the rowgroup mapping fcns don't work completely right in this class
-  shared_array<int> mapping(new int[out.getColumnCount()]);
+  std::shared_ptr<int[]> mapping(new int[out.getColumnCount()]);
 
   for (uint64_t i = 0; i < out.getColumnCount(); i++)
   {
@@ -345,7 +343,7 @@ uint8_t* GroupConcatAgUM::getResult()
   return fConcator->getResult(fGroupConcat->fSeparator);
 }
 
-void GroupConcatAgUM::applyMapping(const boost::shared_array<int>& mapping, const Row& row)
+void GroupConcatAgUM::applyMapping(const std::shared_ptr<int[]>& mapping, const Row& row)
 {
   // For some reason the rowgroup mapping fcns don't work right in this class.
   for (uint64_t i = 0; i < fRow.getColumnCount(); i++)

--- a/dbcon/joblist/groupconcat.cpp
+++ b/dbcon/joblist/groupconcat.cpp
@@ -24,7 +24,7 @@
 #include <string>
 using namespace std;
 
-#include <boost/shared_array.hpp>
+
 using namespace boost;
 
 #include "errorids.h"

--- a/dbcon/joblist/groupconcat.h
+++ b/dbcon/joblist/groupconcat.h
@@ -63,7 +63,7 @@ class GroupConcatInfo
 
  protected:
   uint32_t getColumnKey(const execplan::SRCP& srcp, JobInfo& jobInfo);
-  boost::shared_array<int> makeMapping(const rowgroup::RowGroup&, const rowgroup::RowGroup&);
+  std::shared_ptr<int[]> makeMapping(const rowgroup::RowGroup&, const rowgroup::RowGroup&);
 
   std::set<uint32_t> fColumns;
   std::vector<rowgroup::SP_GroupConcat> fGroupConcat;
@@ -87,7 +87,7 @@ class GroupConcatAgUM : public rowgroup::GroupConcatAg
   EXPORT uint8_t* getResult();
 
  protected:
-  void applyMapping(const boost::shared_array<int>&, const rowgroup::Row&);
+  void applyMapping(const std::shared_ptr<int[]>&, const rowgroup::Row&);
 
   boost::scoped_ptr<GroupConcator> fConcator;
   boost::scoped_array<uint8_t> fData;

--- a/dbcon/joblist/groupconcat.h
+++ b/dbcon/joblist/groupconcat.h
@@ -25,7 +25,7 @@
 #include <set>
 #include <vector>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 
 #include "returnedcolumn.h"  // SRCP
 #include "rowgroup.h"        // RowGroup

--- a/dbcon/joblist/jobstep.h
+++ b/dbcon/joblist/jobstep.h
@@ -29,7 +29,7 @@
 #include <stdexcept>
 
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/uuid/uuid.hpp>
 
 #include "calpontsystemcatalog.h"

--- a/dbcon/joblist/jsonarrayagg.cpp
+++ b/dbcon/joblist/jsonarrayagg.cpp
@@ -21,7 +21,7 @@
 #include <string>
 using namespace std;
 
-#include <boost/shared_array.hpp>
+
 using namespace boost;
 
 #include "errorids.h"

--- a/dbcon/joblist/jsonarrayagg.cpp
+++ b/dbcon/joblist/jsonarrayagg.cpp
@@ -22,8 +22,6 @@
 using namespace std;
 
 
-using namespace boost;
-
 #include "errorids.h"
 #include "exceptclasses.h"
 using namespace logging;
@@ -266,10 +264,10 @@ void JsonArrayInfo::mapColumns(const RowGroup& projRG)
   }
 }
 
-shared_array<int> JsonArrayInfo::makeMapping(const RowGroup& in, const RowGroup& out)
+std::shared_ptr<int[]> JsonArrayInfo::makeMapping(const RowGroup& in, const RowGroup& out)
 {
   // For some reason using the rowgroup mapping fcns don't work completely right in this class
-  shared_array<int> mapping(new int[out.getColumnCount()]);
+  std::shared_ptr<int[]> mapping(new int[out.getColumnCount()]);
 
   for (uint64_t i = 0; i < out.getColumnCount(); i++)
   {
@@ -337,7 +335,7 @@ uint8_t* JsonArrayAggregatAgUM::getResult()
   return fConcator->getResult(fGroupConcat->fSeparator);
 }
 
-void JsonArrayAggregatAgUM::applyMapping(const boost::shared_array<int>& mapping, const Row& row)
+void JsonArrayAggregatAgUM::applyMapping(const std::shared_ptr<int[]>& mapping, const Row& row)
 {
   // For some reason the rowgroup mapping fcns don't work right in this class.
   for (uint64_t i = 0; i < fRow.getColumnCount(); i++)

--- a/dbcon/joblist/jsonarrayagg.h
+++ b/dbcon/joblist/jsonarrayagg.h
@@ -23,7 +23,7 @@
 #include <set>
 #include <vector>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 
 #include "groupconcat.h"
 

--- a/dbcon/joblist/jsonarrayagg.h
+++ b/dbcon/joblist/jsonarrayagg.h
@@ -45,7 +45,7 @@ class JsonArrayInfo : public GroupConcatInfo
 
  protected:
   uint32_t getColumnKey(const execplan::SRCP& srcp, JobInfo& jobInfo);
-  boost::shared_array<int> makeMapping(const rowgroup::RowGroup&, const rowgroup::RowGroup&);
+  std::shared_ptr<int[]> makeMapping(const rowgroup::RowGroup&, const rowgroup::RowGroup&);
 };
 
 class JsonArrayAggregatAgUM : public GroupConcatAgUM
@@ -63,7 +63,7 @@ class JsonArrayAggregatAgUM : public GroupConcatAgUM
   EXPORT uint8_t* getResult();
 
  protected:
-  void applyMapping(const boost::shared_array<int>&, const rowgroup::Row&);
+  void applyMapping(const std::shared_ptr<int[]>&, const rowgroup::Row&);
 };
 
 // JSON_ARRAYAGG base

--- a/dbcon/joblist/limitedorderby.cpp
+++ b/dbcon/joblist/limitedorderby.cpp
@@ -23,9 +23,6 @@
 #include <string>
 using namespace std;
 
-
-using namespace boost;
-
 #include "errorids.h"
 #include "exceptclasses.h"
 using namespace logging;

--- a/dbcon/joblist/limitedorderby.cpp
+++ b/dbcon/joblist/limitedorderby.cpp
@@ -23,7 +23,7 @@
 #include <string>
 using namespace std;
 
-#include <boost/shared_array.hpp>
+
 using namespace boost;
 
 #include "errorids.h"

--- a/dbcon/joblist/primitivestep.h
+++ b/dbcon/joblist/primitivestep.h
@@ -36,7 +36,7 @@
 #include <tr1/memory>
 
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 

--- a/dbcon/joblist/primitivestep.h
+++ b/dbcon/joblist/primitivestep.h
@@ -1324,7 +1324,7 @@ class TupleBPS : public BatchPrimitive, public TupleDeliveryStep
   /* Functions & Expressions vars */
   boost::shared_ptr<funcexp::FuncExpWrapper> fe1, fe2;
   rowgroup::RowGroup fe1Input, fe2Output;
-  boost::shared_array<int> fe2Mapping;
+  std::shared_ptr<int[]> fe2Mapping;
   bool bRunFEonPM;
 
   /* for UM F & E 2 processing */
@@ -1396,12 +1396,12 @@ class TupleBPS : public BatchPrimitive, public TupleDeliveryStep
     boost::scoped_array<rowgroup::Row> smallNulls;
     boost::scoped_array<uint8_t> joinedBaseRowData;
     boost::scoped_array<uint8_t> joinFERowData;
-    boost::shared_array<int> largeMapping;
-    vector<boost::shared_array<int>> smallMappings;
-    vector<boost::shared_array<int>> fergMappings;
+    std::shared_ptr<int[]> largeMapping;
+    vector<std::shared_ptr<int[]>> smallMappings;
+    vector<std::shared_ptr<int[]>> fergMappings;
     rowgroup::RGData joinedData;
     boost::scoped_array<uint8_t> largeNullMemory;
-    boost::scoped_array<boost::shared_array<uint8_t>> smallNullMemory;
+    boost::scoped_array<std::shared_ptr<uint8_t[]>> smallNullMemory;
     uint32_t matchCount;
 
     rowgroup::Row postJoinRow;

--- a/dbcon/joblist/subquerystep.cpp
+++ b/dbcon/joblist/subquerystep.cpp
@@ -24,7 +24,7 @@
 using namespace std;
 
 #include <boost/scoped_array.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread.hpp>

--- a/dbcon/joblist/subquerystep.h
+++ b/dbcon/joblist/subquerystep.h
@@ -244,7 +244,7 @@ class SubAdapterStep : public JobStep, public TupleDeliveryStep
   uint64_t fRowsInput;
   uint64_t fRowsReturned;
   bool fEndOfResult;
-  boost::shared_array<int> fIndexMap;
+  std::shared_ptr<int[]> fIndexMap;
   std::vector<std::pair<uint32_t, uint32_t> > fDupColumns;
 
   RowGroupDL* fInputDL;

--- a/dbcon/joblist/subquerystep.h
+++ b/dbcon/joblist/subquerystep.h
@@ -23,7 +23,7 @@
 
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/thread.hpp>
 
 #include "jobstep.h"

--- a/dbcon/joblist/threadsafequeue.h
+++ b/dbcon/joblist/threadsafequeue.h
@@ -27,7 +27,7 @@
 #include <stdexcept>
 #include <boost/thread.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 
 
 namespace joblist

--- a/dbcon/joblist/tuple-bps.cpp
+++ b/dbcon/joblist/tuple-bps.cpp
@@ -195,7 +195,7 @@ TupleBPS::JoinLocalData::JoinLocalData(TupleBPS* pTupleBPS, RowGroup& primRowGro
     smallNulls.reset(new Row[smallSideCount]);
     smallMappings.resize(smallSideCount);
     fergMappings.resize(smallSideCount + 1);
-    smallNullMemory.reset(new shared_array<uint8_t>[smallSideCount]);
+    smallNullMemory.reset(new std::shared_ptr<uint8_t[]>[smallSideCount]);
     local_primRG.initRow(&largeSideRow);
     local_outputRG.initRow(&joinedBaseRow, true);
     joinedBaseRowData.reset(new uint8_t[joinedBaseRow.getSize()]);
@@ -2719,7 +2719,7 @@ void TupleBPS::receiveMultiPrimitiveMessages()
   {
     struct timeval tvbuf;
     gettimeofday(&tvbuf, 0);
-    FIFO<boost::shared_array<uint8_t>>* pFifo = 0;
+    FIFO<std::shared_ptr<uint8_t[]>>* pFifo = 0;
     uint64_t totalBlockedReadCount = 0;
     uint64_t totalBlockedWriteCount = 0;
 
@@ -2728,7 +2728,7 @@ void TupleBPS::receiveMultiPrimitiveMessages()
 
     for (size_t iDataList = 0; iDataList < inDlCnt; iDataList++)
     {
-      pFifo = dynamic_cast<FIFO<boost::shared_array<uint8_t>>*>(
+      pFifo = dynamic_cast<FIFO<std::shared_ptr<uint8_t[]>>*>(
           fInputJobStepAssociation.outAt(iDataList)->rowGroupDL());
 
       if (pFifo)
@@ -2742,7 +2742,7 @@ void TupleBPS::receiveMultiPrimitiveMessages()
 
     for (size_t iDataList = 0; iDataList < outDlCnt; iDataList++)
     {
-      pFifo = dynamic_cast<FIFO<boost::shared_array<uint8_t>>*>(dlp);
+      pFifo = dynamic_cast<FIFO<std::shared_ptr<uint8_t[]>>*>(dlp);
 
       if (pFifo)
       {

--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -30,7 +30,7 @@
 using namespace std;
 
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/scoped_array.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include "boost/tuple/tuple.hpp"

--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -5298,7 +5298,7 @@ void TupleAggregateStep::threadedAggregateRowGroups(uint32_t threadID)
   RGData rgData;
   scoped_array<RowBucketVec> rowBucketVecs(new RowBucketVec[fNumOfBuckets]);
   scoped_array<Row> distRow;
-  scoped_array<shared_array<uint8_t>> distRowData;
+  scoped_array<std::shared_ptr<uint8_t[]>> distRowData;
   uint32_t bucketID;
   scoped_array<bool> bucketDone(new bool[fNumOfBuckets]);
   vector<uint32_t> hashLens;
@@ -5365,7 +5365,7 @@ void TupleAggregateStep::threadedAggregateRowGroups(uint32_t threadID)
                 rowBucketVecs[i].resize(multiDist->subAggregators().size());
 
               distRow.reset(new Row[multiDist->subAggregators().size()]);
-              distRowData.reset(new shared_array<uint8_t>[multiDist->subAggregators().size()]);
+              distRowData.reset(new std::shared_ptr<uint8_t[]>[multiDist->subAggregators().size()]);
 
               for (uint32_t j = 0; j < multiDist->subAggregators().size(); j++)
               {

--- a/dbcon/joblist/tupleannexstep.cpp
+++ b/dbcon/joblist/tupleannexstep.cpp
@@ -26,7 +26,7 @@
 using namespace std;
 
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/uuid/uuid_io.hpp>
 using namespace boost;
 

--- a/dbcon/joblist/tupleconstantstep.cpp
+++ b/dbcon/joblist/tupleconstantstep.cpp
@@ -25,7 +25,7 @@
 using namespace std;
 
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/uuid/uuid_io.hpp>
 using namespace boost;
 

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -515,7 +515,7 @@ void TupleHashJoinStep::djsRelayFcn()
 
   RowGroup djsInputRG = largeRG + outputRG;
   RowGroup l_largeRG = (tbpsJoiners.empty() ? largeRG : largeRG + outputRG);
-  boost::shared_array<int> relayMapping = makeMapping(l_largeRG, djsInputRG);
+  std::shared_ptr<int[]> relayMapping = makeMapping(l_largeRG, djsInputRG);
   bool more;
   RGData inData, outData;
   Row l_largeRow, djsInputRow;
@@ -1350,7 +1350,7 @@ void TupleHashJoinStep::startJoinThreads()
   for (i = 0; i < smallSideCount; i++)
     smallRGs[i] = joiners[i]->getSmallRG();
 
-  columnMappings.reset(new shared_array<int>[smallSideCount + 1]);
+  columnMappings.reset(new std::shared_ptr<int[]>[smallSideCount + 1]);
 
   for (i = 0; i < smallSideCount; i++)
     columnMappings[i] = makeMapping(smallRGs[i], outputRG);
@@ -1359,7 +1359,7 @@ void TupleHashJoinStep::startJoinThreads()
 
   if (!feIndexes.empty())
   {
-    fergMappings.reset(new shared_array<int>[smallSideCount + 1]);
+    fergMappings.reset(new std::shared_ptr<int[]>[smallSideCount + 1]);
 
     for (i = 0; i < smallSideCount; i++)
       fergMappings[i] = makeMapping(smallRGs[i], joinFilterRG);
@@ -1406,11 +1406,11 @@ void TupleHashJoinStep::finishSmallOuterJoin()
   vector<Row::Pointer> unmatched;
   uint32_t smallSideCount = smallDLs.size();
   uint32_t i, j, k;
-  shared_array<uint8_t> largeNullMemory;
+  std::shared_ptr<uint8_t[]> largeNullMemory;
   RGData joinedData;
   Row joinedBaseRow, fe2InRow, fe2OutRow;
-  shared_array<Row> smallRowTemplates;
-  shared_array<Row> smallNullRows;
+  std::shared_ptr<Row[]> smallRowTemplates;
+  std::shared_ptr<Row[]> smallNullRows;
   Row largeNullRow;
   RowGroup l_outputRG = outputRG;
   RowGroup l_fe2Output = fe2Output;
@@ -1511,11 +1511,11 @@ void TupleHashJoinStep::joinRunnerFcn(uint32_t threadID)
   uint32_t i;
 
   /* thread-local scratch space for join processing */
-  shared_array<uint8_t> joinFERowData;
+  std::shared_ptr<uint8_t[]> joinFERowData;
   Row largeRow, joinFERow, joinedRow, baseRow;
-  shared_array<uint8_t> baseRowData;
+  std::shared_ptr<uint8_t[]> baseRowData;
   vector<vector<Row::Pointer> > joinMatches;
-  shared_array<Row> smallRowTemplates;
+  std::shared_ptr<Row[]> smallRowTemplates;
 
   /* F & E vars */
   FuncExpWrapper local_fe;
@@ -1706,11 +1706,11 @@ void TupleHashJoinStep::grabSomeWork(vector<RGData>* work)
 void TupleHashJoinStep::joinOneRG(
     uint32_t threadID, vector<RGData>& out, RowGroup& inputRG, RowGroup& joinOutput, Row& largeSideRow,
     Row& joinFERow, Row& joinedRow, Row& baseRow, vector<vector<Row::Pointer> >& joinMatches,
-    shared_array<Row>& smallRowTemplates, RowGroupDL* outputDL,
+    std::shared_ptr<Row[]>& smallRowTemplates, RowGroupDL* outputDL,
     // disk-join support vars.  This param list is insane; refactor attempt would be nice at some point.
     vector<std::shared_ptr<joiner::TupleJoiner> >* tjoiners,
-    boost::shared_array<boost::shared_array<int> >* rgMappings,
-    boost::shared_array<boost::shared_array<int> >* feMappings,
+    std::shared_ptr<std::shared_ptr<int[]>[] >* rgMappings,
+    std::shared_ptr<std::shared_ptr<int[]>[] >* feMappings,
     boost::scoped_array<boost::scoped_array<uint8_t> >* smallNullMem)
 {
   /* Disk-join support.
@@ -1841,9 +1841,9 @@ void TupleHashJoinStep::joinOneRG(
 }
 
 void TupleHashJoinStep::generateJoinResultSet(const vector<vector<Row::Pointer> >& joinerOutput, Row& baseRow,
-                                              const shared_array<shared_array<int> >& mappings,
+                                              const std::shared_ptr<std::shared_ptr<int[]>[] >& mappings,
                                               const uint32_t depth, RowGroup& l_outputRG, RGData& rgData,
-                                              vector<RGData>& outputData, const shared_array<Row>& smallRows,
+                                              vector<RGData>& outputData, const std::shared_ptr<Row[]>& smallRows,
                                               Row& joinedRow, RowGroupDL* dlp)
 {
   uint32_t i;

--- a/dbcon/joblist/tuplehashjoin.h
+++ b/dbcon/joblist/tuplehashjoin.h
@@ -536,10 +536,10 @@ class TupleHashJoinStep : public JobStep, public TupleDeliveryStep
   void startJoinThreads();
   void generateJoinResultSet(const std::vector<std::vector<rowgroup::Row::Pointer> >& joinerOutput,
                              rowgroup::Row& baseRow,
-                             const boost::shared_array<boost::shared_array<int> >& mappings,
+                             const std::shared_ptr<std::shared_ptr<int[]>[] >& mappings,
                              const uint32_t depth, rowgroup::RowGroup& outputRG, rowgroup::RGData& rgData,
                              std::vector<rowgroup::RGData>& outputData,
-                             const boost::shared_array<rowgroup::Row>& smallRows, rowgroup::Row& joinedRow,
+                             const std::shared_ptr<rowgroup::Row[]>& smallRows, rowgroup::Row& joinedRow,
                              RowGroupDL* outputDL);
   void grabSomeWork(std::vector<rowgroup::RGData>* work);
   void sendResult(const std::vector<rowgroup::RGData>& res);
@@ -550,19 +550,19 @@ class TupleHashJoinStep : public JobStep, public TupleDeliveryStep
                  rowgroup::RowGroup& joinOutput, rowgroup::Row& largeSideRow, rowgroup::Row& joinFERow,
                  rowgroup::Row& joinedRow, rowgroup::Row& baseRow,
                  std::vector<std::vector<rowgroup::Row::Pointer> >& joinMatches,
-                 boost::shared_array<rowgroup::Row>& smallRowTemplates, RowGroupDL* outputDL,
+                 std::shared_ptr<rowgroup::Row[]>& smallRowTemplates, RowGroupDL* outputDL,
                  std::vector<std::shared_ptr<joiner::TupleJoiner> >* joiners = NULL,
-                 boost::shared_array<boost::shared_array<int> >* rgMappings = NULL,
-                 boost::shared_array<boost::shared_array<int> >* feMappings = NULL,
-                 boost::scoped_array<boost::scoped_array<uint8_t> >* smallNullMem = NULL);
+                 std::shared_ptr<std::shared_ptr<int[]>[] >* rgMappings = NULL,
+                 std::shared_ptr<std::shared_ptr<int[]>[] >* feMappings = NULL,
+                 boost::scoped_array<boost::scoped_array<uint8_t>>* smallNullMem = NULL);
   void finishSmallOuterJoin();
   void makeDupList(const rowgroup::RowGroup& rg);
   void processDupList(uint32_t threadID, rowgroup::RowGroup& ingrp, std::vector<rowgroup::RGData>* rowData);
 
   std::vector<uint64_t> joinRunners;  // thread handles from thread pool
   boost::mutex inputDLLock, outputDLLock;
-  boost::shared_array<boost::shared_array<int> > columnMappings, fergMappings;
-  boost::shared_array<int> fe2Mapping;
+  std::shared_ptr<std::shared_ptr<int[]>[]> columnMappings, fergMappings;
+  std::shared_ptr<int[]> fe2Mapping;
   uint32_t joinThreadCount;
   boost::scoped_array<boost::scoped_array<uint8_t> > smallNullMemory;
   uint64_t outputIt;

--- a/dbcon/joblist/tuplehavingstep.cpp
+++ b/dbcon/joblist/tuplehavingstep.cpp
@@ -24,7 +24,7 @@
 using namespace std;
 
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/uuid/uuid_io.hpp>
 using namespace boost;
 

--- a/dbcon/joblist/windowfunctionstep.cpp
+++ b/dbcon/joblist/windowfunctionstep.cpp
@@ -1033,7 +1033,7 @@ void WindowFunctionStep::doFunction()
 void WindowFunctionStep::doPostProcessForSelect()
 {
   FuncExp* fe = funcexp::FuncExp::instance();
-  boost::shared_array<int> mapping = makeMapping(fRowGroupIn, fRowGroupOut);
+  std::shared_ptr<int[]> mapping = makeMapping(fRowGroupIn, fRowGroupOut);
   Row rowIn, rowOut;
   fRowGroupIn.initRow(&rowIn);
   fRowGroupOut.initRow(&rowOut);
@@ -1089,7 +1089,7 @@ void WindowFunctionStep::doPostProcessForSelect()
 void WindowFunctionStep::doPostProcessForDml()
 {
   FuncExp* fe = funcexp::FuncExp::instance();
-  boost::shared_array<int> mapping = makeMapping(fRowGroupIn, fRowGroupOut);
+  std::shared_ptr<int[]> mapping = makeMapping(fRowGroupIn, fRowGroupOut);
   Row rowIn, rowOut;
   fRowGroupIn.initRow(&rowIn);
   fRowGroupOut.initRow(&rowOut);

--- a/dbcon/joblist/windowfunctionstep.cpp
+++ b/dbcon/joblist/windowfunctionstep.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 #include <boost/algorithm/string.hpp>  //  to_upper_copy
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/thread.hpp>
 #include <boost/uuid/uuid_io.hpp>
 using namespace boost;

--- a/dmlproc/batchinsertprocessor.h
+++ b/dmlproc/batchinsertprocessor.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include <queue>
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/thread.hpp>

--- a/dmlproc/dmlproc.cpp
+++ b/dmlproc/dmlproc.cpp
@@ -215,7 +215,7 @@ void rollbackAll(DBRM* dbrm)
   logging::MessageLog ml(lid);
   ml.logInfoMessage(message);
 
-  boost::shared_array<BRM::SIDTIDEntry> activeTxns;
+  std::shared_ptr<BRM::SIDTIDEntry[]> activeTxns;
   BRM::TxnID txnID;
   SessionManager sessionManager;
   int rc = 0;

--- a/dmlproc/dmlprocessor.cpp
+++ b/dmlproc/dmlprocessor.cpp
@@ -263,7 +263,7 @@ struct CancellationThread
         // If there are any abandonded transactions without locks
         // release them.
         int len;
-        boost::shared_array<BRM::SIDTIDEntry> activeTxns = sessionManager.SIDTIDMap(len);
+        std::shared_ptr<BRM::SIDTIDEntry[]> activeTxns = sessionManager.SIDTIDMap(len);
 
         for (int i = 0; i < len; i++)
         {

--- a/primitives/linux-port/primitiveprocessor.h
+++ b/primitives/linux-port/primitiveprocessor.h
@@ -38,7 +38,7 @@
 #endif
 #include <cstddef>
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 
 #include "primitivemsg.h"
 #include "calpontsystemcatalog.h"

--- a/primitives/linux-port/primitiveprocessor.h
+++ b/primitives/linux-port/primitiveprocessor.h
@@ -165,10 +165,10 @@ class ParsedColumnFilter
   static constexpr uint32_t noSetFilterThreshold = 8;
   ColumnFilterMode columnFilterMode;
   // Very unfortunately prestored_argVals can also be used to store double/float values.
-  boost::shared_array<int64_t> prestored_argVals;
-  boost::shared_array<int128_t> prestored_argVals128;
-  boost::shared_array<CopsType> prestored_cops;
-  boost::shared_array<uint8_t> prestored_rfs;
+  std::shared_ptr<int64_t[]> prestored_argVals;
+  std::shared_ptr<int128_t[]> prestored_argVals128;
+  std::shared_ptr<CopsType[]> prestored_cops;
+  std::shared_ptr<uint8_t[]> prestored_rfs;
   boost::shared_ptr<prestored_set_t> prestored_set;
   boost::shared_ptr<prestored_set_t_128> prestored_set_128;
 

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -312,11 +312,11 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
       // 			cout << "joinerCount = " << joinerCount << endl;
       joinTypes.reset(new JoinType[joinerCount]);
 
-      tJoiners.reset(new boost::shared_array<boost::shared_ptr<TJoiner> >[joinerCount]);
+      tJoiners.reset(new std::shared_ptr<boost::shared_ptr<TJoiner>[]>[joinerCount]);
       for (uint j = 0; j < joinerCount; ++j)
         tJoiners[j].reset(new boost::shared_ptr<TJoiner>[processorThreads]);
 
-      tlJoiners.reset(new boost::shared_array<boost::shared_ptr<TLJoiner> >[joinerCount]);
+      tlJoiners.reset(new std::shared_ptr<boost::shared_ptr<TLJoiner>[]>[joinerCount]);
       for (uint j = 0; j < joinerCount; ++j)
         tlJoiners[j].reset(new boost::shared_ptr<TLJoiner>[processorThreads]);
 
@@ -716,7 +716,7 @@ void BatchPrimitiveProcessor::addToJoiner(ByteStream& bs)
     }
     else
     {
-      boost::shared_array<boost::shared_ptr<TJoiner> > tJoiner = tJoiners[joinerNum];
+      std::shared_ptr<boost::shared_ptr<TJoiner>[]> tJoiner = tJoiners[joinerNum];
       uint64_t nullValue = joinNullValues[joinerNum];
       bool& l_doMatchNulls = doMatchNulls[joinerNum];
       joblist::JoinType joinType = joinTypes[joinerNum];
@@ -997,7 +997,7 @@ void BatchPrimitiveProcessor::initProcessor()
         joinFERG->initRow(&joinFERow, true);
         joinFERowData.reset(new uint8_t[joinFERow.getSize()]);
         joinFERow.setData(rowgroup::Row::Pointer(joinFERowData.get()));
-        joinFEMappings.reset(new shared_array<int>[joinerCount + 1]);
+        joinFEMappings.reset(new std::shared_ptr<int[]>[joinerCount + 1]);
 
         for (i = 0; i < joinerCount; i++)
           joinFEMappings[i] = makeMapping(smallSideRGs[i], *joinFERG);
@@ -1059,7 +1059,7 @@ void BatchPrimitiveProcessor::initProcessor()
 
       baseJRowMem.reset(new uint8_t[baseJRow.getSize()]);
       baseJRow.setData(rowgroup::Row::Pointer(baseJRowMem.get()));
-      gjrgMappings.reset(new shared_array<int>[joinerCount + 1]);
+      gjrgMappings.reset(new std::shared_ptr<int[]>[joinerCount + 1]);
 
       for (i = 0; i < joinerCount; i++)
         gjrgMappings[i] = makeMapping(smallSideRGs[i], joinedRG);

--- a/primitives/primproc/batchprimitiveprocessor.h
+++ b/primitives/primproc/batchprimitiveprocessor.h
@@ -304,8 +304,8 @@ class BatchPrimitiveProcessor
   /* RowGroup support */
   rowgroup::RowGroup outputRG;
   boost::scoped_ptr<rowgroup::RGData> outRowGroupData;
-  boost::shared_array<int> rgMap;          // maps input cols to output cols
-  boost::shared_array<int> projectionMap;  // maps the projection steps to the output RG
+  std::shared_ptr<int[]> rgMap;          // maps input cols to output cols
+  std::shared_ptr<int[]> projectionMap;  // maps the projection steps to the output RG
   bool hasRowGroup;
 
   /* Rowgroups + join */
@@ -331,40 +331,40 @@ class BatchPrimitiveProcessor
   boost::scoped_array<uint8_t> baseJRowMem;
   boost::scoped_ptr<rowgroup::RGData> joinedRGMem;
   boost::scoped_array<rowgroup::Row> smallRows;
-  boost::shared_array<boost::shared_array<int>> gjrgMappings;
+  std::shared_ptr<std::shared_ptr<int[]>[]> gjrgMappings;
 
-  boost::shared_array<boost::shared_array<boost::shared_ptr<TJoiner>>> tJoiners;
+  std::shared_ptr<std::shared_ptr<boost::shared_ptr<TJoiner>[]>[]> tJoiners;
   typedef std::vector<uint32_t> MatchedData[LOGICAL_BLOCK_RIDS];
-  boost::shared_array<MatchedData> tSmallSideMatches;
+  std::shared_ptr<MatchedData[]> tSmallSideMatches;
   uint32_t executeTupleJoin(uint32_t startRid);
   bool getTupleJoinRowGroupData;
   std::vector<rowgroup::RowGroup> smallSideRGs;
   rowgroup::RowGroup largeSideRG;
-  boost::shared_array<rowgroup::RGData> smallSideRowData;
-  boost::shared_array<rowgroup::RGData> smallNullRowData;
-  boost::shared_array<rowgroup::Row::Pointer> smallNullPointers;
-  boost::shared_array<uint64_t> ssrdPos;  // this keeps track of position when building smallSideRowData
-  boost::shared_array<uint32_t> smallSideRowLengths;
-  boost::shared_array<joblist::JoinType> joinTypes;
+  std::shared_ptr<rowgroup::RGData[]> smallSideRowData;
+  std::shared_ptr<rowgroup::RGData[]> smallNullRowData;
+  std::shared_ptr<rowgroup::Row::Pointer[]> smallNullPointers;
+  std::shared_ptr<uint64_t[]> ssrdPos;  // this keeps track of position when building smallSideRowData
+  std::shared_ptr<uint32_t[]> smallSideRowLengths;
+  std::shared_ptr<joblist::JoinType[]> joinTypes;
   uint32_t joinerCount;
-  boost::shared_array<std::atomic<uint32_t>> tJoinerSizes;
+  std::shared_ptr<std::atomic<uint32_t>[]> tJoinerSizes;
   // LSKC[i] = the column in outputRG joiner i uses as its key column
-  boost::shared_array<uint32_t> largeSideKeyColumns;
+  std::shared_ptr<uint32_t[]> largeSideKeyColumns;
   // KCPP[i] = true means a joiner uses projection step i as a key column
-  boost::shared_array<bool> keyColumnProj;
+  std::shared_ptr<bool[]> keyColumnProj;
   rowgroup::Row oldRow, newRow;  // used by executeTupleJoin()
-  boost::shared_array<uint64_t> joinNullValues;
-  boost::shared_array<bool> doMatchNulls;
+  std::shared_ptr<uint64_t[]> joinNullValues;
+  std::shared_ptr<bool[]> doMatchNulls;
   boost::scoped_array<boost::scoped_ptr<funcexp::FuncExpWrapper>> joinFEFilters;
   bool hasJoinFEFilters;
   bool hasSmallOuterJoin;
 
   /* extra typeless join vars & fcns*/
-  boost::shared_array<bool> typelessJoin;
-  boost::shared_array<std::vector<uint32_t>> tlLargeSideKeyColumns;
+  std::shared_ptr<bool[]> typelessJoin;
+  std::shared_ptr<std::vector<uint32_t>[]> tlLargeSideKeyColumns;
   std::shared_ptr<std::vector<uint32_t>> tlSmallSideKeyColumns;
-  boost::shared_array<boost::shared_array<boost::shared_ptr<TLJoiner>>> tlJoiners;
-  boost::shared_array<uint32_t> tlSmallSideKeyLengths;
+  std::shared_ptr<std::shared_ptr<boost::shared_ptr<TLJoiner>[]>[]> tlJoiners;
+  std::shared_ptr<uint32_t[]> tlSmallSideKeyLengths;
   // True if smallSide and largeSide TypelessData key column differs,e.g BIGINT vs DECIMAL(38).
   bool mJOINHasSkewedKeyColumn;
   const rowgroup::RowGroup* mSmallSideRGPtr;
@@ -372,7 +372,7 @@ class BatchPrimitiveProcessor
 
   inline void getJoinResults(const rowgroup::Row& r, uint32_t jIndex, std::vector<uint32_t>& v);
   // these allocators hold the memory for the keys stored in tlJoiners
-  boost::shared_array<utils::PoolAllocator> storedKeyAllocators;
+  std::shared_ptr<utils::PoolAllocator[]> storedKeyAllocators;
 
   /* PM Aggregation */
   rowgroup::RowGroup joinedRG;  // if there's a join, the rows are formatted with this
@@ -393,9 +393,9 @@ class BatchPrimitiveProcessor
   boost::scoped_array<uint8_t> joinFERowData;
   boost::scoped_ptr<rowgroup::RGData> fe1Data,
       fe2Data;  // can probably make these RGDatas not pointers to RGDatas
-  boost::shared_array<int> projectForFE1;
-  boost::shared_array<int> fe1ToProjection, fe2Mapping;  // RG mappings
-  boost::scoped_array<boost::shared_array<int>> joinFEMappings;
+  std::shared_ptr<int[]> projectForFE1;
+  std::shared_ptr<int[]> fe1ToProjection, fe2Mapping;  // RG mappings
+  boost::scoped_array<std::shared_ptr<int[]>> joinFEMappings;
   rowgroup::Row fe1In, fe1Out, fe2In, fe2Out, joinFERow;
 
   bool hasDictStep;

--- a/storage-manager/src/CloudStorage.h
+++ b/storage-manager/src/CloudStorage.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <string>
-#include <boost/shared_array.hpp>
+
 #include "SMLogging.h"
 
 namespace storagemanager

--- a/storage-manager/src/CloudStorage.h
+++ b/storage-manager/src/CloudStorage.h
@@ -29,10 +29,10 @@ class CloudStorage
   virtual ~CloudStorage(){};
   /* These behave like syscalls.  return code -1 means an error, and errno is set */
   virtual int getObject(const std::string& sourceKey, const std::string& destFile, size_t* size = NULL) = 0;
-  virtual int getObject(const std::string& sourceKey, boost::shared_array<uint8_t>* data,
+  virtual int getObject(const std::string& sourceKey, std::shared_ptr<uint8_t[]>* data,
                         size_t* size = NULL) = 0;
   virtual int putObject(const std::string& sourceFile, const std::string& destKey) = 0;
-  virtual int putObject(const boost::shared_array<uint8_t> data, size_t len, const std::string& destKey) = 0;
+  virtual int putObject(const std::shared_ptr<uint8_t[]> data, size_t len, const std::string& destKey) = 0;
   virtual int deleteObject(const std::string& key) = 0;
   virtual int copyObject(const std::string& sourceKey, const std::string& destKey) = 0;
   virtual int exists(const std::string& key, bool* out) = 0;

--- a/storage-manager/src/IOCoordinator.h
+++ b/storage-manager/src/IOCoordinator.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <boost/utility.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/filesystem.hpp>
 
 #include "Config.h"

--- a/storage-manager/src/IOCoordinator.h
+++ b/storage-manager/src/IOCoordinator.h
@@ -37,7 +37,7 @@
 
 namespace storagemanager
 {
-boost::shared_array<char> seekToEndOfHeader1(int fd, size_t* bytesRead);
+std::shared_ptr<char[]> seekToEndOfHeader1(int fd, size_t* bytesRead);
 
 class IOCoordinator : public boost::noncopyable
 {
@@ -57,16 +57,16 @@ class IOCoordinator : public boost::noncopyable
 
   // The shared logic for merging a journal file with its base file.
   // len should be set to the length of the data requested
-  boost::shared_array<uint8_t> mergeJournal(const char* objectPath, const char* journalPath, off_t offset,
+  std::shared_ptr<uint8_t[]> mergeJournal(const char* objectPath, const char* journalPath, off_t offset,
                                             size_t len, size_t* sizeRead) const;
 
   // this version modifies object data in memory, given the journal filename.  Processes the whole object
   // and whole journal file.
-  int mergeJournalInMem(boost::shared_array<uint8_t>& objData, size_t len, const char* journalPath,
+  int mergeJournalInMem(std::shared_ptr<uint8_t[]>& objData, size_t len, const char* journalPath,
                         size_t* sizeRead) const;
 
   // this version of MJIM has a higher IOPS requirement and lower mem usage.
-  int mergeJournalInMem_bigJ(boost::shared_array<uint8_t>& objData, size_t len, const char* journalPath,
+  int mergeJournalInMem_bigJ(std::shared_ptr<uint8_t[]>& objData, size_t len, const char* journalPath,
                              size_t* sizeRead) const;
 
   // this version takes already-open file descriptors, and an already-allocated buffer as input.

--- a/storage-manager/src/LocalStorage.cpp
+++ b/storage-manager/src/LocalStorage.cpp
@@ -127,7 +127,7 @@ int LocalStorage::getObject(const string& source, const string& dest, size_t* si
   return ret;
 }
 
-int LocalStorage::getObject(const std::string& sourceKey, boost::shared_array<uint8_t>* data, size_t* size)
+int LocalStorage::getObject(const std::string& sourceKey, std::shared_ptr<uint8_t[]>* data, size_t* size)
 {
   addLatency();
 
@@ -188,7 +188,7 @@ int LocalStorage::putObject(const string& source, const string& dest)
   return ret;
 }
 
-int LocalStorage::putObject(boost::shared_array<uint8_t> data, size_t len, const string& dest)
+int LocalStorage::putObject(std::shared_ptr<uint8_t[]> data, size_t len, const string& dest)
 {
   addLatency();
 

--- a/storage-manager/src/LocalStorage.h
+++ b/storage-manager/src/LocalStorage.h
@@ -21,6 +21,7 @@
 #include "CloudStorage.h"
 #include "SMLogging.h"
 #include <boost/filesystem/path.hpp>
+#include <memory>
 
 namespace storagemanager
 {
@@ -31,9 +32,9 @@ class LocalStorage : public CloudStorage
   virtual ~LocalStorage();
 
   int getObject(const std::string& sourceKey, const std::string& destFile, size_t* size = NULL);
-  int getObject(const std::string& sourceKey, boost::shared_array<uint8_t>* data, size_t* size = NULL);
+  int getObject(const std::string& sourceKey, std::shared_ptr<uint8_t[]>* data, size_t* size = NULL);
   int putObject(const std::string& sourceFile, const std::string& destKey);
-  int putObject(const boost::shared_array<uint8_t> data, size_t len, const std::string& destKey);
+  int putObject(const std::shared_ptr<uint8_t[]> data, size_t len, const std::string& destKey);
   int deleteObject(const std::string& key);
   int copyObject(const std::string& sourceKey, const std::string& destKey);
   int exists(const std::string& key, bool* out);

--- a/storage-manager/src/Replicator.cpp
+++ b/storage-manager/src/Replicator.cpp
@@ -259,7 +259,7 @@ int Replicator::addJournalEntry(const boost::filesystem::path& filename, const u
   {
     // read the existing header and check if max_offset needs to be updated
     size_t tmp;
-    boost::shared_array<char> headertxt;
+    std::shared_ptr<char[]> headertxt;
     try
     {
       headertxt = seekToEndOfHeader1(fd, &tmp);

--- a/storage-manager/src/Replicator.cpp
+++ b/storage-manager/src/Replicator.cpp
@@ -29,7 +29,7 @@
 #include <boost/filesystem.hpp>
 #define BOOST_SPIRIT_THREADSAFE
 #include <boost/property_tree/json_parser.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/format.hpp>
 #include <iostream>
 

--- a/storage-manager/src/S3Storage.cpp
+++ b/storage-manager/src/S3Storage.cpp
@@ -283,7 +283,7 @@ bool S3Storage::getCredentialsFromMetadataEC2()
 
 void S3Storage::testConnectivityAndPerms()
 {
-  boost::shared_array<uint8_t> testObj(new uint8_t[1]);
+  std::shared_ptr<uint8_t[]> testObj(new uint8_t[1]);
   testObj[0] = 0;
   boost::uuids::uuid u = boost::uuids::random_generator()();
   ostringstream oss;
@@ -317,7 +317,7 @@ void S3Storage::testConnectivityAndPerms()
 int S3Storage::getObject(const string& sourceKey, const string& destFile, size_t* size)
 {
   int fd, err;
-  boost::shared_array<uint8_t> data;
+  std::shared_ptr<uint8_t[]> data;
   size_t len, count = 0;
   char buf[80];
 
@@ -353,7 +353,7 @@ int S3Storage::getObject(const string& sourceKey, const string& destFile, size_t
   return 0;
 }
 
-int S3Storage::getObject(const string& _sourceKey, boost::shared_array<uint8_t>* data, size_t* size)
+int S3Storage::getObject(const string& _sourceKey, std::shared_ptr<uint8_t[]>* data, size_t* size)
 {
   uint8_t err;
   size_t len = 0;
@@ -418,7 +418,7 @@ int S3Storage::getObject(const string& _sourceKey, boost::shared_array<uint8_t>*
 
 int S3Storage::putObject(const string& sourceFile, const string& destKey)
 {
-  boost::shared_array<uint8_t> data;
+  std::shared_ptr<uint8_t[]> data;
   int err, fd;
   size_t len, count = 0;
   char buf[80];
@@ -466,7 +466,7 @@ int S3Storage::putObject(const string& sourceFile, const string& destKey)
   return putObject(data, len, destKey);
 }
 
-int S3Storage::putObject(const boost::shared_array<uint8_t> data, size_t len, const string& _destKey)
+int S3Storage::putObject(const std::shared_ptr<uint8_t[]> data, size_t len, const string& _destKey)
 {
   string destKey = prefix + _destKey;
   uint8_t s3err;
@@ -648,7 +648,7 @@ int S3Storage::copyObject(const string& _sourceKey, const string& _destKey)
     // no s3-s3 copy yet.  get & put for now.
 
     int err;
-    boost::shared_array<uint8_t> data;
+    std::shared_ptr<uint8_t[]> data;
     size_t len;
     err = getObject(sourceKey, &data, &len);
     if (err)

--- a/storage-manager/src/S3Storage.h
+++ b/storage-manager/src/S3Storage.h
@@ -20,6 +20,7 @@
 #include <deque>
 #include <string>
 #include <map>
+#include <memory>
 #include "CloudStorage.h"
 #include "libmarias3/marias3.h"
 #include "Config.h"
@@ -35,9 +36,9 @@ class S3Storage : public CloudStorage
   virtual ~S3Storage();
 
   int getObject(const std::string& sourceKey, const std::string& destFile, size_t* size = NULL);
-  int getObject(const std::string& sourceKey, boost::shared_array<uint8_t>* data, size_t* size = NULL);
+  int getObject(const std::string& sourceKey, std::shared_ptr<uint8_t[]>* data, size_t* size = NULL);
   int putObject(const std::string& sourceFile, const std::string& destKey);
-  int putObject(const boost::shared_array<uint8_t> data, size_t len, const std::string& destKey);
+  int putObject(const std::shared_ptr<uint8_t[]> data, size_t len, const std::string& destKey);
   int deleteObject(const std::string& key);
   int copyObject(const std::string& sourceKey, const std::string& destKey);
   int exists(const std::string& key, bool* out);

--- a/storage-manager/src/Synchronizer.cpp
+++ b/storage-manager/src/Synchronizer.cpp
@@ -645,7 +645,7 @@ void Synchronizer::synchronizeWithJournal(const string& sourceFile, list<string>
   }
 
   int err;
-  boost::shared_array<uint8_t> data;
+  std::shared_ptr<uint8_t[]> data;
   size_t count = 0, size = mdEntry.length, originalSize = 0;
 
   bool oldObjIsCached = cache->exists(prefix, cloudKey);
@@ -673,7 +673,7 @@ void Synchronizer::synchronizeWithJournal(const string& sourceFile, list<string>
     // do any add'l alloc'ing or copying
     if (size < mdEntry.length)
     {
-      boost::shared_array<uint8_t> tmp(new uint8_t[mdEntry.length]());
+      std::shared_ptr<uint8_t[]> tmp(new uint8_t[mdEntry.length]());
       memcpy(tmp.get(), data.get(), size);
       memset(&tmp[size], 0, mdEntry.length - size);
       data.swap(tmp);

--- a/storage-manager/src/unit_tests.cpp
+++ b/storage-manager/src/unit_tests.cpp
@@ -1200,7 +1200,7 @@ bool mergeJournalTest()
   int i;
   IOCoordinator* ioc = IOCoordinator::get();
   size_t len = 8192, tmp;
-  boost::shared_array<uint8_t> data = ioc->mergeJournal("test-object", "test-journal", 0, len, &tmp);
+  std::shared_ptr<uint8_t[]> data = ioc->mergeJournal("test-object", "test-journal", 0, len, &tmp);
   assert(data);
   int* idata = (int*)data.get();
   for (i = 0; i < 5; i++)
@@ -1767,7 +1767,7 @@ void bigMergeJournal1()
     return;
   }
   IOCoordinator* ioc = IOCoordinator::get();
-  boost::shared_array<uint8_t> buf;
+  std::shared_ptr<uint8_t[]> buf;
   size_t tmp;
   buf = ioc->mergeJournal(fNamePath.string().c_str(), jNamePath.string().c_str(), 0, 68332, &tmp);
   assert(buf);

--- a/utils/common/fixedallocator.cpp
+++ b/utils/common/fixedallocator.cpp
@@ -31,13 +31,13 @@
 
 #include <stdint.h>
 #include <iostream>
+#include <memory>
 
 #define FIXEDALLOCATOR_DLLEXPORT
 #include "fixedallocator.h"
 #undef FIXEDALLOCATOR_DLLEXPORT
 
 using namespace std;
-using namespace boost;
 
 namespace utils
 {
@@ -75,7 +75,7 @@ void FixedAllocator::setAllocSize(uint allocSize)
 
 void FixedAllocator::newBlock()
 {
-  shared_array<uint8_t> next;
+  std::shared_ptr<uint8_t[]> next;
 
   capacityRemaining = elementCount * elementSize;
 

--- a/utils/common/fixedallocator.h
+++ b/utils/common/fixedallocator.h
@@ -33,7 +33,7 @@
 #pragma once
 
 #include <stdint.h>
-#include <boost/shared_array.hpp>
+
 #include <vector>
 #include <limits>
 #include <unistd.h>

--- a/utils/common/fixedallocator.h
+++ b/utils/common/fixedallocator.h
@@ -93,7 +93,7 @@ class FixedAllocator
  private:
   void newBlock();
 
-  std::vector<boost::shared_array<uint8_t> > mem;
+  std::vector<std::shared_ptr<uint8_t[]>> mem;
   unsigned long capacityRemaining;
   uint64_t elementCount;
   unsigned long elementSize;

--- a/utils/common/poolallocator.cpp
+++ b/utils/common/poolallocator.cpp
@@ -24,10 +24,11 @@
 //#define NDEBUG
 #include <cassert>
 
+
 #include "poolallocator.h"
 
 using namespace std;
-using namespace boost;
+
 
 namespace utils
 {
@@ -51,7 +52,7 @@ void PoolAllocator::deallocateAll()
 
 void PoolAllocator::newBlock()
 {
-  shared_array<uint8_t> next;
+  std::shared_ptr<uint8_t[]> next;
 
   capacityRemaining = allocSize;
 

--- a/utils/common/poolallocator.h
+++ b/utils/common/poolallocator.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <vector>
 #include <map>
-#include <boost/shared_array.hpp>
+
 #include <atomic>
 
 namespace utils

--- a/utils/common/poolallocator.h
+++ b/utils/common/poolallocator.h
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <vector>
 #include <map>
+#include <memory>
 
 #include <atomic>
 
@@ -89,7 +90,7 @@ class PoolAllocator
   void* allocOOB(uint64_t size);
 
   unsigned allocSize;
-  std::vector<boost::shared_array<uint8_t> > mem;
+  std::vector<std::shared_ptr<uint8_t[]>> mem;
   bool tmpSpace;
   unsigned capacityRemaining;
   uint64_t memUsage;
@@ -99,7 +100,7 @@ class PoolAllocator
 
   struct OOBMemInfo
   {
-    boost::shared_array<uint8_t> mem;
+    std::shared_ptr<uint8_t[]> mem;
     uint64_t size;
   };
   typedef std::map<void*, OOBMemInfo> OutOfBandMap;

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -913,14 +913,14 @@ void TupleJoiner::setInUM(vector<RGData>& rgs)
   }
 }
 
-void TupleJoiner::setPMJoinResults(boost::shared_array<vector<uint32_t>> jr, uint32_t threadID)
+void TupleJoiner::setPMJoinResults(std::shared_ptr<vector<uint32_t>[]> jr, uint32_t threadID)
 {
   pmJoinResults[threadID] = jr;
 }
 
 void TupleJoiner::markMatches(uint32_t threadID, uint32_t rowCount)
 {
-  boost::shared_array<vector<uint32_t>> matches = pmJoinResults[threadID];
+  std::shared_ptr<vector<uint32_t>[]> matches = pmJoinResults[threadID];
   uint32_t i, j;
 
   for (i = 0; i < rowCount; i++)
@@ -946,7 +946,7 @@ void TupleJoiner::markMatches(uint32_t threadID, const vector<Row::Pointer>& mat
   }
 }
 
-boost::shared_array<std::vector<uint32_t>> TupleJoiner::getPMJoinArrays(uint32_t threadID)
+std::shared_ptr<std::vector<uint32_t>[]> TupleJoiner::getPMJoinArrays(uint32_t threadID)
 {
   return pmJoinResults[threadID];
 }
@@ -954,7 +954,7 @@ boost::shared_array<std::vector<uint32_t>> TupleJoiner::getPMJoinArrays(uint32_t
 void TupleJoiner::setThreadCount(uint32_t cnt)
 {
   threadCount = cnt;
-  pmJoinResults.reset(new boost::shared_array<vector<uint32_t>>[cnt]);
+  pmJoinResults.reset(new std::shared_ptr<vector<uint32_t>[]>[cnt]);
   smallRow.reset(new Row[cnt]);
 
   for (uint32_t i = 0; i < cnt; i++)

--- a/utils/joiner/tuplejoiner.h
+++ b/utils/joiner/tuplejoiner.h
@@ -321,8 +321,8 @@ class TupleJoiner
   void umJoinConvert(size_t begin, size_t end);
 
   void setThreadCount(uint32_t cnt);
-  void setPMJoinResults(boost::shared_array<std::vector<uint32_t> >, uint32_t threadID);
-  boost::shared_array<std::vector<uint32_t> > getPMJoinArrays(uint32_t threadID);
+  void setPMJoinResults(std::shared_ptr<std::vector<uint32_t>[]>, uint32_t threadID);
+  std::shared_ptr<std::vector<uint32_t>[]> getPMJoinArrays(uint32_t threadID);
   std::vector<rowgroup::Row::Pointer>* getSmallSide()
   {
     return &rows;
@@ -502,10 +502,10 @@ class TupleJoiner
   the logical block being processed.  There are X threads at once, so
   up to X logical blocks being processed.  For each of those there's a vector
   of matches.  Each match is an index into 'rows'. */
-  boost::shared_array<boost::shared_array<std::vector<uint32_t> > > pmJoinResults;
+  std::shared_ptr<std::shared_ptr<std::vector<uint32_t>[]>[]> pmJoinResults;
   rowgroup::RowGroup smallRG, largeRG;
   boost::scoped_array<rowgroup::Row> smallRow;
-  // boost::shared_array<uint8_t> smallNullMemory;
+
   rowgroup::Row smallNullRow;
 
   enum JoinAlg
@@ -517,7 +517,7 @@ class TupleJoiner
   };
   JoinAlg joinAlg;
   joblist::JoinType joinType;
-  boost::shared_array<boost::shared_ptr<utils::PoolAllocator> > _pool;  // pools for the table and nodes
+  std::shared_ptr<boost::shared_ptr<utils::PoolAllocator>[]> _pool;  // pools for the table and nodes
   uint32_t threadCount;
   std::string tableName;
 

--- a/utils/joiner/tuplejoiner.h
+++ b/utils/joiner/tuplejoiner.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/scoped_array.hpp>
 #include <tr1/unordered_map>
 

--- a/utils/messageqcpp/bytestream.cpp
+++ b/utils/messageqcpp/bytestream.cpp
@@ -152,17 +152,17 @@ void ByteStream::growBuf(uint32_t toSize)
   }
 }
 
-std::vector<boost::shared_array<uint8_t>>& ByteStream::getLongStrings()
+std::vector<std::shared_ptr<uint8_t[]>>& ByteStream::getLongStrings()
 {
   return longStrings;
 }
 
-const std::vector<boost::shared_array<uint8_t>>& ByteStream::getLongStrings() const
+const std::vector<std::shared_ptr<uint8_t[]>>& ByteStream::getLongStrings() const
 {
   return longStrings;
 }
 
-void ByteStream::setLongStrings(const std::vector<boost::shared_array<uint8_t>>& other)
+void ByteStream::setLongStrings(const std::vector<std::shared_ptr<uint8_t[]>>& other)
 {
   longStrings = other;
 }

--- a/utils/messageqcpp/bytestream.h
+++ b/utils/messageqcpp/bytestream.h
@@ -26,7 +26,7 @@
 #include <vector>
 #include <set>
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/version.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <stdint.h>

--- a/utils/messageqcpp/bytestream.h
+++ b/utils/messageqcpp/bytestream.h
@@ -444,9 +444,9 @@ class ByteStream : public Serializeable
       3 * sizeof(uint32_t);  // space for the BS magic & length & number of long strings.
 
   // Methods to get and set `long strings`.
-  EXPORT std::vector<boost::shared_array<uint8_t>>& getLongStrings();
-  EXPORT const std::vector<boost::shared_array<uint8_t>>& getLongStrings() const;
-  EXPORT void setLongStrings(const std::vector<boost::shared_array<uint8_t>>& other);
+  EXPORT std::vector<std::shared_ptr<uint8_t[]>>& getLongStrings();
+  EXPORT const std::vector<std::shared_ptr<uint8_t[]>>& getLongStrings() const;
+  EXPORT void setLongStrings(const std::vector<std::shared_ptr<uint8_t[]>>& other);
 
   friend class ::ByteStreamTestSuite;
 
@@ -478,7 +478,7 @@ class ByteStream : public Serializeable
   uint8_t* fCurOutPtr;  // the point in fBuf where data is extracted from next
   uint32_t fMaxLen;     // how big fBuf is currently
   // Stores `long strings`.
-  std::vector<boost::shared_array<uint8_t>> longStrings;
+    std::vector<std::shared_ptr<uint8_t[]>> longStrings;
 };
 
 template <int W, typename T = void>

--- a/utils/messageqcpp/inetstreamsocket.cpp
+++ b/utils/messageqcpp/inetstreamsocket.cpp
@@ -73,7 +73,7 @@ using namespace std;
 #include <boost/scoped_array.hpp>
 using boost::scoped_array;
 
-#include <boost/shared_array.hpp>
+
 
 #define INETSTREAMSOCKET_DLLEXPORT
 #include "inetstreamsocket.h"

--- a/utils/messageqcpp/inetstreamsocket.cpp
+++ b/utils/messageqcpp/inetstreamsocket.cpp
@@ -515,7 +515,7 @@ const SBS InetStreamSocket::read(const struct ::timespec* timeout, bool* isTimeO
     return SBS(new ByteStream(0));
   res->advanceInputPtr(msglen);
 
-  std::vector<boost::shared_array<uint8_t>> longStrings;
+  std::vector<std::shared_ptr<uint8_t[]>> longStrings;
   try
   {
     for (uint32_t i = 0; i < longStringSize; ++i)
@@ -527,7 +527,7 @@ const SBS InetStreamSocket::read(const struct ::timespec* timeout, bool* isTimeO
         return SBS(new ByteStream(0));
 
       // Allocate new memory for the `long string`.
-      boost::shared_array<uint8_t> longString(
+      std::shared_ptr<uint8_t[]> longString(
           new uint8_t[sizeof(rowgroup::StringStore::MemChunk) + memChunk.currentSize]);
 
       uint8_t* longStringData = longString.get();

--- a/utils/rowgroup/rowaggregation.cpp
+++ b/utils/rowgroup/rowaggregation.cpp
@@ -607,7 +607,7 @@ void RowAggregation::setJoinRowGroups(vector<RowGroup>* pSmallSideRG, RowGroup* 
   fSmallSideRGs = pSmallSideRG;
   fLargeSideRG = pLargeSideRG;
   fSmallSideCount = fSmallSideRGs->size();
-  fSmallMappings.reset(new shared_array<int>[fSmallSideCount]);
+  fSmallMappings.reset(new std::shared_ptr<int[]>[fSmallSideCount]);
 
   for (uint32_t i = 0; i < fSmallSideCount; i++)
     fSmallMappings[i] = makeMapping((*fSmallSideRGs)[i], fRowGroupIn);

--- a/utils/rowgroup/rowaggregation.h
+++ b/utils/rowgroup/rowaggregation.h
@@ -335,7 +335,7 @@ struct GroupConcat
   uint64_t fSize;
 
   RowGroup fRowGroup;
-  boost::shared_array<int> fMapping;
+  std::shared_ptr<int[]> fMapping;
   std::vector<std::pair<int, bool>> fOrderCond;  // position to order by [asc/desc]
   joblist::ResourceManager* fRm;                 // resource manager
   boost::shared_ptr<int64_t> fSessionMemLimit;
@@ -586,8 +586,8 @@ class RowAggregation : public messageqcpp::Serializeable
   // for support PM aggregation after PM hashjoin
   std::vector<RowGroup>* fSmallSideRGs;
   RowGroup* fLargeSideRG;
-  boost::shared_array<boost::shared_array<int>> fSmallMappings;
-  boost::shared_array<int> fLargeMapping;
+  std::shared_ptr<std::shared_ptr<int[]>[]> fSmallMappings;
+  std::shared_ptr<int[]> fLargeMapping;
   uint32_t fSmallSideCount;
   boost::scoped_array<Row> rowSmalls;
 

--- a/utils/rowgroup/rowaggregation.h
+++ b/utils/rowgroup/rowaggregation.h
@@ -35,7 +35,7 @@
 #include <tr1/unordered_map>
 #include <tr1/unordered_set>
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/scoped_array.hpp>
 #include <boost/scoped_ptr.hpp>
 

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -33,7 +33,6 @@ using namespace std;
 
 
 #include <numeric>
-using namespace boost;
 
 #include "bytestream.h"
 using namespace messageqcpp;
@@ -97,7 +96,7 @@ uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
 
   if ((len + 4) >= CHUNK_SIZE)
   {
-    shared_array<uint8_t> newOne(new uint8_t[len + sizeof(MemChunk) + 4]);
+    std::shared_ptr<uint8_t[]> newOne(new uint8_t[len + sizeof(MemChunk) + 4]);
     longStrings.push_back(newOne);
     lastMC = (MemChunk*)longStrings.back().get();
     lastMC->capacity = lastMC->currentSize = len + 4;
@@ -114,7 +113,7 @@ uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
       // mem usage debugging
       // if (lastMC)
       // cout << "Memchunk efficiency = " << lastMC->currentSize << "/" << lastMC->capacity << endl;
-      shared_array<uint8_t> newOne(new uint8_t[CHUNK_SIZE + sizeof(MemChunk)]);
+      std::shared_ptr<uint8_t[]> newOne(new uint8_t[CHUNK_SIZE + sizeof(MemChunk)]);
       mem.push_back(newOne);
       lastMC = (MemChunk*)mem.back().get();
       lastMC->currentSize = 0;
@@ -196,8 +195,8 @@ void StringStore::deserialize(ByteStream& bs)
 
 void StringStore::clear()
 {
-  vector<shared_array<uint8_t> > emptyv;
-  vector<shared_array<uint8_t> > emptyv2;
+  vector<std::shared_ptr<uint8_t[]> > emptyv;
+  vector<std::shared_ptr<uint8_t[]> > emptyv2;
   mem.swap(emptyv);
   longStrings.swap(emptyv2);
   empty = true;
@@ -1325,9 +1324,9 @@ string RowGroup::toString(const std::vector<uint64_t>& used) const
   return os.str();
 }
 
-boost::shared_array<int> makeMapping(const RowGroup& r1, const RowGroup& r2)
+std::shared_ptr<int[]> makeMapping(const RowGroup& r1, const RowGroup& r2)
 {
-  shared_array<int> ret(new int[r1.getColumnCount()]);
+  std::shared_ptr<int[]> ret(new int[r1.getColumnCount()]);
   // bool reserved[r2.getColumnCount()];
   bool* reserved = (bool*)alloca(r2.getColumnCount() * sizeof(bool));
   uint32_t i, j;
@@ -1352,7 +1351,7 @@ boost::shared_array<int> makeMapping(const RowGroup& r1, const RowGroup& r2)
   return ret;
 }
 
-void applyMapping(const boost::shared_array<int>& mapping, const Row& in, Row* out)
+void applyMapping(const std::shared_ptr<int[]>& mapping, const Row& in, Row* out)
 {
   applyMapping(mapping.get(), in, out);
 }
@@ -1397,7 +1396,7 @@ void applyMapping(const int* mapping, const Row& in, Row* out)
 
 RowGroup& RowGroup::operator+=(const RowGroup& rhs)
 {
-  boost::shared_array<bool> tmp;
+  std::shared_ptr<bool[]> tmp;
   uint32_t i, j;
   // not appendable if data is set
   assert(!data);

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -31,7 +31,7 @@
 #include <iterator>
 using namespace std;
 
-#include <boost/shared_array.hpp>
+
 #include <numeric>
 using namespace boost;
 

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -33,7 +33,7 @@
 // #define NDEBUG
 #include <cassert>
 #include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/thread/mutex.hpp>
 #include <cmath>
 #include <cfloat>

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -183,10 +183,10 @@ class StringStore
   std::string empty_str;
   static constexpr const uint32_t CHUNK_SIZE = 64 * 1024;  // allocators like powers of 2
 
-  std::vector<boost::shared_array<uint8_t>> mem;
+  std::vector<std::shared_ptr<uint8_t[]>> mem;
 
   // To store strings > 64KB (BLOB/TEXT)
-  std::vector<boost::shared_array<uint8_t>> longStrings;
+  std::vector<std::shared_ptr<uint8_t[]>> longStrings;
   bool empty = true;
   bool fUseStoreStringMutex = false;  //@bug6065, make StringStore::storeString() thread safe
   boost::mutex fMutex;
@@ -628,7 +628,7 @@ private:
   bool hasCollation = false;
   bool hasLongStringField = false;
   uint32_t sTableThreshold = 20;
-  boost::shared_array<bool> forceInline;
+  std::shared_ptr<bool[]> forceInline;
   UserDataStore* userDataStore = nullptr;  // For UDAF
 
   friend class RowGroup;
@@ -1521,7 +1521,7 @@ class RowGroup : public messageqcpp::Serializeable
   inline std::vector<execplan::CalpontSystemCatalog::ColDataType>& getColTypes();
   inline const std::vector<uint32_t>& getCharsetNumbers() const;
   inline uint32_t getCharsetNumber(uint32_t colIndex) const;
-  inline boost::shared_array<bool>& getForceInline();
+  inline std::shared_ptr<bool[]>& getForceInline();
   static inline uint32_t getHeaderSize()
   {
     return headerSize;
@@ -1613,7 +1613,7 @@ class RowGroup : public messageqcpp::Serializeable
   bool hasCollation = false;
   bool hasLongStringField = false;
   uint32_t sTableThreshold = 20;
-  boost::shared_array<bool> forceInline;
+  std::shared_ptr<bool[]> forceInline;
 
   static const uint32_t headerSize = 18;
   static const uint32_t rowCountOffset = 0;
@@ -1639,8 +1639,8 @@ inline uint64_t getFileRelativeRid(uint64_t baseRid);
  */
 RowGroup operator+(const RowGroup& lhs, const RowGroup& rhs);
 
-boost::shared_array<int> makeMapping(const RowGroup& r1, const RowGroup& r2);
-void applyMapping(const boost::shared_array<int>& mapping, const Row& in, Row* out);
+std::shared_ptr<int[]> makeMapping(const RowGroup& r1, const RowGroup& r2);
+void applyMapping(const std::shared_ptr<int[]>& mapping, const Row& in, Row* out);
 void applyMapping(const std::vector<int>& mapping, const Row& in, Row* out);
 void applyMapping(const int* mapping, const Row& in, Row* out);
 
@@ -1863,7 +1863,7 @@ inline const std::vector<uint32_t>& RowGroup::getColWidths() const
   return colWidths;
 }
 
-inline boost::shared_array<bool>& RowGroup::getForceInline()
+inline std::shared_ptr<bool[]>& RowGroup::getForceInline()
 {
   return forceInline;
 }

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -28,7 +28,7 @@ using namespace std;
 #include "calpontselectexecutionplan.h"
 #include "rowgroup.h"
 
-#include <boost/shared_array.hpp>
+
 using namespace boost;
 
 #include "errorids.h"

--- a/utils/windowfunction/idborderby.h
+++ b/utils/windowfunction/idborderby.h
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 #include <sstream>
-#include <boost/shared_array.hpp>
+
 #include <boost/scoped_ptr.hpp>
 
 #include <tr1/unordered_set>

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -3184,7 +3184,7 @@ const TxnID DBRM::getTxnID(const SessionManagerServer::SID session)
   return ret;
 }
 
-boost::shared_array<SIDTIDEntry> DBRM::SIDTIDMap(int& len)
+std::shared_ptr<SIDTIDEntry[]> DBRM::SIDTIDMap(int& len)
 {
 #ifdef BRM_INFO
 
@@ -3201,7 +3201,7 @@ boost::shared_array<SIDTIDEntry> DBRM::SIDTIDMap(int& len)
   uint8_t err, tmp8;
   uint32_t tmp32;
   int i;
-  boost::shared_array<SIDTIDEntry> ret;
+  std::shared_ptr<SIDTIDEntry[]> ret;
 
   command << SID_TID_MAP;
   err = send_recv(command, response);

--- a/versioning/BRM/dbrm.h
+++ b/versioning/BRM/dbrm.h
@@ -32,7 +32,7 @@
 #include <set>
 #include <string>
 #include <boost/thread.hpp>
-#include <boost/shared_array.hpp>
+
 #include <boost/scoped_ptr.hpp>
 
 #include "brmtypes.h"

--- a/versioning/BRM/dbrm.h
+++ b/versioning/BRM/dbrm.h
@@ -757,7 +757,7 @@ class DBRM
   EXPORT void committed(BRM::TxnID& txnid);
   EXPORT void rolledback(BRM::TxnID& txnid);
   EXPORT const BRM::TxnID getTxnID(const SessionManagerServer::SID session);
-  EXPORT boost::shared_array<SIDTIDEntry> SIDTIDMap(int& len);
+  EXPORT std::shared_ptr<SIDTIDEntry[]> SIDTIDMap(int& len);
   EXPORT void sessionmanager_reset();
 
   /* Note, these pull #s from two separate sequences.  That is, they both

--- a/versioning/BRM/masterdbrmnode.cpp
+++ b/versioning/BRM/masterdbrmnode.cpp
@@ -1544,7 +1544,7 @@ void MasterDBRMNode::doSIDTIDMap(ByteStream& msg, ThreadParams* p)
 {
   ByteStream reply;
   int len, i;
-  boost::shared_array<SIDTIDEntry> entries;
+  std::shared_ptr<SIDTIDEntry[]> entries;
 
   try
   {

--- a/versioning/BRM/sessionmanagerserver.cpp
+++ b/versioning/BRM/sessionmanagerserver.cpp
@@ -346,10 +346,10 @@ const TxnID SessionManagerServer::getTxnID(const SID session)
   return ret;
 }
 
-shared_array<SIDTIDEntry> SessionManagerServer::SIDTIDMap(int& len)
+std::shared_ptr<SIDTIDEntry[]> SessionManagerServer::SIDTIDMap(int& len)
 {
   int j;
-  shared_array<SIDTIDEntry> ret;
+  std::shared_ptr<SIDTIDEntry[]> ret;
   boost::mutex::scoped_lock lk(mutex);
   iterator it;
 

--- a/versioning/BRM/sessionmanagerserver.h
+++ b/versioning/BRM/sessionmanagerserver.h
@@ -193,7 +193,7 @@ class SessionManagerServer
    * @return A pointer to the array.  Note: The caller is responsible for
    * deallocating it.  Use delete[].
    */
-  EXPORT boost::shared_array<SIDTIDEntry> SIDTIDMap(int& len);
+  EXPORT std::shared_ptr<SIDTIDEntry[]> SIDTIDMap(int& len);
 
   /**
    * get a unique 32-bit number

--- a/versioning/BRM/sessionmanagerserver.h
+++ b/versioning/BRM/sessionmanagerserver.h
@@ -28,7 +28,7 @@
 
 #include <map>
 
-#include <boost/shared_array.hpp>
+
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition_variable.hpp>
 

--- a/writeengine/redistribute/we_redistributeworkerthread.h
+++ b/writeengine/redistribute/we_redistributeworkerthread.h
@@ -27,7 +27,6 @@
 #include <cstdio>
 
 #include "boost/shared_ptr.hpp"
-#include "boost/shared_array.hpp"
 #include "boost/thread/mutex.hpp"
 
 #include "brmtypes.h"
@@ -126,7 +125,7 @@ class RedistributeWorkerThread
   FILE* fOldFilePtr;
   std::set<std::string> fNewDirSet;
   std::set<std::string> fOldDirSet;
-  boost::shared_array<char> fWriteBuffer;
+  std::shared_ptr<char[]> fWriteBuffer;
 
   boost::shared_ptr<BRM::DBRM> fDbrm;
 


### PR DESCRIPTION
Replace ```boost::shared_array<T>``` with ```std::shared_ptr<T[]>``` due to ```boost::shared_array<T>``` is deprecated and produces warnings with ```gcc-12```