### PR TITLE
fix(packaging) dh_missing: errors fix 

### DIFF
--- a/utils/messageqcpp/CMakeLists.txt
+++ b/utils/messageqcpp/CMakeLists.txt
@@ -18,4 +18,5 @@ add_library(messageqcpp STATIC ${messageqcpp_LIB_SRCS})
 
 add_dependencies(messageqcpp loggingcpp)
 
-install(TARGETS messageqcpp DESTINATION ${ENGINE_LIBDIR} COMPONENT columnstore-engine)
+#We don't isntall static library
+#install(TARGETS messageqcpp DESTINATION ${ENGINE_LIBDIR} COMPONENT columnstore-engine)

--- a/utils/pron/CMakeLists.txt
+++ b/utils/pron/CMakeLists.txt
@@ -1,9 +1,7 @@
 include_directories( ${ENGINE_COMMON_INCLUDES} )
-
 set(pron_LIB_SRCS pron.cpp)
-
 add_library(pron STATIC ${pron_LIB_SRCS})
-
 target_link_libraries(pron messageqcpp loggingcpp)
 
-install(TARGETS pron DESTINATION ${ENGINE_LIBDIR} COMPONENT columnstore-engine)
+#We don't isntall static library
+#install(TARGETS pron DESTINATION ${ENGINE_LIBDIR} COMPONENT columnstore-engine)


### PR DESCRIPTION
 warning are treated as errors for buildbot… debians
```
dh_missing: warning: Compatibility levels before 10 are deprecated (level 9 in use)
dh_missing: warning: usr/lib/x86_64-linux-gnu/libmessageqcpp.a exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/lib/x86_64-linux-gnu/libpron.a exists in debian/tmp but is not installed to anywhere
```
so do not install static libraries as targets on CMake