### PR TITLE
MCOL-5522 Properly process pm join result count.

### DIFF
--- a/dbcon/execplan/calpontselectexecutionplan.cpp
+++ b/dbcon/execplan/calpontselectexecutionplan.cpp
@@ -87,6 +87,7 @@ CalpontSelectExecutionPlan::CalpontSelectExecutionPlan(const int location)
  , fDJSPartitionSize(100 * 1024 * 1024)
  , fDJSMaxPartitionTreeDepth(8)
  , fDJSForceRun(false)
+ , fMaxPmJoinResultCount(1048576)
  ,  // 100MB mem usage for disk based join,
  fUMMemLimit(numeric_limits<int64_t>::max())
  , fIsDML(false)
@@ -461,6 +462,7 @@ void CalpontSelectExecutionPlan::serialize(messageqcpp::ByteStream& b) const
   b << fDJSPartitionSize;
   b << fDJSMaxPartitionTreeDepth;
   b << (uint8_t)fDJSForceRun;
+  b << (uint32_t)fMaxPmJoinResultCount;
   b << fUMMemLimit;
   b << (uint8_t)fIsDML;
   messageqcpp::ByteStream::octbyte timeZone = fTimeZone;
@@ -658,6 +660,7 @@ void CalpontSelectExecutionPlan::unserialize(messageqcpp::ByteStream& b)
   b >> fDJSPartitionSize;
   b >> fDJSMaxPartitionTreeDepth;
   b >> (uint8_t&)fDJSForceRun;
+  b >> (uint32_t&)fMaxPmJoinResultCount;
   b >> fUMMemLimit;
   b >> tmp8;
   fIsDML = tmp8;

--- a/dbcon/execplan/calpontselectexecutionplan.h
+++ b/dbcon/execplan/calpontselectexecutionplan.h
@@ -706,6 +706,15 @@ class CalpontSelectExecutionPlan : public CalpontExecutionPlan
     return fDJSForceRun;
   }
 
