### PR TITLE
fix(cmapi, brm): MCOL-5535 Use an accurate glob when forcing owner of files in /dev/shm on startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,8 @@ IF(NOT TARGET columnstore)
   RETURN()
 ENDIF()
 
+SET (SHMEM_FILE_GLOB "MCS-shm-")
+
 ADD_SUBDIRECTORY(utils)
 ADD_SUBDIRECTORY(oam/oamcpp)
 ADD_SUBDIRECTORY(dbcon/execplan)

--- a/oam/install_scripts/mcs-loadbrm.py.in
+++ b/oam/install_scripts/mcs-loadbrm.py.in
@@ -440,7 +440,7 @@ if __name__ == '__main__':
             # There were cases when shmem segments belongs to root so
             # explicitly chowns segments.
             if use_systemd:
-                for shm_file in glob.glob('/dev/shm/*'):
+                for shm_file in glob.glob('/dev/shm/@SHMEM_FILE_GLOB@*'):
                     shutil.chown(shm_file, USER, GROUP)
         except subprocess.CalledProcessError as exc:
             logging.error('{} exits with {}.'.format(cmd, exc.returncode))

--- a/versioning/BRM/CMakeLists.txt
+++ b/versioning/BRM/CMakeLists.txt
@@ -1,6 +1,9 @@
 
 include_directories( ${ENGINE_COMMON_INCLUDES} )
 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/shmkeys.cpp.in" "${CMAKE_CURRENT_SOURCE_DIR}/shmkeys.cpp" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/brmshmimpl.h.in" "${CMAKE_CURRENT_SOURCE_DIR}/brmshmimpl.h" @ONLY)
+
 
 ########### next target ###############
 

--- a/versioning/BRM/brmshmimpl.h.in
+++ b/versioning/BRM/brmshmimpl.h.in
@@ -27,7 +27,7 @@
 #pragma once
 
 #include <unistd.h>
-//#define NDEBUG
+// #define NDEBUG
 #include <cassert>
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/managed_shared_memory.hpp>
@@ -131,7 +131,7 @@ class BRMManagedShmImplRBTree : public BRMShmImplParent
 
  private:
   // The `segment` name is fixed.
-  const char* segmentName = "MCS-shm-00020001";
+  const char* segmentName = "@SHMEM_FILE_GLOB@00020001";
 };
 
 }  // namespace BRM

--- a/versioning/BRM/shmkeys.cpp.in
+++ b/versioning/BRM/shmkeys.cpp.in
@@ -63,7 +63,7 @@ ShmKeys::ShmKeys()
 string ShmKeys::keyToName(unsigned key)
 {
   ostringstream oss;
-  oss << "MCS-shm-";
+  oss << "@SHMEM_FILE_GLOB@";
   oss << setw(8) << setfill('0') << hex << key;
   return oss.str();
 }


### PR DESCRIPTION
MCS chowns all files in /dev/shm to mysql.mysql on startup by default. This patch makes the glob used more accurate. 