### PR TITLE
Shorter returns

### DIFF
--- a/dbcon/ddlpackageproc/altertableprocessor.cpp
+++ b/dbcon/ddlpackageproc/altertableprocessor.cpp
@@ -728,7 +728,7 @@ void AlterTableProcessor::addColumn(uint32_t sessionID, execplan::CalpontSystemC
       {
         fWEClient->write(bs, (uint32_t)pmNum);
 
-        while (1)
+        while (true)
         {
           bsIn.reset(new ByteStream());
           fWEClient->read(uniqueId, bsIn);
@@ -793,7 +793,7 @@ void AlterTableProcessor::addColumn(uint32_t sessionID, execplan::CalpontSystemC
       {
         fWEClient->write(bs, (uint32_t)pmNum);
 
-        while (1)
+        while (true)
         {
           bsIn.reset(new ByteStream());
           fWEClient->read(uniqueId, bsIn);
@@ -938,7 +938,7 @@ void AlterTableProcessor::addColumn(uint32_t sessionID, execplan::CalpontSystemC
         fWEClient->write_to_all(bs);
         bsIn.reset(new ByteStream());
 
-        while (1)
+        while (true)
         {
           if (msgRecived == fPMCount)
             break;
@@ -984,7 +984,7 @@ void AlterTableProcessor::addColumn(uint32_t sessionID, execplan::CalpontSystemC
             bsIn.reset(new ByteStream());
             ByteStream::byte tmp8;
 
-            while (1)
+            while (true)
             {
               if (msgRecived == fWEClient->getPmCount())
                 break;
@@ -1183,7 +1183,7 @@ void AlterTableProcessor::dropColumn(uint32_t sessionID, execplan::CalpontSystem
     cout << "Alter table drop column sending WE_SVR_DELETE_SYSCOLUMN_ROW to pm " << pmNum << endl;
 #endif
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);
@@ -1249,7 +1249,7 @@ void AlterTableProcessor::dropColumn(uint32_t sessionID, execplan::CalpontSystem
       cout << "Alter table drop column sending WE_SVR_UPDATE_SYSTABLE_AUTO to pm " << pmNum << endl;
 #endif
 
-      while (1)
+      while (true)
       {
         bsIn.reset(new ByteStream());
         fWEClient->read(uniqueId, bsIn);
@@ -1314,7 +1314,7 @@ void AlterTableProcessor::dropColumn(uint32_t sessionID, execplan::CalpontSystem
     cout << "Alter table drop column sending WE_SVR_UPDATE_SYSTABLE_AUTO to pm " << pmNum << endl;
 #endif
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);
@@ -1401,7 +1401,7 @@ void AlterTableProcessor::dropColumn(uint32_t sessionID, execplan::CalpontSystem
     bsIn.reset(new ByteStream());
     ByteStream::byte tmp8;
 
-    while (1)
+    while (true)
     {
       if (msgRecived == fWEClient->getPmCount())
         break;
@@ -1586,7 +1586,7 @@ void AlterTableProcessor::setColumnDefault(uint32_t sessionID, execplan::Calpont
   {
     fWEClient->write(bs, (uint32_t)pmNum);
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);
@@ -1671,7 +1671,7 @@ void AlterTableProcessor::dropColumnDefault(uint32_t sessionID, execplan::Calpon
   {
     fWEClient->write(bs, (uint32_t)pmNum);
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);
@@ -1862,7 +1862,7 @@ void AlterTableProcessor::renameTable(uint32_t sessionID, execplan::CalpontSyste
     cout << "Rename table sending WE_SVR_UPDATE_SYSTABLE_TABLENAME to pm " << pmNum << endl;
 #endif
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);
@@ -1926,7 +1926,7 @@ void AlterTableProcessor::renameTable(uint32_t sessionID, execplan::CalpontSyste
     cout << "Rename table sending WE_SVR_UPDATE_SYSCOLUMN_TABLENAME to pm " << pmNum << endl;
 #endif
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);
@@ -2145,7 +2145,7 @@ void AlterTableProcessor::tableComment(uint32_t sessionID, execplan::CalpontSyst
   {
     fWEClient->write(bs, (uint32_t)pmNum);
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);
@@ -2284,7 +2284,7 @@ void AlterTableProcessor::renameColumn(uint32_t sessionID, execplan::CalpontSyst
       {
         fWEClient->write(bs, (uint32_t)pmNum);
 
-        while (1)
+        while (true)
         {
           bsIn.reset(new ByteStream());
           fWEClient->read(uniqueId, bsIn);
@@ -2396,7 +2396,7 @@ void AlterTableProcessor::renameColumn(uint32_t sessionID, execplan::CalpontSyst
     {
       fWEClient->write(bs, (uint32_t)pmNum);
 
-      while (1)
+      while (true)
       {
         bsIn.reset(new ByteStream());
         fWEClient->read(uniqueId, bsIn);

--- a/dbcon/ddlpackageproc/altertableprocessor.cpp
+++ b/dbcon/ddlpackageproc/altertableprocessor.cpp
@@ -91,190 +91,103 @@ bool typesAreSame(const CalpontSystemCatalog::ColType& colType, const ColumnType
 {
   switch (colType.colDataType)
   {
-    case (CalpontSystemCatalog::BIT):
-      if (newType.fType == DDL_BIT)
-        return true;
-
-      break;
+    case (CalpontSystemCatalog::BIT): return (newType.fType == DDL_BIT);
 
     case (CalpontSystemCatalog::TINYINT):
-      if (newType.fType == DDL_TINYINT && colType.precision == newType.fPrecision &&
-          colType.scale == newType.fScale)
-        return true;
-
+      return (newType.fType == DDL_TINYINT && colType.precision == newType.fPrecision &&
+              colType.scale == newType.fScale);
       //@Bug 5443 Not allow user change data type.
       // Not sure this is possible...
       // if (newType.fType == DDL_DECIMAL && colType.precision == newType.fPrecision &&
       //	colType.scale == newType.fScale) return true;
-      break;
 
     case (CalpontSystemCatalog::UTINYINT):
-      if (newType.fType == DDL_UNSIGNED_TINYINT && colType.precision == newType.fPrecision &&
-          colType.scale == newType.fScale)
-        return true;
-
-      break;
+      return (newType.fType == DDL_UNSIGNED_TINYINT && colType.precision == newType.fPrecision &&
+              colType.scale == newType.fScale);
 
     case (CalpontSystemCatalog::CHAR):
-      if (newType.fType == DDL_CHAR && colType.colWidth == newType.fLength)
-        return true;
-
-      break;
+      return (newType.fType == DDL_CHAR && colType.colWidth == newType.fLength);
 
     case (CalpontSystemCatalog::SMALLINT):
-      if (newType.fType == DDL_SMALLINT && colType.precision == newType.fPrecision &&
-          colType.scale == newType.fScale)
-        return true;
-
+      return (newType.fType == DDL_SMALLINT && colType.precision == newType.fPrecision &&
+              colType.scale == newType.fScale);
       // if (newType.fType == DDL_DECIMAL && colType.precision == newType.fPrecision &&
       //	colType.scale == newType.fScale) return true;
-      break;
 
     case (CalpontSystemCatalog::USMALLINT):
-      if (newType.fType == DDL_UNSIGNED_SMALLINT && colType.precision == newType.fPrecision &&
-          colType.scale == newType.fScale)
-        return true;
-
-      break;
+      return (newType.fType == DDL_UNSIGNED_SMALLINT && colType.precision == newType.fPrecision &&
+              colType.scale == newType.fScale);
 
     case (CalpontSystemCatalog::DECIMAL):
-      if ((newType.fType == DDL_DECIMAL || newType.fType == DDL_NUMERIC) &&
-          colType.precision == newType.fPrecision && colType.scale == newType.fScale)
-        return true;
-
-      break;
+      return ((newType.fType == DDL_DECIMAL || newType.fType == DDL_NUMERIC) &&
+              colType.precision == newType.fPrecision && colType.scale == newType.fScale);
 
     case (CalpontSystemCatalog::UDECIMAL):
-      if ((newType.fType == DDL_UNSIGNED_DECIMAL || newType.fType == DDL_UNSIGNED_NUMERIC) &&
-          colType.precision == newType.fPrecision && colType.scale == newType.fScale)
-        return true;
-
-      break;
+      return ((newType.fType == DDL_UNSIGNED_DECIMAL || newType.fType == DDL_UNSIGNED_NUMERIC) &&
+              colType.precision == newType.fPrecision && colType.scale == newType.fScale);
 
     case (CalpontSystemCatalog::MEDINT):
-      if (newType.fType == DDL_MEDINT && colType.precision == newType.fPrecision &&
-          colType.scale == newType.fScale)
-        return true;
-
+      return (newType.fType == DDL_MEDINT && colType.precision == newType.fPrecision &&
+              colType.scale == newType.fScale);
       //@Bug 5443 Not allow user change data type.
       // if (newType.fType == DDL_DECIMAL && colType.precision == newType.fPrecision &&
       //	colType.scale == newType.fScale) return true;
-      break;
 
     case (CalpontSystemCatalog::UMEDINT):
-      if (newType.fType == DDL_UNSIGNED_MEDINT && colType.precision == newType.fPrecision &&
-          colType.scale == newType.fScale)
-        return true;
-
-      break;
+      return (newType.fType == DDL_UNSIGNED_MEDINT && colType.precision == newType.fPrecision &&
+              colType.scale == newType.fScale);
 
     case (CalpontSystemCatalog::INT):
-      if (newType.fType == DDL_INT && colType.precision == newType.fPrecision &&
-          colType.scale == newType.fScale)
-        return true;
-
+      return (newType.fType == DDL_INT && colType.precision == newType.fPrecision &&
+              colType.scale == newType.fScale);
       // if (newType.fType == DDL_DECIMAL && colType.precision == newType.fPrecision &&
       //	colType.scale == newType.fScale) return true;
-      break;
 
     case (CalpontSystemCatalog::UINT):
-      if (newType.fType == DDL_UNSIGNED_INT && colType.precision == newType.fPrecision &&
-          colType.scale == newType.fScale)
-        return true;
+      return (newType.fType == DDL_UNSIGNED_INT && colType.precision == newType.fPrecision &&
+              colType.scale == newType.fScale);
 
-      break;
+    case (CalpontSystemCatalog::FLOAT): return (newType.fType == DDL_FLOAT);
 
-    case (CalpontSystemCatalog::FLOAT):
-      if (newType.fType == DDL_FLOAT)
-        return true;
+    case (CalpontSystemCatalog::UFLOAT): return (newType.fType == DDL_UNSIGNED_FLOAT);
 
-      break;
-
-    case (CalpontSystemCatalog::UFLOAT):
-      if (newType.fType == DDL_UNSIGNED_FLOAT)
-        return true;
-
-      break;
-
-    case (CalpontSystemCatalog::DATE):
-      if (newType.fType == DDL_DATE)
-        return true;
-
-      break;
+    case (CalpontSystemCatalog::DATE): return (newType.fType == DDL_DATE);
 
     case (CalpontSystemCatalog::BIGINT):
-      if (newType.fType == DDL_BIGINT && colType.precision == newType.fPrecision &&
-          colType.scale == newType.fScale)
-        return true;
-
+      return (newType.fType == DDL_BIGINT && colType.precision == newType.fPrecision &&
+              colType.scale == newType.fScale);
       //@Bug 5443 Not allow user change data type.
       // decimal is mapped to bigint in syscat
       // if (newType.fType == DDL_DECIMAL && colType.precision == newType.fPrecision &&
       //	colType.scale == newType.fScale) return true;
-      break;
 
     case (CalpontSystemCatalog::UBIGINT):
-      if (newType.fType == DDL_UNSIGNED_BIGINT && colType.precision == newType.fPrecision &&
-          colType.scale == newType.fScale)
-        return true;
+      return (newType.fType == DDL_UNSIGNED_BIGINT && colType.precision == newType.fPrecision &&
+              colType.scale == newType.fScale);
 
-      break;
+    case (CalpontSystemCatalog::DOUBLE): return (newType.fType == DDL_DOUBLE);
 
-    case (CalpontSystemCatalog::DOUBLE):
-      if (newType.fType == DDL_DOUBLE)
-        return true;
+    case (CalpontSystemCatalog::UDOUBLE): return (newType.fType == DDL_UNSIGNED_DOUBLE);
 
-      break;
+    case (CalpontSystemCatalog::DATETIME): return (newType.fType == DDL_DATETIME);
 
-    case (CalpontSystemCatalog::UDOUBLE):
-      if (newType.fType == DDL_UNSIGNED_DOUBLE)
-        return true;
+    case (CalpontSystemCatalog::TIMESTAMP): return (newType.fType == DDL_TIMESTAMP);
 
-      break;
-
-    case (CalpontSystemCatalog::DATETIME):
-      if (newType.fType == DDL_DATETIME)
-        return true;
-
-      break;
-
-    case (CalpontSystemCatalog::TIMESTAMP):
-      if (newType.fType == DDL_TIMESTAMP)
-        return true;
-
-      break;
-
-    case (CalpontSystemCatalog::TIME):
-      if (newType.fType == DDL_TIME)
-        return true;
-
-      break;
+    case (CalpontSystemCatalog::TIME): return (newType.fType == DDL_TIME);
 
     case (CalpontSystemCatalog::VARCHAR):
-      if (newType.fType == DDL_VARCHAR && colType.colWidth == newType.fLength)
-        return true;
-
-      break;
+      return (newType.fType == DDL_VARCHAR && colType.colWidth == newType.fLength);
 
     case (CalpontSystemCatalog::VARBINARY):
-      if (newType.fType == DDL_VARBINARY && colType.colWidth == newType.fLength)
-        return true;
-
-      break;
+      return (newType.fType == DDL_VARBINARY && colType.colWidth == newType.fLength);
 
     case (CalpontSystemCatalog::CLOB): break;
 
     case (CalpontSystemCatalog::BLOB):
-      if (newType.fType == DDL_BLOB && colType.colWidth == newType.fLength)
-        return true;
-
-      break;
+      return (newType.fType == DDL_BLOB && colType.colWidth == newType.fLength);
 
     case (CalpontSystemCatalog::TEXT):
-      if (newType.fType == DDL_TEXT && colType.colWidth == newType.fLength)
-        return true;
-
-      break;
+      return (newType.fType == DDL_TEXT && colType.colWidth == newType.fLength);
 
     default: break;
   }

--- a/dbcon/ddlpackageproc/createtableprocessor.cpp
+++ b/dbcon/ddlpackageproc/createtableprocessor.cpp
@@ -255,7 +255,7 @@ CreateTableProcessor::DDLResult CreateTableProcessor::processPackage(
 #endif
 
     uint32_t numColumnOids = numColumns + numDictCols;
-    numColumnOids += 1; // MCOL-5021
+    numColumnOids += 1;  // MCOL-5021
 
     if (fStartingColOID < 0)
     {
@@ -316,7 +316,7 @@ CreateTableProcessor::DDLResult CreateTableProcessor::processPackage(
 #endif
       fWEClient->write(bytestream, (unsigned)pmNum);
 
-      while (1)
+      while (true)
       {
         bsIn.reset(new ByteStream());
         fWEClient->read(uniqueId, bsIn);
@@ -437,7 +437,7 @@ CreateTableProcessor::DDLResult CreateTableProcessor::processPackage(
 #endif
       fWEClient->write(bytestream, (uint32_t)pmNum);
 
-      while (1)
+      while (true)
       {
         bsIn.reset(new ByteStream());
         fWEClient->read(uniqueId, bsIn);
@@ -644,7 +644,7 @@ CreateTableProcessor::DDLResult CreateTableProcessor::processPackage(
 #endif
       fWEClient->write(bytestream, pmNum);
 
-      while (1)
+      while (true)
       {
         bsIn.reset(new ByteStream());
         fWEClient->read(uniqueId, bsIn);
@@ -687,7 +687,7 @@ CreateTableProcessor::DDLResult CreateTableProcessor::processPackage(
 
         fWEClient->write(bytestream, pmNum);
 
-        while (1)
+        while (true)
         {
           bsIn.reset(new ByteStream());
           fWEClient->read(uniqueId, bsIn);

--- a/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
+++ b/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
@@ -21,7 +21,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-//#define NDEBUG
+// #define NDEBUG
 #include <cassert>
 using namespace std;
 
@@ -508,7 +508,7 @@ void DDLPackageProcessor::removeFiles(const uint64_t uniqueId,
 
     bsIn.reset(new ByteStream());
 
-    while (1)
+    while (true)
     {
       if (msgRecived == fWEClient->getPmCount())
         break;
@@ -562,10 +562,9 @@ void DDLPackageProcessor::createFiles(CalpontSystemCatalog::TableName aTableName
 {
   SUMMARY_INFO("DDLPackageProcessor::createFiles");
   boost::shared_ptr<CalpontSystemCatalog> systemCatalogPtr =
-    CalpontSystemCatalog::makeCalpontSystemCatalog(1);
+      CalpontSystemCatalog::makeCalpontSystemCatalog(1);
   CalpontSystemCatalog::RIDList ridList = systemCatalogPtr->columnRIDs(aTableName);
-  CalpontSystemCatalog::OID tableAUXColOid =
-    systemCatalogPtr->tableAUXColumnOID(aTableName);
+  CalpontSystemCatalog::OID tableAUXColOid = systemCatalogPtr->tableAUXColumnOID(aTableName);
 
   if (tableAUXColOid > 3000)
   {
@@ -618,7 +617,7 @@ void DDLPackageProcessor::createFiles(CalpontSystemCatalog::TableName aTableName
     fWEClient->write(bytestream, (uint32_t)pmNum);
     bsIn.reset(new ByteStream());
 
-    while (1)
+    while (true)
     {
       fWEClient->read(uniqueId, bsIn);
 
@@ -784,7 +783,7 @@ void DDLPackageProcessor::createWriteDropLogFile(execplan::CalpontSystemCatalog:
   {
     fWEClient->write(bytestream, (uint32_t)parentId);
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);
@@ -845,7 +844,7 @@ void DDLPackageProcessor::deleteLogFile(LogFileType fileType, execplan::CalpontS
   {
     fWEClient->write(bytestream, (uint32_t)parentId);
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);
@@ -913,7 +912,7 @@ void DDLPackageProcessor::fetchLogFile(TableLogInfo& tableLogInfos, uint64_t uni
   {
     fWEClient->write(bytestream, (uint32_t)parentId);
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);
@@ -1019,7 +1018,7 @@ void DDLPackageProcessor::createWritePartitionLogFile(
   {
     fWEClient->write(bytestream, (uint32_t)parentId);
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);
@@ -1088,7 +1087,7 @@ void DDLPackageProcessor::createWriteTruncateTableLogFile(
   {
     fWEClient->write(bytestream, (uint32_t)parentId);
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);
@@ -1423,7 +1422,7 @@ int DDLPackageProcessor::rollBackTransaction(uint64_t uniqueId, BRM::TxnID txnID
   ByteStream::byte tmp8;
   std::string errorMsg;
 
-  while (1)
+  while (true)
   {
     if (msgRecived == fWEClient->getPmCount())
       break;
@@ -1463,7 +1462,7 @@ int DDLPackageProcessor::rollBackTransaction(uint64_t uniqueId, BRM::TxnID txnID
     bsIn.reset(new ByteStream());
     msgRecived = 0;
 
-    while (1)
+    while (true)
     {
       if (msgRecived == fWEClient->getPmCount())
         break;

--- a/dbcon/ddlpackageproc/droptableprocessor.cpp
+++ b/dbcon/ddlpackageproc/droptableprocessor.cpp
@@ -228,7 +228,6 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackage(
           abs_ts.tv_nsec = rm_ts.tv_nsec;
         } while (nanosleep(&abs_ts, &rm_ts) < 0);
 
-
         try
         {
           processID = ::getpid();
@@ -336,7 +335,7 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackage(
       // cout << "deleting systable entries with txnid " << txnID.id << endl;
       fWEClient->write(bytestream, (uint32_t)pmNum);
 
-      while (1)
+      while (true)
       {
         bsIn.reset(new ByteStream());
         fWEClient->read(uniqueId, bsIn);
@@ -429,7 +428,7 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackage(
 #endif
       fWEClient->write(bytestream, (unsigned)pmNum);
 
-      while (1)
+      while (true)
       {
         bsIn.reset(new ByteStream());
         fWEClient->read(uniqueId, bsIn);
@@ -645,7 +644,7 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackage(
     bsIn.reset(new ByteStream());
     ByteStream::byte tmp8;
 
-    while (1)
+    while (true)
     {
       if (msgRecived == fWEClient->getPmCount())
         break;
@@ -886,7 +885,6 @@ TruncTableProcessor::DDLResult TruncTableProcessor::processPackage(
           abs_ts.tv_nsec = rm_ts.tv_nsec;
         } while (nanosleep(&abs_ts, &rm_ts) < 0);
 
-
         try
         {
           processID = ::getpid();
@@ -1072,7 +1070,7 @@ TruncTableProcessor::DDLResult TruncTableProcessor::processPackage(
 
       bsIn.reset(new ByteStream());
 
-      while (1)
+      while (true)
       {
         if (msgRecived == fWEClient->getPmCount())
           break;
@@ -1212,7 +1210,7 @@ TruncTableProcessor::DDLResult TruncTableProcessor::processPackage(
 #endif
       fWEClient->write(bytestream, pmNum);
 
-      while (1)
+      while (true)
       {
         bsIn.reset(new ByteStream());
         fWEClient->read(uniqueId, bsIn);
@@ -1252,7 +1250,7 @@ TruncTableProcessor::DDLResult TruncTableProcessor::processPackage(
 
         fWEClient->write(bytestream, pmNum);
 
-        while (1)
+        while (true)
         {
           bsIn.reset(new ByteStream());
           fWEClient->read(uniqueId, bsIn);
@@ -1380,4 +1378,3 @@ TruncTableProcessor::DDLResult TruncTableProcessor::processPackage(
 }
 
 }  // namespace ddlpackageprocessor
-

--- a/dbcon/dmlpackageproc/deletepackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/deletepackageprocessor.cpp
@@ -174,7 +174,6 @@ DMLPackageProcessor::DMLResult DeletePackageProcessor::processPackage(dmlpackage
               abs_ts.tv_nsec = rm_ts.tv_nsec;
             } while (nanosleep(&abs_ts, &rm_ts) < 0);
 
-
             try
             {
               processID = ::getpid();
@@ -660,7 +659,7 @@ bool DeletePackageProcessor::processRowgroup(ByteStream& aRowGroup, DMLResult& r
   {
     fWEClient->write_to_all(bytestream);
 
-    while (1)
+    while (true)
     {
       if (msgRecived == fWEClient->getPmCount())
         break;
@@ -723,7 +722,7 @@ bool DeletePackageProcessor::processRowgroup(ByteStream& aRowGroup, DMLResult& r
   }
   else
   {
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
 
@@ -841,7 +840,7 @@ bool DeletePackageProcessor::receiveAll(DMLResult& result, const uint64_t unique
     ByteStream::quadbyte tmp32;
     uint64_t blocksChanged = 0;
 
-    while (1)
+    while (true)
     {
       if (msgReceived == messagesNotReceived)
         break;

--- a/dbcon/dmlpackageproc/dmlpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/dmlpackageprocessor.cpp
@@ -323,7 +323,7 @@ int DMLPackageProcessor::rollBackTransaction(uint64_t uniqueId, BRM::TxnID txnID
     bsIn.reset(new ByteStream());
     ByteStream::byte tmp8;
 
-    while (1)
+    while (true)
     {
       if (msgRecived == fWEClient->getPmCount())
         break;
@@ -444,7 +444,7 @@ int DMLPackageProcessor::commitBatchAutoOnTransaction(uint64_t uniqueId, BRM::Tx
   typedef std::vector<BRM::BulkSetHWMArg> BulkSetHWMArgs;
   std::vector<BulkSetHWMArgs> hwmArgsAllPms;
 
-  while (1)
+  while (true)
   {
     if (msgRecived == fWEClient->getPmCount())
       break;
@@ -540,7 +540,7 @@ int DMLPackageProcessor::commitBatchAutoOnTransaction(uint64_t uniqueId, BRM::Tx
   msgRecived = 0;
   fWEClient->write_to_all(bytestream);
 
-  while (1)
+  while (true)
   {
     if (msgRecived == fWEClient->getPmCount())
       break;
@@ -609,7 +609,7 @@ int DMLPackageProcessor::rollBackBatchAutoOnTransaction(uint64_t uniqueId, BRM::
   ByteStream::byte tmp8;
 
   // cout << "waiting for reply from WES" << endl;
-  while (1)
+  while (true)
   {
     if (msgRecived == fWEClient->getPmCount())
       break;
@@ -671,7 +671,7 @@ int DMLPackageProcessor::rollBackBatchAutoOnTransaction(uint64_t uniqueId, BRM::
   msgRecived = 0;
   fWEClient->write_to_all(bytestream);
 
-  while (1)
+  while (true)
   {
     if (msgRecived == fWEClient->getPmCount())
       break;
@@ -755,7 +755,7 @@ int DMLPackageProcessor::commitBatchAutoOffTransaction(uint64_t uniqueId, BRM::T
   uint32_t msgRecived = 0;
   fWEClient->write_to_all(bytestream);
 
-  while (1)
+  while (true)
   {
     if (msgRecived == fWEClient->getPmCount())
       break;
@@ -796,7 +796,7 @@ int DMLPackageProcessor::rollBackBatchAutoOffTransaction(uint64_t uniqueId, BRM:
   int rc = 0;
   ByteStream::byte tmp8;
 
-  while (1)
+  while (true)
   {
     if (msgRecived == fWEClient->getPmCount())
       break;
@@ -848,7 +848,7 @@ int DMLPackageProcessor::flushDataFiles(int rcIn, std::map<FID, FID>& columnOids
 
   try
   {
-    while (1)
+    while (true)
     {
       if (msgRecived == fWEClient->getPmCount())
         break;
@@ -900,7 +900,7 @@ int DMLPackageProcessor::endTransaction(uint64_t uniqueId, BRM::TxnID txnID, boo
 
   try
   {
-    while (1)
+    while (true)
     {
       if (msgRecived == fWEClient->getPmCount())
         break;

--- a/dbcon/dmlpackageproc/updatepackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/updatepackageprocessor.cpp
@@ -22,7 +22,7 @@
 #include <fstream>
 #include <ctype.h>
 #include <string>
-//#define NDEBUG
+// #define NDEBUG
 #include <cassert>
 #include <map>
 #include <boost/scoped_ptr.hpp>
@@ -57,7 +57,7 @@ using namespace messageqcpp;
 using namespace BRM;
 using namespace oam;
 
-//#define PROFILE 1
+// #define PROFILE 1
 namespace dmlpackageprocessor
 {
 // StopWatch timer;
@@ -117,9 +117,9 @@ DMLPackageProcessor::DMLResult UpdatePackageProcessor::processPackage(dmlpackage
   fWEClient->addQueue(uniqueId);
   execplan::CalpontSystemCatalog::ROPair roPair;
 
-  //#ifdef PROFILE
+  // #ifdef PROFILE
   //	StopWatch timer;
-  //#endif
+  // #endif
   try
   {
     LoggingID logid(DMLLoggingId, fSessionID, txnid.id);
@@ -200,7 +200,6 @@ DMLPackageProcessor::DMLResult UpdatePackageProcessor::processPackage(dmlpackage
               abs_ts.tv_sec = rm_ts.tv_sec;
               abs_ts.tv_nsec = rm_ts.tv_nsec;
             } while (nanosleep(&abs_ts, &rm_ts) < 0);
-
 
             try
             {
@@ -742,7 +741,7 @@ bool UpdatePackageProcessor::processRowgroup(ByteStream& aRowGroup, DMLResult& r
     cpackage.write(bytestream);
     fWEClient->write_to_all(bytestream);
 
-    while (1)
+    while (true)
     {
       if (msgRecived == fWEClient->getPmCount())
         break;
@@ -812,7 +811,7 @@ bool UpdatePackageProcessor::processRowgroup(ByteStream& aRowGroup, DMLResult& r
   }
   else
   {
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
 
@@ -944,7 +943,7 @@ bool UpdatePackageProcessor::receiveAll(DMLResult& result, const uint64_t unique
     ByteStream::quadbyte tmp32;
     uint64_t blocksChanged = 0;
 
-    while (1)
+    while (true)
     {
       if (msgReceived == messagesNotReceived)
         break;

--- a/dbcon/execplan/aggregatecolumn.cpp
+++ b/dbcon/execplan/aggregatecolumn.cpp
@@ -157,7 +157,8 @@ string AggregateColumn::toCppCode(IncludeSet& includes) const
   stringstream ss;
   auto fContent = fData.substr(fFunctionName.size() + 1, fData.size() - fFunctionName.size() - 2);
 
-  ss << "AggregateColumn(" << std::quoted(fFunctionName) << ", " << std::quoted(fContent) << ", " << sessionID() << ")";
+  ss << "AggregateColumn(" << std::quoted(fFunctionName) << ", " << std::quoted(fContent) << ", "
+     << sessionID() << ")";
 
   return ss.str();
 }
@@ -278,9 +279,7 @@ bool AggregateColumn::operator==(const AggregateColumn& t) const
     return false;
 
   if (aggParms().size() != t.aggParms().size())
-  {
     return false;
-  }
 
   for (it = fAggParms.begin(), it2 = t.fAggParms.begin(); it != fAggParms.end(); ++it, ++it2)
   {

--- a/dbcon/execplan/operator.cpp
+++ b/dbcon/execplan/operator.cpp
@@ -241,10 +241,7 @@ void Operator::unserialize(messageqcpp::ByteStream& b)
 
 bool Operator::operator==(const Operator& t) const
 {
-  if (fOp == t.fOp)
-    return true;
-
-  return false;
+  return (fOp == t.fOp);
 }
 
 bool Operator::operator==(const TreeNode* t) const

--- a/dbcon/execplan/sessionmonitor.cpp
+++ b/dbcon/execplan/sessionmonitor.cpp
@@ -477,10 +477,7 @@ bool SessionMonitor::isStaleSIDTID(const SIDTIDEntry& a, const MonSIDTIDEntry& b
 
 bool SessionMonitor::isEqualSIDTID(const SIDTIDEntry& a, const MonSIDTIDEntry& b) const
 {
-  if (a.sessionid == b.sessionid && a.txnid.id == b.txnid.id && a.txnid.valid == b.txnid.valid)
-    return true;
-
-  return false;
+  return (a.sessionid == b.sessionid && a.txnid.id == b.txnid.id && a.txnid.valid == b.txnid.valid);
 }
 
 vector<SessionMonitor::MonSIDTIDEntry_t*> SessionMonitor::timedOutTxns()

--- a/dbcon/joblist/fifo.h
+++ b/dbcon/joblist/fifo.h
@@ -318,10 +318,7 @@ inline void FIFO<element_t>::waitTillReadyForInserts()
 template <typename element_t>
 inline bool FIFO<element_t>::isOutputBlocked() const
 {
-  if (ppos == fMaxElements)
-    return true;
-  else
-    return false;
+  return (ppos == fMaxElements);
 }
 
 template <typename element_t>
@@ -528,4 +525,3 @@ void FIFO<element_t>::totalFileCounts(uint64_t& numFiles, uint64_t& numBytes) co
 }
 
 }  // namespace joblist
-

--- a/dbcon/joblist/tdriver-deliver.cpp
+++ b/dbcon/joblist/tdriver-deliver.cpp
@@ -396,7 +396,7 @@ void runStep(DeliveryStep& dstep, const string& message)
 //...Perform table band projection and serialization in succession
 #if 0
 
-    while (1)
+    while (true)
     {
         // timer.start(nextBandMsg);
         tb = dstep.nextBand();
@@ -435,7 +435,7 @@ void runStep(DeliveryStep& dstep, const string& message)
   pthread_create(&projectionThread, 0, projectThreadWrapper, &tableBandMgr);
   // timer.stop (thrCreateMsg);
 
-  while (1)
+  while (true)
   {
     //...The amount of time we spend waiting will help tell us how
     //...much extra time is being spent constructing the table bands

--- a/dbcon/joblist/tuple-bps.cpp
+++ b/dbcon/joblist/tuple-bps.cpp
@@ -19,7 +19,7 @@
 //  $Id: tuple-bps.cpp 9705 2013-07-17 20:06:07Z pleblanc $
 
 #include <unistd.h>
-//#define NDEBUG
+// #define NDEBUG
 #include <cassert>
 #include <sstream>
 #include <iomanip>
@@ -77,7 +77,7 @@ using namespace querytele;
 
 #include "columnwidth.h"
 #include "pseudocolumn.h"
-//#define DEBUG 1
+// #define DEBUG 1
 
 extern boost::mutex fileLock_g;
 
@@ -556,14 +556,14 @@ TupleBPS::TupleBPS(const pColScanStep& rhs, const JobInfo& jobInfo) : BatchPrimi
 
       throw runtime_error(oss.str());
     }
-    catch(std::exception& ex)
+    catch (std::exception& ex)
     {
       std::ostringstream oss;
       oss << "Error getting AUX column OID for table " << tableName.toString();
       oss << " due to:  " << ex.what();
       throw runtime_error(oss.str());
     }
-    catch(...)
+    catch (...)
     {
       std::ostringstream oss;
       oss << "Error getting AUX column OID for table " << tableName.toString();
@@ -2412,7 +2412,7 @@ void TupleBPS::receiveMultiPrimitiveMessages()
   {
     tplLock.lock();
 
-    while (1)
+    while (true)
     {
       // sync with the send side
       while (!finishedSending && msgsSent == msgsRecvd)

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -6544,10 +6544,7 @@ bool isMCSTable(TABLE* table_ptr)
   string engineName = table_ptr->s->db_plugin->name.str;
 #endif
 
-  if (engineName == "Columnstore" || engineName == "Columnstore_cache")
-    return true;
-  else
-    return false;
+  return (engineName == "Columnstore" || engineName == "Columnstore_cache");
 }
 
 bool isForeignTableUpdate(THD* thd)
@@ -6597,10 +6594,7 @@ bool isMCSTableDelete(THD* thd)
 
   TABLE_LIST* table_ptr = lex->first_select_lex()->get_table_list();
 
-  if (table_ptr && table_ptr->table && isMCSTable(table_ptr->table))
-    return true;
-
-  return false;
+  return (table_ptr && table_ptr->table && isMCSTable(table_ptr->table));
 }
 
 // This function is different from isForeignTableUpdate()

--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -308,10 +308,7 @@ struct cal_connection_info
   bool checkQueryStats(config::Config* cfg)
   {
     std::string qsVal = cfg->getConfig("QueryStats", "Enabled");
-    if (qsVal == "Y" || qsVal == "Y")
-      return true;
-
-    return false;
+    return (qsVal == "Y" || qsVal == "Y");
   }
 
   static bool checkSlave(config::Config* cf = nullptr)

--- a/ddlproc/ddlprocessor.cpp
+++ b/ddlproc/ddlprocessor.cpp
@@ -35,7 +35,7 @@ using namespace std;
 #include "markpartitionprocessor.h"
 #include "restorepartitionprocessor.h"
 #include "droppartitionprocessor.h"
-//#define 	SERIALIZE_DDL_DML_CPIMPORT 	1
+// #define 	SERIALIZE_DDL_DML_CPIMPORT 	1
 
 #include "cacheutils.h"
 #include "vss.h"
@@ -837,7 +837,7 @@ int DDLProcessor::commitTransaction(uint32_t txnID, std::string& errorMsg)
   int rc = 0;
   ByteStream::byte tmp8;
 
-  while (1)
+  while (true)
   {
     if (msgRecived == fPMCount)
       break;

--- a/dmlproc/batchinsertprocessor.cpp
+++ b/dmlproc/batchinsertprocessor.cpp
@@ -293,7 +293,7 @@ void BatchInsertProc::sendNextBatch()
   else
   {
     // cout << "current pm state for pm is false for pm " << fCurrentPMid<< endl;
-    while (1)
+    while (true)
     {
       // cout << "Read from WES for pm id " << (uint32_t) tmp32 << endl;
       bsIn.reset(new ByteStream());
@@ -377,7 +377,7 @@ void BatchInsertProc::receiveOutstandingMsg()
     string errorMsg;
     uint32_t msgReceived = 0;
 
-    while (1)
+    while (true)
     {
       if (msgReceived == messagesNotReceived)
         break;
@@ -430,7 +430,7 @@ void BatchInsertProc::receiveAllMsg()
 
   try
   {
-    while (1)
+    while (true)
     {
       if (msgRevd == fWEClient->getPmCount())
         break;

--- a/primitives/blockcache/iomanager.cpp
+++ b/primitives/blockcache/iomanager.cpp
@@ -61,7 +61,7 @@
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 #include <pthread.h>
-//#define NDEBUG
+// #define NDEBUG
 #include <cassert>
 
 using namespace std;
@@ -191,20 +191,10 @@ struct fdCacheMapLessThan
 {
   bool operator()(const FdEntry& lhs, const FdEntry& rhs) const
   {
-    if (lhs.oid < rhs.oid)
-      return true;
-
-    if (lhs.oid == rhs.oid && lhs.dbroot < rhs.dbroot)
-      return true;
-
-    if (lhs.oid == rhs.oid && lhs.dbroot == rhs.dbroot && lhs.partNum < rhs.partNum)
-      return true;
-
-    if (lhs.oid == rhs.oid && lhs.dbroot == rhs.dbroot && lhs.partNum == rhs.partNum &&
-        lhs.segNum < rhs.segNum)
-      return true;
-
-    return false;
+    return ((lhs.oid < rhs.oid) || (lhs.oid == rhs.oid && lhs.dbroot < rhs.dbroot) ||
+            (lhs.oid == rhs.oid && lhs.dbroot == rhs.dbroot && lhs.partNum < rhs.partNum) ||
+            (lhs.oid == rhs.oid && lhs.dbroot == rhs.dbroot && lhs.partNum == rhs.partNum &&
+             lhs.segNum < rhs.segNum));
   }
 };
 

--- a/primitives/linux-port/column.cpp
+++ b/primitives/linux-port/column.cpp
@@ -18,7 +18,7 @@
 
 #include <iostream>
 #include <sstream>
-//#define NDEBUG
+// #define NDEBUG
 #include <cassert>
 #include <cmath>
 #include <functional>
@@ -589,9 +589,8 @@ inline bool matchingColValue(
     {
       auto filterValue = filterValues[0];
       // This can be future optimized checking if a filterValue is NULL or not
-      bool cmp =
-          colCompare<KIND, COL_WIDTH, IS_NULL>(curValue, filterValue, filterCOPs[0], filterRFs[0], typeHolder,
-                                               NULL_VALUE);
+      bool cmp = colCompare<KIND, COL_WIDTH, IS_NULL>(curValue, filterValue, filterCOPs[0], filterRFs[0],
+                                                      typeHolder, NULL_VALUE);
       return cmp;
     }
 
@@ -603,13 +602,11 @@ inline bool matchingColValue(
         auto filterValue = filterValues[argIndex];
         // This can be future optimized checking if a filterValues are NULLs or not before the higher level
         // loop.
-        bool cmp = colCompare<KIND, COL_WIDTH, IS_NULL>(curValue, filterValue, filterCOPs[argIndex],
-                                                        filterRFs[argIndex], typeHolder,
-                                                        NULL_VALUE);
+        if (colCompare<KIND, COL_WIDTH, IS_NULL>(curValue, filterValue, filterCOPs[argIndex],
+                                                 filterRFs[argIndex], typeHolder, NULL_VALUE))
+          return true;
 
         // Short-circuit the filter evaluation - true || ... == true
-        if (cmp == true)
-          return true;
       }
 
       // We can get here only if all filters returned false
@@ -625,8 +622,7 @@ inline bool matchingColValue(
         // This can be future optimized checking if a filterValues are NULLs or not before the higher level
         // loop.
         bool cmp = colCompare<KIND, COL_WIDTH, IS_NULL>(curValue, filterValue, filterCOPs[argIndex],
-                                                        filterRFs[argIndex], typeHolder,
-                                                        NULL_VALUE);
+                                                        filterRFs[argIndex], typeHolder, NULL_VALUE);
 
         // Short-circuit the filter evaluation - false && ... = false
         if (cmp == false)
@@ -648,8 +644,7 @@ inline bool matchingColValue(
         // This can be future optimized checking if a filterValues are NULLs or not before the higher level
         // loop.
         bool cmp = colCompare<KIND, COL_WIDTH, IS_NULL>(curValue, filterValue, filterCOPs[argIndex],
-                                                        filterRFs[argIndex], typeHolder,
-                                                        NULL_VALUE);
+                                                        filterRFs[argIndex], typeHolder, NULL_VALUE);
         result ^= cmp;
       }
 
@@ -694,7 +689,8 @@ template <ENUM_KIND KIND, typename T, typename std::enable_if<KIND == KIND_TEXT,
 inline void updateMinMax(T& Min, T& Max, const T curValue, NewColRequestHeader* in)
 {
   constexpr int COL_WIDTH = sizeof(T);
-  const T DUMMY_NULL_VALUE = ~curValue; // it SHALL NOT be equal to curValue, other constraints do not matter.
+  const T DUMMY_NULL_VALUE =
+      ~curValue;  // it SHALL NOT be equal to curValue, other constraints do not matter.
   if (colCompare<KIND_TEXT, COL_WIDTH>(Min, curValue, COMPARE_GT, false, in->colType, DUMMY_NULL_VALUE))
     Min = curValue;
 

--- a/primitives/primproc/tdriver.cpp
+++ b/primitives/primproc/tdriver.cpp
@@ -926,7 +926,7 @@ int main(int argc, char* argv[])
   }
   else if (vm.count("loop"))
   {
-    while (1)
+    while (true)
     {
       testColByScan();
       testColByRid();

--- a/storage-manager/src/IOCoordinator.cpp
+++ b/storage-manager/src/IOCoordinator.cpp
@@ -1271,7 +1271,7 @@ std::shared_ptr<uint8_t[]> IOCoordinator::mergeJournal(const char* object, const
   assert(header.get<int>("version") == 1);
 
   // start processing the entries
-  while (1)
+  while (true)
   {
     uint64_t offlen[2];
     int err = ::read(journalFD, &offlen, 16);
@@ -1438,7 +1438,7 @@ int IOCoordinator::mergeJournalInMem_bigJ(std::shared_ptr<uint8_t[]>& objData, s
   assert(header.get<int>("version") == 1);
 
   // start processing the entries
-  while (1)
+  while (true)
   {
     uint64_t offlen[2];
     int err = ::read(journalFD, &offlen, 16);

--- a/storage-manager/src/ThreadPool.cpp
+++ b/storage-manager/src/ThreadPool.cpp
@@ -83,7 +83,7 @@ void ThreadPool::prune()
   set<ID_Thread>::iterator it;
   boost::unique_lock<boost::mutex> s(mutex);
 
-  while (1)
+  while (true)
   {
     while (pruneable.empty() && !die)
       somethingToPrune.wait(s);

--- a/tools/editem/editem.cpp
+++ b/tools/editem/editem.cpp
@@ -554,7 +554,7 @@ int extendOids()
     cout << "Enter OID, DBRoot, and Partition#, and Segment# "
             "(separated by spaces): ";
 
-    while (1)
+    while (true)
     {
       cin >> oid >> dbRoot >> partNum >> segNum;
 
@@ -574,11 +574,11 @@ int extendOids()
   }
   else
   {
-    while (1)
+    while (true)
     {
       bool bFinished = false;
 
-      while (1)
+      while (true)
       {
         cout << "Enter OID and column width (separated by spaces); "
                 "0 OID represents end of list: ";
@@ -615,7 +615,7 @@ int extendOids()
 
     vector<CreateStripeColumnExtentsArgOut> newExtents;
 
-    while (1)
+    while (true)
     {
       cout << "Enter DBRoot and partition# (partition "
               "only used for empty DBRoot): ";
@@ -663,7 +663,7 @@ int rollbackExtents(OID_t oid)
     vector<uint16_t> segNums;
     vector<HWM_t> hwms;
 
-    while (1)
+    while (true)
     {
       cout << "Enter DBRoot#, part#, and the number of HWMs to be entered "
               "(separated by spaces): ";
@@ -675,7 +675,7 @@ int rollbackExtents(OID_t oid)
 
     for (unsigned int k = 0; k < hwmCount; k++)
     {
-      while (1)
+      while (true)
       {
         cout << "Enter seg# and HWM for that segment file "
              << "(separated by spaces): ";
@@ -693,7 +693,7 @@ int rollbackExtents(OID_t oid)
   }
   else
   {
-    while (1)
+    while (true)
     {
       cout << "Enter DBRoot#, part#, seg#, and HWM for the last extent "
               "on that DBRoot (separated by spaces): ";
@@ -746,7 +746,7 @@ int editHWM(OID_t oid)
   uint32_t partNum = 0;
   uint16_t segNum = 0;
 
-  while (1)
+  while (true)
   {
     cout << "Enter Partition#, and Segment# (separated by spaces): ";
     cin >> partNum >> segNum;

--- a/utils/cloudio/SocketPool.cpp
+++ b/utils/cloudio/SocketPool.cpp
@@ -143,7 +143,7 @@ retry:
   uint i;
   storagemanager::sm_msg_header* resp = NULL;
 
-  while (1)
+  while (true)
   {
     // cout << "SP receiving msg on sock " << sock << endl;
     // here remainingBytes means the # of bytes from the previous message

--- a/utils/common/MonitorProcMem.cpp
+++ b/utils/common/MonitorProcMem.cpp
@@ -51,7 +51,7 @@ int MonitorProcMem::fMemPctCheck = 0;
 void MonitorProcMem::operator()() const
 {
   utils::setThreadName("MonitorProcMem");
-  while (1)
+  while (true)
   {
     if (fMaxPct > 0)
     {
@@ -135,7 +135,7 @@ void MonitorProcMem::pause_() const
   rem.tv_sec = 0;
   rem.tv_nsec = 0;
 
-  while (1)
+  while (true)
   {
 
     if (nanosleep(&req, &rem) != 0)

--- a/utils/dataconvert/dataconvert.h
+++ b/utils/dataconvert/dataconvert.h
@@ -104,7 +104,6 @@ const int64_t IDB_pow[19] = {1,
                              100000000000000000LL,
                              1000000000000000000LL};
 
-
 const int32_t SECS_PER_MIN = 60;
 const int32_t MINS_PER_HOUR = 60;
 const int32_t HOURS_PER_DAY = 24;
@@ -363,13 +362,7 @@ inline int32_t leapsThruEndOf(int32_t year)
 
 inline bool isLeapYear(int year)
 {
-  if (year % 400 == 0)
-    return true;
-
-  if ((year % 4 == 0) && (year % 100 != 0))
-    return true;
-
-  return false;
+  return ((year % 400 == 0) || ((year % 4 == 0) && (year % 100 != 0)));
 }
 
 static uint32_t daysInMonth[13] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31, 0};
@@ -1553,7 +1546,6 @@ inline int128_t strtoll128(const char* data, bool& saturate, char** ep)
 
   return res;
 }
-
 
 template <class T>
 T decimalRangeUp(int32_t precision)

--- a/utils/funcexp/func_find_in_set.cpp
+++ b/utils/funcexp/func_find_in_set.cpp
@@ -77,7 +77,7 @@ int64_t Func_find_in_set::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool
   size_t find_str_len = searchStr.length();
   int position = 0;
   static const char separator = ',';
-  while (1)
+  while (true)
   {
     int symbol_len;
     if ((symbol_len = cs->mb_wc(&wc, (uchar*)str_end, (uchar*)real_end)) > 0)

--- a/utils/funcexp/func_regexp.cpp
+++ b/utils/funcexp/func_regexp.cpp
@@ -220,10 +220,7 @@ inline bool getBool(rowgroup::Row& row, funcexp::FunctionParm& pm, bool& isNull,
   int res = regexec(&re, expr.c_str(), 0, NULL, 0);
   regfree(&re);
 
-  if (res == 0)
-    return true;
-  else
-    return false;
+  return res == 0;
 
 #else
   std::regex pat(pattern.c_str());

--- a/utils/funcexp/utf8/core.h
+++ b/utils/funcexp/utf8/core.h
@@ -107,23 +107,7 @@ inline typename std::iterator_traits<octet_iterator>::difference_type sequence_l
 template <typename octet_difference_type>
 inline bool is_overlong_sequence(uint32_t cp, octet_difference_type length)
 {
-  if (cp < 0x80)
-  {
-    if (length != 1)
-      return true;
-  }
-  else if (cp < 0x800)
-  {
-    if (length != 2)
-      return true;
-  }
-  else if (cp < 0x10000)
-  {
-    if (length != 3)
-      return true;
-  }
-
-  return false;
+  return (cp < 0x80 && length != 1) || (cp < 0x800 && length != 2) || (cp < 0x10000 && length != 3);
 }
 
 enum utf_error

--- a/utils/idbdatafile/PosixFileSystem.cpp
+++ b/utils/idbdatafile/PosixFileSystem.cpp
@@ -120,7 +120,7 @@ size_t readFillBuffer(idbdatafile::IDBDataFile* pFile, char* buffer, size_t byte
   size_t bytesToRead = bytesReq;
   size_t totalBytesRead = 0;
 
-  while (1)
+  while (true)
   {
     nBytes = pFile->read(pBuf, bytesToRead);
 

--- a/utils/joiner/joinpartition.cpp
+++ b/utils/joiner/joinpartition.cpp
@@ -322,7 +322,7 @@ bool JoinPartition::canConvertToSplitMode()
   std::unordered_map<uint32_t, uint32_t> rowDist;
 
   nextSmallOffset = 0;
-  while (1)
+  while (true)
   {
     uint32_t hash;
     readByteStream(0, &bs);
@@ -399,7 +399,7 @@ int64_t JoinPartition::convertToSplitMode()
   Row& row = smallRow;
   nextSmallOffset = 0;
 
-  while (1)
+  while (true)
   {
     readByteStream(0, &bs);
 

--- a/utils/loggingcpp/stopwatch.cpp
+++ b/utils/loggingcpp/stopwatch.cpp
@@ -106,10 +106,7 @@ bool StopWatch::stop(const string& message, const int limit)
 
   fProcessStats[idx].processStop();
 
-  if (fProcessStats[idx].fStopCount >= limit)
-    return true;
-
-  return false;
+  return (fProcessStats[idx].fStopCount >= limit);
 }
 
 void StopWatch::start(const string& message)

--- a/utils/messageqcpp/inetstreamsocket.cpp
+++ b/utils/messageqcpp/inetstreamsocket.cpp
@@ -73,8 +73,6 @@ using namespace std;
 #include <boost/scoped_array.hpp>
 using boost::scoped_array;
 
-
-
 #define INETSTREAMSOCKET_DLLEXPORT
 #include "inetstreamsocket.h"
 #undef INETSTREAMSOCKET_DLLEXPORT
@@ -96,7 +94,6 @@ namespace
 // sometimes seeing "unknown error 512" error msgs in response to calls to
 // read(), so adding logic to retry after ERESTARTSYS the way we do for EINTR.
 // const int KERR_ERESTARTSYS = 512;
-
 
 int in_cksum(unsigned short* buf, int sz)
 {
@@ -171,7 +168,6 @@ void InetStreamSocket::open()
 #endif
     throw runtime_error(msg);
   }
-
 
   /*  XXXPAT:  If we have latency problems again, try these...
       bufferSizeSize = 4;
@@ -380,8 +376,7 @@ bool InetStreamSocket::readToMagic(long msecs, bool* isTimeOut, Stats* stats) co
 
       ostringstream oss;
       oss << "InetStreamSocket::readToMagic(): I/O error2.1: "
-          << "err = " << err << " e = " << e <<
-          ": " << strerror(e);
+          << "err = " << err << " e = " << e << ": " << strerror(e);
       throw runtime_error(oss.str());
     }
 
@@ -880,9 +875,9 @@ const string InetStreamSocket::toString() const
   ostringstream oss;
   char buf[INET_ADDRSTRLEN];
   const SocketParms& sp = fSocketParms;
-  oss << "InetStreamSocket: sd: " << sp.sd() <<
-      " inet: " << inet_ntop(AF_INET, &fSa.sin_addr, buf, INET_ADDRSTRLEN) <<
-      " port: " << ntohs(fSa.sin_port);
+  oss << "InetStreamSocket: sd: " << sp.sd()
+      << " inet: " << inet_ntop(AF_INET, &fSa.sin_addr, buf, INET_ADDRSTRLEN)
+      << " port: " << ntohs(fSa.sin_port);
   return oss.str();
 }
 
@@ -1047,7 +1042,6 @@ int InetStreamSocket::ping(const std::string& ipaddr, const struct timespec* tim
 
   ::close(pingsock);
 
-
   return 0;
 }
 
@@ -1088,10 +1082,7 @@ bool InetStreamSocket::hasData() const
   // EAGAIN | EWOULDBLOCK means the socket is clear. Anything else is data or error
   retval = recv(fSocketParms.sd(), buf, 1, MSG_DONTWAIT);
 
-  if (retval & (EAGAIN | EWOULDBLOCK))
-    return false;
-
-  return true;
+  return !(retval & (EAGAIN | EWOULDBLOCK));
 }
 
 }  // namespace messageqcpp

--- a/utils/messageqcpp/srv.cpp
+++ b/utils/messageqcpp/srv.cpp
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
   ByteStream obs;
   uint32_t qb = 0;
 
-  while (1)
+  while (true)
   {
     ios = mqs.accept();
     ibs = ios.read();

--- a/utils/multicast/impl.cpp
+++ b/utils/multicast/impl.cpp
@@ -1615,7 +1615,7 @@ THREAD_RETURN returnChannelMain(void* args)
 {
   struct returnChannel* returnChannel = (struct returnChannel*)args;
 
-  while (1)
+  while (true)
   {
     struct sockaddr_in from;
     int clNo;
@@ -1726,7 +1726,7 @@ int freeSlice(sender_state_t sendst, struct slice* slice)
   i = slice - sendst->slices;
   slice->state = slice::SLICE_PRE_FREE;
 
-  while (1)
+  while (true)
   {
     int pos = pc_getProducerPosition(sendst->free_slices_pc);
 
@@ -2533,7 +2533,7 @@ void localReader(struct fifo* fifo, const uint8_t* buf, uint32_t len)
   // cerr << "starting to send " << len << " bytes" << endl;
   uint32_t offset = 0;
 
-  while (1)
+  while (true)
   {
     int pos = pc_getConsumerPosition(fifo->freeMemQueue);
     int bytes = pc_consumeContiguousMinAmount(fifo->freeMemQueue, BLOCKSIZE);
@@ -2841,7 +2841,7 @@ void advanceReceivedPointer(struct clientState* clst)
 {
   int pos = clst->receivedPtr;
 
-  while (1)
+  while (true)
   {
     slice_t slice = &clst->slices[pos];
 
@@ -2870,7 +2870,7 @@ void receiverStatsAddBytes(receiver_stats_t rs, long bytes)
 
 void cleanupSlices(struct clientState* clst, unsigned int doneState)
 {
-  while (1)
+  while (true)
   {
     int pos = pc_getProducerPosition(clst->free_slices_pc);
     int bytes;
@@ -3372,7 +3372,7 @@ int writer(struct fifo* fifo, SBS outbs)
   outbs->restart();
   int fifoSize = pc_getSize(fifo->data);
 
-  while (1)
+  while (true)
   {
     int pos = pc_getConsumerPosition(fifo->data);
     int bytes = pc_consumeContiguousMinAmount(fifo->data, BLOCKSIZE);
@@ -3680,7 +3680,7 @@ void MulticastImpl::startReceiver()
 
   fClient_config.clientNumber = 0; /*default number for asynchronous transfer*/
 
-  while (1)
+  while (true)
   {
     // int len;
     int msglen;

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -39,7 +39,6 @@
 #include <cfloat>
 #include <execinfo.h>
 
-
 #include "hasher.h"
 
 #include "joblisttypes.h"
@@ -143,7 +142,7 @@ class StringStore
   // returns the offset.
   // it may receive nullptr as data and it is proper way to store NULL values.
   uint64_t storeString(const uint8_t* data, uint32_t length);
-  //please note getPointer can return nullptr.
+  // please note getPointer can return nullptr.
   inline const uint8_t* getPointer(uint64_t offset) const;
   inline uint32_t getStringLength(uint64_t offset) const;
   inline utils::ConstString getConstString(uint64_t offset) const
@@ -222,7 +221,6 @@ class UserDataStore
   UserDataStore& operator=(const UserDataStore&) = delete;
   UserDataStore& operator=(UserDataStore&&) = delete;
 
-
   void serialize(messageqcpp::ByteStream&) const;
   void deserialize(messageqcpp::ByteStream&);
 
@@ -243,13 +241,11 @@ class UserDataStore
   boost::shared_ptr<mcsv1sdk::UserData> getUserData(uint32_t offset) const;
 
  private:
-
   std::vector<StoreData> vStoreData;
 
   bool fUseUserDataMutex = false;
   boost::mutex fMutex;
 };
-
 
 class RowGroup;
 class Row;
@@ -266,8 +262,6 @@ class RGData
   RGData(const RGData&) = default;
   RGData(RGData&&) = default;
   virtual ~RGData() = default;
-
-
 
   // amount should be the # returned by RowGroup::getDataSize()
   void serialize(messageqcpp::ByteStream&, uint32_t amount) const;
@@ -371,7 +365,7 @@ class Row
   inline uint32_t getColumnWidth(uint32_t colIndex) const;
   inline uint32_t getColumnCount() const;
   inline uint32_t getInternalSize() const;  // this is only accurate if there is no string table
-  inline uint32_t getSize() const;  // this is only accurate if there is no string table
+  inline uint32_t getSize() const;          // this is only accurate if there is no string table
   // if a string table is being used, getRealSize() takes into account variable-length strings
   inline uint32_t getRealSize() const;
   inline uint32_t getOffset(uint32_t colIndex) const;
@@ -606,10 +600,10 @@ class Row
 
   const CHARSET_INFO* getCharset(uint32_t col) const;
 
-private:
- inline bool inStringTable(uint32_t col) const;
+ private:
+  inline bool inStringTable(uint32_t col) const;
 
-private:
+ private:
   uint32_t columnCount = 0;
   uint64_t baseRid = 0;
 
@@ -695,7 +689,7 @@ inline uint32_t Row::getRealSize() const
   if (!useStringTable)
     return getSize();
 
-  uint32_t ret = columnCount; // account for NULL flags.
+  uint32_t ret = columnCount;  // account for NULL flags.
 
   for (uint32_t i = 0; i < columnCount; i++)
   {
@@ -862,8 +856,7 @@ inline int64_t Row::getIntField(uint32_t colIndex) const
 
     case 8: return *((int64_t*)&data[offsets[colIndex]]);
 
-    default:
-      idbassert(0); throw std::logic_error("Row::getIntField(): bad length.");
+    default: idbassert(0); throw std::logic_error("Row::getIntField(): bad length.");
   }
 }
 
@@ -1045,12 +1038,13 @@ inline void Row::setStringField(const utils::ConstString& str, uint32_t colIndex
   else
   {
     uint8_t* buf = &data[offsets[colIndex]];
-    memset(buf + length, 0, offsets[colIndex + 1] - (offsets[colIndex] + length)); // needed for memcmp in equals().
+    memset(buf + length, 0,
+           offsets[colIndex + 1] - (offsets[colIndex] + length));  // needed for memcmp in equals().
     if (str.str())
     {
       memcpy(buf, str.str(), length);
     }
-    else if (colWidth <= 8) // special magic value.
+    else if (colWidth <= 8)  // special magic value.
     {
       setToNull(colIndex);
     }
@@ -1599,7 +1593,7 @@ class RowGroup : public messageqcpp::Serializeable
 
   std::vector<uint32_t> oldOffsets;  // inline data offsets
   std::vector<uint32_t> stOffsets;   // string table offsets
-  uint32_t* offsets = nullptr;                 // offsets either points to oldOffsets or stOffsets
+  uint32_t* offsets = nullptr;       // offsets either points to oldOffsets or stOffsets
   std::vector<uint32_t> colWidths;
   // oids: the real oid of the column, may have duplicates with alias.
   // This oid is necessary for front-end to decide the real column width.
@@ -2048,7 +2042,6 @@ inline void copyRowInline(const Row& in, Row* out, uint32_t colCount)
   copyRow(in, out, colCount);
 }
 
-
 inline utils::NullString StringStore::getString(uint64_t off) const
 {
   uint32_t length;
@@ -2128,9 +2121,7 @@ inline const uint8_t* StringStore::getPointer(uint64_t off) const
 
 inline bool StringStore::isNullValue(uint64_t off) const
 {
- if (off == std::numeric_limits<uint64_t>::max())
-    return true;
-  return false;
+  return (off == std::numeric_limits<uint64_t>::max());
 }
 
 inline uint32_t StringStore::getStringLength(uint64_t off) const

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -28,7 +28,6 @@ using namespace std;
 #include "calpontselectexecutionplan.h"
 #include "rowgroup.h"
 
-
 using namespace boost;
 
 #include "errorids.h"
@@ -535,10 +534,8 @@ bool CompareRule::less(Row::Pointer r1, Row::Pointer r2)
   {
     int c = ((*(*i))(fIdbCompare, r1, r2));
 
-    if (c < 0)
-      return true;
-    else if (c > 0)
-      return false;
+    if (c != 0)
+      return (c < 0);
   }
 
   return false;

--- a/versioning/BRM/extentmap.cpp
+++ b/versioning/BRM/extentmap.cpp
@@ -205,10 +205,7 @@ EMEntry& EMEntry::operator=(const EMEntry& e)
 
 bool EMEntry::operator<(const EMEntry& e) const
 {
-  if (range.start < e.range.start)
-    return true;
-
-  return false;
+  return range.start < e.range.start;
 }
 
 /*static*/
@@ -520,9 +517,7 @@ LBID_tFindResult ExtentMapIndexImpl::search3dLayer(PartitionIndexContainerT& par
 bool ExtentMapIndexImpl::isDBRootEmpty(const DBRootT dbroot)
 {
   ExtentMapIndex& extMapIndex = *get();
-  if (dbroot >= extMapIndex.size())
-    return true;
-  return extMapIndex[dbroot].empty();
+  return dbroot >= extMapIndex.size() || extMapIndex[dbroot].empty();
 }
 
 void ExtentMapIndexImpl::deleteDbRoot(const DBRootT dbroot)

--- a/versioning/BRM/extentmap.h
+++ b/versioning/BRM/extentmap.h
@@ -192,20 +192,11 @@ struct ExtentSorter
 {
   bool operator()(const EMEntry& e1, const EMEntry& e2)
   {
-    if (e1.dbRoot < e2.dbRoot)
-      return true;
-
-    if (e1.dbRoot == e2.dbRoot && e1.partitionNum < e2.partitionNum)
-      return true;
-
-    if (e1.dbRoot == e2.dbRoot && e1.partitionNum == e2.partitionNum && e1.blockOffset < e2.blockOffset)
-      return true;
-
-    if (e1.dbRoot == e2.dbRoot && e1.partitionNum == e2.partitionNum && e1.blockOffset == e2.blockOffset &&
-        e1.segmentNum < e2.segmentNum)
-      return true;
-
-    return false;
+    return (
+        e1.dbRoot < e2.dbRoot || (e1.dbRoot == e2.dbRoot && e1.partitionNum < e2.partitionNum) ||
+        (e1.dbRoot == e2.dbRoot && e1.partitionNum == e2.partitionNum && e1.blockOffset < e2.blockOffset) ||
+        (e1.dbRoot == e2.dbRoot && e1.partitionNum == e2.partitionNum && e1.blockOffset == e2.blockOffset &&
+         e1.segmentNum < e2.segmentNum));
   }
 };
 

--- a/writeengine/bulk/we_bulkloadbuffer.cpp
+++ b/writeengine/bulk/we_bulkloadbuffer.cpp
@@ -47,7 +47,6 @@ using namespace std;
 using namespace boost;
 using namespace execplan;
 
-
 namespace
 {
 const std::string INPUT_ERROR_WRONG_NO_COLUMNS = "Data contains wrong number of columns";
@@ -79,13 +78,13 @@ inline void resizeRowDataArray(char** pRowData, unsigned int dataLength, unsigne
 {
   char* tmpRaw = new char[newArrayCapacity];
   memcpy(tmpRaw, *pRowData, dataLength);
-  delete[] * pRowData;
+  delete[] *pRowData;
   *pRowData = tmpRaw;
 }
 
 }  // namespace
 
-//#define DEBUG_TOKEN_PARSING 1
+// #define DEBUG_TOKEN_PARSING 1
 
 namespace WriteEngine
 {
@@ -3297,10 +3296,7 @@ bool BulkLoadBuffer::setColumnStatus(const int& columnId, const Status& status)
   if (status == WriteEngine::PARSE_COMPLETE)
     fParseComplete++;
 
-  if (fParseComplete == fNumberOfColumns)
-    return true;
-
-  return false;
+  return (fParseComplete == fNumberOfColumns);
 }
 
 //------------------------------------------------------------------------------

--- a/writeengine/bulk/we_colbufmgr.cpp
+++ b/writeengine/bulk/we_colbufmgr.cpp
@@ -130,7 +130,7 @@ int ColumnBufferManager::reserveSection(RID startRowId, uint32_t nRowsIn, uint32
   //..Ensure that ColumnBufferSection allocations are made in input row order
   bool bWaitedForInSequence = false;
 
-  while (1)
+  while (true)
   {
     RID startRowTest = (std::numeric_limits<WriteEngine::RID>::max() == fMaxRowId) ? 0 : fMaxRowId + 1;
 

--- a/writeengine/client/we_ddlcommandclient.cpp
+++ b/writeengine/client/we_ddlcommandclient.cpp
@@ -67,7 +67,7 @@ uint8_t WE_DDLCommandClient::UpdateSyscolumnNextval(uint32_t columnOid, uint64_t
     fOam.getDbrootPmConfig(dbRoot, pmNum);
     fWEClient->write(command, pmNum);
 
-    while (1)
+    while (true)
     {
       bsIn.reset(new ByteStream());
       fWEClient->read(uniqueId, bsIn);

--- a/writeengine/server/we_getfilesizes.cpp
+++ b/writeengine/server/we_getfilesizes.cpp
@@ -74,7 +74,7 @@ size_t readFillBuffer(idbdatafile::IDBDataFile* pFile, char* buffer, size_t byte
   size_t bytesToRead = bytesReq;
   size_t totalBytesRead = 0;
 
-  while (1)
+  while (true)
   {
     nBytes = pFile->read(pBuf, bytesToRead);
 

--- a/writeengine/shared/tconfig.cpp
+++ b/writeengine/shared/tconfig.cpp
@@ -61,7 +61,7 @@ int main()
   int nTest = 0;
   std::cout << std::endl;
 
-  while (1)
+  while (true)
   {
     std::cout << "test" << nTest << "..." << std::endl;
     test();

--- a/writeengine/shared/we_brm.cpp
+++ b/writeengine/shared/we_brm.cpp
@@ -619,7 +619,7 @@ int BRMWrapper::copyVBBlock(IDBDataFile* pSourceFile, const OID sourceOid, IDBDa
       size_t numContiguousBlocksAvaliableForReading = 1;
       size_t tmp = startOffsetInInput;
 
-      while (1)
+      while (true)
       {
         if (numContiguousBlocksAvaliableForReading == spaceAvailableInBuffer)
           break;

--- a/writeengine/shared/we_bulkrollbackfilecompressed.cpp
+++ b/writeengine/shared/we_bulkrollbackfilecompressed.cpp
@@ -927,7 +927,7 @@ size_t BulkRollbackFileCompressed::readFillBuffer(IDBDataFile* pFile, char* buff
   size_t bytesToRead = bytesReq;
   size_t totalBytesRead = 0;
 
-  while (1)
+  while (true)
   {
     nBytes = pFile->read(pBuf, bytesToRead);
 

--- a/writeengine/shared/we_bulkrollbackmgr.cpp
+++ b/writeengine/shared/we_bulkrollbackmgr.cpp
@@ -798,7 +798,7 @@ void BulkRollbackMgr::deleteColumn1ExtentsV4(const char* inBuf)
   // reach a partition that has no column segment files to roll back.
   bool useHdfs = IDBPolicy::useHdfs();
 
-  while (1)
+  while (true)
   {
     std::vector<uint32_t> segList;
     std::string dirName;
@@ -1042,7 +1042,7 @@ void BulkRollbackMgr::deleteColumn2ExtentsV4(const char* inBuf)
   // reach a partition that has no column segment files to roll back.
   bool useHdfs = IDBPolicy::useHdfs();
 
-  while (1)
+  while (true)
   {
     std::vector<uint32_t> segList;
     std::string dirName;
@@ -1272,7 +1272,7 @@ void BulkRollbackMgr::deleteDctnryExtentsV4()
   // reach a partition that has no dctnry store segment files to roll back.
   bool useHdfs = IDBPolicy::useHdfs();
 
-  while (1)
+  while (true)
   {
     std::vector<uint32_t> segList;
     std::string dirName;

--- a/writeengine/shared/we_dbrootextenttracker.cpp
+++ b/writeengine/shared/we_dbrootextenttracker.cpp
@@ -55,10 +55,7 @@ DBRootExtentInfo::DBRootExtentInfo(uint16_t dbRoot, uint32_t partition, uint16_t
 //------------------------------------------------------------------------------
 bool DBRootExtentInfo::operator<(const DBRootExtentInfo& entry) const
 {
-  if (fDbRoot < entry.fDbRoot)
-    return true;
-
-  return false;
+  return (fDbRoot < entry.fDbRoot);
 }
 
 //------------------------------------------------------------------------------

--- a/writeengine/splitter/we_cmdargs.cpp
+++ b/writeengine/splitter/we_cmdargs.cpp
@@ -1286,12 +1286,10 @@ bool WECmdArgs::getPmStatus(int Id)
 
   VecInts::iterator aIt = fPmVec.begin();
 
-  while (aIt != fPmVec.end())
+  for (; aIt != fPmVec.end(); ++aIt)
   {
     if (*aIt == static_cast<unsigned int>(Id))
       return true;
-
-    ++aIt;
   }
 
   return false;


### PR DESCRIPTION
This request contains 2 types of changes:
1) changing the pattern of 
```
if (condition)
  return true;
return false;
```
and similar to it. I went all out on that, which means that there might be places where it became less readable. However, I think that this way it is consistent with both codestyle in the repo and general guidelines. Also, there are definitely places in the codebase where the returned boolean expressions are enormous. Maybe those should be reduced, but that is a different task.

2) Changing the `while (1)` conditions to `while (true)`
Not the best pattern anyway, but it seems that in most places changing it to a meaningful condition would take serious refactoring effort. The way I put it it is at least a better codestyle + it is more consistent now across codebase.