### PR TITLE
MCOL-5594: Interactive "mcs cluster stop" command for CMAPI.

### DIFF
--- a/cmapi/cmapi_server/controllers/dispatcher.py
+++ b/cmapi/cmapi_server/controllers/dispatcher.py
@@ -6,7 +6,7 @@ from cmapi_server.controllers.endpoints import (
     StatusController, ConfigController, BeginController, CommitController,
     RollbackController, StartController, ShutdownController,
     ExtentMapController, ClusterController, ApiKeyController,
-    LoggingConfigController, AppController
+    LoggingConfigController, AppController, NodeProcessController
 )
 
 from cmapi_server.controllers.s3dataload import S3DataLoadController
@@ -237,6 +237,26 @@ dispatcher.connect(
     route = '/cmapi/ready',
     action = 'ready',
     controller = AppController(),
+    conditions = {'method': ['GET']}
+)
+
+
+# /_version/node/stop_dmlproc/ (PUT)
+dispatcher.connect(
+    name = 'stop_dmlproc',
+    route = f'/cmapi/{_version}/node/stop_dmlproc',
+    action = 'put_stop_dmlproc',
+    controller = NodeProcessController(),
+    conditions = {'method': ['PUT']}
+)
+
+
+# /_version/node/is_process_running/ (PUT)
+dispatcher.connect(
+    name = 'is_process_running',
+    route = f'/cmapi/{_version}/node/is_process_running',
+    action = 'get_process_running',
+    controller = NodeProcessController(),
     conditions = {'method': ['GET']}
 )
 

--- a/cmapi/cmapi_server/handlers/cluster.py
+++ b/cmapi/cmapi_server/handlers/cluster.py
@@ -156,7 +156,7 @@ class ClusterHandler():
         :type logger: logging.Logger, optional
         :param in_transaction: is function called in existing transaction or no
         :type in_transaction: bool
-        :param timeout: timeout in seconds for gracefully stop DMLProc
+        :param timeout: timeout in seconds to gracefully stop DMLProc
                         TODO: for next releases
         :type timeout: int
         :raises CMAPIBasicError: if no nodes in the cluster

--- a/cmapi/cmapi_server/managers/process.py
+++ b/cmapi/cmapi_server/managers/process.py
@@ -275,9 +275,9 @@ class MCSProcessManager:
                 )
         except (ConnectionRefusedError, RuntimeError):
             logging.error(
-                'Cannot set SS_ROLLBACK and SS_SHUTDOWN_PENDING '
-                'using DBRM while trying to gracefully auto stop DMLProc.'
-                'Continue with a regular stop method.'
+                'Cannot set SS_ROLLBACK and SS_SHUTDOWN_PENDING via DBRM, '
+                'graceful auto stop of DMLProc failed. '
+                'Try a regular stop method.'
             )
             raise
 

