### PR TITLE
Add DEVELOPING.md and Vagrantfile to improve developing documentation and flow.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,87 @@
+## Logging
+
+How to log in MCS:
+
+```bash
+std::cout << row.toString() << std::endl;
+```
+
+Stuff gets printed to journalctl, check with:
+
+```bash
+journalctl -u mariadb | tail
+```
+
+As mariadb runs as a system service / daemon its logs get collected by journalctl (which shows logs from the systemd journal). 
+
+## Restarting services after a crash
+
+Sometimes e.g. during debugging single processes can crash. 
+
+To restart a mcs-specific unit process run:
+
+```
+systemctl restart mcs-<process_name>
+```
+
+(So e.g. `systemctl restart mcs-primproc` )
+
+If you need to restart the whole installation use
+
+```
+systemctl restart mariadb-columnstore
+```
+
+## Interaction with MariaDB Server
+
+MCS is one of the many [storage engines](https://mariadb.com/kb/en/choosing-the-right-storage-engine/) offered by MariaDB. A storage engine handles the SQL operations for a certain table type, e.g. Columnstore is designed for big data, uses a columnar storage system and can process petabytes of data. The default engine for MariaDB is InnoDB. You can see all currently available engines on your server by running the SQL statement: `SHOW ENGINES;` in your mariadb console. Columnstore needs to be explicitly installed, but if you’re reading this you probably built MariaDB and MCS from source for development purposes and should see it listed.
+
+MDB has a notion of a [storage engine](https://mariadb.com/kb/en/choosing-the-right-storage-engine/), e.g. InnoDB, Columnstore. InnoDB is a dumb engine, means the best it can deliver is a filtered output. Columnstore is so-called smart engine. It grabs parsed syntax tree and executes the whole query on its own.
+
+MDB has a template for storage engines that is basically a number of API methods that are used by MDB processing a query. API methods are used by both dumb and smart engines whilst handlers are used by smart handlers, e.g. select handler is a structure with couple methods. SH ctor is another API method. This ctor is either returns nullptr or SH instance. In the latter case MDB hands future processing to SH instance method calling its `run`method.
+
+## Troubleshooting
+
+### Killing a process during Debugging
+
+Especially during debugging you might end up killing a process, which leads to error messages like e.g.:
+
+`ERROR 1815 (HY000): Internal error: MCS-2033: Error occurred when calling system catalog.` 
+
+Which occurs when the `PrimProc` process is killed, but all other processes continue running and then cannot access the system catalog which is served by `PrimProc`.
+
+You can verified that this happened by having a look at all running processes for mariadb/mysql via:
+
+```bash
+ps -axwffu | grep mysql
+```
+
+And restart any service via 
+
+```bash
+systemctl restart mcs-<process_name>
+```
+
+How to kill Zombie-Processes:
+
+https://www.linuxjournal.com/content/how-kill-zombie-processes-linux
+
+## Development Setup with Local Linux VM for M1 Macs
+
+As MCS only builds on Linux, everyone working on a MacOS or Windows system will need some access to a Linux system. This guide is written and tested for a M1 Mac, but will probably be easily adaptable to other operating systems.
+
+Using the ssh remote development features of common IDEs (e.g. VSCode or CLion), makes simply developing on a remote Linux server the easiest solution for development from MacOS. However, this has two drawbacks:
+
+1. Development requires a (stable) internet connection and even with sufficient connection can sometimes exhibit weird load times / freezes.
+2. Depending on the capabilities of the available remote server, building times might be better on a M1 Mac. (Virtualization especially with VMWare works quite nice performance wise.)
+
+Using the provided Vagrantfile the setup of a VM to develop in is as easy as:
+
+1. Adapting the parameters in the given file. Especially important - the current state of the Vagrantfile uses `vmware` as a VM provider. VMware provides free licenses for personal use, students and open-source development, otherwise it is a paid service. If you don’t have a license or want to use another provider either way, you can either use the out of the box provided `virtualbox` provider or install another provider. Read more about vagrant vm providers here. Read more about how to install vmware as a provider here.
+    
+    Check if the chosen image works for you (especially regarding the architecture of your machine).
+    
+    Adapt the number of cores and the amount of RAM you want to give your vm. 
+    
+2. Run `vagrant up` to create and/or start the virtual machine as specified in the `Vagrantfile`. 
+3. Run `vagrant ssh` to obtain a terminal directly in your vm - or to develop on the virtual machine in your preferred IDE, obtain the ssh config data of the machine with `vagrant ssh-config` and use it to connect. (For even easier connection add the ssh connection data to your `~/.ssh/config` .)

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,30 +1,32 @@
+This file documents helpful knowledge, commands and setup instructions for better developing flow.
+
 ## Logging
 
-How to log in MCS:
-
-```bash
-std::cout << row.toString() << std::endl;
-```
-
-Stuff gets printed to journalctl, check with:
+As MariaDB runs as a system service/daemon its logs (and print-outs to stdout) get collected by journalctl (which shows logs from the systemd journal). You can check it with:
 
 ```bash
 journalctl -u mariadb | tail
 ```
 
-As mariadb runs as a system service / daemon its logs get collected by journalctl (which shows logs from the systemd journal). 
+**Logging different objects**
+
+Rows:
+
+```bash
+std::cout << row.toString() << std::endl;
+```
 
 ## Restarting services after a crash
 
-Sometimes e.g. during debugging single processes can crash. 
+Sometimes, e.g. during debugging, single processes can crash. 
 
-To restart a mcs-specific unit process run:
+To restart a MCS specific unit process run:
 
 ```
 systemctl restart mcs-<process_name>
 ```
 
-(So e.g. `systemctl restart mcs-primproc` )
+(So e.g. `systemctl restart mcs-primproc` ).
 
 If you need to restart the whole installation use
 
@@ -34,23 +36,23 @@ systemctl restart mariadb-columnstore
 
 ## Interaction with MariaDB Server
 
-MCS is one of the many [storage engines](https://mariadb.com/kb/en/choosing-the-right-storage-engine/) offered by MariaDB. A storage engine handles the SQL operations for a certain table type, e.g. Columnstore is designed for big data, uses a columnar storage system and can process petabytes of data. The default engine for MariaDB is InnoDB. You can see all currently available engines on your server by running the SQL statement: `SHOW ENGINES;` in your mariadb console. Columnstore needs to be explicitly installed, but if you’re reading this you probably built MariaDB and MCS from source for development purposes and should see it listed.
+MCS is one of the many [storage engines](https://mariadb.com/kb/en/choosing-the-right-storage-engine/) offered by MariaDB. A storage engine handles the SQL operations for a certain table type, e.g. Columnstore is designed for big data, uses a columnar storage system and can process petabytes of data. The default engine for MariaDB is InnoDB. You can see all currently available engines on your server by running the SQL statement: `SHOW ENGINES;` in your MariaDB console. Columnstore needs to be explicitly installed, but if you’re reading this you probably built MariaDB and MCS from source for development purposes and should see it listed.
 
-MDB has a notion of a [storage engine](https://mariadb.com/kb/en/choosing-the-right-storage-engine/), e.g. InnoDB, Columnstore. InnoDB is a dumb engine, means the best it can deliver is a filtered output. Columnstore is so-called smart engine. It grabs parsed syntax tree and executes the whole query on its own.
+Storage Engines differ in their capabilities. E.g. InnoDB is a “dumb” engine, and doesn’t work itself with the parsed syntax tree and only provides basic (e.g. filtered) output. In contrast, Columnstore is a “smart” engine, which gets the parsed syntax tree and executes the whole query on its own.
 
-MDB has a template for storage engines that is basically a number of API methods that are used by MDB processing a query. API methods are used by both dumb and smart engines whilst handlers are used by smart handlers, e.g. select handler is a structure with couple methods. SH ctor is another API method. This ctor is either returns nullptr or SH instance. In the latter case MDB hands future processing to SH instance method calling its `run`method.
+For interaction with storage engines, MariaDB has a template that is basically a number of API methods that are used by MariaDB for processing a query. API methods are used by both dumb and smart engines. Handlers are used by smart handlers, e.g. the Select handler is a structure with a couple of methods. The constructor the select handler is another API method. This constructor either returns nullptr or Select handler instance. In the latter case MariaDB hands future processing to the Select Handler instance method via calling its `run`method.
 
 ## Troubleshooting
 
 ### Killing a process during Debugging
 
-Especially during debugging you might end up killing a process, which leads to error messages like e.g.:
+Especially during debugging you might end up killing a process, which leads to error messages like:
 
 `ERROR 1815 (HY000): Internal error: MCS-2033: Error occurred when calling system catalog.` 
 
-Which occurs when the `PrimProc` process is killed, but all other processes continue running and then cannot access the system catalog which is served by `PrimProc`.
+This error message occurs when the `PrimProc` process is killed, but all other processes continue running and cannot access the system catalog which is served by `PrimProc`.
 
-You can verified that this happened by having a look at all running processes for mariadb/mysql via:
+You can verified that this happened by having a look at all running processes for MariaDB/mysql via:
 
 ```bash
 ps -axwffu | grep mysql
@@ -62,26 +64,27 @@ And restart any service via
 systemctl restart mcs-<process_name>
 ```
 
-How to kill Zombie-Processes:
+### Zombie/Defunct processes
 
-https://www.linuxjournal.com/content/how-kill-zombie-processes-linux
+Sometimes Zombie/Defunct processes can cause problems, e.g. when one PrimProc process has become defunct, a new one has been started, but MariaDB still attaches to the defunct process. Refer to [here](https://www.linuxjournal.com/content/how-kill-zombie-processes-linux) for ways to kill Zombie processes. Sometimes a restart of the development machine can be the quickest way to resolve this problem, however.
 
 ## Development Setup with Local Linux VM for M1 Macs
 
-As MCS only builds on Linux, everyone working on a MacOS or Windows system will need some access to a Linux system. This guide is written and tested for a M1 Mac, but will probably be easily adaptable to other operating systems.
+As MCS only supports Linux-based operating systems, everyone working on a MacOS or Windows system will need some way to access a Linux system. This guide is written and tested for a M1 Mac, but will probably be easily adaptable to other operating systems.
 
-Using the ssh remote development features of common IDEs (e.g. VSCode or CLion), makes simply developing on a remote Linux server the easiest solution for development from MacOS. However, this has two drawbacks:
+Using the ssh remote development features of common IDEs (e.g. VSCode or CLion), makes developing on a remote Linux server the easiest solution for development from MacOS. However, this has two drawbacks:
 
 1. Development requires a (stable) internet connection and even with sufficient connection can sometimes exhibit weird load times / freezes.
-2. Depending on the capabilities of the available remote server, building times might be better on a M1 Mac. (Virtualization especially with VMWare works quite nice performance wise.)
+2. Depending on the capabilities of the available remote server, building times might be better on a M1 Mac. (Virtualization, especially with VMWare, works quite nice performance wise.)
 
-Using the provided Vagrantfile the setup of a VM to develop in is as easy as:
+Additionally, Vagrant allows to specify provisioning steps, which make setting up a new develop VM as easy as running two commands. (And already have everything necessary installed and built.)
 
-1. Adapting the parameters in the given file. Especially important - the current state of the Vagrantfile uses `vmware` as a VM provider. VMware provides free licenses for personal use, students and open-source development, otherwise it is a paid service. If you don’t have a license or want to use another provider either way, you can either use the out of the box provided `virtualbox` provider or install another provider. Read more about vagrant vm providers here. Read more about how to install vmware as a provider here.
-    
-    Check if the chosen image works for you (especially regarding the architecture of your machine).
-    
-    Adapt the number of cores and the amount of RAM you want to give your vm. 
-    
+Using the provided Vagrantfile the setup of develop VM is as easy as:
+
+1. Adapting the parameters in the provided Vagrantfile. Currently the following options can/need to be adapted:
+    1. `MARIA_DB_SERVER_REPOSITORY` and `MCS_REPOSITORY` . These options expect the HTTPS GitHub URL of the referenced repositories. If a build with a fork of the official repos is wanted, this is where the fork URLs should be provided. (For any questions regarding a general build, please refer to the `BUILD.md`).
+    2. `PROVIDER` . Vagrant allows to configure the underlying VM software used (the so called provider). The current version of the Vagrantfile uses VMWare as a VM provider. VMware provides free licenses for personal use, students and open-source development, otherwise it is a paid service. If you don’t have a license or want to use another provider either way, you can either use the out of the box provided VirtualBox provider or install another provider. Read more about Vagrant VM providers [here](https://developer.hashicorp.com/vagrant/docs/providers). Read more about how to install VMWare as a provider [here](https://developer.hashicorp.com/vagrant/docs/providers/vmware/installation).
+    3. `BOX` . Vagrant uses boxes to package Vagrant environments. The box needs to match your system and architecture. The easiest way to obtain a a box is to select one from the publicly available, pre-defined boxes at [VagrantCloud](https://app.vagrantup.com/boxes/search).
+    4. `MEMSIZE/NUMVCPUS`: Adapt the number of cores and the amount of RAM you want to give your VM. 
 2. Run `vagrant up` to create and/or start the virtual machine as specified in the `Vagrantfile`. 
-3. Run `vagrant ssh` to obtain a terminal directly in your vm - or to develop on the virtual machine in your preferred IDE, obtain the ssh config data of the machine with `vagrant ssh-config` and use it to connect. (For even easier connection add the ssh connection data to your `~/.ssh/config` .)
+3. Run `vagrant ssh` to obtain a terminal directly in your VM - or to develop on the virtual machine in your preferred IDE, obtain the ssh config data of the machine with `vagrant ssh-config` and use it to connect. (For even easier connection add the ssh connection data to your `~/.ssh/config` .)

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -68,7 +68,7 @@ systemctl restart mcs-<process_name>
 
 Sometimes Zombie/Defunct processes can cause problems, e.g. when one PrimProc process has become defunct, a new one has been started, but MariaDB still attaches to the defunct process. Refer to [here](https://www.linuxjournal.com/content/how-kill-zombie-processes-linux) for ways to kill Zombie processes. Sometimes a restart of the development machine can be the quickest way to resolve this problem, however.
 
-## Development Setup with Local Linux VM for M1 Macs
+## Development Setup with Local Linux VM for ARM-based Macs
 
 As MCS only supports Linux-based operating systems, everyone working on a MacOS or Windows system will need some way to access a Linux system. This guide is written and tested for a M1 Mac, but will probably be easily adaptable to other operating systems.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 # Update with your own fork of MariaDB Server and MariaDB ColumnStore if needed.
 MARIA_DB_SERVER_REPOSITORY = "https://github.com/MariaDB/server.git"
-MCS_REPOSITORY = "https://github.com/phoeinx/mariadb-columnstore-engine.git"
+MCS_REPOSITORY = "https://github.com/mariadb-corporation/mariadb-columnstore-engine.git"
 
 # Set provider for the VM.
 # PROVIDER = :virtualbox # default - if you don't have installed a specific provider use this one.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,40 +1,71 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# This Vagrantfile is used to create a local VM for MariaDB ColumnStore development.
+# If not disabled, it automatically installs the latest develop branch of MariaDB ColumnStore on the VM.
+# Basic usage:
+#   1. Install Vagrant and optionally VMWare as a provider.
+#   2. Configure the options below to your needs.
+#   3. Run "vagrant up" to create the VM and "vagrant ssh" to access it.
+# More documentation can be found in DEVELOPING.md.
+
 VAGRANTFILE_API_VERSION = "2"
 
+# Update with your own fork of MariaDB Server and MariaDB ColumnStore if needed.
+MARIA_DB_SERVER_REPOSITORY = "https://github.com/MariaDB/server.git"
+MCS_REPOSITORY = "https://github.com/phoeinx/mariadb-columnstore-engine.git"
+
+# Set provider for the VM.
+# PROVIDER = :virtualbox # default - if you don't have installed a specific provider use this one.
+PROVIDER = :vmware_fusion
+
+# Choose image/"box" for the VM for your architecture from https://app.vagrantup.com/boxes/search
+BOX = "bento/ubuntu-20.04-arm64"
+
+# Set hardware resources for the VM
+MEMSIZE = 16384 #MB
+NUMVCPUS = 8
+
+$provision_script = <<-'SCRIPT'
+# enable autocompletion via arrow up and down keys using readline library
+cat > ~/.inputrc <<-'AUTOCOMPLETION'
+  # Respect default shortcuts.
+  $include /etc/inputrc
+  ## arrow up
+  "\e[A":history-search-backward
+  ## arrow down
+  "\e[B":history-search-forward
+AUTOCOMPLETION
+
+# run setup for MariaDB ColumnStore
+
+git clone $1
+cd server
+git submodule update --init --recursive --depth=1
+
+cd storage/columnstore/columnstore
+git remote remove origin
+git remote add origin $2
+
+cd server/storage/columnstore/columnstore
+git checkout develop
+git config --global --add safe.directory `pwd`
+
+sudo -E build/bootstrap_mcs.sh --install-deps -t RelWithDebInfo
+SCRIPT
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "bento/ubuntu-20.04-arm64"
+  config.vm.define "mcs-dev"
+  config.vm.box = BOX
   
-  config.vm.provider :vmware_fusion do |v|
-    v.vmx["memsize"] = "16384"
-    v.vmx["numvcpus"] = "8"
+  config.vm.provider PROVIDER do |v|
+    v.vmx["memsize"] = MEMSIZE
+    v.vmx["numvcpus"] = NUMVCPUS
   end
 
-#   config.vm.provision :shell, :inline => <<-SCRIPT
-#     cat > ~/.inputrc <<-EOF
-#       # Respect default shortcuts.
-#       $include /etc/inputrc
-#       ## arrow up
-#       "\e[A":history-search-backward
-#       ## arrow down
-#       "\e[B":history-search-forward
-#     EOF
-#     bind -f ~/.inputrc
-
-#     git clone https://github.com/MariaDB/server.git
-#     cd server
-#     git submodule update --init --recursive --depth=1
-
-#     cd storage/columnstore/columnstore
-#     git remote -v #this should return: origin https://github.com/mariadb-corporation/mariadb-columnstore-engine.git (fetch)
-#     git remote remove origin
-#     git remote add origin https://github.com/phoeinx/mariadb-columnstore-engine
-
-#     cd server/storage/columnstore/columnstore
-#     git checkout develop
-#     git config --global --add safe.directory `pwd`
-
-#     sudo -E build/bootstrap_mcs.sh --install-deps -t RelWithDebInfo
-#   SCRIPT
+  config.vm.provision "shell" do |script|
+    script.inline = $provision_script
+    script.args = [MARIA_DB_SERVER_REPOSITORY, MCS_REPOSITORY]
+    script.privileged = false
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,40 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "bento/ubuntu-20.04-arm64"
+  
+  config.vm.provider :vmware_fusion do |v|
+    v.vmx["memsize"] = "16384"
+    v.vmx["numvcpus"] = "8"
+  end
+
+#   config.vm.provision :shell, :inline => <<-SCRIPT
+#     cat > ~/.inputrc <<-EOF
+#       # Respect default shortcuts.
+#       $include /etc/inputrc
+#       ## arrow up
+#       "\e[A":history-search-backward
+#       ## arrow down
+#       "\e[B":history-search-forward
+#     EOF
+#     bind -f ~/.inputrc
+
+#     git clone https://github.com/MariaDB/server.git
+#     cd server
+#     git submodule update --init --recursive --depth=1
+
+#     cd storage/columnstore/columnstore
+#     git remote -v #this should return: origin https://github.com/mariadb-corporation/mariadb-columnstore-engine.git (fetch)
+#     git remote remove origin
+#     git remote add origin https://github.com/phoeinx/mariadb-columnstore-engine
+
+#     cd server/storage/columnstore/columnstore
+#     git checkout develop
+#     git config --global --add safe.directory `pwd`
+
+#     sudo -E build/bootstrap_mcs.sh --install-deps -t RelWithDebInfo
+#   SCRIPT
+end


### PR DESCRIPTION
This infrastructure PR contains:

- 1. A new documentation file: `DEVELOPING.md`, which serves to document helpful knowledge, commands and setup instructions for better developing flow. (During my GSoC project I've started documenting helpful guidance I've received from @drrtuy and things that I found out, which helped in my understanding and development and wanted to share.)

- 2. A Vagrantfile which serves to set up a local VM to develop in for developers on non-Linux machines. Currently, the Vagrantfile is configured for ARM-based Macs, but could probably be easily adapted for other systems. More documentation can be found in the `Development Setup with Local Linux VM for ARM-based Mac` part of the `DEVELOPING.md`.