### PR TITLE
Fix assertion failure leading to disk-based aggregation failure.

### DIFF
--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -414,9 +414,17 @@ void RGData::deserialize(ByteStream& bs, uint32_t defAmount)
     uint32_t rowSizeTemp;
     bs >> colCountTemp;
     bs >> rowSizeTemp;
-    if (rowSize != 0)
+    if (rowSize != 0 || columnCount != 0)
     {
-      idbassert(colCountTemp == columnCount && rowSize == rowSizeTemp);
+      idbassert(rowSize == rowSizeTemp && colCountTemp == columnCount);
+    }
+    else
+    {
+      // if deserializing into an empty RGData created by default constructor
+      // which sets columnCount = 0 and rowSize = 0, set columnCount and rowSize
+      // from deserialized bytestream
+      columnCount = colCountTemp;
+      rowSize = rowSizeTemp;
     }
     rowData.reset(new uint8_t[std::max(amount, defAmount)]);
     buf = bs.buf();

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -2197,8 +2197,7 @@ inline uint64_t StringStore::getSize() const
 
 inline void RGData::getRow(uint32_t num, Row* row)
 {
-  // commented due MCOL-5583 TODO: investigate, why this invariant can be broken
-  // idbassert(columnCount == row->getColumnCount() && rowSize == row->getSize());
+  idbassert(columnCount == row->getColumnCount() && rowSize == row->getSize());
   uint32_t size = row->getSize();
   row->setData(
       Row::Pointer(&rowData[RowGroup::getHeaderSize() + (num * size)], strings.get(), userDataStore.get()));


### PR DESCRIPTION
The newly added invariant checking that `RGData` knows the number of columns and fixed size columns was failing for disk-based aggregation workloads, leading them to provide a wrong result. (The assertion failure happened in `RGData::getRow(uint32_t num, Row* row)` which is called in the finalization of sub-aggregation results, necessary for merging part results. As the merging failed, duplicate results were output for disk-based aggregation queries. 

The assertion failure was caused by `RGData::deserialize(ByteStream& bs, uint32_t defAmount)` not setting rowSize and colCount if necessary (e.g. when the deserialization happens into a new, default RGData, which doesn't know anything about its structure yet. This is the case when the `RGData()` default constructor sets rowSize and columnCount to 0 each.)

There are three code parts that make use of the default `RGData()` ctor. 

The fix is for the use in `RowGroupStorage::loadRG(uint64_t rgid, std::unique_ptr<RGData>& rgdata, bool unlinkDump = false)`, where the default `RGData` object is used to directly deserialize a ByteStream into a new `RGData`. The deserialize method now checks if both rowSize and columnCount are 0 and if yes sets the read values from the ByteStream for both. 

We should probably check the other two code parts using the default `RGData` ctor, too. This happens in` joinpartition.cpp` and `tuplejoiner.cpp`.