--- a/cmapi/cmapi_server/managers/transaction.py
+++ b/cmapi/cmapi_server/managers/transaction.py
@@ -1,0 +1,136 @@
+"""Module related to CMAPI transaction management logic."""
+import logging
+from contextlib import ContextDecorator
+from signal import (
+    SIGINT, SIGTERM, SIGHUP, SIG_DFL, signal, default_int_handler
+)
+from typing import Optional, Type
+
+from cmapi_server.constants import DEFAULT_MCS_CONF_PATH
+from cmapi_server.exceptions import CMAPIBasicError
+from cmapi_server.helpers import (
+    get_id, commit_transaction, rollback_transaction, start_transaction
+)
+
+
+class TransactionManager(ContextDecorator):
+    """Context manager and decorator to put any code inside CMAPI transaction.
+
+    :param timeout: time in sec after transaction will be autocommitted,
+                    defaults to 300.0
+
+    :param timeout: _description_, defaults to 300
+    :type timeout: float, optional
+    :param txn_id: custom transaction id, defaults to None
+    :type txn_id: Optional[int], optional
+    :param handle_signals: handle specific signals or not, defaults to False
+    :type handle_signals: bool, optional
+    """
+
+    def __init__(
+            self, timeout: float = 300, txn_id: Optional[int] = None,
+            handle_signals: bool = False
+    ):
+        self.timeout = timeout
+        self.txn_id = txn_id or get_id()
+        self.handle_signals = handle_signals
+        self.active_transaction = False
+
+    def _handle_exception(
+            self, exc: Optional[Type[Exception]] = None,
+            signum: Optional[int] = None
+    ) -> None:
+        """Handle raised exceptions.
+
+        We need to rollback transaction in some cases and return back default
+        signal handlers.
+
+        :param exc: exception passed, defaults to None
+        :type exc: Optional[Type[Exception]], optional
+        :param signum: signal if it cause exception, defaults to None
+        :type signum: Optional[int], optional
+        :raises exc: raises passed exception
+        """
+        # message = 'Got exception in transaction manager'
+        if (exc or signum) and self.active_transaction:
+            self.rollback_transaction()
+        self.set_default_signals()
+        raise exc
+
+    def _handle_signal(self, signum, frame) -> None:
+        """Handler for signals.
+
+        :param signum: signal number
+        :type signum: int
+        """
+        logging.error(f'Caught signal "{signum}" in transaction manager.')
+        self._handle_exception(signum=signum)
+
+    def set_custom_signals(self) -> None:
+        """Set handlers for several signals."""
+        # register handler for signals for proper handling them
+        for sig in SIGINT, SIGTERM, SIGHUP:
+            signal(sig, self._handle_signal)
+
+    def set_default_signals(self) -> None:
+        """Return defalt handlers for specific signals."""
+        if self.handle_signals:
+            signal.signal(signal.SIGINT, default_int_handler)
+            signal.signal(signal.SIGTERM, SIG_DFL)
+            signal.signal(signal.SIGHUP, SIG_DFL)
+
+    def rollback_transaction(self) -> None:
+        """Rollback transaction."""
+        try:
+            rollback_transaction(self.txn_id)
+            self.active_transaction = False
+            logging.debug(f'Success rollback of transaction "{self.txn_id}".')
+        except Exception:
+            logging.error(
+                f'Error while rollback transaction "{self.txn_id}"',
+                exc_info=True
+            )
+
+    def commit_transaction(self):
+        """Commit transaction."""
+        try:
+            commit_transaction(
+                self.txn_id, cs_config_filename=DEFAULT_MCS_CONF_PATH
+            )
+        except Exception:
+            logging.error(f'Error while committing transaction {self.txn_id}')
+            self.rollback_transaction()
+            self.set_default_signals()
+            raise
+
+    def __enter__(self):
+        if self.handle_signals:
+            self.set_custom_signals()
+        try:
+            suceeded, _transaction_id, successes = start_transaction(
+                cs_config_filename=DEFAULT_MCS_CONF_PATH,
+                txn_id=self.txn_id, timeout=self.timeout
+            )
+        except Exception as exc:
+            logging.error('Error while starting the transaction.')
+            self._handle_exception(exc=exc)
+        if not suceeded:
+            self._handle_exception(
+                exc=CMAPIBasicError('Starting transaction isn\'t succesfull.')
+            )
+        if suceeded and len(successes) == 0:
+            self._handle_exception(
+                exc=CMAPIBasicError('There are no nodes in the cluster.')
+            )
+        self.active_transaction = True
+        return self
+
+    def __exit__(self, *exc):
+        if exc[0] and self.active_transaction:
+            self.rollback_transaction()
+            self.set_default_signals()
+            return False
+        if self.active_transaction:
+            self.commit_transaction()
+            self.set_default_signals()
+        return True

