### PR TITLE
Mcol 5568 error for invalid conversion

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -3656,6 +3656,7 @@ ArithmeticColumn* buildArithmeticColumn(Item_func* item, gp_walk_info& gwi, bool
         if (rc)
           lhs = new ParseTree(rc);
       }
+
       rhs = new ParseTree(buildReturnedColumn(sfitempp[1], gwi, nonSupport));
 
       if (!rhs->data() && (sfitempp[1]->type() == Item::FUNC_ITEM))

--- a/mysql-test/columnstore/basic/r/MCOL-5568-out-of-range.result
+++ b/mysql-test/columnstore/basic/r/MCOL-5568-out-of-range.result
@@ -1,0 +1,61 @@
+DROP DATABASE IF EXISTS MCOL5568;
+CREATE DATABASE MCOL5568;
+USE MCOL5568;
+CREATE TABLE test_mult (
+indemnity_paid INT(11),
+n_clms TINYINT(3) UNSIGNED
+) ENGINE=COLUMNSTORE;
+INSERT INTO test_mult (indemnity_paid, n_clms) VALUES (-10, 1);
+SELECT indemnity_paid, n_clms, indemnity_paid * n_clms FROM test_mult;
+ERROR HY000: Internal error: MCS-2053: The result is out of range for function "*" using value(s): -10.000000 1.000000
+SELECT indemnity_paid, n_clms, indemnity_paid + n_clms FROM test_mult;
+ERROR HY000: Internal error: MCS-2053: The result is out of range for function "+" using value(s): -10.000000 1.000000
+SELECT indemnity_paid, n_clms, (indemnity_paid + 9) + n_clms FROM test_mult;
+indemnity_paid	n_clms	(indemnity_paid + 9) + n_clms
+-10	1	0
+CREATE TABLE test_mult2 (
+indemnity_paid TINYINT,
+n_clms TINYINT UNSIGNED
+) ENGINE=COLUMNSTORE;
+INSERT INTO test_mult2 (indemnity_paid, n_clms) VALUES (-10, 1);
+SELECT indemnity_paid, n_clms, indemnity_paid * n_clms FROM test_mult2;
+ERROR HY000: Internal error: MCS-2053: The result is out of range for function "*" using value(s): -10.000000 1.000000
+SELECT indemnity_paid, n_clms, indemnity_paid + n_clms FROM test_mult2;
+ERROR HY000: Internal error: MCS-2053: The result is out of range for function "+" using value(s): -10.000000 1.000000
+SELECT indemnity_paid, n_clms, (indemnity_paid + 9) + n_clms FROM test_mult2;
+indemnity_paid	n_clms	(indemnity_paid + 9) + n_clms
+-10	1	0
+CREATE TABLE test_mult3 (
+indemnity_paid SMALLINT,
+n_clms TINYINT UNSIGNED
+) ENGINE=COLUMNSTORE;
+INSERT INTO test_mult3 (indemnity_paid, n_clms) VALUES (-10, 1);
+SELECT indemnity_paid, n_clms, indemnity_paid * n_clms FROM test_mult3;
+ERROR HY000: Internal error: MCS-2053: The result is out of range for function "*" using value(s): -10.000000 1.000000
+SELECT indemnity_paid, n_clms, indemnity_paid + n_clms FROM test_mult3;
+ERROR HY000: Internal error: MCS-2053: The result is out of range for function "+" using value(s): -10.000000 1.000000
+SELECT indemnity_paid, n_clms, (indemnity_paid + 9) + n_clms FROM test_mult3;
+indemnity_paid	n_clms	(indemnity_paid + 9) + n_clms
+-10	1	0
+CREATE TABLE test_mult4 (
+indemnity_paid INTEGER,
+n_clms TINYINT UNSIGNED
+) ENGINE=COLUMNSTORE;
+INSERT INTO test_mult4 (indemnity_paid, n_clms) VALUES (-10, 1);
+SELECT indemnity_paid, n_clms, indemnity_paid * n_clms FROM test_mult4;
+ERROR HY000: Internal error: MCS-2053: The result is out of range for function "*" using value(s): -10.000000 1.000000
+SELECT indemnity_paid, n_clms, indemnity_paid + n_clms FROM test_mult4;
+ERROR HY000: Internal error: MCS-2053: The result is out of range for function "+" using value(s): -10.000000 1.000000
+SELECT indemnity_paid, n_clms, (indemnity_paid + 9) + n_clms FROM test_mult4;
+indemnity_paid	n_clms	(indemnity_paid + 9) + n_clms
+-10	1	0
+SELECT indemnity_paid, n_clms, n_clms * indemnity_paid FROM test_mult4;
+ERROR HY000: Internal error: MCS-2053: The result is out of range for function "*" using value(s): 1.000000 -10.000000
+SELECT indemnity_paid, n_clms, n_clms + indemnity_paid FROM test_mult4;
+ERROR HY000: Internal error: MCS-2053: The result is out of range for function "+" using value(s): 1.000000 -10.000000
+SELECT indemnity_paid, n_clms, n_clms + (indemnity_paid + 9) FROM test_mult4;
+indemnity_paid	n_clms	n_clms + (indemnity_paid + 9)
+-10	1	0
+SELECT indemnity_paid, n_clms, n_clms - 2 FROM test_mult4;
+ERROR HY000: Internal error: MCS-2053: The result is out of range for function "-" using value(s): 1.000000 2.000000
+DROP DATABASE MCOL5568;

