### PR TITLE
MCOL-5559 This patch extends the scope of the crit section to cover remap operation to avoid access races running EMIndex operations

### DIFF
--- a/versioning/BRM/extentmap.h
+++ b/versioning/BRM/extentmap.h
@@ -372,6 +372,8 @@ class ExtentMapIndexImpl
   {
     if (fInstance_)
     {
+      // effectively umpas a mapped managed shmem segment changing the segment VA address
+      // when mapped next time.
       delete fInstance_;
       fInstance_ = nullptr;
     }


### PR DESCRIPTION
Similar to MCOL-5487. Remap op wasn't covered by an exclusive shmem lock.