### PR TITLE
chore(datatypes): this refactors the placement of the main SQL data types enum to enable templates that are parametrized with this enum(see mcs_datatype_basic.h changes for more details).

### DIFF
--- a/datatypes/mcs_datatype.cpp
+++ b/datatypes/mcs_datatype.cpp
@@ -47,8 +47,7 @@ using namespace dataconvert;
 
 namespace datatypes
 {
-int128_t SystemCatalog::TypeAttributesStd::decimal128FromString(const std::string& value,
-                                                                bool* saturate) const
+int128_t TypeAttributesStd::decimal128FromString(const std::string& value, bool* saturate) const
 {
   int128_t result = 0;
   bool pushWarning = false;
@@ -58,8 +57,7 @@ int128_t SystemCatalog::TypeAttributesStd::decimal128FromString(const std::strin
   return result;
 }
 
-int128_t SystemCatalog::TypeAttributesStd::decimal128FromString(const utils::NullString& value,
-                                                                bool* saturate) const
+int128_t TypeAttributesStd::decimal128FromString(const utils::NullString& value, bool* saturate) const
 {
   if (value.isNull())
   {
@@ -287,8 +285,7 @@ TypeHandlerClob mcs_type_handler_clob;
 TypeHandlerVarbinary mcs_type_handler_varbinary;
 TypeHandlerBlob mcs_type_handler_blob;
 
-const TypeHandler* TypeHandler::find(SystemCatalog::ColDataType typeCode,
-                                     const SystemCatalog::TypeAttributesStd& ct)
+const TypeHandler* TypeHandler::find(SystemCatalog::ColDataType typeCode, const TypeAttributesStd& ct)
 {
   switch (typeCode)
   {
@@ -339,12 +336,12 @@ const TypeHandler* TypeHandler::find(SystemCatalog::ColDataType typeCode,
   return NULL;
 }
 
-const TypeHandler* SystemCatalog::TypeHolderStd::typeHandler() const
+const TypeHandler* TypeHolderStd::typeHandler() const
 {
   return TypeHandler::find(colDataType, *this);
 }
 
-boost::any SystemCatalog::TypeHolderStd::getNullValueForType() const
+boost::any TypeHolderStd::getNullValueForType() const
 {
   const TypeHandler* h = typeHandler();
   if (!h)
@@ -581,27 +578,27 @@ int TypeHandlerBinary::storeValueToField(rowgroup::Row &row, int pos,
 
 /****************************************************************************/
 
-string TypeHandlerDate::format(const SimpleValue& v, const SystemCatalog::TypeAttributesStd& attr) const
+string TypeHandlerDate::format(const SimpleValue& v, const TypeAttributesStd& attr) const
 {
   return DataConvert::dateToString(v.toSInt64());
 }
 
-string TypeHandlerDatetime::format(const SimpleValue& v, const SystemCatalog::TypeAttributesStd& attr) const
+string TypeHandlerDatetime::format(const SimpleValue& v, const TypeAttributesStd& attr) const
 {
   return DataConvert::datetimeToString(v.toSInt64());
 }
 
-string TypeHandlerTimestamp::format(const SimpleValue& v, const SystemCatalog::TypeAttributesStd& attr) const
+string TypeHandlerTimestamp::format(const SimpleValue& v, const TypeAttributesStd& attr) const
 {
   return DataConvert::timestampToString(v.toSInt64(), v.timeZone());
 }
 
-string TypeHandlerTime::format(const SimpleValue& v, const SystemCatalog::TypeAttributesStd& attr) const
+string TypeHandlerTime::format(const SimpleValue& v, const TypeAttributesStd& attr) const
 {
   return DataConvert::timeToString(v.toSInt64());
 }
 
-string TypeHandlerChar::format(const SimpleValue& v, const SystemCatalog::TypeAttributesStd& attr) const
+string TypeHandlerChar::format(const SimpleValue& v, const TypeAttributesStd& attr) const
 {
   // swap again to retain the string byte order
   ostringstream oss;
@@ -610,7 +607,7 @@ string TypeHandlerChar::format(const SimpleValue& v, const SystemCatalog::TypeAt
   return oss.str();
 }
 
-string TypeHandlerVarchar::format(const SimpleValue& v, const SystemCatalog::TypeAttributesStd& attr) const
+string TypeHandlerVarchar::format(const SimpleValue& v, const TypeAttributesStd& attr) const
 {
   // swap again to retain the string byte order
   ostringstream oss;
@@ -619,26 +616,26 @@ string TypeHandlerVarchar::format(const SimpleValue& v, const SystemCatalog::Typ
   return oss.str();
 }
 
-string TypeHandlerInt::formatSInt64(const SimpleValue& v, const SystemCatalog::TypeAttributesStd& attr) const
+string TypeHandlerInt::formatSInt64(const SimpleValue& v, const TypeAttributesStd& attr) const
 {
   ostringstream oss;
   oss << v.toSInt64();
   return oss.str();
 }
 
-string TypeHandlerInt::formatUInt64(const SimpleValue& v, const SystemCatalog::TypeAttributesStd& attr) const
+string TypeHandlerInt::formatUInt64(const SimpleValue& v, const TypeAttributesStd& attr) const
 {
   ostringstream oss;
   oss << static_cast<uint64_t>(v.toSInt64());
   return oss.str();
 }
 
-string TypeHandlerVarbinary::format(const SimpleValue& v, const SystemCatalog::TypeAttributesStd& attr) const
+string TypeHandlerVarbinary::format(const SimpleValue& v, const TypeAttributesStd& attr) const
 {
   return "N/A";
 }
 
-string TypeHandlerXDecimal::format64(const SimpleValue& v, const SystemCatalog::TypeAttributesStd& attr) const
+string TypeHandlerXDecimal::format64(const SimpleValue& v, const TypeAttributesStd& attr) const
 {
   idbassert(isValidXDecimal64(attr));
   if (attr.scale > 0)
@@ -651,8 +648,7 @@ string TypeHandlerXDecimal::format64(const SimpleValue& v, const SystemCatalog::
   return oss.str();
 }
 
-string TypeHandlerXDecimal::format128(const SimpleValue& v,
-                                      const SystemCatalog::TypeAttributesStd& attr) const
+string TypeHandlerXDecimal::format128(const SimpleValue& v, const TypeAttributesStd& attr) const
 {
   idbassert(isValidXDecimal128(attr));
   datatypes::Decimal dec(0, attr.scale, attr.precision, v.toSInt128());
@@ -670,8 +666,7 @@ class ostringstreamL : public ostringstream
   }
 };
 
-string TypeHandler::formatPartitionInfoSInt64(const SystemCatalog::TypeAttributesStd& attr,
-                                              const MinMaxInfo& pi) const
+string TypeHandler::formatPartitionInfoSInt64(const TypeAttributesStd& attr, const MinMaxInfo& pi) const
 {
   ostringstreamL output;
   if (pi.isEmptyOrNullSInt64())
@@ -682,8 +677,7 @@ string TypeHandler::formatPartitionInfoSInt64(const SystemCatalog::TypeAttribute
   return output.str();
 }
 
-string TypeHandler::formatPartitionInfoUInt64(const SystemCatalog::TypeAttributesStd& attr,
-                                              const MinMaxInfo& pi) const
+string TypeHandler::formatPartitionInfoUInt64(const TypeAttributesStd& attr, const MinMaxInfo& pi) const
 {
   ostringstreamL output;
   if (pi.isEmptyOrNullUInt64())
@@ -694,8 +688,7 @@ string TypeHandler::formatPartitionInfoUInt64(const SystemCatalog::TypeAttribute
   return output.str();
 }
 
-string TypeHandlerXDecimal::formatPartitionInfo128(const SystemCatalog::TypeAttributesStd& attr,
-                                                   const MinMaxInfo& pi) const
+string TypeHandlerXDecimal::formatPartitionInfo128(const TypeAttributesStd& attr, const MinMaxInfo& pi) const
 {
   ostringstreamL output;
   if (pi.isEmptyOrNullSInt128())
@@ -707,7 +700,7 @@ string TypeHandlerXDecimal::formatPartitionInfo128(const SystemCatalog::TypeAttr
   return output.str();
 }
 
-string TypeHandlerStr::formatPartitionInfoSmallCharVarchar(const SystemCatalog::TypeAttributesStd& attr,
+string TypeHandlerStr::formatPartitionInfoSmallCharVarchar(const TypeAttributesStd& attr,
                                                            const MinMaxInfo& pi) const
 {
   ostringstreamL output;
@@ -723,8 +716,7 @@ string TypeHandlerStr::formatPartitionInfoSmallCharVarchar(const SystemCatalog::
   return output.str();
 }
 
-string TypeHandlerChar::formatPartitionInfo(const SystemCatalog::TypeAttributesStd& attr,
-                                            const MinMaxInfo& pi) const
+string TypeHandlerChar::formatPartitionInfo(const TypeAttributesStd& attr, const MinMaxInfo& pi) const
 {
   // char column order swap for compare in subsequent loop
   if (attr.colWidth <= 8)
@@ -732,8 +724,7 @@ string TypeHandlerChar::formatPartitionInfo(const SystemCatalog::TypeAttributesS
   return formatPartitionInfoSInt64(attr, pi);
 }
 
-string TypeHandlerVarchar::formatPartitionInfo(const SystemCatalog::TypeAttributesStd& attr,
-                                               const MinMaxInfo& pi) const
+string TypeHandlerVarchar::formatPartitionInfo(const TypeAttributesStd& attr, const MinMaxInfo& pi) const
 {
   // varchar column order swap for compare in subsequent loop
   if (attr.colWidth <= 7)
@@ -744,7 +735,7 @@ string TypeHandlerVarchar::formatPartitionInfo(const SystemCatalog::TypeAttribut
 /****************************************************************************/
 
 execplan::SimpleColumn* TypeHandlerSInt8::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                          SystemCatalog::TypeHolderStd& ct,
+                                                          TypeHolderStd& ct,
                                                           const SimpleColumnParam& prm) const
 {
   if (ct.scale == 0)
@@ -756,7 +747,7 @@ execplan::SimpleColumn* TypeHandlerSInt8::newSimpleColumn(const DatabaseQualifie
 }
 
 execplan::SimpleColumn* TypeHandlerSInt16::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                           SystemCatalog::TypeHolderStd& ct,
+                                                           TypeHolderStd& ct,
                                                            const SimpleColumnParam& prm) const
 {
   if (ct.scale == 0)
@@ -768,7 +759,7 @@ execplan::SimpleColumn* TypeHandlerSInt16::newSimpleColumn(const DatabaseQualifi
 }
 
 execplan::SimpleColumn* TypeHandlerSInt24::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                           SystemCatalog::TypeHolderStd& ct,
+                                                           TypeHolderStd& ct,
                                                            const SimpleColumnParam& prm) const
 {
   if (ct.scale == 0)
@@ -780,7 +771,7 @@ execplan::SimpleColumn* TypeHandlerSInt24::newSimpleColumn(const DatabaseQualifi
 }
 
 execplan::SimpleColumn* TypeHandlerSInt32::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                           SystemCatalog::TypeHolderStd& ct,
+                                                           TypeHolderStd& ct,
                                                            const SimpleColumnParam& prm) const
 {
   if (ct.scale == 0)
@@ -792,7 +783,7 @@ execplan::SimpleColumn* TypeHandlerSInt32::newSimpleColumn(const DatabaseQualifi
 }
 
 execplan::SimpleColumn* TypeHandlerSInt64::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                           SystemCatalog::TypeHolderStd& ct,
+                                                           TypeHolderStd& ct,
                                                            const SimpleColumnParam& prm) const
 {
   if (ct.scale == 0)
@@ -804,7 +795,7 @@ execplan::SimpleColumn* TypeHandlerSInt64::newSimpleColumn(const DatabaseQualifi
 }
 
 execplan::SimpleColumn* TypeHandlerUInt8::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                          SystemCatalog::TypeHolderStd& ct,
+                                                          TypeHolderStd& ct,
                                                           const SimpleColumnParam& prm) const
 {
   // QQ: why scale is not checked (unlike SInt1)?
@@ -813,7 +804,7 @@ execplan::SimpleColumn* TypeHandlerUInt8::newSimpleColumn(const DatabaseQualifie
 }
 
 execplan::SimpleColumn* TypeHandlerUInt16::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                           SystemCatalog::TypeHolderStd& ct,
+                                                           TypeHolderStd& ct,
                                                            const SimpleColumnParam& prm) const
 {
   return new execplan::SimpleColumn_UINT<2>(name.db(), name.table(), name.column(), prm.columnStore(),
@@ -821,7 +812,7 @@ execplan::SimpleColumn* TypeHandlerUInt16::newSimpleColumn(const DatabaseQualifi
 }
 
 execplan::SimpleColumn* TypeHandlerUInt24::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                           SystemCatalog::TypeHolderStd& ct,
+                                                           TypeHolderStd& ct,
                                                            const SimpleColumnParam& prm) const
 {
   return new execplan::SimpleColumn_UINT<4>(name.db(), name.table(), name.column(), prm.columnStore(),
@@ -829,7 +820,7 @@ execplan::SimpleColumn* TypeHandlerUInt24::newSimpleColumn(const DatabaseQualifi
 }
 
 execplan::SimpleColumn* TypeHandlerUInt32::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                           SystemCatalog::TypeHolderStd& ct,
+                                                           TypeHolderStd& ct,
                                                            const SimpleColumnParam& prm) const
 {
   return new execplan::SimpleColumn_UINT<4>(name.db(), name.table(), name.column(), prm.columnStore(),
@@ -837,7 +828,7 @@ execplan::SimpleColumn* TypeHandlerUInt32::newSimpleColumn(const DatabaseQualifi
 }
 
 execplan::SimpleColumn* TypeHandlerUInt64::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                           SystemCatalog::TypeHolderStd& ct,
+                                                           TypeHolderStd& ct,
                                                            const SimpleColumnParam& prm) const
 {
   return new execplan::SimpleColumn_UINT<8>(name.db(), name.table(), name.column(), prm.columnStore(),
@@ -845,7 +836,7 @@ execplan::SimpleColumn* TypeHandlerUInt64::newSimpleColumn(const DatabaseQualifi
 }
 
 execplan::SimpleColumn* TypeHandlerReal::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                         SystemCatalog::TypeHolderStd& ct,
+                                                         TypeHolderStd& ct,
                                                          const SimpleColumnParam& prm) const
 {
   // QQ
@@ -854,7 +845,7 @@ execplan::SimpleColumn* TypeHandlerReal::newSimpleColumn(const DatabaseQualified
 }
 
 execplan::SimpleColumn* TypeHandlerXDecimal::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                             SystemCatalog::TypeHolderStd& ct,
+                                                             TypeHolderStd& ct,
                                                              const SimpleColumnParam& prm) const
 {
   // QQ
@@ -863,8 +854,7 @@ execplan::SimpleColumn* TypeHandlerXDecimal::newSimpleColumn(const DatabaseQuali
 }
 
 execplan::SimpleColumn* TypeHandlerStr::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                        SystemCatalog::TypeHolderStd& ct,
-                                                        const SimpleColumnParam& prm) const
+                                                        TypeHolderStd& ct, const SimpleColumnParam& prm) const
 {
   // QQ
   return new execplan::SimpleColumn(name.db(), name.table(), name.column(), prm.columnStore(),
@@ -872,7 +862,7 @@ execplan::SimpleColumn* TypeHandlerStr::newSimpleColumn(const DatabaseQualifiedC
 }
 
 execplan::SimpleColumn* TypeHandlerTemporal::newSimpleColumn(const DatabaseQualifiedColumnName& name,
-                                                             SystemCatalog::TypeHolderStd& ct,
+                                                             TypeHolderStd& ct,
                                                              const SimpleColumnParam& prm) const
 {
   // QQ
@@ -892,7 +882,7 @@ class SimpleConverter : public boost::any
   bool m_pushWarning;
 
  public:
-  SimpleConverter(const SessionParam& sp, const TypeHandler* h, const SystemCatalog::TypeAttributesStd& attr,
+  SimpleConverter(const SessionParam& sp, const TypeHandler* h, const TypeAttributesStd& attr,
                   const char* str)
    : boost::any(h->convertFromString(attr, ConvertFromStringParam(sp.timeZone(), true, false), str,
                                      initPushWarning()))
@@ -939,8 +929,8 @@ class SimpleConverter : public boost::any
 class SimpleConverterSNumeric : public SimpleConverter
 {
  public:
-  SimpleConverterSNumeric(const SessionParam& sp, const TypeHandler* h,
-                          const SystemCatalog::TypeAttributesStd& attr, const char* str, round_style_t& rf)
+  SimpleConverterSNumeric(const SessionParam& sp, const TypeHandler* h, const TypeAttributesStd& attr,
+                          const char* str, round_style_t& rf)
    : SimpleConverter(sp, h, attr, str)
   {
     rf = roundStyle(str);
@@ -948,133 +938,117 @@ class SimpleConverterSNumeric : public SimpleConverter
 };
 
 template <typename T>
-SimpleValue toSimpleValueSInt(const SessionParam& sp, const TypeHandler* h,
-                              const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                              round_style_t& rf)
+SimpleValue toSimpleValueSInt(const SessionParam& sp, const TypeHandler* h, const TypeAttributesStd& attr,
+                              const char* str, round_style_t& rf)
 {
   idbassert(attr.colWidth <= SystemCatalog::EIGHT_BYTE);
   SimpleConverterSNumeric anyVal(sp, h, attr, str, rf);
   return SimpleValueSInt64(static_cast<int64_t>(boost::any_cast<T>(anyVal)));
 }
 
-SimpleValue TypeHandlerSInt8::toSimpleValue(const SessionParam& sp,
-                                            const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                            round_style_t& rf) const
+SimpleValue TypeHandlerSInt8::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                            const char* str, round_style_t& rf) const
 {
   return toSimpleValueSInt<char>(sp, this, attr, str, rf);
 }
 
-SimpleValue TypeHandlerSInt16::toSimpleValue(const SessionParam& sp,
-                                             const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                             round_style_t& rf) const
+SimpleValue TypeHandlerSInt16::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                             const char* str, round_style_t& rf) const
 {
   return toSimpleValueSInt<int16_t>(sp, this, attr, str, rf);
 }
 
-SimpleValue TypeHandlerSInt24::toSimpleValue(const SessionParam& sp,
-                                             const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                             round_style_t& rf) const
+SimpleValue TypeHandlerSInt24::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                             const char* str, round_style_t& rf) const
 {
   return toSimpleValueSInt<mcs_sint32_t>(sp, this, attr, str, rf);
 }
 
-SimpleValue TypeHandlerSInt32::toSimpleValue(const SessionParam& sp,
-                                             const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                             round_style_t& rf) const
+SimpleValue TypeHandlerSInt32::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                             const char* str, round_style_t& rf) const
 {
   return toSimpleValueSInt<mcs_sint32_t>(sp, this, attr, str, rf);
 }
 
-SimpleValue TypeHandlerSInt64::toSimpleValue(const SessionParam& sp,
-                                             const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                             round_style_t& rf) const
+SimpleValue TypeHandlerSInt64::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                             const char* str, round_style_t& rf) const
 {
   return toSimpleValueSInt<long long>(sp, this, attr, str, rf);
 }
 
 template <typename T>
-SimpleValue toSimpleValueUInt(const SessionParam& sp, const TypeHandler* h,
-                              const SystemCatalog::TypeAttributesStd& attr, const char* str)
+SimpleValue toSimpleValueUInt(const SessionParam& sp, const TypeHandler* h, const TypeAttributesStd& attr,
+                              const char* str)
 {
   idbassert(attr.colWidth <= SystemCatalog::EIGHT_BYTE);
   SimpleConverter anyVal(sp, h, attr, str);
   return SimpleValueSInt64(static_cast<int64_t>(boost::any_cast<T>(anyVal)));
 }
 
-SimpleValue TypeHandlerUInt8::toSimpleValue(const SessionParam& sp,
-                                            const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                            round_style_t& rf) const
+SimpleValue TypeHandlerUInt8::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                            const char* str, round_style_t& rf) const
 {
   return toSimpleValueUInt<uint8_t>(sp, this, attr, str);
 }
 
-SimpleValue TypeHandlerUInt16::toSimpleValue(const SessionParam& sp,
-                                             const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                             round_style_t& rf) const
+SimpleValue TypeHandlerUInt16::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                             const char* str, round_style_t& rf) const
 {
   return toSimpleValueUInt<uint16_t>(sp, this, attr, str);
 }
 
-SimpleValue TypeHandlerUInt24::toSimpleValue(const SessionParam& sp,
-                                             const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                             round_style_t& rf) const
+SimpleValue TypeHandlerUInt24::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                             const char* str, round_style_t& rf) const
 {
   return toSimpleValueUInt<uint32_t>(sp, this, attr, str);
 }
 
-SimpleValue TypeHandlerUInt32::toSimpleValue(const SessionParam& sp,
-                                             const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                             round_style_t& rf) const
+SimpleValue TypeHandlerUInt32::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                             const char* str, round_style_t& rf) const
 {
   return toSimpleValueUInt<uint32_t>(sp, this, attr, str);
 }
 
-SimpleValue TypeHandlerUInt64::toSimpleValue(const SessionParam& sp,
-                                             const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                             round_style_t& rf) const
+SimpleValue TypeHandlerUInt64::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                             const char* str, round_style_t& rf) const
 {
   return toSimpleValueUInt<uint64_t>(sp, this, attr, str);
 }
 
-SimpleValue TypeHandlerDate::toSimpleValue(const SessionParam& sp,
-                                           const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                           round_style_t& rf) const
+SimpleValue TypeHandlerDate::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                           const char* str, round_style_t& rf) const
 {
   idbassert(attr.colWidth <= SystemCatalog::EIGHT_BYTE);
   SimpleConverter anyVal(sp, this, attr, str);
   return SimpleValueSInt64(static_cast<int64_t>(anyVal.to_uint32()));
 }
 
-SimpleValue TypeHandlerDatetime::toSimpleValue(const SessionParam& sp,
-                                               const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                               round_style_t& rf) const
+SimpleValue TypeHandlerDatetime::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                               const char* str, round_style_t& rf) const
 {
   idbassert(attr.colWidth <= SystemCatalog::EIGHT_BYTE);
   SimpleConverter anyVal(sp, this, attr, str);
   return SimpleValueSInt64(static_cast<int64_t>(anyVal.to_uint64()));
 }
 
-SimpleValue TypeHandlerTimestamp::toSimpleValue(const SessionParam& sp,
-                                                const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                                round_style_t& rf) const
+SimpleValue TypeHandlerTimestamp::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                                const char* str, round_style_t& rf) const
 {
   idbassert(attr.colWidth <= SystemCatalog::EIGHT_BYTE);
   SimpleConverter anyVal(sp, this, attr, str);
   return SimpleValueTimestamp(anyVal.to_uint64(), sp.timeZone());
 }
 
-SimpleValue TypeHandlerTime::toSimpleValue(const SessionParam& sp,
-                                           const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                           round_style_t& rf) const
+SimpleValue TypeHandlerTime::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                           const char* str, round_style_t& rf) const
 {
   idbassert(attr.colWidth <= SystemCatalog::EIGHT_BYTE);
   SimpleConverter anyVal(sp, this, attr, str);
   return SimpleValueSInt64(anyVal.to_sint64());
 }
 
-SimpleValue TypeHandlerXDecimal::toSimpleValue(const SessionParam& sp,
-                                               const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                               round_style_t& rf) const
+SimpleValue TypeHandlerXDecimal::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                               const char* str, round_style_t& rf) const
 {
   if (attr.colWidth <= SystemCatalog::EIGHT_BYTE)
   {
@@ -1103,9 +1077,8 @@ SimpleValue TypeHandlerXDecimal::toSimpleValue(const SessionParam& sp,
   }
 }
 
-SimpleValue TypeHandlerStr::toSimpleValue(const SessionParam& sp,
-                                          const SystemCatalog::TypeAttributesStd& attr, const char* str,
-                                          round_style_t& rf) const
+SimpleValue TypeHandlerStr::toSimpleValue(const SessionParam& sp, const TypeAttributesStd& attr,
+                                          const char* str, round_style_t& rf) const
 {
   SimpleConverter anyVal(sp, this, attr, str);
   rf = anyVal.roundStyle();
@@ -1122,9 +1095,8 @@ MinMaxPartitionInfo::MinMaxPartitionInfo(const BRM::EMEntry& entry)
 {
 }
 
-MinMaxPartitionInfo TypeHandler::getExtentPartitionInfo(const SystemCatalog::TypeAttributesStd& attr,
-                                                        BRM::DBRM& em, const BRM::EMEntry& entry,
-                                                        int* state) const
+MinMaxPartitionInfo TypeHandler::getExtentPartitionInfo(const TypeAttributesStd& attr, BRM::DBRM& em,
+                                                        const BRM::EMEntry& entry, int* state) const
 {
   int32_t seqNum;
   MinMaxPartitionInfo partInfo(entry);
@@ -1132,8 +1104,9 @@ MinMaxPartitionInfo TypeHandler::getExtentPartitionInfo(const SystemCatalog::Typ
   return partInfo;
 }
 
-MinMaxPartitionInfo TypeHandlerXDecimal::getExtentPartitionInfo64(
-    const SystemCatalog::TypeAttributesStd& attr, BRM::DBRM& em, const BRM::EMEntry& entry, int* state) const
+MinMaxPartitionInfo TypeHandlerXDecimal::getExtentPartitionInfo64(const TypeAttributesStd& attr,
+                                                                  BRM::DBRM& em, const BRM::EMEntry& entry,
+                                                                  int* state) const
 {
   int32_t seqNum;
   MinMaxPartitionInfo partInfo(entry);
@@ -1141,8 +1114,9 @@ MinMaxPartitionInfo TypeHandlerXDecimal::getExtentPartitionInfo64(
   return partInfo;
 }
 
-MinMaxPartitionInfo TypeHandlerXDecimal::getExtentPartitionInfo128(
-    const SystemCatalog::TypeAttributesStd& attr, BRM::DBRM& em, const BRM::EMEntry& entry, int* state) const
+MinMaxPartitionInfo TypeHandlerXDecimal::getExtentPartitionInfo128(const TypeAttributesStd& attr,
+                                                                   BRM::DBRM& em, const BRM::EMEntry& entry,
+                                                                   int* state) const
 {
   int32_t seqNum;
   MinMaxPartitionInfo partInfo(entry);
@@ -1150,9 +1124,8 @@ MinMaxPartitionInfo TypeHandlerXDecimal::getExtentPartitionInfo128(
   return partInfo;
 }
 
-MinMaxPartitionInfo TypeHandlerChar::getExtentPartitionInfo(const SystemCatalog::TypeAttributesStd& attr,
-                                                            BRM::DBRM& em, const BRM::EMEntry& entry,
-                                                            int* state) const
+MinMaxPartitionInfo TypeHandlerChar::getExtentPartitionInfo(const TypeAttributesStd& attr, BRM::DBRM& em,
+                                                            const BRM::EMEntry& entry, int* state) const
 {
   int32_t seqNum;
   MinMaxPartitionInfo partInfo(entry);
@@ -1166,9 +1139,8 @@ MinMaxPartitionInfo TypeHandlerChar::getExtentPartitionInfo(const SystemCatalog:
   return partInfo;
 }
 
-MinMaxPartitionInfo TypeHandlerVarchar::getExtentPartitionInfo(const SystemCatalog::TypeAttributesStd& attr,
-                                                               BRM::DBRM& em, const BRM::EMEntry& entry,
-                                                               int* state) const
+MinMaxPartitionInfo TypeHandlerVarchar::getExtentPartitionInfo(const TypeAttributesStd& attr, BRM::DBRM& em,
+                                                               const BRM::EMEntry& entry, int* state) const
 {
   int32_t seqNum;
   MinMaxPartitionInfo partInfo(entry);
@@ -1184,7 +1156,7 @@ MinMaxPartitionInfo TypeHandlerVarchar::getExtentPartitionInfo(const SystemCatal
 
 /****************************************************************************/
 
-string TypeHandler::PrintPartitionValueSInt64(const SystemCatalog::TypeAttributesStd& attr,
+string TypeHandler::PrintPartitionValueSInt64(const TypeAttributesStd& attr,
                                               const MinMaxPartitionInfo& partInfo,
                                               const SimpleValue& startVal, round_style_t rfMin,
                                               const SimpleValue& endVal, round_style_t rfMax) const
@@ -1201,7 +1173,7 @@ string TypeHandler::PrintPartitionValueSInt64(const SystemCatalog::TypeAttribute
   return oss.str();
 }
 
-string TypeHandler::PrintPartitionValueUInt64(const SystemCatalog::TypeAttributesStd& attr,
+string TypeHandler::PrintPartitionValueUInt64(const TypeAttributesStd& attr,
                                               const MinMaxPartitionInfo& partInfo,
                                               const SimpleValue& startVal, round_style_t rfMin,
                                               const SimpleValue& endVal, round_style_t rfMax) const
@@ -1218,7 +1190,7 @@ string TypeHandler::PrintPartitionValueUInt64(const SystemCatalog::TypeAttribute
   return oss.str();
 }
 
-string TypeHandlerXDecimal::PrintPartitionValue128(const SystemCatalog::TypeAttributesStd& attr,
+string TypeHandlerXDecimal::PrintPartitionValue128(const TypeAttributesStd& attr,
                                                    const MinMaxPartitionInfo& partInfo,
                                                    const SimpleValue& startVal, round_style_t rfMin,
                                                    const SimpleValue& endVal, round_style_t rfMax) const
@@ -1238,77 +1210,77 @@ string TypeHandlerXDecimal::PrintPartitionValue128(const SystemCatalog::TypeAttr
 
 /****************************************************************************/
 
-boost::any TypeHandlerSInt8::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerSInt8::getNullValueForType(const TypeAttributesStd& attr) const
 {
   char tinyintvalue = joblist::TINYINTNULL;
   boost::any value = tinyintvalue;
   return value;
 }
 
-boost::any TypeHandlerUInt8::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerUInt8::getNullValueForType(const TypeAttributesStd& attr) const
 {
   uint8_t utinyintvalue = joblist::UTINYINTNULL;
   boost::any value = utinyintvalue;
   return value;
 }
 
-boost::any TypeHandlerSInt16::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerSInt16::getNullValueForType(const TypeAttributesStd& attr) const
 {
   short smallintvalue = joblist::SMALLINTNULL;
   boost::any value = smallintvalue;
   return value;
 }
 
-boost::any TypeHandlerUInt16::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerUInt16::getNullValueForType(const TypeAttributesStd& attr) const
 {
   uint16_t usmallintvalue = joblist::USMALLINTNULL;
   boost::any value = usmallintvalue;
   return value;
 }
 
-boost::any TypeHandlerSInt24::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerSInt24::getNullValueForType(const TypeAttributesStd& attr) const
 {
   int intvalue = joblist::INTNULL;
   boost::any value = intvalue;
   return value;
 }
 
-boost::any TypeHandlerSInt32::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerSInt32::getNullValueForType(const TypeAttributesStd& attr) const
 {
   int intvalue = joblist::INTNULL;
   boost::any value = intvalue;
   return value;
 }
 
-boost::any TypeHandlerUInt24::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerUInt24::getNullValueForType(const TypeAttributesStd& attr) const
 {
   uint32_t uintvalue = joblist::UINTNULL;
   boost::any value = uintvalue;
   return value;
 }
 
-boost::any TypeHandlerUInt32::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerUInt32::getNullValueForType(const TypeAttributesStd& attr) const
 {
   uint32_t uintvalue = joblist::UINTNULL;
   boost::any value = uintvalue;
   return value;
 }
 
-boost::any TypeHandlerSInt64::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerSInt64::getNullValueForType(const TypeAttributesStd& attr) const
 {
   long long bigint = joblist::BIGINTNULL;
   boost::any value = bigint;
   return value;
 }
 
-boost::any TypeHandlerUInt64::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerUInt64::getNullValueForType(const TypeAttributesStd& attr) const
 {
   uint64_t ubigint = joblist::UBIGINTNULL;
   boost::any value = ubigint;
   return value;
 }
 
-boost::any TypeHandlerXDecimal::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerXDecimal::getNullValueForType(const TypeAttributesStd& attr) const
 {
   if (LIKELY(attr.colWidth == 16))
   {
@@ -1346,7 +1318,7 @@ boost::any TypeHandlerXDecimal::getNullValueForType(const SystemCatalog::TypeAtt
   return value;
 }
 
-boost::any TypeHandlerSFloat::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerSFloat::getNullValueForType(const TypeAttributesStd& attr) const
 {
   uint32_t jlfloatnull = joblist::FLOATNULL;
   float* fp = reinterpret_cast<float*>(&jlfloatnull);
@@ -1354,7 +1326,7 @@ boost::any TypeHandlerSFloat::getNullValueForType(const SystemCatalog::TypeAttri
   return value;
 }
 
-boost::any TypeHandlerUFloat::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerUFloat::getNullValueForType(const TypeAttributesStd& attr) const
 {
   uint32_t jlfloatnull = joblist::FLOATNULL;
   float* fp = reinterpret_cast<float*>(&jlfloatnull);
@@ -1362,7 +1334,7 @@ boost::any TypeHandlerUFloat::getNullValueForType(const SystemCatalog::TypeAttri
   return value;
 }
 
-boost::any TypeHandlerSDouble::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerSDouble::getNullValueForType(const TypeAttributesStd& attr) const
 {
   uint64_t jldoublenull = joblist::DOUBLENULL;
   double* dp = reinterpret_cast<double*>(&jldoublenull);
@@ -1370,7 +1342,7 @@ boost::any TypeHandlerSDouble::getNullValueForType(const SystemCatalog::TypeAttr
   return value;
 }
 
-boost::any TypeHandlerUDouble::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerUDouble::getNullValueForType(const TypeAttributesStd& attr) const
 {
   uint64_t jldoublenull = joblist::DOUBLENULL;
   double* dp = reinterpret_cast<double*>(&jldoublenull);
@@ -1378,35 +1350,35 @@ boost::any TypeHandlerUDouble::getNullValueForType(const SystemCatalog::TypeAttr
   return value;
 }
 
-boost::any TypeHandlerDate::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerDate::getNullValueForType(const TypeAttributesStd& attr) const
 {
   uint32_t d = joblist::DATENULL;
   boost::any value = d;
   return value;
 }
 
-boost::any TypeHandlerDatetime::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerDatetime::getNullValueForType(const TypeAttributesStd& attr) const
 {
   uint64_t d = joblist::DATETIMENULL;
   boost::any value = d;
   return value;
 }
 
-boost::any TypeHandlerTime::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerTime::getNullValueForType(const TypeAttributesStd& attr) const
 {
   int64_t d = joblist::TIMENULL;
   boost::any value = d;
   return value;
 }
 
-boost::any TypeHandlerTimestamp::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerTimestamp::getNullValueForType(const TypeAttributesStd& attr) const
 {
   uint64_t d = joblist::TIMESTAMPNULL;
   boost::any value = d;
   return value;
 }
 
-boost::any TypeHandlerChar::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerChar::getNullValueForType(const TypeAttributesStd& attr) const
 {
   switch (attr.colWidth)
   {
@@ -1448,7 +1420,7 @@ boost::any TypeHandlerChar::getNullValueForType(const SystemCatalog::TypeAttribu
   return value;
 }
 
-boost::any TypeHandlerStr::getNullValueForTypeVarcharText(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerStr::getNullValueForTypeVarcharText(const TypeAttributesStd& attr) const
 {
   switch (attr.colWidth)
   {
@@ -1483,14 +1455,14 @@ boost::any TypeHandlerStr::getNullValueForTypeVarcharText(const SystemCatalog::T
   return value;
 }
 
-boost::any TypeHandlerBlob::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerBlob::getNullValueForType(const TypeAttributesStd& attr) const
 {
   WriteEngine::Token nullToken;
   boost::any value = nullToken;
   return value;
 }
 
-boost::any TypeHandlerVarbinary::getNullValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+boost::any TypeHandlerVarbinary::getNullValueForType(const TypeAttributesStd& attr) const
 {
   WriteEngine::Token nullToken;
   boost::any value = nullToken;
@@ -1499,14 +1471,14 @@ boost::any TypeHandlerVarbinary::getNullValueForType(const SystemCatalog::TypeAt
 
 /****************************************************************************/
 
-boost::any TypeHandlerBit::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerBit::convertFromString(const TypeAttributesStd& colType,
                                              const ConvertFromStringParam& prm, const std::string& data,
                                              bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToBit(colType, prm, data, pushWarning);
 }
 
-boost::any TypeHandlerSInt8::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerSInt8::convertFromString(const TypeAttributesStd& colType,
                                                const ConvertFromStringParam& prm, const std::string& data,
                                                bool& pushWarning) const
 {
@@ -1516,7 +1488,7 @@ boost::any TypeHandlerSInt8::convertFromString(const SystemCatalog::TypeAttribut
   return value;
 }
 
-boost::any TypeHandlerSInt16::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerSInt16::convertFromString(const TypeAttributesStd& colType,
                                                 const ConvertFromStringParam& prm, const std::string& data,
                                                 bool& pushWarning) const
 {
@@ -1526,7 +1498,7 @@ boost::any TypeHandlerSInt16::convertFromString(const SystemCatalog::TypeAttribu
   return value;
 }
 
-boost::any TypeHandlerSInt24::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerSInt24::convertFromString(const TypeAttributesStd& colType,
                                                 const ConvertFromStringParam& prm, const std::string& data,
                                                 bool& pushWarning) const
 {
@@ -1536,7 +1508,7 @@ boost::any TypeHandlerSInt24::convertFromString(const SystemCatalog::TypeAttribu
   return value;
 }
 
-boost::any TypeHandlerSInt32::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerSInt32::convertFromString(const TypeAttributesStd& colType,
                                                 const ConvertFromStringParam& prm, const std::string& data,
                                                 bool& pushWarning) const
 {
@@ -1546,7 +1518,7 @@ boost::any TypeHandlerSInt32::convertFromString(const SystemCatalog::TypeAttribu
   return value;
 }
 
-boost::any TypeHandlerSInt64::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerSInt64::convertFromString(const TypeAttributesStd& colType,
                                                 const ConvertFromStringParam& prm, const std::string& data,
                                                 bool& pushWarning) const
 {
@@ -1556,7 +1528,7 @@ boost::any TypeHandlerSInt64::convertFromString(const SystemCatalog::TypeAttribu
   return value;
 }
 
-boost::any TypeHandlerUInt8::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerUInt8::convertFromString(const TypeAttributesStd& colType,
                                                const ConvertFromStringParam& prm, const std::string& data,
                                                bool& pushWarning) const
 
@@ -1566,7 +1538,7 @@ boost::any TypeHandlerUInt8::convertFromString(const SystemCatalog::TypeAttribut
   return value;
 }
 
-boost::any TypeHandlerUInt16::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerUInt16::convertFromString(const TypeAttributesStd& colType,
                                                 const ConvertFromStringParam& prm, const std::string& data,
                                                 bool& pushWarning) const
 {
@@ -1575,7 +1547,7 @@ boost::any TypeHandlerUInt16::convertFromString(const SystemCatalog::TypeAttribu
   return value;
 }
 
-boost::any TypeHandlerUInt24::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerUInt24::convertFromString(const TypeAttributesStd& colType,
                                                 const ConvertFromStringParam& prm, const std::string& data,
                                                 bool& pushWarning) const
 {
@@ -1584,7 +1556,7 @@ boost::any TypeHandlerUInt24::convertFromString(const SystemCatalog::TypeAttribu
   return value;
 }
 
-boost::any TypeHandlerUInt32::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerUInt32::convertFromString(const TypeAttributesStd& colType,
                                                 const ConvertFromStringParam& prm, const std::string& data,
                                                 bool& pushWarning) const
 {
@@ -1593,7 +1565,7 @@ boost::any TypeHandlerUInt32::convertFromString(const SystemCatalog::TypeAttribu
   return value;
 }
 
-boost::any TypeHandlerUInt64::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerUInt64::convertFromString(const TypeAttributesStd& colType,
                                                 const ConvertFromStringParam& prm, const std::string& data,
                                                 bool& pushWarning) const
 {
@@ -1602,84 +1574,84 @@ boost::any TypeHandlerUInt64::convertFromString(const SystemCatalog::TypeAttribu
   return value;
 }
 
-boost::any TypeHandlerSFloat::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerSFloat::convertFromString(const TypeAttributesStd& colType,
                                                 const ConvertFromStringParam& prm, const std::string& data,
                                                 bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToFloat(SystemCatalog::FLOAT, data, pushWarning);
 }
 
-boost::any TypeHandlerUFloat::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerUFloat::convertFromString(const TypeAttributesStd& colType,
                                                 const ConvertFromStringParam& prm, const std::string& data,
                                                 bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToFloat(SystemCatalog::UFLOAT, data, pushWarning);
 }
 
-boost::any TypeHandlerSDouble::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerSDouble::convertFromString(const TypeAttributesStd& colType,
                                                  const ConvertFromStringParam& prm, const std::string& data,
                                                  bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToDouble(SystemCatalog::DOUBLE, data, pushWarning);
 }
 
-boost::any TypeHandlerUDouble::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerUDouble::convertFromString(const TypeAttributesStd& colType,
                                                  const ConvertFromStringParam& prm, const std::string& data,
                                                  bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToDouble(SystemCatalog::UDOUBLE, data, pushWarning);
 }
 
-boost::any TypeHandlerDate::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerDate::convertFromString(const TypeAttributesStd& colType,
                                               const ConvertFromStringParam& prm, const std::string& data,
                                               bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToDate(data, pushWarning);
 }
 
-boost::any TypeHandlerDatetime::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerDatetime::convertFromString(const TypeAttributesStd& colType,
                                                   const ConvertFromStringParam& prm, const std::string& data,
                                                   bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToDatetime(data, pushWarning);
 }
 
-boost::any TypeHandlerTime::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerTime::convertFromString(const TypeAttributesStd& colType,
                                               const ConvertFromStringParam& prm, const std::string& data,
                                               bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToTime(colType, data, pushWarning);
 }
 
-boost::any TypeHandlerTimestamp::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerTimestamp::convertFromString(const TypeAttributesStd& colType,
                                                    const ConvertFromStringParam& prm, const std::string& data,
                                                    bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToTimestamp(prm, data, pushWarning);
 }
 
-boost::any TypeHandlerChar::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerChar::convertFromString(const TypeAttributesStd& colType,
                                               const ConvertFromStringParam& prm, const std::string& data,
                                               bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToString(colType, data, pushWarning);
 }
 
-boost::any TypeHandlerVarchar::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerVarchar::convertFromString(const TypeAttributesStd& colType,
                                                  const ConvertFromStringParam& prm, const std::string& data,
                                                  bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToString(colType, data, pushWarning);
 }
 
-boost::any TypeHandlerText::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerText::convertFromString(const TypeAttributesStd& colType,
                                               const ConvertFromStringParam& prm, const std::string& data,
                                               bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToString(colType, data, pushWarning);
 }
 
-boost::any TypeHandlerClob::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerClob::convertFromString(const TypeAttributesStd& colType,
                                               const ConvertFromStringParam& prm, const std::string& data,
                                               bool& pushWarning) const
 {
@@ -1687,7 +1659,7 @@ boost::any TypeHandlerClob::convertFromString(const SystemCatalog::TypeAttribute
   return value;
 }
 
-boost::any TypeHandlerBlob::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerBlob::convertFromString(const TypeAttributesStd& colType,
                                               const ConvertFromStringParam& prm, const std::string& data,
                                               bool& pushWarning) const
 {
@@ -1695,7 +1667,7 @@ boost::any TypeHandlerBlob::convertFromString(const SystemCatalog::TypeAttribute
   return value;
 }
 
-boost::any TypeHandlerVarbinary::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerVarbinary::convertFromString(const TypeAttributesStd& colType,
                                                    const ConvertFromStringParam& prm, const std::string& data,
                                                    bool& pushWarning) const
 {
@@ -1703,28 +1675,28 @@ boost::any TypeHandlerVarbinary::convertFromString(const SystemCatalog::TypeAttr
   return value;
 }
 
-boost::any TypeHandlerSDecimal64::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerSDecimal64::convertFromString(const TypeAttributesStd& colType,
                                                     const ConvertFromStringParam& prm,
                                                     const std::string& data, bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToSDecimal(colType, prm, data, pushWarning);
 }
 
-boost::any TypeHandlerUDecimal64::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerUDecimal64::convertFromString(const TypeAttributesStd& colType,
                                                     const ConvertFromStringParam& prm,
                                                     const std::string& data, bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToUDecimal(colType, prm, data, pushWarning);
 }
 
-boost::any TypeHandlerSDecimal128::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerSDecimal128::convertFromString(const TypeAttributesStd& colType,
                                                      const ConvertFromStringParam& prm,
                                                      const std::string& data, bool& pushWarning) const
 {
   return dataconvert::DataConvert::StringToSDecimal(colType, prm, data, pushWarning);
 }
 
-boost::any TypeHandlerUDecimal128::convertFromString(const SystemCatalog::TypeAttributesStd& colType,
+boost::any TypeHandlerUDecimal128::convertFromString(const TypeAttributesStd& colType,
                                                      const ConvertFromStringParam& prm,
                                                      const std::string& data, bool& pushWarning) const
 {
@@ -1738,7 +1710,7 @@ const uint8_t* getEmptyTypeHandlerSInt8()
   return &TINYINTEMPTYROW;
 }
 
-const uint8_t* TypeHandlerSInt8::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerSInt8::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerSInt8();
 }
@@ -1749,7 +1721,7 @@ const uint8_t* getEmptyTypeHandlerSInt16()
   return reinterpret_cast<const uint8_t*>(&SMALLINTEMPTYROW);
 }
 
-const uint8_t* TypeHandlerSInt16::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerSInt16::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerSInt16();
 }
@@ -1760,12 +1732,12 @@ const uint8_t* getEmptyTypeHandlerSInt32()
   return reinterpret_cast<const uint8_t*>(&INTEMPTYROW);
 }
 
-const uint8_t* TypeHandlerSInt24::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerSInt24::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerSInt32();
 }
 
-const uint8_t* TypeHandlerSInt32::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerSInt32::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerSInt32();
 }
@@ -1776,18 +1748,18 @@ const uint8_t* getEmptyTypeHandlerSInt64()
   return reinterpret_cast<const uint8_t*>(&BIGINTEMPTYROW);
 }
 
-const uint8_t* TypeHandlerSInt64::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerSInt64::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerSInt64();
 }
 
-const uint8_t* TypeHandlerUInt8::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerUInt8::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   const static uint8_t UTINYINTEMPTYROW = joblist::UTINYINTEMPTYROW;
   return reinterpret_cast<const uint8_t*>(&UTINYINTEMPTYROW);
 }
 
-const uint8_t* TypeHandlerUInt16::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerUInt16::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   const static uint16_t USMALLINTEMPTYROW = joblist::USMALLINTEMPTYROW;
   return reinterpret_cast<const uint8_t*>(&USMALLINTEMPTYROW);
@@ -1799,50 +1771,50 @@ const uint8_t* getEmptyTypeHandlerUInt32()
   return reinterpret_cast<const uint8_t*>(&UINTEMPTYROW);
 }
 
-const uint8_t* TypeHandlerUInt24::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerUInt24::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerUInt32();
 }
 
-const uint8_t* TypeHandlerUInt32::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerUInt32::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerUInt32();
 }
 
-const uint8_t* TypeHandlerUInt64::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerUInt64::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   const static uint64_t UBIGINTEMPTYROW = joblist::UBIGINTEMPTYROW;
   return reinterpret_cast<const uint8_t*>(&UBIGINTEMPTYROW);
 }
 
-const uint8_t* getEmptyTypeHandlerFloat(const SystemCatalog::TypeAttributesStd& attr)
+const uint8_t* getEmptyTypeHandlerFloat(const TypeAttributesStd& attr)
 {
   const static uint32_t FLOATEMPTYROW = joblist::FLOATEMPTYROW;
   return reinterpret_cast<const uint8_t*>(&FLOATEMPTYROW);
 }
 
-const uint8_t* TypeHandlerUFloat::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerUFloat::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerFloat(attr);
 }
 
-const uint8_t* TypeHandlerSFloat::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerSFloat::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerFloat(attr);
 }
 
-const uint8_t* getEmptyTypeHandlerDouble(const SystemCatalog::TypeAttributesStd& attr)
+const uint8_t* getEmptyTypeHandlerDouble(const TypeAttributesStd& attr)
 {
   const static uint64_t DOUBLEEMPTYROW = joblist::DOUBLEEMPTYROW;
   return reinterpret_cast<const uint8_t*>(&DOUBLEEMPTYROW);
 }
 
-const uint8_t* TypeHandlerUDouble::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerUDouble::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerDouble(attr);
 }
 
-const uint8_t* TypeHandlerSDouble::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerSDouble::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerDouble(attr);
 }
@@ -1851,7 +1823,7 @@ const uint8_t* TypeHandlerSDouble::getEmptyValueForType(const SystemCatalog::Typ
 // args
 //  attr - width, precision and scale
 //  offset - offset value to reduce width for VARCHAR by 1
-const uint8_t* getEmptyTypeHandlerStr(const SystemCatalog::TypeAttributesStd& attr, int8_t offset)
+const uint8_t* getEmptyTypeHandlerStr(const TypeAttributesStd& attr, int8_t offset)
 {
   const static uint8_t CHAR1EMPTYROW = joblist::CHAR1EMPTYROW;
   const static uint16_t CHAR2EMPTYROW = joblist::CHAR2EMPTYROW;
@@ -1868,17 +1840,17 @@ const uint8_t* getEmptyTypeHandlerStr(const SystemCatalog::TypeAttributesStd& at
   return reinterpret_cast<const uint8_t*>(&CHAR1EMPTYROW);
 }
 
-const uint8_t* TypeHandlerStr::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerStr::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerStr(attr, 0);
 }
 
-const uint8_t* TypeHandlerVarchar::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerVarchar::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyTypeHandlerStr(attr, -1);
 }
 
-inline const uint8_t* getEmptyValueForDecimal64(const SystemCatalog::TypeAttributesStd& attr)
+inline const uint8_t* getEmptyValueForDecimal64(const TypeAttributesStd& attr)
 {
   if (attr.colWidth <= 1)
     return getEmptyTypeHandlerSInt8();
@@ -1890,24 +1862,22 @@ inline const uint8_t* getEmptyValueForDecimal64(const SystemCatalog::TypeAttribu
     return getEmptyTypeHandlerSInt64();
 }
 
-const uint8_t* TypeHandlerSDecimal64::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerSDecimal64::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyValueForDecimal64(attr);
 }
 
-const uint8_t* TypeHandlerUDecimal64::getEmptyValueForType(const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerUDecimal64::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return getEmptyValueForDecimal64(attr);
 }
 
-const uint8_t* TypeHandlerSDecimal128::getEmptyValueForType(
-    const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerSDecimal128::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return reinterpret_cast<const uint8_t*>(&datatypes::Decimal128Empty);
 }
 
-const uint8_t* TypeHandlerUDecimal128::getEmptyValueForType(
-    const SystemCatalog::TypeAttributesStd& attr) const
+const uint8_t* TypeHandlerUDecimal128::getEmptyValueForType(const TypeAttributesStd& attr) const
 {
   return reinterpret_cast<const uint8_t*>(&datatypes::Decimal128Empty);
 }
@@ -1915,4 +1885,3 @@ const uint8_t* TypeHandlerUDecimal128::getEmptyValueForType(
 /****************************************************************************/
 
 }  // end of namespace datatypes
-

--- a/datatypes/mcs_datatype_basic.h
+++ b/datatypes/mcs_datatype_basic.h
@@ -26,38 +26,241 @@
   needed in multiple mcs_TYPE.h files.
 */
 
+namespace datatypes
+{
+class SystemCatalog
+{
+ public:
+  /** the set of Calpont column widths
+   *
+   */
+  enum ColWidth
+  {
+    ONE_BIT,
+    ONE_BYTE,
+    TWO_BYTE,
+    THREE_BYTE,
+    FOUR_BYTE,
+    FIVE_BYTE,
+    SIX_BYTE,
+    SEVEN_BYTE,
+    EIGHT_BYTE
+  };
+
+  /** the set of Calpont column data types
+   *
+   */
+  enum ColDataType
+  {
+    BIT,                  /*!< BIT type */
+    TINYINT,              /*!< TINYINT type */
+    CHAR,                 /*!< CHAR type */
+    SMALLINT,             /*!< SMALLINT type */
+    DECIMAL,              /*!< DECIMAL type */
+    MEDINT,               /*!< MEDINT type */
+    INT,                  /*!< INT type */
+    FLOAT,                /*!< FLOAT type */
+    DATE,                 /*!< DATE type */
+    BIGINT,               /*!< BIGINT type */
+    DOUBLE,               /*!< DOUBLE type */
+    DATETIME,             /*!< DATETIME type */
+    VARCHAR,              /*!< VARCHAR type */
+    VARBINARY,            /*!< VARBINARY type */
+    CLOB,                 /*!< CLOB type */
+    BLOB,                 /*!< BLOB type */
+    UTINYINT,             /*!< Unsigned TINYINT type */
+    USMALLINT,            /*!< Unsigned SMALLINT type */
+    UDECIMAL,             /*!< Unsigned DECIMAL type */
+    UMEDINT,              /*!< Unsigned MEDINT type */
+    UINT,                 /*!< Unsigned INT type */
+    UFLOAT,               /*!< Unsigned FLOAT type */
+    UBIGINT,              /*!< Unsigned BIGINT type */
+    UDOUBLE,              /*!< Unsigned DOUBLE type */
+    TEXT,                 /*!< TEXT type */
+    TIME,                 /*!< TIME type */
+    TIMESTAMP,            /*!< TIMESTAMP type */
+    NUM_OF_COL_DATA_TYPE, /* NEW TYPES ABOVE HERE */
+    LONGDOUBLE,           /* @bug3241, dev and variance calculation only */
+    STRINT,               /* @bug3532, string as int for fast comparison */
+    UNDEFINED,            /*!< Undefined - used in UDAF API */
+  };
+};
+
+template <SystemCatalog::ColDataType>
+struct ColTypeToIntegral
+{
+  using type = struct
+  {
+  };
+};
+
+template <>
+struct ColTypeToIntegral<SystemCatalog::TINYINT>
+{
+  using type = int8_t;
+};
+
+template <>
+struct ColTypeToIntegral<SystemCatalog::UTINYINT>
+{
+  using type = uint8_t;
+};
+
+template <>
+struct ColTypeToIntegral<SystemCatalog::SMALLINT>
+{
+  using type = int16_t;
+};
+
+template <>
+struct ColTypeToIntegral<SystemCatalog::USMALLINT>
+{
+  using type = uint16_t;
+};
+
+template <>
+struct ColTypeToIntegral<SystemCatalog::MEDINT>
+{
+  using type = int32_t;
+};
+
+template <>
+struct ColTypeToIntegral<SystemCatalog::UMEDINT>
+{
+  using type = uint32_t;
+};
+
+template <>
+struct ColTypeToIntegral<SystemCatalog::INT>
+{
+  using type = int32_t;
+};
+
+template <>
+struct ColTypeToIntegral<SystemCatalog::UINT>
+{
+  using type = uint32_t;
+};
+
+template <>
+struct ColTypeToIntegral<SystemCatalog::BIGINT>
+{
+  using type = int64_t;
+};
+
+template <>
+struct ColTypeToIntegral<SystemCatalog::UBIGINT>
+{
+  using type = uint64_t;
+};
+
+template <SystemCatalog::ColDataType CT>
+struct ranges_limits
+{
+  using T = ColTypeToIntegral<CT>::type;
+  static constexpr T min()
+  {
+    if constexpr (std::is_signed_v<T>)
+      return std::numeric_limits<T>::min() + 2;
+    else
+      return std::numeric_limits<T>::min();
+  }
+  static constexpr T max()
+  {
+    if constexpr (std::is_signed_v<T>)
+      return std::numeric_limits<T>::max();
+    else
+      return std::numeric_limits<T>::max() - 2;
+  }
+};
+
+template <>
+struct ranges_limits<SystemCatalog::MEDINT>
+{
+  using T = int32_t;
+  static constexpr T min()
+  {
+    return static_cast<T>(-(1ULL << 23));
+  }
+  static constexpr T max()
+  {
+    return static_cast<T>((1ULL << 23) - 1);
+  }
+};
+
+template <>
+struct ranges_limits<SystemCatalog::UMEDINT>
+{
+  using T = int32_t;
+  static constexpr T min()
+  {
+    return static_cast<T>(0);
+  }
+  static constexpr T max()
+  {
+    return static_cast<T>((1ULL << 24) - 1);
+  }
+};
+
+}  // namespace datatypes
+
 namespace
 {
-const int64_t MIN_TINYINT __attribute__((unused)) = std::numeric_limits<int8_t>::min() + 2;    // -126;
-const int64_t MAX_TINYINT __attribute__((unused)) = std::numeric_limits<int8_t>::max();        //  127;
-const int64_t MIN_SMALLINT __attribute__((unused)) = std::numeric_limits<int16_t>::min() + 2;  // -32766;
-const int64_t MAX_SMALLINT __attribute__((unused)) = std::numeric_limits<int16_t>::max();      //  32767;
-const int64_t MIN_MEDINT __attribute__((unused)) = -(1ULL << 23);                              // -8388608;
-const int64_t MAX_MEDINT __attribute__((unused)) = (1ULL << 23) - 1;                           //  8388607;
-const int64_t MIN_INT __attribute__((unused)) = std::numeric_limits<int32_t>::min() + 2;       // -2147483646;
-const int64_t MAX_INT __attribute__((unused)) = std::numeric_limits<int32_t>::max();           //  2147483647;
-const int64_t MIN_BIGINT = std::numeric_limits<int64_t>::min() + 2;  // -9223372036854775806LL;
-const int64_t MAX_BIGINT = std::numeric_limits<int64_t>::max();      //  9223372036854775807
+// Signed types
+const int64_t MIN_TINYINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::TINYINT>::min();  // -126;
+const int64_t MIN_SMALLINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::SMALLINT>::min();  // -32766;
+const int64_t MIN_MEDINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::MEDINT>::min();  // -8388608;
+const int64_t MIN_INT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::INT>::min();  // -2147483646;
+const int64_t MIN_BIGINT =
+    datatypes::ranges_limits<datatypes::SystemCatalog::BIGINT>::min();  // -9223372036854775806LL;
 
-const uint64_t MIN_UINT __attribute__((unused)) = 0;
-const uint64_t MIN_UTINYINT __attribute__((unused)) = 0;
-const uint64_t MIN_USMALLINT __attribute__((unused)) = 0;
-const uint64_t MIN_UMEDINT __attribute__((unused)) = 0;
-const uint64_t MIN_UBIGINT = 0;
-const uint64_t MAX_UINT __attribute__((unused)) = std::numeric_limits<uint32_t>::max() - 2;     // 4294967293
-const uint64_t MAX_UTINYINT __attribute__((unused)) = std::numeric_limits<uint8_t>::max() - 2;  // 253;
-const uint64_t MAX_USMALLINT __attribute__((unused)) = std::numeric_limits<uint16_t>::max() - 2;  // 65533;
-const uint64_t MAX_UMEDINT __attribute__((unused)) = (1ULL << 24) - 1;                            // 16777215
-const uint64_t MAX_UBIGINT = std::numeric_limits<uint64_t>::max() - 2;  // 18446744073709551613
+const int64_t MAX_TINYINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::TINYINT>::max();  //  127;
+const int64_t MAX_SMALLINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::SMALLINT>::max();  //  32767;
+const int64_t MAX_MEDINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::MEDINT>::max();  //  8388607;
+const int64_t MAX_INT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::INT>::max();  //  2147483647;
+const int64_t MAX_BIGINT =
+    datatypes::ranges_limits<datatypes::SystemCatalog::BIGINT>::max();  //  9223372036854775807
 
-const float MAX_FLOAT __attribute__((unused)) = std::numeric_limits<float>::max();  // 3.402823466385289e+38
+// Unsigned types
+const uint64_t MIN_UTINYINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::UTINYINT>::min();
+const uint64_t MIN_USMALLINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::USMALLINT>::min();
+const uint64_t MIN_UMEDINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::UMEDINT>::min();
+const uint64_t MIN_UINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::UINT>::min();
+const uint64_t MIN_UBIGINT = datatypes::ranges_limits<datatypes::SystemCatalog::UBIGINT>::min();
+
+const uint64_t MAX_UTINYINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::UTINYINT>::max();  // 253;
+const uint64_t MAX_USMALLINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::USMALLINT>::max();  // 65533;
+const uint64_t MAX_UMEDINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::UMEDINT>::max();  // 16777215
+const uint64_t MAX_UINT __attribute__((unused)) =
+    datatypes::ranges_limits<datatypes::SystemCatalog::UINT>::max();  // 4294967293
+const uint64_t MAX_UBIGINT =
+    datatypes::ranges_limits<datatypes::SystemCatalog::UBIGINT>::max();  // 18446744073709551613
+
+// Floating point types
 const float MIN_FLOAT __attribute__((unused)) = -std::numeric_limits<float>::max();
-const double MAX_DOUBLE __attribute__((unused)) =
-    std::numeric_limits<double>::max();  // 1.7976931348623157e+308
-const double MIN_DOUBLE __attribute__((unused)) = -std::numeric_limits<double>::max();
 const long double MAX_LONGDOUBLE __attribute__((unused)) =
     std::numeric_limits<long double>::max();  // 1.7976931348623157e+308
 const long double MIN_LONGDOUBLE __attribute__((unused)) = -std::numeric_limits<long double>::max();
+
+const float MAX_FLOAT __attribute__((unused)) = std::numeric_limits<float>::max();  // 3.402823466385289e+38
+const double MAX_DOUBLE __attribute__((unused)) =
+    std::numeric_limits<double>::max();  // 1.7976931348623157e+308
+const double MIN_DOUBLE __attribute__((unused)) = -std::numeric_limits<double>::max();
 
 const uint64_t AUTOINCR_SATURATED __attribute__((unused)) = std::numeric_limits<uint64_t>::max();
 }  // namespace

--- a/dbcon/execplan/calpontsystemcatalog.h
+++ b/dbcon/execplan/calpontsystemcatalog.h
@@ -134,13 +134,12 @@ class CalpontSystemCatalog : public datatypes::SystemCatalog
     DictOID() : dictOID(0), listOID(0), treeOID(0), compressionType(0)
     {
     }
-    DictOID(OID dictOID_, OID listOID_, OID treeOID_, int compressionType_) :
-      dictOID(dictOID_), listOID(listOID_), treeOID(treeOID_),
-      compressionType(compressionType_)
+    DictOID(OID dictOID_, OID listOID_, OID treeOID_, int compressionType_)
+     : dictOID(dictOID_), listOID(listOID_), treeOID(treeOID_), compressionType(compressionType_)
     {
     }
     DictOID(const DictOID& rhs)
-    : dictOID(rhs.dictOID), listOID(rhs.listOID), treeOID(rhs.treeOID), compressionType(rhs.compressionType)
+     : dictOID(rhs.dictOID), listOID(rhs.listOID), treeOID(rhs.treeOID), compressionType(rhs.compressionType)
     {
     }
     OID dictOID;
@@ -213,7 +212,7 @@ class CalpontSystemCatalog : public datatypes::SystemCatalog
    *
    * defaultValue is only meaningful when constraintType == DEFAULT_CONSTRAINT
    */
-  struct ColType : public datatypes::SystemCatalog::TypeHolderStd
+  struct ColType : public datatypes::TypeHolderStd
   {
     ConstraintType constraintType = NO_CONSTRAINT;
     DictOID ddn;
@@ -232,9 +231,9 @@ class CalpontSystemCatalog : public datatypes::SystemCatalog
    public:
     ColType() = default;
     ColType(const ColType& rhs);
-    ColType(int32_t colWidth_, int32_t scale_, int32_t precision_,
-            const ConstraintType& constraintType_, const DictOID& ddn_, int32_t colPosition_,
-            int32_t compressionType_, OID columnOID_, const ColDataType& colDataType_);
+    ColType(int32_t colWidth_, int32_t scale_, int32_t precision_, const ConstraintType& constraintType_,
+            const DictOID& ddn_, int32_t colPosition_, int32_t compressionType_, OID columnOID_,
+            const ColDataType& colDataType_);
     ColType& operator=(const ColType& rhs);
 
     CHARSET_INFO* getCharset();
@@ -1270,8 +1269,8 @@ const int OID_SYSCOLUMN_MINVALUE = SYSCOLUMN_BASE + 19;        /** @brief min va
 const int OID_SYSCOLUMN_MAXVALUE = SYSCOLUMN_BASE + 20;        /** @brief max value col */
 const int OID_SYSCOLUMN_COMPRESSIONTYPE = SYSCOLUMN_BASE + 21; /** @brief compression type */
 const int OID_SYSCOLUMN_NEXTVALUE = SYSCOLUMN_BASE + 22;       /** @brief next value */
-const int OID_SYSCOLUMN_CHARSETNUM = SYSCOLUMN_BASE + 23;      /** @brief character set number for the column */
-const int SYSCOLUMN_MAX = SYSCOLUMN_BASE + 24;                 // be sure this is one more than the highest #
+const int OID_SYSCOLUMN_CHARSETNUM = SYSCOLUMN_BASE + 23; /** @brief character set number for the column */
+const int SYSCOLUMN_MAX = SYSCOLUMN_BASE + 24;            // be sure this is one more than the highest #
 
 /*****************************************************
  * SYSTABLE columns dictionary OID definition

--- a/primitives/primproc/columncommand.cpp
+++ b/primitives/primproc/columncommand.cpp
@@ -49,7 +49,6 @@ using namespace rowgroup;
 #include "messageids.h"
 using namespace logging;
 
-
 namespace primitiveprocessor
 {
 extern int noVB;
@@ -177,7 +176,7 @@ void ColumnCommand::_loadData()
     {
       // fill remaining blocks with empty values when col scan
       uint32_t blockLen = BLOCK_SIZE / W;
-      auto attrs = datatypes::SystemCatalog::TypeAttributesStd(W, 0, -1);
+      auto attrs = datatypes::TypeAttributesStd(W, 0, -1);
       const auto* typeHandler = datatypes::TypeHandler::find(colType.colDataType, attrs);
       const uint8_t* emptyValue = typeHandler->getEmptyValueForType(attrs);
       uint8_t* blockDataPtr = &bpp->blockData[i * BLOCK_SIZE];
@@ -206,9 +205,9 @@ void ColumnCommand::_loadData()
     uint8_t** blockPtrsAux = (uint8_t**)alloca(1 * sizeof(uint8_t*));
     blockPtrsAux[0] = &bpp->blockDataAux[0];
     lbidsAux[0] = lbidAux;
-    wasCached = primitiveprocessor::loadBlocks(lbidsAux, bpp->versionInfo, bpp->txnID, 2,
-                                               blockPtrsAux, &blocksRead, bpp->LBIDTrace, bpp->sessionID,
-                                               1, &wasVersioned, true, &bpp->vssCache);
+    wasCached = primitiveprocessor::loadBlocks(lbidsAux, bpp->versionInfo, bpp->txnID, 2, blockPtrsAux,
+                                               &blocksRead, bpp->LBIDTrace, bpp->sessionID, 1, &wasVersioned,
+                                               true, &bpp->vssCache);
     bpp->cachedIO += wasCached;
     bpp->physIO += blocksRead;
     bpp->touchedBlocks += 1;
@@ -631,8 +630,7 @@ void ColumnCommand::fillInPrimitiveMessageHeader(const int8_t outputType, const 
   size_t inputMsgBufSize = baseMsgLength + (LOGICAL_BLOCK_RIDS * sizeof(primitives::RIDType));
 
   if (!inputMsg)
-    inputMsg.reset(new(std::align_val_t(utils::MAXCOLUMNWIDTH)) uint8_t[inputMsgBufSize]);
-
+    inputMsg.reset(new (std::align_val_t(utils::MAXCOLUMNWIDTH)) uint8_t[inputMsgBufSize]);
 
   primMsg = (NewColRequestHeader*)inputMsg.get();
   outMsg = (ColResultHeader*)bpp->outputMsg.get();

--- a/tests/dataconvert-tests.cpp
+++ b/tests/dataconvert-tests.cpp
@@ -151,7 +151,7 @@ TEST(DataConvertTest, Strtoll128)
 
 TEST(DataConvertTest, NumberIntValue)
 {
-  datatypes::SystemCatalog::TypeAttributesStd ct;
+  datatypes::TypeAttributesStd ct;
 
   int128_t res, valMax;
   string data;

--- a/utils/dataconvert/dataconvert.cpp
+++ b/utils/dataconvert/dataconvert.cpp
@@ -98,9 +98,8 @@ int64_t getSInt64LE(const char* ptr)
 }
 
 template <typename T>
-void number_int_value(const string& data, cscDataType typeCode,
-                      const datatypes::SystemCatalog::TypeAttributesStd& ct, bool& pushwarning,
-                      bool noRoundup, T& intVal, bool* saturate)
+void number_int_value(const string& data, cscDataType typeCode, const datatypes::TypeAttributesStd& ct,
+                      bool& pushwarning, bool noRoundup, T& intVal, bool* saturate)
 {
   // copy of the original input
   string valStr(data);
@@ -487,16 +486,15 @@ void number_int_value(const string& data, cscDataType typeCode,
 
 // Explicit template instantiation
 template void number_int_value<int64_t>(const std::string& data, cscDataType typeCode,
-                                        const datatypes::SystemCatalog::TypeAttributesStd& ct,
-                                        bool& pushwarning, bool noRoundup, int64_t& intVal, bool* saturate);
+                                        const datatypes::TypeAttributesStd& ct, bool& pushwarning,
+                                        bool noRoundup, int64_t& intVal, bool* saturate);
 
 template void number_int_value<int128_t>(const std::string& data, cscDataType typeCode,
-                                         const datatypes::SystemCatalog::TypeAttributesStd& ct,
-                                         bool& pushwarning, bool noRoundup, int128_t& intVal, bool* saturate);
+                                         const datatypes::TypeAttributesStd& ct, bool& pushwarning,
+                                         bool noRoundup, int128_t& intVal, bool* saturate);
 
-uint64_t number_uint_value(const string& data, cscDataType typeCode,
-                           const datatypes::SystemCatalog::TypeAttributesStd& ct, bool& pushwarning,
-                           bool noRoundup)
+uint64_t number_uint_value(const string& data, cscDataType typeCode, const datatypes::TypeAttributesStd& ct,
+                           bool& pushwarning, bool noRoundup)
 {
   // copy of the original input
   string valStr(data);
@@ -1214,7 +1212,7 @@ bool stringToTimestampStruct(const string& data, TimeStamp& timeStamp, long time
   return true;
 }
 
-boost::any DataConvert::StringToBit(const datatypes::SystemCatalog::TypeAttributesStd& colType,
+boost::any DataConvert::StringToBit(const datatypes::TypeAttributesStd& colType,
                                     const datatypes::ConvertFromStringParam& prm, const std::string& dataOrig,
                                     bool& pushWarning)
 {
@@ -1254,7 +1252,7 @@ boost::any DataConvert::StringToBit(const datatypes::SystemCatalog::TypeAttribut
   return boost::any();
 }
 
-boost::any DataConvert::StringToSDecimal(const datatypes::SystemCatalog::TypeAttributesStd& colType,
+boost::any DataConvert::StringToSDecimal(const datatypes::TypeAttributesStd& colType,
                                          const datatypes::ConvertFromStringParam& prm,
                                          const std::string& data, bool& pushWarning)
 {
@@ -1299,7 +1297,7 @@ boost::any DataConvert::StringToSDecimal(const datatypes::SystemCatalog::TypeAtt
   return boost::any();
 }
 
-boost::any DataConvert::StringToUDecimal(const datatypes::SystemCatalog::TypeAttributesStd& colType,
+boost::any DataConvert::StringToUDecimal(const datatypes::TypeAttributesStd& colType,
                                          const datatypes::ConvertFromStringParam& prm,
                                          const std::string& data, bool& pushWarning)
 {
@@ -1490,7 +1488,7 @@ boost::any DataConvert::StringToDouble(cscDataType typeCode, const std::string& 
   return value;
 }
 
-boost::any DataConvert::StringToString(const datatypes::SystemCatalog::TypeAttributesStd& colType,
+boost::any DataConvert::StringToString(const datatypes::TypeAttributesStd& colType,
                                        const std::string& dataOrig, bool& pushWarning)
 
 {
@@ -1546,8 +1544,8 @@ boost::any DataConvert::StringToDatetime(const std::string& data, bool& pushWarn
   return value;
 }
 
-boost::any DataConvert::StringToTime(const datatypes::SystemCatalog::TypeAttributesStd& colType,
-                                     const std::string& data, bool& pushWarning)
+boost::any DataConvert::StringToTime(const datatypes::TypeAttributesStd& colType, const std::string& data,
+                                     bool& pushWarning)
 {
   Time aTime;
 
@@ -2907,8 +2905,8 @@ int64_t DataConvert::stringToTime(const string& data)
   return getSInt64LE((const char*)&atime);
 }
 
-void DataConvert::joinColTypeForUnion(datatypes::SystemCatalog::TypeHolderStd& unionedType,
-                                      const datatypes::SystemCatalog::TypeHolderStd& type, unsigned int& rc)
+void DataConvert::joinColTypeForUnion(datatypes::TypeHolderStd& unionedType,
+                                      const datatypes::TypeHolderStd& type, unsigned int& rc)
 {
   // limited support for VARBINARY, no implicit conversion.
   if (type.colDataType == datatypes::SystemCatalog::VARBINARY ||

--- a/utils/dataconvert/dataconvert.h
+++ b/utils/dataconvert/dataconvert.h
@@ -104,7 +104,6 @@ const int64_t IDB_pow[19] = {1,
                              100000000000000000LL,
                              1000000000000000000LL};
 
-
 const int32_t SECS_PER_MIN = 60;
 const int32_t MINS_PER_HOUR = 60;
 const int32_t HOURS_PER_DAY = 24;
@@ -1085,13 +1084,11 @@ inline uint64_t string_to_ull(const std::string& data, bool& bSaturate)
 }
 
 template <typename T>
-void number_int_value(const std::string& data, cscDataType typeCode,
-                      const datatypes::SystemCatalog::TypeAttributesStd& ct, bool& pushwarning,
-                      bool noRoundup, T& intVal, bool* saturate = 0);
+void number_int_value(const std::string& data, cscDataType typeCode, const datatypes::TypeAttributesStd& ct,
+                      bool& pushwarning, bool noRoundup, T& intVal, bool* saturate = 0);
 
-uint64_t number_uint_value(const string& data, cscDataType typeCode,
-                           const datatypes::SystemCatalog::TypeAttributesStd& ct, bool& pushwarning,
-                           bool noRoundup);
+uint64_t number_uint_value(const string& data, cscDataType typeCode, const datatypes::TypeAttributesStd& ct,
+                           bool& pushwarning, bool noRoundup);
 
 /** @brief DataConvert is a component for converting string data to Calpont format
  */
@@ -1266,19 +1263,18 @@ class DataConvert
   EXPORT static int64_t stringToTime(const std::string& data);
   EXPORT static int64_t stringToTime(const utils::NullString& data);
   // bug4388, union type conversion
-  EXPORT static void joinColTypeForUnion(datatypes::SystemCatalog::TypeHolderStd& unionedType,
-                                         const datatypes::SystemCatalog::TypeHolderStd& type,
-                                         unsigned int& rc);
+  EXPORT static void joinColTypeForUnion(datatypes::TypeHolderStd& unionedType,
+                                         const datatypes::TypeHolderStd& type, unsigned int& rc);
 
-  static boost::any StringToBit(const datatypes::SystemCatalog::TypeAttributesStd& colType,
+  static boost::any StringToBit(const datatypes::TypeAttributesStd& colType,
                                 const datatypes::ConvertFromStringParam& prm, const std::string& dataOrig,
                                 bool& pushWarning);
 
-  static boost::any StringToSDecimal(const datatypes::SystemCatalog::TypeAttributesStd& colType,
+  static boost::any StringToSDecimal(const datatypes::TypeAttributesStd& colType,
                                      const datatypes::ConvertFromStringParam& prm, const std::string& data,
                                      bool& pushWarning);
 
-  static boost::any StringToUDecimal(const datatypes::SystemCatalog::TypeAttributesStd& colType,
+  static boost::any StringToUDecimal(const datatypes::TypeAttributesStd& colType,
                                      const datatypes::ConvertFromStringParam& prm, const std::string& data,
                                      bool& pushWarning);
 
@@ -1286,15 +1282,15 @@ class DataConvert
 
   static boost::any StringToDouble(cscDataType typeCode, const std::string& dataOrig, bool& pushWarning);
 
-  static boost::any StringToString(const datatypes::SystemCatalog::TypeAttributesStd& colType,
-                                   const std::string& dataOrig, bool& pushWarning);
+  static boost::any StringToString(const datatypes::TypeAttributesStd& colType, const std::string& dataOrig,
+                                   bool& pushWarning);
 
   static boost::any StringToDate(const std::string& data, bool& pushWarning);
 
   static boost::any StringToDatetime(const std::string& data, bool& pushWarning);
 
-  static boost::any StringToTime(const datatypes::SystemCatalog::TypeAttributesStd& colType,
-                                 const std::string& data, bool& pushWarning);
+  static boost::any StringToTime(const datatypes::TypeAttributesStd& colType, const std::string& data,
+                                 bool& pushWarning);
 
   static boost::any StringToTimestamp(const datatypes::ConvertFromStringParam& prm, const std::string& data,
                                       bool& pushWarning);
@@ -1553,7 +1549,6 @@ inline int128_t strtoll128(const char* data, bool& saturate, char** ep)
 
   return res;
 }
-
 
 template <class T>
 T decimalRangeUp(int32_t precision)

--- a/utils/rowgroup/rowaggregation.cpp
+++ b/utils/rowgroup/rowaggregation.cpp
@@ -57,7 +57,7 @@
 #include "rowstorage.h"
 
 //..comment out NDEBUG to enable assertions, uncomment NDEBUG to disable
-//#define NDEBUG
+// #define NDEBUG
 #include "mcs_decimal.h"
 
 using namespace std;
@@ -315,7 +315,7 @@ void RowAggregation::updateStringMinMax(utils::NullString val1, utils::NullStrin
   if (val1.isNull())
   {
     // as any comparison with NULL is false, it should not affect min/max ranges.
-    return ; // do nothing.
+    return;  // do nothing.
   }
   CHARSET_INFO* cs = fRow.getCharset(col);
   int tmp = cs->strnncoll(val1.str(), val1.length(), val2.str(), val2.length());
@@ -816,8 +816,9 @@ void RowAggregation::aggregateRow(Row& row, const uint64_t* hash,
                                   std::vector<mcsv1sdk::mcsv1Context>* rgContextColl)
 {
   uint32_t cnt = fRollupFlag ? fGroupByCols.size() : 1;
-  for (uint32_t z = 0; z < cnt; z++) {
-  // groupby column list is not empty, find the entry.
+  for (uint32_t z = 0; z < cnt; z++)
+  {
+    // groupby column list is not empty, find the entry.
     if (!fGroupByCols.empty())
     {
       bool is_new_row;
@@ -862,7 +863,8 @@ void RowAggregation::aggregateRow(Row& row, const uint64_t* hash,
     updateEntry(row, rgContextColl);
     // these quantities are unsigned and comparing z and cnt - 1 can be incorrect
     // because cnt can be zero.
-    if ((z + 1 < cnt)) {
+    if ((z + 1 < cnt))
+    {
       // if we are rolling up, we mark appropriate field as NULL and also increment
       // value in the "mark" column, so that we can differentiate between data and
       // various rollups.
@@ -1175,8 +1177,8 @@ void RowAggregation::doMinMax(const Row& rowIn, int64_t colIn, int64_t colOut, i
     {
       if (LIKELY(rowIn.getColumnWidth(colIn) == datatypes::MAXDECIMALWIDTH))
       {
-        updateIntMinMax(rowIn.getTSInt128Field(colIn).getValue(), fRow.getTSInt128Field(colOut).getValue(), colOut,
-                        funcType);
+        updateIntMinMax(rowIn.getTSInt128Field(colIn).getValue(), fRow.getTSInt128Field(colOut).getValue(),
+                        colOut, funcType);
       }
       else if (rowIn.getColumnWidth(colIn) <= datatypes::MAXLEGACYWIDTH)
       {
@@ -2013,9 +2015,8 @@ void RowAggregation::doStatistics(const Row& rowIn, int64_t colIn, int64_t colOu
   long double mean = fRow.getLongDoubleField(colAux);
   long double scaledMomentum2 = fRow.getLongDoubleField(colAux + 1);
   volatile long double delta = valIn - mean;
-  mean += delta/count;
+  mean += delta / count;
   scaledMomentum2 += delta * (valIn - mean);
-
 
   fRow.setDoubleField(count, colOut);
   fRow.setLongDoubleField(mean, colAux);
@@ -2066,8 +2067,7 @@ void RowAggregation::doUDAF(const Row& rowIn, int64_t colIn, int64_t colOut, int
       cc = dynamic_cast<execplan::ConstantColumn*>(fFunctionCols[funcColsIdx]->fpConstCol.get());
     }
 
-    if ((cc && cc->isNull()) ||
-        (!cc && isNull(&fRowGroupIn, rowIn, colIn) == true))
+    if ((cc && cc->isNull()) || (!cc && isNull(&fRowGroupIn, rowIn, colIn) == true))
     {
       if (udafContextsColl[origFuncColsIdx].getRunFlag(mcsv1sdk::UDAF_IGNORE_NULLS))
       {
@@ -2393,7 +2393,8 @@ void RowAggregation::loadEmptySet(messageqcpp::ByteStream& bs)
 //------------------------------------------------------------------------------
 RowAggregationUM::RowAggregationUM(const vector<SP_ROWAGG_GRPBY_t>& rowAggGroupByCols,
                                    const vector<SP_ROWAGG_FUNC_t>& rowAggFunctionCols,
-                                   joblist::ResourceManager* r, boost::shared_ptr<int64_t> sessionLimit, bool withRollup)
+                                   joblist::ResourceManager* r, boost::shared_ptr<int64_t> sessionLimit,
+                                   bool withRollup)
  : RowAggregation(rowAggGroupByCols, rowAggFunctionCols, r, sessionLimit, withRollup)
  , fHasAvg(false)
  , fHasStatsFunc(false)
@@ -3115,7 +3116,7 @@ void RowAggregationUM::SetUDAFAnyValue(static_any::any& valOut, int64_t colOut)
 
     case execplan::CalpontSystemCatalog::CHAR:
     case execplan::CalpontSystemCatalog::VARCHAR:
-    case execplan::CalpontSystemCatalog::TEXT:    fRow.setStringField(strOut, colOut); break;
+    case execplan::CalpontSystemCatalog::TEXT: fRow.setStringField(strOut, colOut); break;
 
     case execplan::CalpontSystemCatalog::VARBINARY:
     case execplan::CalpontSystemCatalog::CLOB:
@@ -3585,7 +3586,7 @@ void RowAggregationUM::doNotNullConstantAggregate(const ConstantAggData& aggData
           auto width = fRow.getColumnWidth(colOut);
           if (width == datatypes::MAXDECIMALWIDTH)
           {
-            execplan::CalpontSystemCatalog::TypeHolderStd colType;
+            datatypes::TypeHolderStd colType;
             colType.colWidth = width;
             colType.precision = fRow.getPrecision(i);
             colType.scale = fRow.getScale(i);
@@ -3707,7 +3708,7 @@ void RowAggregationUM::doNotNullConstantAggregate(const ConstantAggData& aggData
           auto width = fRow.getColumnWidth(colOut);
           if (width == datatypes::MAXDECIMALWIDTH)
           {
-            execplan::CalpontSystemCatalog::TypeHolderStd colType;
+            datatypes::TypeHolderStd colType;
             colType.colWidth = width;
             colType.precision = fRow.getPrecision(i);
             colType.scale = fRow.getScale(i);
@@ -4110,7 +4111,8 @@ bool RowAggregationUM::nextRowGroup()
 //------------------------------------------------------------------------------
 RowAggregationUMP2::RowAggregationUMP2(const vector<SP_ROWAGG_GRPBY_t>& rowAggGroupByCols,
                                        const vector<SP_ROWAGG_FUNC_t>& rowAggFunctionCols,
-                                       joblist::ResourceManager* r, boost::shared_ptr<int64_t> sessionLimit, bool withRollup)
+                                       joblist::ResourceManager* r, boost::shared_ptr<int64_t> sessionLimit,
+                                       bool withRollup)
  : RowAggregationUM(rowAggGroupByCols, rowAggFunctionCols, r, sessionLimit, withRollup)
 {
 }
@@ -4328,7 +4330,8 @@ void RowAggregationUMP2::doAvg(const Row& rowIn, int64_t colIn, int64_t colOut, 
   {
     if (LIKELY(cnt > 0))
     {
-      int128_t valOut = fRow.getTSInt128Field(colOut).getValue();;
+      int128_t valOut = fRow.getTSInt128Field(colOut).getValue();
+      ;
       int128_t sum = valOut + wideValue;
       fRow.setInt128Field(sum, colOut);
       fRow.setUintField(rowIn.getUintField(colAuxIn) + cnt, colAux);
@@ -4387,7 +4390,8 @@ void RowAggregationUMP2::doStatistics(const Row& rowIn, int64_t colIn, int64_t c
   {
     volatile long double delta = mean - blockMean;
     nextMean = (mean * count + blockMean * blockCount) / nextCount;
-    nextScaledMomentum2 = scaledMomentum2 + blockScaledMomentum2 + delta * delta * (count * blockCount / nextCount);
+    nextScaledMomentum2 =
+        scaledMomentum2 + blockScaledMomentum2 + delta * delta * (count * blockCount / nextCount);
   }
   fRow.setDoubleField(nextCount, colOut);
   fRow.setLongDoubleField(nextMean, colAux);

--- a/writeengine/bulk/we_bulkloadbuffer.cpp
+++ b/writeengine/bulk/we_bulkloadbuffer.cpp
@@ -47,7 +47,6 @@ using namespace std;
 using namespace boost;
 using namespace execplan;
 
-
 namespace
 {
 const std::string INPUT_ERROR_WRONG_NO_COLUMNS = "Data contains wrong number of columns";
@@ -79,13 +78,13 @@ inline void resizeRowDataArray(char** pRowData, unsigned int dataLength, unsigne
 {
   char* tmpRaw = new char[newArrayCapacity];
   memcpy(tmpRaw, *pRowData, dataLength);
-  delete[] * pRowData;
+  delete[] *pRowData;
   *pRowData = tmpRaw;
 }
 
 }  // namespace
 
-//#define DEBUG_TOKEN_PARSING 1
+// #define DEBUG_TOKEN_PARSING 1
 
 namespace WriteEngine
 {
@@ -516,7 +515,7 @@ void BulkLoadBuffer::convert(char* field, int fieldLength, bool nullFlag, unsign
         if (column.cs->mbmaxlen > 1)
         {
           const CHARSET_INFO* cs = column.cs;
-          const char* start = (const char*) field;
+          const char* start = (const char*)field;
           const char* end = (const char*)(field + fieldLength);
           size_t numChars = cs->numchars(start, end);
           size_t maxCharLength = column.definedWidth / cs->mbmaxlen;
@@ -529,7 +528,7 @@ void BulkLoadBuffer::convert(char* field, int fieldLength, bool nullFlag, unsign
             bufStats.satCount++;
           }
         }
-        else // cs->mbmaxlen == 1
+        else  // cs->mbmaxlen == 1
         {
           if (fieldLength > column.definedWidth)
           {
@@ -1193,8 +1192,8 @@ void BulkLoadBuffer::convert(char* field, int fieldLength, bool nullFlag, unsign
           // number_int_value(), and the bSatVal flag is set to true
           dataconvert::number_int_value(
               string(field), column.dataType,
-              datatypes::SystemCatalog::TypeAttributesStd(column.width, column.scale, column.precision),
-              dummy, false, bigllVal, &bSatVal);
+              datatypes::TypeAttributesStd(column.width, column.scale, column.precision), dummy, false,
+              bigllVal, &bSatVal);
         }
       }
 

--- a/writeengine/shared/we_blockop.cpp
+++ b/writeengine/shared/we_blockop.cpp
@@ -86,7 +86,7 @@ bool BlockOp::calculateRowId(RID rowId, const int epb, const int width, int& fbo
 const uint8_t* BlockOp::getEmptyRowValue(const CalpontSystemCatalog::ColDataType colDataType,
                                          const int width) const
 {
-  auto attrs = datatypes::SystemCatalog::TypeAttributesStd(width, 0, -1);
+  auto attrs = datatypes::TypeAttributesStd(width, 0, -1);
   // Bulk operation runtime should have m_typeHandler nullptr calling this
   // Non-bulk operations runtime branch
   if (m_typeHandler)
@@ -224,7 +224,7 @@ void BlockOp::findTypeHandler(const int colWidth,
                               const execplan::CalpontSystemCatalog::ColDataType colDataType)
 
 {
-  auto attrs = datatypes::SystemCatalog::TypeAttributesStd(colWidth, 0, -1);
+  auto attrs = datatypes::TypeAttributesStd(colWidth, 0, -1);
   m_typeHandler = datatypes::TypeHandler::find(colDataType, attrs);
 }
 

--- a/writeengine/splitter/we_brmupdater.cpp
+++ b/writeengine/splitter/we_brmupdater.cpp
@@ -36,7 +36,7 @@ using namespace std;
 #include <boost/lexical_cast.hpp>
 using namespace boost;
 
-//#include "we_simplesyslog.h"
+// #include "we_simplesyslog.h"
 #include "we_sdhandler.h"
 
 #include "brm.h"
@@ -331,8 +331,7 @@ bool WEBrmUpdater::prepareCasualPartitionInfo()
 
       if (datatypes::isWideDecimalType(cpInfoMerge.type, cpInfoMerge.colWidth))
       {
-        datatypes::SystemCatalog::TypeAttributesStd tyAttr(cpInfoMerge.colWidth, 0,
-                                                           datatypes::INT128MAXPRECISION);
+        datatypes::TypeAttributesStd tyAttr(cpInfoMerge.colWidth, 0, datatypes::INT128MAXPRECISION);
 
         pTok = strtok(NULL, " ");
 
@@ -479,7 +478,7 @@ bool WEBrmUpdater::prepareHighWaterMarkInfo()
 }
 
 //------------------------------------------------------------------------------
-//#ROWS: numRowsRead numRowsInserted
+// #ROWS: numRowsRead numRowsInserted
 
 bool WEBrmUpdater::prepareRowsInsertedInfo(std::string Entry, int64_t& TotRows, int64_t& InsRows)
 {
@@ -527,7 +526,7 @@ bool WEBrmUpdater::prepareRowsInsertedInfo(std::string Entry, int64_t& TotRows, 
 }
 
 //------------------------------------------------------------------------------
-//#DATA: columnNumber columnType columnName numOutOfRangeValues
+// #DATA: columnNumber columnType columnName numOutOfRangeValues
 
 bool WEBrmUpdater::prepareColumnOutOfRangeInfo(std::string Entry, int& ColNum,
                                                execplan::CalpontSystemCatalog::ColDataType& ColType,
@@ -609,7 +608,7 @@ bool WEBrmUpdater::prepareColumnOutOfRangeInfo(std::string Entry, int& ColNum,
 }
 
 //------------------------------------------------------------------------------
-//#ERR:  error message file
+// #ERR:  error message file
 
 bool WEBrmUpdater::prepareErrorFileInfo(std::string Entry, std::string& ErrFileName)
 {
@@ -650,7 +649,7 @@ bool WEBrmUpdater::prepareErrorFileInfo(std::string Entry, std::string& ErrFileN
 }
 
 //------------------------------------------------------------------------------
-//#BAD:  bad data file, with rejected rows
+// #BAD:  bad data file, with rejected rows
 
 bool WEBrmUpdater::prepareBadDataFileInfo(std::string Entry, std::string& BadFileName)
 {


### PR DESCRIPTION
The main changes belong to mcs_basic_datatype.h and mcs_datatype.h. Everything else is just a renaming byproduct.
I ll leverage the changes in [the PR](https://github.com/mariadb-corporation/mariadb-columnstore-engine/pull/3005/files). 