### PR TITLE
fix(rowstorage): MCOL-5472 SplitMix64 PRNG implementation to replace stdlib MT PRNG that uses /dev/urandom guarded by spinlock

### DIFF
--- a/utils/rowgroup/rowstorage.cpp
+++ b/utils/rowgroup/rowstorage.cpp
@@ -1495,9 +1495,6 @@ RowAggStorage::RowAggStorage(const std::string& tmpDir, RowGroup* rowGroupOut, R
  , fTmpDir(tmpDir)
  , fRowGroupOut(rowGroupOut)
  , fKeysRowGroup(keysRowGroup)
- , fRD()
- , fRandGen(fRD())
- , fRandDistr(0, 100)
 {
   char suffix[PATH_MAX];
   snprintf(suffix, sizeof(suffix), "/p%u-t%p/", getpid(), this);
@@ -1683,7 +1680,7 @@ void RowAggStorage::dump()
       break;
   }
 
-  int64_t totalMem = fMM->getConfigured();
+  const int64_t totalMem = fMM->getConfigured();
   // If the generations are allowed and there are less than half of
   // rowgroups in memory, then we start a new generation
   if (fAllowGenerations && fStorage->fLRU->size() < fStorage->fRGDatas.size() / 2 &&
@@ -1691,7 +1688,7 @@ void RowAggStorage::dump()
   {
     startNewGeneration();
   }
-  else if (fAllowGenerations && freeMem < totalMem / 10 * 3 && fRandDistr(fRandGen) < 30)
+  else if (fAllowGenerations && freeMem < totalMem / 10 * 3 && nextRandDistib() < 30)
   {
     startNewGeneration();
   }

--- a/utils/rowgroup/rowstorage.h
+++ b/utils/rowgroup/rowstorage.h
@@ -311,6 +311,21 @@ class RowAggStorage
   static constexpr uint8_t INIT_INFO_HASH_SHIFT{0};
   static constexpr uint16_t MAX_INMEMORY_GENS{4};
 
+  // This is SplitMix64 implementation borrowed from here
+  // https://thompsonsed.co.uk/random-number-generators-for-c-performance-tested
+  inline uint64_t nextRandom()
+  {
+    uint64_t z = (fRandom += UINT64_C(0x9E3779B97F4A7C15));
+    z = (z ^ (z >> 30)) * UINT64_C(0xBF58476D1CE4E5B9);
+    z = (z ^ (z >> 27)) * UINT64_C(0x94D049BB133111EB);
+    return z ^ (z >> 31);
+  }
+
+  inline uint64_t nextRandDistib()
+  {
+    return nextRandom() % 100;
+  }
+
   struct Data
   {
     RowPosHashStoragePtr fHashes;
@@ -349,9 +364,7 @@ class RowAggStorage
   bool fInitialized{false};
   rowgroup::RowGroup* fRowGroupOut;
   rowgroup::RowGroup* fKeysRowGroup;
-  std::random_device fRD;
-  std::mt19937 fRandGen;
-  std::uniform_int_distribution<uint8_t> fRandDistr;
+  uint64_t fRandom = 0xc4ceb9fe1a85ec53ULL;  // initial integer to set PRNG up
 };
 
 }  // namespace rowgroup


### PR DESCRIPTION
This adds a new PRNG to produce a pseudo random number for probability checks.