### PR TITLE
fix(bootstrap_mcs): this fixes the error introduced by the charset default patch

### DIFF
--- a/build/bootstrap_mcs.sh
+++ b/build/bootstrap_mcs.sh
@@ -363,11 +363,14 @@ disable_plugins_for_bootstrap()
 {
     find /etc -type f -exec sed -i 's/plugin-load-add=auth_gssapi.so//g' {} +
     find /etc -type f -exec sed -i 's/plugin-load-add=ha_columnstore.so//g' {} +
+    find /etc -type f -exec sed -i 's/columnstore_use_import_for_batchinsert = ON//g' {} +
 }
 
 enable_columnstore_back()
 {
     echo plugin-load-add=ha_columnstore.so >> $CONFIG_DIR/columnstore.cnf
+    sed -i '/\[mysqld\]/a\plugin-load-add=ha_columnstore.so' $CONFIG_DIR/columnstore.cnf
+    sed -i '/plugin-load-add=ha_columnstore.so/a\columnstore_use_import_for_batchinsert = ON' $CONFIG_DIR/columnstore.cnf
 }
 
 fix_config_files()


### PR DESCRIPTION
The  patch for MCOL-5519 adds new unrelated default value for columnstore plugin affecting bootstrap_mcs.sh fragile logic. This fixes the issue arised.