### PR TITLE
Mcol 678 support with rollup subquery fix

### DIFF
--- a/mysql-test/columnstore/basic/r/mcs84_rollup.result
+++ b/mysql-test/columnstore/basic/r/mcs84_rollup.result
@@ -56,6 +56,15 @@ Paraguay	non-fiction	17790
 Senegal	NULL	171762
 Senegal	fiction	27881
 Senegal	non-fiction	143881
+SELECT country, genre, SUM(sales) FROM (SELECT country, genre, sales FROM booksales) t1 GROUP BY country, genre WITH ROLLUP;
+country	genre	SUM(sales)
+NULL	NULL	354462
+Paraguay	NULL	182700
+Paraguay	fiction	164910
+Paraguay	non-fiction	17790
+Senegal	NULL	171762
+Senegal	fiction	27881
+Senegal	non-fiction	143881
 CREATE TABLE three_cols ( key1 INTEGER, key2 INTEGER, value DECIMAL(38)) ENGINE=COLUMNSTORE;
 INSERT INTO three_cols(key1, key2, value) VALUES
 (NULL, NULL, NULL)

--- a/mysql-test/columnstore/basic/t/mcs84_rollup.test
+++ b/mysql-test/columnstore/basic/t/mcs84_rollup.test
@@ -42,6 +42,9 @@ SELECT year, SUM(sales) FROM booksales GROUP BY year WITH ROLLUP;
 --sorted_result
 SELECT country, genre, SUM(sales) FROM booksales GROUP BY country, genre WITH ROLLUP;
 
+--sorted_result
+SELECT country, genre, SUM(sales) FROM (SELECT country, genre, sales FROM booksales) t1 GROUP BY country, genre WITH ROLLUP;
+
 CREATE TABLE three_cols ( key1 INTEGER, key2 INTEGER, value DECIMAL(38)) ENGINE=COLUMNSTORE;
 
 INSERT INTO three_cols(key1, key2, value) VALUES

--- a/utils/common/string_prefixes.cpp
+++ b/utils/common/string_prefixes.cpp
@@ -42,7 +42,7 @@ int64_t encodeStringPrefix(const uint8_t* str, size_t len, datatypes::Charset& c
 
 int64_t encodeStringPrefix_check_null(const uint8_t* str, size_t len, datatypes::Charset& cset)
 {
-  if (len < 1 && str == nullptr)
+  if (len < 1)
   {
     return joblist::UBIGINTNULL;
   }

--- a/utils/rowgroup/rowaggregation.h
+++ b/utils/rowgroup/rowaggregation.h
@@ -425,6 +425,8 @@ class RowAggregation : public messageqcpp::Serializeable
 
   void clearRollup() { fRollupFlag = false; }
 
+  bool hasRollup() const { return fRollupFlag; }
+
   /** @brief Define content of data to be joined
    *
    *    This method must be call after setInputOutput() for PM hashjoin case.


### PR DESCRIPTION
The incorrect behavior, uncovered by Kirill, was due to use of single-phase aggergation over subquery.

This patch fixes that, but makes abysmal performance in this patricular case (WITH ROLLUP over subquery) - there is no parallel execution there.