### PR TITLE
MCOL-5357 Fix TPC-DS query error "MCS-3009: Unknown column '.<colname>'".

### DIFF
--- a/mysql-test/columnstore/bugfixes/mcol-5357.result
+++ b/mysql-test/columnstore/bugfixes/mcol-5357.result
@@ -1,0 +1,18 @@
+DROP DATABASE IF EXISTS mcol_5357;
+CREATE DATABASE mcol_5357;
+USE mcol_5357;
+CREATE TABLE t1 (a INT)engine=columnstore;
+INSERT INTO t1 VALUES (1), (2), (3);
+SELECT item FROM (
+SELECT item FROM (SELECT a AS item FROM t1) tt
+UNION ALL
+SELECT item FROM (SELECT a AS item FROM t1) tt
+) ttt;
+item
+1
+2
+3
+1
+2
+3
+DROP DATABASE mcol_5357;

--- a/mysql-test/columnstore/bugfixes/mcol-5357.test
+++ b/mysql-test/columnstore/bugfixes/mcol-5357.test
@@ -1,0 +1,24 @@
+#
+# MCOL-5357 Fix TPC-DS query error "MCS-3009: Unknown column '.<colname>'"
+#
+
+--source ../include/have_columnstore.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol_5357;
+--enable_warnings
+CREATE DATABASE mcol_5357;
+USE mcol_5357;
+
+CREATE TABLE t1 (a INT)engine=columnstore;
+INSERT INTO t1 VALUES (1), (2), (3);
+
+SELECT item FROM (
+SELECT item FROM (SELECT a AS item FROM t1) tt
+UNION ALL
+SELECT item FROM (SELECT a AS item FROM t1) tt
+) ttt;
+
+--disable_warnings
+DROP DATABASE mcol_5357;
+--enable_warnings


### PR DESCRIPTION
For the following query:

select item from (
select item from (select a as item from t1) tt
union all
select item from (select a as item from t1) tt
) ttt;

There is an if predicate in buildSimpleColFromDerivedTable() that compares the outermost query field name (ttt.item) to the returned column list of the inner query (tt.item) when building the returned column list of the outer most query. In the above query example, the inner query field name is an alias set in the inner most query and is set to "`tt`.`item`", while the outermost query field name is set to "item". The use of backticks "`" in the inner query alias is causing the execution to not enter the if block which creates the SimpleColumn for the outermost query field name. As a fix, we strip off the backticks from the inner query alias.