### PR TITLE
Fix resource leak in DDLProc/DMLProc/PrimProc/WriteengineServer processes.

### DIFF
--- a/ddlproc/ddlproc.cpp
+++ b/ddlproc/ddlproc.cpp
@@ -193,6 +193,9 @@ int ServiceDDLProc::Child()
 
   ddlprocessor::DDLProcessor ddlprocessor(1, 20);
 
+  // Initialize the charset library
+  MY_INIT("DDLProc");
+
   NotifyServiceStarted();
 
   try
@@ -210,6 +213,10 @@ int ServiceDDLProc::Child()
     message.format(args);
     logging::Logger logger(logid.fSubsysID);
     logger.logMessage(LOG_TYPE_CRITICAL, message, logid);
+
+    // Free up resources allocated by MY_INIT() above.
+    my_end(0);
+
     return 1;
   }
   catch (...)
@@ -223,8 +230,15 @@ int ServiceDDLProc::Child()
     message.format(args);
     logging::Logger logger(logid.fSubsysID);
     logger.logMessage(LOG_TYPE_CRITICAL, message, logid);
+
+    // Free up resources allocated by MY_INIT() above.
+    my_end(0);
+
     return 1;
   }
+
+  // Free up resources allocated by MY_INIT() above.
+  my_end(0);
 
   return 0;
 }
@@ -237,8 +251,6 @@ int main(int argc, char** argv)
   setlocale(LC_NUMERIC, "C");
   // This is unset due to the way we start it
   program_invocation_short_name = const_cast<char*>("DDLProc");
-  // Initialize the charset library
-  MY_INIT(argv[0]);
 
   return ServiceDDLProc(opt).Run();
 }

--- a/dmlproc/dmlproc.cpp
+++ b/dmlproc/dmlproc.cpp
@@ -588,6 +588,9 @@ int ServiceDMLProc::Child()
 
   WriteEngine::WriteEngineWrapper::init(WriteEngine::SUBSYSTEM_ID_DMLPROC);
 
+  // Initialize the charset library
+  MY_INIT("DMLProc");
+
   //@Bug 1627
   try
   {
@@ -607,6 +610,10 @@ int ServiceDMLProc::Child()
 
     cerr << "DMLProc failed to start due to : " << e.what() << endl;
     NotifyServiceInitializationFailed();
+
+    // Free up resources allocated by MY_INIT() above.
+    my_end(0);
+
     return 1;
   }
 
@@ -666,6 +673,9 @@ int ServiceDMLProc::Child()
 
   _exit(dmlserver.start());
 
+  // Free up resources allocated by MY_INIT() above.
+  my_end(0);
+
   return 1;
 }
 
@@ -678,9 +688,6 @@ int main(int argc, char** argv)
   setlocale(LC_NUMERIC, "C");
   // This is unset due to the way we start it
   program_invocation_short_name = const_cast<char*>("DMLProc");
-  // Initialize the charset library
-  MY_INIT(argv[0]);
 
   return ServiceDMLProc(opt).Run();
 }
-

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -299,6 +299,9 @@ int ServicePrimProc::Child()
   int err = 0;
   err = setupCwd(cf);
 
+  // Initialize the charset library
+  MY_INIT("PrimProc");
+
   mlp = new primitiveprocessor::Logger();
 
   if (!m_debug)
@@ -328,6 +331,10 @@ int ServicePrimProc::Child()
     cerr << errMsg << endl;
 
     NotifyServiceInitializationFailed();
+
+    // Free up resources allocated by MY_INIT() above.
+    my_end(0);
+
     return 2;
   }
   utils::USpaceSpinLock startupRaceLock(getStartupRaceFlag());
@@ -693,6 +700,9 @@ int ServicePrimProc::Child()
 
   cerr << "server.start() exited!" << endl;
 
+  // Free up resources allocated by MY_INIT() above.
+  my_end(0);
+
   return 1;
 }
 
@@ -709,8 +719,6 @@ int main(int argc, char** argv)
   setlocale(LC_NUMERIC, "C");
   // This is unset due to the way we start it
   program_invocation_short_name = const_cast<char*>("PrimProc");
-  // Initialize the charset library
-  MY_INIT(argv[0]);
 
   ServicePrimProc::instance()->setOpt(opt);
   return ServicePrimProc::instance()->Run();

--- a/writeengine/server/we_server.cpp
+++ b/writeengine/server/we_server.cpp
@@ -174,6 +174,9 @@ int ServiceWriteEngine::Child()
   // Init WriteEngine Wrapper (including Config Columnstore.xml cache)
   WriteEngine::WriteEngineWrapper::init(WriteEngine::SUBSYSTEM_ID_WE_SRV);
 
+  // Initialize the charset library
+  MY_INIT("WriteEngineServer");
+
   Config weConfig;
 
   ostringstream serverParms;
@@ -221,6 +224,10 @@ int ServiceWriteEngine::Child()
         logging::MessageLog ml(lid);
         ml.logCriticalMessage(message);
         NotifyServiceInitializationFailed();
+
+        // Free up resources allocated by MY_INIT() above.
+        my_end(0);
+
         return 2;
       }
     }
@@ -258,6 +265,10 @@ int ServiceWriteEngine::Child()
     cerr << errMsg << endl;
 
     NotifyServiceInitializationFailed();
+
+    // Free up resources allocated by MY_INIT() above.
+    my_end(0);
+
     return 2;
   }
 
@@ -304,6 +315,9 @@ int ServiceWriteEngine::Child()
     }
   }
 
+  // Free up resources allocated by MY_INIT() above.
+  my_end(0);
+
   // It is an error to reach here...
   return 1;
 }
@@ -317,8 +331,6 @@ int main(int argc, char** argv)
   setlocale(LC_NUMERIC, "C");
   // This is unset due to the way we start it
   program_invocation_short_name = const_cast<char*>("WriteEngineServ");
-  // Initialize the charset library
-  MY_INIT(argv[0]);
 
   return ServiceWriteEngine(opt).Run();
 }


### PR DESCRIPTION
As part of the charset support, a call to MY_INIT() was added at the initialization of the above processes. This call initializes the MySQL thread environment required by the charset library. However, the accompanying my_end() call required to terminate this thread environment was not added at the termination of these process, hence leaking resources. As a fix, we move the MY_INIT() calls to the Child() functions of these services and also add the missing my_end() call.