### PR TITLE
MCOL-4988 Table lock remained after DML failure due to DBRM in read-only mode.

### DIFF
--- a/dbcon/dmlpackageproc/dmlpackageprocessor.h
+++ b/dbcon/dmlpackageproc/dmlpackageprocessor.h
@@ -97,7 +97,8 @@ class DMLPackageProcessor
     ACTIVE_TRANSACTION_ERROR,
     TABLE_LOCK_ERROR,
     JOB_ERROR,
-    JOB_CANCELED
+    JOB_CANCELED,
+    DBRM_READ_ONLY
   };
 
   enum DebugLevel /** @brief Debug level type enumeration */

--- a/dmlproc/dmlprocessor.cpp
+++ b/dmlproc/dmlprocessor.cpp
@@ -1387,7 +1387,7 @@ void DMLProcessor::operator()()
           0)  // > 0 implies succesful retrieval. It doesn't imply anything about the contents
       {
         messageqcpp::ByteStream results;
-        const char* responseMsg = 0;
+        std::string responseMsg;
         bool bReject = false;
 
         // Check to see if we're in write suspended mode
@@ -1431,6 +1431,14 @@ void DMLProcessor::operator()()
               status = DMLPackageProcessor::NOT_ACCEPTING_PACKAGES;
               bReject = true;
             }
+          }
+
+          // MCOL-4988 Check if DBRM is in READ ONLY mode
+          if (fDbrm->isReadWrite() == BRM::ERR_READONLY)
+          {
+            BRM::errString(BRM::ERR_READONLY, responseMsg);
+            status = DMLPackageProcessor::DBRM_READ_ONLY;
+            bReject = true;
           }
 
           if (bReject)


### PR DESCRIPTION
DMLProcessor functor earlier did not check if the DBRM was in read-only mode. This allowed DML statements to continue execution to the point where it locks the table and then sends the statement down to the WriteEngineServer, which ultimately returns back in an error state to DMLProc when it fails to perform BRM updates due to DBRM in read-only mode. This caused a lingering table lock in the system which could only be cleared on a system restart.

As a fix, we add a check in the DMLProcessor functor to detect if DBRM is in read only mode, and if so, return back early in the execution of the DML statement.