### PR TITLE
MCOL-5572 - fixing bad handling of UTF-8 CHAR(1) column in calpont system catalog table processing

### DIFF
--- a/dbcon/execplan/calpontsystemcatalog.cpp
+++ b/dbcon/execplan/calpontsystemcatalog.cpp
@@ -6043,7 +6043,12 @@ void CalpontSystemCatalog::buildSysColinfomap()
   fColinfomap[OID_SYSCOLUMN_PRECISION] = ColType(4, scale, precision, NOTNULL_CONSTRAINT,
     notDict, colPosition++, compressionType, OID_SYSCOLUMN_PRECISION, INT);
 
-  fColinfomap[OID_SYSCOLUMN_AUTOINC] = ColType(1, scale, precision, NO_CONSTRAINT,
+  // please note that column width specified in table creation is 1.
+  // we specify 4 because we use strnxfrm in filtering and it may convert
+  // data to, well, unsigned long int (my_cw_t type). But, all of the
+  // contemporary character sets have weights up to 32-bit, thus, here we
+  // specify 4-byte width which ill be enough for time being.
+  fColinfomap[OID_SYSCOLUMN_AUTOINC] = ColType(4, scale, precision, NO_CONSTRAINT,
     notDict, colPosition++, compressionType, OID_SYSCOLUMN_AUTOINC, CHAR);
 
   fColinfomap[OID_SYSCOLUMN_DISTCOUNT] = ColType(4, scale, precision, NO_CONSTRAINT,

--- a/mysql-test/columnstore/basic/r/MCOL-5572-autoincrement-filtering.result
+++ b/mysql-test/columnstore/basic/r/MCOL-5572-autoincrement-filtering.result
@@ -1,0 +1,20 @@
+SET default_storage_engine=columnstore;
+DROP DATABASE IF EXISTS mcol5572;
+CREATE DATABASE mcol5572;
+USE mcol5572;
+create table foo (col1 int) engine=columnstore;
+insert into foo values ( 1 ), ( 2 ), ( 3 ), ( 4 ), ( 5 );
+Alter table foo add column newcol bigint comment 'autoincrement';
+select callastinsertid('foo');
+callastinsertid('foo')
+5
+select tablename, autoincrement, nextvalue from calpontsys.syscolumn where autoincrement = 'y' and `schema`='mcol5572' and tablename='foo';
+tablename	autoincrement	nextvalue
+foo	y	6
+select tablename, autoincrement, nextvalue from calpontsys.syscolumn where autoincrement != 'n' and `schema`='mcol5572' and tablename='foo';
+tablename	autoincrement	nextvalue
+foo	y	6
+select tablename, autoincrement, nextvalue from calpontsys.syscolumn where autoincrement = 'n' and `schema`='mcol5572' and tablename='foo';
+tablename	autoincrement	nextvalue
+foo	n	1
+DROP DATABASE mcol5572;

--- a/mysql-test/columnstore/basic/t/MCOL-5572-autoincrement-filtering.test
+++ b/mysql-test/columnstore/basic/t/MCOL-5572-autoincrement-filtering.test
@@ -1,0 +1,22 @@
+--source ../include/have_columnstore.inc
+
+SET default_storage_engine=columnstore;
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol5572;
+--enable_warnings
+
+
+CREATE DATABASE mcol5572;
+USE mcol5572;
+
+create table foo (col1 int) engine=columnstore;
+insert into foo values ( 1 ), ( 2 ), ( 3 ), ( 4 ), ( 5 );
+Alter table foo add column newcol bigint comment 'autoincrement';
+select callastinsertid('foo');
+select tablename, autoincrement, nextvalue from calpontsys.syscolumn where autoincrement = 'y' and `schema`='mcol5572' and tablename='foo';
+select tablename, autoincrement, nextvalue from calpontsys.syscolumn where autoincrement != 'n' and `schema`='mcol5572' and tablename='foo';
+select tablename, autoincrement, nextvalue from calpontsys.syscolumn where autoincrement = 'n' and `schema`='mcol5572' and tablename='foo';
+
+DROP DATABASE mcol5572;
+


### PR DESCRIPTION
UTF-8 requires at least 3-byte wide columns and internal processing of ``autoincrement`` columns of ``syscolumn`` table used 1. ASCII characters have least byte zero in the strnxfrm encoding and, because of this, 'y' and 'n' got converted into zeroes (as would 'z', 'Z', '?' and even '~') and, thusly, that resulted in 'y' being equal to 'n'.

We have here a fix and a test.