### PR TITLE
MCOL-5522 Temporary disable join match limit on BPP

### DIFF
--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -1409,8 +1409,9 @@ uint32_t BatchPrimitiveProcessor::executeTupleJoin(uint32_t startRid)
     // The caller will restart to continue where we left off.
     if (resultCount >= maxResultCount)
     {
-      newStartRid += newRowCount;
-      break;
+      // FIXME: Implement proper pipleline. (MCOL-5522).
+      cerr << "BPP join match count exceeded the limit, match count: " << resultCount << endl;
+      resultCount = 0;
     }
   }
 


### PR DESCRIPTION
Current join pipeline is not designed to send a temporal result and
continue execution. RowGroup for large side is the same where we store
the matched rows, we cannot continue to iterate over it, requires a
proper refactoring.
