### PR TITLE
After container starts, wait for systemd to start for every detached one

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -232,6 +232,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
     volumes: [pipeline._volumes.docker],
     commands: [
       'docker run --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --name smoke$${DRONE_BUILD_NUMBER} --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target',
+      'apk add bash && bash core_dumps/docker-awaiter.sh smoke$${DRONE_BUILD_NUMBER}',
       if (pkg_format == 'rpm') then 'docker exec -t smoke$${DRONE_BUILD_NUMBER} bash -c "yum install -y wget gdb gawk epel-release which rsyslog hostname procps-ng"' else 'docker exec -t smoke$${DRONE_BUILD_NUMBER} bash -c "apt update --yes && apt install -y gdb gawk rsyslog hostname procps wget"',
       if (pkg_format == 'deb') then 'docker exec -t smoke$${DRONE_BUILD_NUMBER} sed -i "s/exit 101/exit 0/g" /usr/sbin/policy-rc.d',
       'docker exec -t smoke$${DRONE_BUILD_NUMBER} mkdir core',
@@ -265,6 +266,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
     },
     commands: [
       'docker run --volume /sys/fs/cgroup:/sys/fs/cgroup:ro --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --name upgrade$${DRONE_BUILD_NUMBER}' + version + ' --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target',
+      'apk add bash && bash core_dumps/docker-awaiter.sh upgrade$${DRONE_BUILD_NUMBER}',
       'docker cp core_dumps/. upgrade$${DRONE_BUILD_NUMBER}' + version + ':/',
       'docker cp setup-repo.sh upgrade$${DRONE_BUILD_NUMBER}' + version + ':/',
       if (pkg_format == 'deb' && !(result == "debian12") && !(arch == "arm64" && (version == "10.6.4-1" || version == "10.6.5-2" || version == "10.6.7-3" || version == "10.6.8-4")) && !((version == "10.6.4-1" || version == "10.6.8-4") && (result == "debian11" || result == "ubuntu22.04")) && !(result == "ubuntu22.04" && (version == "10.6.5-2" || version == "10.6.7-3"))) then 'docker exec -t upgrade$${DRONE_BUILD_NUMBER}' + version + ' bash -c "./upgrade_setup_deb.sh '+ version + ' ' + result + ' ' + arch + ' ' + repo_pkg_url_no_res +' $${UPGRADE_TOKEN}"',
@@ -294,6 +296,8 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
     },
     commands: [
       'docker run --shm-size=500m --env MYSQL_TEST_DIR=' + mtr_path + ' --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --name mtr$${DRONE_BUILD_NUMBER} --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target',
+      'apk add bash && bash core_dumps/docker-awaiter.sh mtr$${DRONE_BUILD_NUMBER}',
+
       if (std.split(platform, ':')[0] == 'centos' || std.split(platform, ':')[0] == 'rockylinux') then 'docker exec -t mtr$${DRONE_BUILD_NUMBER} bash -c "yum install -y wget tar lz4 procps-ng"',
       if (pkg_format == 'deb') then 'docker exec -t mtr$${DRONE_BUILD_NUMBER} sed -i "s/exit 101/exit 0/g" /usr/sbin/policy-rc.d',
       if (pkg_format == 'deb') then 'docker exec -t mtr$${DRONE_BUILD_NUMBER} bash -c "apt update --yes && apt install -y procps wget tar liblz4-tool"',
@@ -383,6 +387,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
       'git rev-parse --abbrev-ref HEAD && git rev-parse HEAD',
       'cd ..',
       'docker run --shm-size=500m --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --name regression$${DRONE_BUILD_NUMBER} --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target',
+      'apk add bash && bash core_dumps/docker-awaiter.sh regression$${DRONE_BUILD_NUMBER}',
       if (pkg_format == 'rpm') then 'docker exec -t regression$${DRONE_BUILD_NUMBER} bash -c "yum install -y wget gawk gdb gcc-c++ epel-release diffutils tar findutils lz4 wget which rsyslog hostname procps-ng elfutils"' else 'docker exec -t regression$${DRONE_BUILD_NUMBER} bash -c "apt update --yes && apt install -y wget tar liblz4-tool procps wget findutils gawk gdb rsyslog hostname g++ elfutils"',
       if (platform == 'centos:7') then 'docker exec -t regression$${DRONE_BUILD_NUMBER} bash -c "yum install -y sysvinit-tools"',
       if (pkg_format == 'deb') then 'docker exec -t regression$${DRONE_BUILD_NUMBER} sed -i "s/exit 101/exit 0/g" /usr/sbin/policy-rc.d',
@@ -585,6 +590,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
     },
     commands: [
       'docker run --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --env PYTHONPATH=$${PYTHONPATH} --name cmapi$${DRONE_BUILD_NUMBER} --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target',
+      'apk add bash && bash core_dumps/docker-awaiter.sh cmapi$${DRONE_BUILD_NUMBER}',
       if (pkg_format == 'rpm') then 'docker exec -t cmapi$${DRONE_BUILD_NUMBER} bash -c "yum install -y iproute sudo epel-release which rsyslog hostname procps-ng"' else 'docker exec -t cmapi$${DRONE_BUILD_NUMBER} bash -c "apt update --yes && apt install -y iproute2 rsyslog hostname procps sudo"',
       if (pkg_format == 'deb') then 'docker exec -t cmapi$${DRONE_BUILD_NUMBER} sed -i "s/exit 101/exit 0/g" /usr/sbin/policy-rc.d',
       if (platform == 'rockylinux:9') then 'docker exec -t cmapi$${DRONE_BUILD_NUMBER} bash -c "yum install -y libxcrypt-compat"',

--- a/core_dumps/docker-awaiter.sh
+++ b/core_dumps/docker-awaiter.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+DOCKER_IMAGE=$1
+
+zhdun()
+{
+    command=$1
+    expected_result=$2
+    waiting_message=$3
+    retries=$4
+    sleep_delay=$5
+    result=$($command)
+    result="${result%%[[:cntrl:]]}"
+    retries_counter=1
+
+    while true;
+    do
+        if [ "$result" != "$expected_result" ]; then
+            echo $waiting_message " Status: " $result ", attempt: " $retries_counter
+            sleep $sleep_delay
+        else
+            echo Finished waiting for \'"$command"\' to return \'"$expected_result"\'
+            exit
+        fi
+
+        if [ $retries_counter -ge $retries ]; then
+            echo "Tired to wait for retry, $retries_counter attemps were made"
+            exit
+        fi
+        retries_counter=$(($retries_counter + 1))
+    done
+}
+
+check_result="running"
+check_command="docker exec -t $DOCKER_IMAGE systemctl is-system-running"
+waiting_message="Waiting for docker container to start systemd."
+
+zhdun "$check_command" "$check_result" "$waiting_message" 60 2


### PR DESCRIPTION
Attempt to fix flacky tests like this 
https://ci.columnstore.mariadb.net/mariadb-corporation/mariadb-columnstore-engine/8681/7/25
idea is based on the article 
https://www.jeffgeerling.com/blog/2020/resolving-fedora-dnf-error-no-such-file-or-directory-varlibdnfrpmdblockpid