--- a/mysql-test/columnstore/basic/t/MCOL-5568-out-of-range.test
+++ b/mysql-test/columnstore/basic/t/MCOL-5568-out-of-range.test
@@ -1,0 +1,109 @@
+--disable_warnings
+DROP DATABASE IF EXISTS MCOL5568;
+--enable_warnings
+
+CREATE DATABASE MCOL5568;
+
+USE MCOL5568;
+
+CREATE TABLE test_mult (
+
+indemnity_paid INT(11),
+
+n_clms TINYINT(3) UNSIGNED
+
+) ENGINE=COLUMNSTORE;
+
+INSERT INTO test_mult (indemnity_paid, n_clms) VALUES (-10, 1);
+
+# an error.
+--error 1815
+SELECT indemnity_paid, n_clms, indemnity_paid * n_clms FROM test_mult;
+
+# an error.
+--error 1815
+SELECT indemnity_paid, n_clms, indemnity_paid + n_clms FROM test_mult;
+
+# not an error.
+SELECT indemnity_paid, n_clms, (indemnity_paid + 9) + n_clms FROM test_mult;
+
+CREATE TABLE test_mult2 (
+
+indemnity_paid TINYINT,
+
+n_clms TINYINT UNSIGNED
+
+) ENGINE=COLUMNSTORE;
+
+INSERT INTO test_mult2 (indemnity_paid, n_clms) VALUES (-10, 1);
+
+# an error.
+--error 1815
+SELECT indemnity_paid, n_clms, indemnity_paid * n_clms FROM test_mult2;
+
+# an error.
+--error 1815
+SELECT indemnity_paid, n_clms, indemnity_paid + n_clms FROM test_mult2;
+
+# not an error.
+SELECT indemnity_paid, n_clms, (indemnity_paid + 9) + n_clms FROM test_mult2;
+
+CREATE TABLE test_mult3 (
+
+indemnity_paid SMALLINT,
+
+n_clms TINYINT UNSIGNED
+
+) ENGINE=COLUMNSTORE;
+
+INSERT INTO test_mult3 (indemnity_paid, n_clms) VALUES (-10, 1);
+
+# an error.
+--error 1815
+SELECT indemnity_paid, n_clms, indemnity_paid * n_clms FROM test_mult3;
+
+# an error.
+--error 1815
+SELECT indemnity_paid, n_clms, indemnity_paid + n_clms FROM test_mult3;
+
+# not an error.
+SELECT indemnity_paid, n_clms, (indemnity_paid + 9) + n_clms FROM test_mult3;
+
+CREATE TABLE test_mult4 (
+
+indemnity_paid INTEGER,
+
+n_clms TINYINT UNSIGNED
+
+) ENGINE=COLUMNSTORE;
+
+INSERT INTO test_mult4 (indemnity_paid, n_clms) VALUES (-10, 1);
+
+# an error.
+--error 1815
+SELECT indemnity_paid, n_clms, indemnity_paid * n_clms FROM test_mult4;
+
+# an error.
+--error 1815
+SELECT indemnity_paid, n_clms, indemnity_paid + n_clms FROM test_mult4;
+
+# not an error.
+SELECT indemnity_paid, n_clms, (indemnity_paid + 9) + n_clms FROM test_mult4;
+
+# an error.
+--error 1815
+SELECT indemnity_paid, n_clms, n_clms * indemnity_paid FROM test_mult4;
+
+# an error.
+--error 1815
+SELECT indemnity_paid, n_clms, n_clms + indemnity_paid FROM test_mult4;
+
+# not an error.
+SELECT indemnity_paid, n_clms, n_clms + (indemnity_paid + 9) FROM test_mult4;
+
+# an error again.
+--error 1815
+SELECT indemnity_paid, n_clms, n_clms - 2 FROM test_mult4;
+
+DROP DATABASE MCOL5568;
+


### PR DESCRIPTION
A smallest fix for our inability to detect overflows in the query results.