### PR TITLE
MCOL-5572 Force the charset on the autoincrement column of calpontsys.syscolumn syscat table to be latin1.

### DIFF
--- a/dbcon/execplan/calpontsystemcatalog.cpp
+++ b/dbcon/execplan/calpontsystemcatalog.cpp
@@ -6043,12 +6043,7 @@ void CalpontSystemCatalog::buildSysColinfomap()
   fColinfomap[OID_SYSCOLUMN_PRECISION] = ColType(4, scale, precision, NOTNULL_CONSTRAINT,
     notDict, colPosition++, compressionType, OID_SYSCOLUMN_PRECISION, INT);
 
-  // please note that column width specified in table creation is 1.
-  // we specify 4 because we use strnxfrm in filtering and it may convert
-  // data to, well, unsigned long int (my_cw_t type). But, all of the
-  // contemporary character sets have weights up to 32-bit, thus, here we
-  // specify 4-byte width which ill be enough for time being.
-  fColinfomap[OID_SYSCOLUMN_AUTOINC] = ColType(4, scale, precision, NO_CONSTRAINT,
+  fColinfomap[OID_SYSCOLUMN_AUTOINC] = ColType(1, scale, precision, NO_CONSTRAINT,
     notDict, colPosition++, compressionType, OID_SYSCOLUMN_AUTOINC, CHAR);
 
   fColinfomap[OID_SYSCOLUMN_DISTCOUNT] = ColType(4, scale, precision, NO_CONSTRAINT,

--- a/dbcon/joblist/pcolstep.cpp
+++ b/dbcon/joblist/pcolstep.cpp
@@ -88,6 +88,14 @@ pColStep::pColStep(CalpontSystemCatalog::OID o, CalpontSystemCatalog::OID t,
   int err, i;
   uint32_t mask;
 
+  // MCOL-5572 Force the charset on the autoincrement column
+  // of calpontsys.syscolumn syscat table to be latin1.
+  if (fOid == execplan::OID_SYSCOLUMN_AUTOINC)
+  {
+    const CHARSET_INFO* cs = &my_charset_latin1;
+    fColType.charsetNumber = cs->number;
+  }
+
   if (fOid < 1000)
     throw runtime_error("pColStep: invalid column");
 


### PR DESCRIPTION
This change is done in one of the ctors of pColStep which is initiated while building the job list from the execution plan.