### PR TITLE
fix(pp-threadpool): MCOL-5565 the workaround for a stuck tests001 in CI

### DIFF
--- a/primitives/primproc/primitiveserver.cpp
+++ b/primitives/primproc/primitiveserver.cpp
@@ -31,7 +31,7 @@
 #include <mutex>
 #include <stdexcept>
 
-//#define NDEBUG
+// #define NDEBUG
 #include <cassert>
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
@@ -350,7 +350,6 @@ uint32_t loadBlocks(LBID_t* lbids, QueryContext qc, VER_t txn, int compType, uin
 
   *blocksWereVersioned = false;
 
-
   if (LBIDTrace)
   {
     for (i = 0; i < blockCount; i++)
@@ -411,7 +410,6 @@ uint32_t loadBlocks(LBID_t* lbids, QueryContext qc, VER_t txn, int compType, uin
   if (ret != blockCount && doPrefetch)
   {
     prefetchBlocks(lbids[0], compType, &blksRead);
-
 
     if (fPMProfOn)
       pmstats.markEvent(lbids[0], (pthread_t)-1, sessionID, 'M');
@@ -496,10 +494,8 @@ void loadBlock(uint64_t lbid, QueryContext v, uint32_t t, int compType, void* bu
   uint32_t blksRead = 0;
   VSSCache::iterator it;
 
-
   if (LBIDTrace)
     stats.touchedLBID(lbid, pthread_self(), sessionID);
-
 
   if (vssCache)
   {
@@ -556,13 +552,11 @@ void loadBlock(uint64_t lbid, QueryContext v, uint32_t t, int compType, void* bu
         SUMMARY_INFO2("open failed: ", fileNamePtr);
         char errbuf[80];
         string errMsg;
-        //#if STRERROR_R_CHAR_P
+        // #if STRERROR_R_CHAR_P
         const char* p;
 
         if ((p = strerror_r(errCode, errbuf, 80)) != 0)
           errMsg = p;
-
-
 
         if (errCode == EINVAL)
         {
@@ -811,7 +805,6 @@ void loadBlock(uint64_t lbid, QueryContext v, uint32_t t, int compType, void* bu
   {
     prefetchBlocks(lbid, compType, &blksRead);
 
-
     if (fPMProfOn)
       pmstats.markEvent(lbid, (pthread_t)-1, sessionID, 'M');
 
@@ -983,7 +976,7 @@ void loadBlockAsync(uint64_t lbid, const QueryContext& c, uint32_t txn, int comp
 
 }  // namespace primitiveprocessor
 
-//#define DCT_DEBUG 1
+// #define DCT_DEBUG 1
 #define SETUP_GUARD                      \
   {                                      \
     unsigned char* o = outputp.get();    \
@@ -1565,6 +1558,14 @@ struct BPPHandler
 
   int destroyBPP(ByteStream& bs, const posix_time::ptime& dieTime)
   {
+    // This is a corner case that damages bs so its length becomes less than a header length.
+    // The damaged bs doesn't pass the if that checks bs at least has header + 3x int32_t.
+    // The if block below works around the issue.
+    if (posix_time::second_clock::universal_time() > dieTime)
+    {
+      return 0;
+    }
+
     uint32_t uniqueID, sessionID, stepID;
     BPPMap::iterator it;
 
@@ -1944,7 +1945,7 @@ struct ReadThread
         const uint32_t txnId = *((uint32_t*)&buf[pos + 2]);
         const uint32_t stepID = *((uint32_t*)&buf[pos + 6]);
         const uint32_t uniqueID = *((uint32_t*)&buf[pos + 10]);
-        const uint32_t weight = 1;
+        const uint32_t weight = threadpool::MetaJobsInitialWeight;
         const uint32_t priority = 0;
         uint32_t id = 0;
         boost::shared_ptr<FairThreadPool::Functor> functor;

--- a/utils/threadpool/fair_threadpool.cpp
+++ b/utils/threadpool/fair_threadpool.cpp
@@ -228,6 +228,7 @@ void FairThreadPool::threadFcn(const PriorityThreadPool::Priority preferredQueue
       {
         // to avoid excessive CPU usage waiting for data from storage
         usleep(500);
+        runList[0].weight_ += RescheduleWeightIncrement;
         addJob(runList[0]);
       }
     }

--- a/utils/threadpool/fair_threadpool.h
+++ b/utils/threadpool/fair_threadpool.h
@@ -40,6 +40,12 @@
 namespace threadpool
 {
 
+// Meta Jobs, e.g. BATCH_PRIMITIVE_CREATE has very small weight if a number of such Jobs
+// stuck in the scheduler queue they will starve the whole queue so that no Job could be run
+// except these meta jobs.
+constexpr const uint32_t RescheduleWeightIncrement = 10000;
+constexpr const uint32_t MetaJobsInitialWeight = 1;
+
 // The idea of this thread pool is to run morsel jobs(primitive job) is to equaly distribute CPU time
 // b/w multiple parallel queries(thread maps morsel to query using txnId). Query(txnId) has its weight
 // stored in PriorityQueue that thread increases before run another morsel for the query. When query is


### PR DESCRIPTION
    CI ocassionaly stuck running test001 b/c PP threadpool endlessly reschedules
    meta jobs, e.g. BATCH_PRIMITIVE_CREATE, which ByteStreams were somehow damaged or read out.
JFYI this is a backport of the patch that resolves the issue for develop in CI.