### PR TITLE
MCOL-5560: Fix garbage charset using ColType ctor 

### DIFF
--- a/dbcon/execplan/calpontsystemcatalog.cpp
+++ b/dbcon/execplan/calpontsystemcatalog.cpp
@@ -6146,18 +6146,6 @@ void CalpontSystemCatalog::checkSysCatVer()
   }
 }
 
-CalpontSystemCatalog::ColType::ColType()
- : constraintType(NO_CONSTRAINT)
- , colPosition(-1)
- , compressionType(NO_COMPRESSION)
- , columnOID(0)
- , autoincrement(0)
- , nextvalue(0)
- , cs(NULL)
-{
-  charsetNumber = default_charset_info->number;
-}
-
 CalpontSystemCatalog::ColType::ColType(const ColType& rhs) : TypeHolderStd(rhs)
 {
   constraintType = rhs.constraintType;

--- a/dbcon/execplan/calpontsystemcatalog.h
+++ b/dbcon/execplan/calpontsystemcatalog.h
@@ -215,22 +215,22 @@ class CalpontSystemCatalog : public datatypes::SystemCatalog
    */
   struct ColType : public datatypes::SystemCatalog::TypeHolderStd
   {
-    ConstraintType constraintType;
+    ConstraintType constraintType = NO_CONSTRAINT;
     DictOID ddn;
     NullString defaultValue;
-    int32_t colPosition;  // temporally put here. may need to have ColInfo struct later
-    int32_t compressionType;
-    OID columnOID;
-    bool autoincrement;  // set to true if  SYSCOLUMN autoincrement is �y�
-    uint64_t nextvalue;  // next autoincrement value
-    uint32_t charsetNumber;
-    const CHARSET_INFO* cs;
+    int32_t colPosition = -1;  // temporally put here. may need to have ColInfo struct later
+    int32_t compressionType = NO_COMPRESSION;
+    OID columnOID = 0;
+    bool autoincrement = 0;  // set to true if  SYSCOLUMN autoincrement is �y�
+    uint64_t nextvalue = 0;  // next autoincrement value
+    uint32_t charsetNumber = default_charset_info->number;
+    const CHARSET_INFO* cs = nullptr;
 
    private:
     long timeZone;
 
    public:
-    ColType();
+    ColType() = default;
     ColType(const ColType& rhs);
     ColType(int32_t colWidth_, int32_t scale_, int32_t precision_,
             const ConstraintType& constraintType_, const DictOID& ddn_, int32_t colPosition_,


### PR DESCRIPTION
This PR https://github.com/mariadb-corporation/mariadb-columnstore-engine/pull/2912/
added new ctor for ColType
`CalpontSystemCatalog::ColType::ColType(int32_t colWidth_, int32_t scale_, int32_t precision_,
  const ConstraintType& constraintType_, const DictOID& ddn_, int32_t colPosition_,
  int32_t compressionType_, OID columnOID_, const ColDataType& colDataType_)`


  This ctor missed to initilize `charsetNumber`, that caused garbage in that field and many reccuring 
`Character set '#1566723866' is not a compiled character set and is not specified in the '/usr/share/mysql/charsets/Index.xml' file`
in primproc log file

here I've deleted implementation of default ctor and added default values for all the fields