--- a/cmapi/cmapi_server/managers/transaction.py
+++ b/cmapi/cmapi_server/managers/transaction.py
@@ -116,7 +116,7 @@ class TransactionManager(ContextDecorator):
             self._handle_exception(exc=exc)
         if not suceeded:
             self._handle_exception(
-                exc=CMAPIBasicError('Starting transaction isn\'t succesfull.')
+                exc=CMAPIBasicError('Starting transaction isn\'t succesful.')
             )
         if suceeded and len(successes) == 0:
             self._handle_exception(

--- a/cmapi/cmapi_server/process_dispatchers/container.py
+++ b/cmapi/cmapi_server/process_dispatchers/container.py
@@ -107,6 +107,9 @@ class ContainerDispatcher(BaseDispatcher):
         :type use_sudo: bool, optional
         :return: True if service is running, otherwise False
         :rtype: bool
+
+        ..Note:
+            Not working with multiple services at a time.
         """
         try:
             cls._get_proc_object(service)

--- a/cmapi/cmapi_server/process_dispatchers/systemd.py
+++ b/cmapi/cmapi_server/process_dispatchers/systemd.py
@@ -55,7 +55,7 @@ class SystemdDispatcher(BaseDispatcher):
         """Check if systemd service is running.
 
         :param service: service name
-        :type service: str, optional
+        :type service: str
         :param use_sudo: use sudo or not, defaults to True
         :type use_sudo: bool, optional
         :return: True if service is running, otherwise False

--- a/cmapi/mcs_cluster_tool/cluster_app.py
+++ b/cmapi/mcs_cluster_tool/cluster_app.py
@@ -3,14 +3,25 @@
 Formally this module contains all subcommands for "mcs cluster" cli command.
 """
 import logging
+import time
 from typing import List, Optional
 
 import pyotp
+import requests
 import typer
+from typing_extensions import Annotated
 
-from cmapi_server.constants import SECRET_KEY
+from cmapi_server.constants import (
+    CMAPI_CONF_PATH, DEFAULT_MCS_CONF_PATH, SECRET_KEY
+)
+from cmapi_server.exceptions import CMAPIBasicError
 from cmapi_server.handlers.cluster import ClusterHandler
+from cmapi_server.helpers import (
+    commit_transaction, get_config_parser, get_current_key, get_id,
+    get_version, start_transaction, rollback_transaction, build_url
+)
 from mcs_cluster_tool.decorators import handle_output
+from mcs_node_control.models.node_config import NodeConfig
 
 
 logger = logging.getLogger('mcs_cli')
@@ -32,9 +43,152 @@ def status():
 
 @app.command()
 @handle_output
-def stop():
+def stop(
+    interactive: Annotated[
+        bool,
+        typer.Option(
+            '--interactive/--no-interactive', '-i/-no-i',
+            help=(
+                'Use this option on a highly loaded cluster. '
+                'It prevents data loss.'
+            ),
+        )
+    ] = False,
+    timeout: Annotated[
+        int,
+        typer.Option(
+            '-t', '--timeout',
+            help=(
+                'Time in seconds to wait DMLproc gracefully stops. '
+                'Use this with caution: on a working cluster '
+                'low values could cause data loss. '
+                'In interactive mode means delay time between promts.'
+            )
+        )
+    ] = 15,
+    force: Annotated[
+        bool,
+        typer.Option(
+            '--force/--no-force', '-f/-no-f',
+            help=(
+                'Force stopping a cluster.'
+                'WARNING: It could cause data corruption or/and data loss.'
+            ),
+            #TODO: hide from help till not investigated in decreased timeout
+            #      affect
+            hidden=True
+        )
+    ] = False
+):
     """Stop the Columnstore cluster."""
-    return ClusterHandler.shutdown(logger=logger)
+    transaction_id = None
+    if interactive:
+        # TODO: for standalone cli tool need to change primary detection
+        #       method. Partially move logic below to ClusterController
+        nc = NodeConfig()
+        root = nc.get_current_config_root(
+            config_filename=DEFAULT_MCS_CONF_PATH
+        )
+        primary_node = root.find("./PrimaryNode").text
+
+        cfg_parser = get_config_parser(CMAPI_CONF_PATH)
+        api_key = get_current_key(cfg_parser)
+
+        version = get_version()
+
+        headers = {'x-api-key': api_key}
+
+        # start_time = str(datetime.now())
+        transaction_id = get_id()
+
+        try:
+            suceeded, transaction_id, successes = start_transaction(
+                cs_config_filename=DEFAULT_MCS_CONF_PATH, id=transaction_id
+            )
+        except Exception as err:
+            rollback_transaction(
+                transaction_id, cs_config_filename=DEFAULT_MCS_CONF_PATH
+            )
+            raise CMAPIBasicError(
+                'Error while starting the transaction.'
+            ) from err
+        if not suceeded:
+            rollback_transaction(
+                transaction_id, cs_config_filename=DEFAULT_MCS_CONF_PATH
+            )
+            raise CMAPIBasicError('Starting transaction isn\'t successful.')
+
+        if suceeded and len(successes) == 0:
+            rollback_transaction(
+                transaction_id, cs_config_filename=DEFAULT_MCS_CONF_PATH
+            )
+            raise CMAPIBasicError('There are no nodes in the cluster.')
+
+        body = {'force': False, 'timeout': timeout}
+        url = f'https://{primary_node}:8640/cmapi/{version}/node/stop_dmlproc'
+        try:
+            resp = requests.put(
+                url, verify=False, headers=headers, json=body,
+                timeout=timeout+1
+            )
+            resp.raise_for_status()
+        except Exception as err:
+            rollback_transaction(
+                transaction_id, cs_config_filename=DEFAULT_MCS_CONF_PATH
+            )
+            raise CMAPIBasicError(
+                f'Error while stopping DMLProc on primary node.'
+            ) from err
+
+        force = True
+        while True:
+            time.sleep(timeout)
+            url = build_url(
+                base_url=primary_node, port=8640,
+                query_params={'process_name': 'DMLProc'},
+                path=f'cmapi/{version}/node/is_process_running',
+            )
+            try:
+                resp = requests.get(
+                    url, verify=False, headers=headers, timeout=timeout
+                )
+                resp.raise_for_status()
+            except Exception as err:
+                rollback_transaction(
+                    transaction_id, cs_config_filename=DEFAULT_MCS_CONF_PATH
+                )
+                raise CMAPIBasicError(
+                    f'Error while getting mcs DMLProc status.'
+                ) from err
+
+            # check DMLPRoc state
+            # if ended, show message and break
+            dmlproc_running = resp.json()['running']
+            if not dmlproc_running:
+                print(
+                    'DMLProc stopped gracefully. '
+                    'Continue stopping other processes.'
+                )
+                break
+            else:
+                force = typer.confirm(
+                    'DMLProc still working. '
+                    'Do you want to force stop? WARNING: It could cause data '
+                    'loss and broken cluster.',
+                    prompt_suffix=' '
+                )
+                if force:
+                    break
+                else:
+                    continue
+
+    if force:
+        # TODO: investigate more on how changing the hardcoded timeout
+        #       could affect put_config (helpers.py broadcast_config) operation
+        timeout = 0
+    return ClusterHandler.shutdown(
+        logger=logger, transaction_id=transaction_id
+    )
 
 
 @app.command()

--- a/cmapi/mcs_cluster_tool/cluster_app.py
+++ b/cmapi/mcs_cluster_tool/cluster_app.py
@@ -53,8 +53,10 @@ def stop(
         typer.Option(
             '--interactive/--no-interactive', '-i/-no-i',
             help=(
-                'Use this option on a highly loaded cluster. '
-                'It prevents data loss.'
+                'Use this option on active cluster as interactive stop '
+                'waits for current writes to complete in DMLProc before '
+                'shutting down. Ensuring consistency, preventing data loss '
+                'of active writes.'
             ),
         )
     ] = False,
@@ -63,9 +65,9 @@ def stop(
         typer.Option(
             '-t', '--timeout',
             help=(
-                'Time in seconds to wait DMLproc gracefully stops. '
-                'Use this with caution: on a working cluster '
-                'low values could cause data loss. '
+                'Time in seconds to wait for DMLproc to gracefully stop.'
+                'Warning: Low wait timeout values could result in data loss '
+                'if the cluster is very active.'
                 'In interactive mode means delay time between promts.'
             )
         )
@@ -75,8 +77,8 @@ def stop(
         typer.Option(
             '--force/--no-force', '-f/-no-f',
             help=(
-                'Force stopping a cluster.'
-                'WARNING: It could cause data corruption or/and data loss.'
+                'Force stops Columnstore.'
+                'Warning: This could cause data corruption and/or data loss.'
             ),
             #TODO: hide from help till not investigated in decreased timeout
             #      affect
@@ -142,9 +144,9 @@ def stop(
                 break
             else:
                 force = typer.confirm(
-                    'DMLProc still working. '
-                    'Do you want to force stop? WARNING: It could cause data '
-                    'loss and broken cluster.',
+                    'DMLProc is still running. '
+                    'Do you want to force stop? '
+                    'WARNING: Could cause data loss and/or broken cluster.',
                     prompt_suffix=' '
                 )
                 if force:

--- a/cmapi/mcs_node_control/models/node_config.py
+++ b/cmapi/mcs_node_control/models/node_config.py
@@ -115,7 +115,6 @@ class NodeConfig:
         maintenance = etree.SubElement(root, 'Maintenance')
         maintenance.text = str(False).lower()
 
-
     def upgrade_config(self, tree=None, root=None, upgrade=True):
         """
         Add the parts that might be missing after an upgrade from an earlier
@@ -290,7 +289,6 @@ class NodeConfig:
                 return pm_num
         raise Exception("Did not find my IP addresses or names in the SystemModuleConfig section")
 
-
     def rollback_config(self, config_filename: str = DEFAULT_MCS_CONF_PATH):
         """Rollback the configuration.
 
@@ -306,7 +304,6 @@ class NodeConfig:
         config_file_copy = Path(backup_path)
         if config_file_copy.exists():
             replace(backup_path, config_file)   # atomic replacement
-
 
     def get_current_config(self, config_filename: str = DEFAULT_MCS_CONF_PATH):
         """Retrievs current configuration.
@@ -325,7 +322,6 @@ class NodeConfig:
             tree.getroot(), pretty_print=True, encoding='unicode'
         )
 