+  void maxPmJoinResultCount(uint32_t value)
+  {
+    fMaxPmJoinResultCount = value;
+  }
+  uint32_t maxPmJoinResultCount()
+  {
+    return fMaxPmJoinResultCount;
+  }
+
   void umMemLimit(uint64_t l)
   {
     fUMMemLimit = l;
@@ -940,6 +949,7 @@ class CalpontSelectExecutionPlan : public CalpontExecutionPlan
   uint64_t fDJSPartitionSize = 100 * 1024 * 1024;
   uint32_t fDJSMaxPartitionTreeDepth = 8;
   bool fDJSForceRun = false;
+  uint32_t fMaxPmJoinResultCount = 1048576;
   int64_t fUMMemLimit = numeric_limits<int64_t>::max();
   bool fIsDML = false;
   long fTimeZone = 0;

--- a/dbcon/joblist/batchprimitiveprocessor-jl.cpp
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.cpp
@@ -1105,6 +1105,7 @@ void BatchPrimitiveProcessorJL::createBPP(ByteStream& bs) const
   /* if HAS_JOINER, send the init params */
   if (flags & HAS_JOINER)
   {
+    bs << (uint32_t)maxPmJoinResultCount;
     if (ot == ROW_GROUP)
     {
       idbassert(tJoiners.size() > 0);

--- a/dbcon/joblist/batchprimitiveprocessor-jl.h
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.h
@@ -252,6 +252,11 @@ class BatchPrimitiveProcessorJL
     uuid = u;
   }
 
+  void setMaxPmJoinResultCount(uint32_t count)
+  {
+    maxPmJoinResultCount = count;
+  }
+
  private:
   const size_t perColumnProjectWeight_ = 10;
   const size_t perColumnFilteringWeight_ = 10;
@@ -374,6 +379,7 @@ class BatchPrimitiveProcessorJL
   unsigned fJoinerChunkSize;
   uint32_t dbRoot;
   bool hasSmallOuterJoin;
+  uint32_t maxPmJoinResultCount = 1048576;
 
   uint32_t _priority;
 

--- a/dbcon/joblist/jlf_common.h
+++ b/dbcon/joblist/jlf_common.h
@@ -211,6 +211,7 @@ struct JobInfo
    , wfqLimitStart(0)
    , wfqLimitCount(-1)
    , timeZone(0)
+   , maxPmJoinResultCount(1048576)
   {
   }
   ResourceManager* rm;
@@ -368,6 +369,7 @@ struct JobInfo
   bool djsForceRun;
   bool isDML;
   long timeZone;
+  uint32_t maxPmJoinResultCount;
 
   // This is for tracking any dynamically allocated ParseTree objects
   // in simpleScalarFilterToParseTree() for later deletion in

--- a/dbcon/joblist/joblistfactory.cpp
+++ b/dbcon/joblist/joblistfactory.cpp
@@ -2068,6 +2068,7 @@ SJLP makeJobList_(CalpontExecutionPlan* cplan, ResourceManager* rm,
     jobInfo.partitionSize = csep->djsPartitionSize();
     jobInfo.djsMaxPartitionTreeDepth = csep->djsMaxPartitionTreeDepth();
     jobInfo.djsForceRun = csep->djsForceRun();
+    jobInfo.maxPmJoinResultCount = csep->maxPmJoinResultCount();
     jobInfo.umMemLimit.reset(new int64_t);
     *(jobInfo.umMemLimit) = csep->umMemLimit();
     jobInfo.isDML = csep->isDML();

--- a/dbcon/joblist/jobstep.cpp
+++ b/dbcon/joblist/jobstep.cpp
@@ -91,6 +91,7 @@ JobStep::JobStep(const JobInfo& j)
  , fProgress(0)
  , fStartTime(-1)
  , fTimeZone(j.timeZone)
+ , fMaxPmJoinResultCount(j.maxPmJoinResultCount)
 {
   QueryTeleServerParms tsp;
   string teleServerHost(Config::makeConfig()->getConfig("QueryTele", "Host"));

--- a/dbcon/joblist/jobstep.h
+++ b/dbcon/joblist/jobstep.h
@@ -497,6 +497,7 @@ class JobStep
   int64_t fStartTime;
   int64_t fLastStepTeleTime;
   long fTimeZone;
+  uint32_t fMaxPmJoinResultCount;
 
  private:
   static boost::mutex fLogMutex;

--- a/dbcon/joblist/primitivestep.h
+++ b/dbcon/joblist/primitivestep.h
@@ -1198,6 +1198,11 @@ class TupleBPS : public BatchPrimitive, public TupleDeliveryStep
     return bRunFEonPM;
   }
 
+  void setMaxPmJoinResultCount(uint32_t count)
+  {
+    maxPmJoinResultCount = count;
+  }
+
  protected:
   void sendError(uint16_t status);
 
@@ -1338,6 +1343,8 @@ class TupleBPS : public BatchPrimitive, public TupleDeliveryStep
 
   boost::shared_ptr<RowGroupDL> deliveryDL;
   uint32_t deliveryIt;
+
+  uint32_t maxPmJoinResultCount;
 
   class JoinLocalData
   {

--- a/dbcon/joblist/tuple-bps.cpp
+++ b/dbcon/joblist/tuple-bps.cpp
@@ -1458,8 +1458,12 @@ void TupleBPS::run()
   fBPP->setThreadCount(fMaxNumProcessorThreads);
 
   if (doJoin)
+  {
     for (i = 0; i < smallSideCount; i++)
       tjoiners[i]->setThreadCount(fMaxNumProcessorThreads);
+
+    fBPP->setMaxPmJoinResultCount(fMaxPmJoinResultCount);
+  }
 
   if (fe1)
     fBPP->setFEGroup1(fe1, fe1Input);

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -6642,6 +6642,7 @@ void setExecutionParams(gp_walk_info& gwi, SCSEP& csep)
   csep->djsPartitionSize(get_diskjoin_bucketsize(gwi.thd) * 1024ULL * 1024);
   csep->djsMaxPartitionTreeDepth(get_diskjoin_max_partition_tree_depth(gwi.thd));
   csep->djsForceRun(get_diskjoin_force_run(gwi.thd));
+  csep->maxPmJoinResultCount(get_max_pm_join_result_count(gwi.thd));
   if (get_um_mem_limit(gwi.thd) == 0)
     csep->umMemLimit(numeric_limits<int64_t>::max());
   else

--- a/dbcon/mysql/ha_mcs_sysvars.cpp
+++ b/dbcon/mysql/ha_mcs_sysvars.cpp
@@ -141,6 +141,10 @@ static MYSQL_THDVAR_ULONG(diskjoin_max_partition_tree_depth, PLUGIN_VAR_RQCMDARG
 static MYSQL_THDVAR_BOOL(diskjoin_force_run, PLUGIN_VAR_RQCMDARG, "Force run for the disk join step.", NULL,
                          NULL, 0);
 
+static MYSQL_THDVAR_ULONG(max_pm_join_result_count, PLUGIN_VAR_RQCMDARG,
+                          "The maximum size of the join result for the single block on BPP.", NULL, NULL,
+                          1048576, 1, ~0U, 1);
+
 static MYSQL_THDVAR_ULONG(um_mem_limit, PLUGIN_VAR_RQCMDARG,
                           "Per user Memory limit(MB). Switch to disk-based JOIN when limit is reached", NULL,
                           NULL, 0, 0, ~0U, 1);
@@ -232,6 +236,7 @@ st_mysql_sys_var* mcs_system_variables[] = {MYSQL_SYSVAR(compression_type),
                                             MYSQL_SYSVAR(diskjoin_bucketsize),
                                             MYSQL_SYSVAR(diskjoin_max_partition_tree_depth),
                                             MYSQL_SYSVAR(diskjoin_force_run),
+                                            MYSQL_SYSVAR(max_pm_join_result_count),
                                             MYSQL_SYSVAR(um_mem_limit),
                                             MYSQL_SYSVAR(double_for_decimal_math),
                                             MYSQL_SYSVAR(decimal_overflow_check),
@@ -444,6 +449,15 @@ bool get_diskjoin_force_run(THD* thd)
 void set_diskjoin_force_run(THD* thd, bool value)
 {
   THDVAR(thd, diskjoin_force_run) = value;
+}
+
+ulong get_max_pm_join_result_count(THD* thd)
+{
+  return (thd == NULL) ? 0 : THDVAR(thd, max_pm_join_result_count);
+}
+void set_max_pm_join_result_count(THD* thd, ulong value)
+{
+  THDVAR(thd, max_pm_join_result_count) = value;
 }
 
 ulong get_um_mem_limit(THD* thd)

--- a/dbcon/mysql/ha_mcs_sysvars.h
+++ b/dbcon/mysql/ha_mcs_sysvars.h
@@ -114,6 +114,9 @@ void set_diskjoin_force_run(THD* thd, bool value);
 ulong get_diskjoin_max_partition_tree_depth(THD* thd);
 void set_diskjoin_max_partition_tree_depth(THD* thd, ulong value);
 
+ulong get_max_pm_join_result_count(THD* thd);
+void set_max_pm_join_result_count(THD* thd, ulong value);
+
 ulong get_um_mem_limit(THD* thd);
 void set_um_mem_limit(THD* thd, ulong value);
 

--- a/mysql-test/columnstore/bugfixes/mcol-5522.result
+++ b/mysql-test/columnstore/bugfixes/mcol-5522.result
@@ -1,0 +1,36 @@
+DROP DATABASE IF EXISTS mcol_5522;
+CREATE DATABASE mcol_5522;
+USE mcol_5522;
+create table t1 (a int) engine=columnstore;
+create table t2 (a int) engine=columnstore;
+insert into t1 values (1), (2), (3), (4);
+insert into t2 values (1), (2), (3), (4);
+create table t3 (a varchar(200)) engine=columnstore;
+create table t4 (a varchar(200)) engine=columnstore;
+insert into t3 values ("one"), ("two"), ("three");
+insert into t4 values ("one"), ("two"), ("three");
+set session columnstore_max_pm_join_result_count=1;
+select * from t1, t2 where t1.a = t2.a;
+a	a
+1	1
+2	2
+3	3
+4	4
+select * from t3, t4 where t3.a = t4.a;
+a	a
+one	one
+two	two
+three	three
+set session columnstore_max_pm_join_result_count=1048576;
+select * from t1, t2 where t1.a = t2.a;
+a	a
+1	1
+2	2
+3	3
+4	4
+select * from t3, t4 where t3.a = t4.a;
+a	a
+one	one
+two	two
+three	three
+DROP DATABASE mcol_5522;

--- a/mysql-test/columnstore/bugfixes/mcol-5522.test
+++ b/mysql-test/columnstore/bugfixes/mcol-5522.test
@@ -1,0 +1,29 @@
+--source ../include/have_columnstore.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol_5522;
+--enable_warnings
+CREATE DATABASE mcol_5522;
+USE mcol_5522;
+
+create table t1 (a int) engine=columnstore;
+create table t2 (a int) engine=columnstore;
+insert into t1 values (1), (2), (3), (4);
+insert into t2 values (1), (2), (3), (4);
+
+create table t3 (a varchar(200)) engine=columnstore;
+create table t4 (a varchar(200)) engine=columnstore;
+insert into t3 values ("one"), ("two"), ("three");
+insert into t4 values ("one"), ("two"), ("three");
+
+set session columnstore_max_pm_join_result_count=1;
+select * from t1, t2 where t1.a = t2.a;
+select * from t3, t4 where t3.a = t4.a;
+
+set session columnstore_max_pm_join_result_count=1048576;
+select * from t1, t2 where t1.a = t2.a;
+select * from t3, t4 where t3.a = t4.a;
+
+--disable_warnings
+DROP DATABASE mcol_5522;
+--enable_warnings

--- a/primitives/primproc/batchprimitiveprocessor.h
+++ b/primitives/primproc/batchprimitiveprocessor.h
@@ -336,7 +336,7 @@ class BatchPrimitiveProcessor
   std::shared_ptr<std::shared_ptr<boost::shared_ptr<TJoiner>[]>[]> tJoiners;
   typedef std::vector<uint32_t> MatchedData[LOGICAL_BLOCK_RIDS];
   std::shared_ptr<MatchedData[]> tSmallSideMatches;
-  uint32_t executeTupleJoin(uint32_t startRid);
+  uint32_t executeTupleJoin(uint32_t startRid, rowgroup::RowGroup& largeSideRowGroup);
   bool getTupleJoinRowGroupData;
   std::vector<rowgroup::RowGroup> smallSideRGs;
   rowgroup::RowGroup largeSideRG;
@@ -438,7 +438,7 @@ class BatchPrimitiveProcessor
   bool initiatedByEM_;
   uint32_t weight_;
 
-  static const uint64_t maxResultCount = 1048576;  // 2^20
+  uint32_t maxPmJoinResultCount = 1048576;
   friend class Command;
   friend class ColumnCommand;
   friend class DictStep;


### PR DESCRIPTION
This patch:
1. Properly processes situation when pm join result count is exceeded.
2. Adds session variable 'columnstore_max_pm_join_result_count` to control the limit.