### PR TITLE
fix(pp-threadpool): the workaround for a stuck tests001 in CI

### DIFF
--- a/utils/threadpool/fair_threadpool.cpp
+++ b/utils/threadpool/fair_threadpool.cpp
@@ -228,6 +228,7 @@ void FairThreadPool::threadFcn(const PriorityThreadPool::Priority preferredQueue
       {
         // to avoid excessive CPU usage waiting for data from storage
         usleep(500);
+        runList[0].weight_ += RescheduleWeightIncrement;
         addJob(runList[0]);
       }
     }

--- a/utils/threadpool/fair_threadpool.h
+++ b/utils/threadpool/fair_threadpool.h
@@ -40,6 +40,12 @@
 namespace threadpool
 {
 
+// Meta Jobs, e.g. BATCH_PRIMITIVE_CREATE has very small weight if a number of such Jobs
+// stuck in the scheduler queue they will starve the whole queue so that no Job could be run
+// except these meta jobs.
+constexpr const uint32_t RescheduleWeightIncrement = 10000;
+constexpr const uint32_t MetaJobsInitialWeight = 1;
+
 // The idea of this thread pool is to run morsel jobs(primitive job) is to equaly distribute CPU time
 // b/w multiple parallel queries(thread maps morsel to query using txnId). Query(txnId) has its weight
 // stored in PriorityQueue that thread increases before run another morsel for the query. When query is


### PR DESCRIPTION
    CI ocassionaly stuck running test001 b/c PP threadpool endlessly reschedules
    meta jobs, e.g. BATCH_PRIMITIVE_CREATE, which ByteStreams were somehow damaged or read out.