-
     def get_current_sm_config(
         self, config_filename: str = DEFAULT_SM_CONF_PATH
     ) -> str:
@@ -342,7 +338,6 @@ class NodeConfig:
         except FileNotFoundError:
             module_logger.error(f"{func_name} SM config {config_filename} not found.")
             return ''
-
 
     def s3_enabled(self, config_filename: str = DEFAULT_SM_CONF_PATH) -> bool:
         """Checks if SM is enabled


### PR DESCRIPTION
- [x] [add] NodeProcessController class to handle Node operations
- [x] [add] two endpoints: stop_dmlproc (PUT) and is_process_running (GET)
- [x] [add] NodeProcessController.put_stop_dmlproc method to separately stop DMLProc on primary Node
- [x] [add] NodeProcessController.get_process_running method to check if specified process running or not
- [x] [add] build_url function to helpers.py. It needed to build urls with query_params
- [x] [add] MCSProcessManager.gracefully_stop_dmlproc method
- [x] [add] MCSProcessManager.is_service_running method as a top level wrapper to the same method in dispatcher
- [x] [fix] MCSProcessManager.stop by using new gracefully_stop_dmlproc
- [x] [add] interactive option and mode to mcs cluster stop command
- [x] [fix] requirements.txt with typer version to 0.9.0 where supports various of features including "Annotated"
- [x] [fix] requirements.txt click version (8.1.3 -> 8.1.7) and typing-extensions (4.3.0 -> 4.8.0). This is dependencies for typer package. 
- [x] [fix] multiple minor formatting, docstrings and comments
- [x] [add] TransactionManager ContextDecorator to manage transactions in less code and in one place
- [x] [add] TransactionManager to cli cluster stop command and to API cluster shutdown command
- [x] [fix] id -> txn_id in ClusterHandler class
- [x] [fix] ClusterHandler.shutdown class to use inside existing transaction
- [x] [add] docstrings in multiple places 