### PR TITLE
MCOL-5610: Aliases on internally dependent tools.

### DIFF
--- a/cmapi/CMakeLists.txt
+++ b/cmapi/CMakeLists.txt
@@ -58,6 +58,8 @@ CONFIGURE_FILE(postinst.template postinst)
 CONFIGURE_FILE(prerm.template prerm)
 CONFIGURE_FILE(conffiles.template conffiles)
 CONFIGURE_FILE(mcs.template mcs)
+CONFIGURE_FILE(mcs_aws.template mcs_aws)
+CONFIGURE_FILE(mcs_gsutil.template mcs_gsutil)
 
 INSTALL(DIRECTORY python deps mcs_node_control failover cmapi_server engine_files mcs_cluster_tool
             DESTINATION ${CMAPI_DIR}
@@ -74,6 +76,12 @@ INSTALL(FILES cmapi_server/cmapi_server.conf systemd.env
 INSTALL(FILES ${SYSTEMD_UNIT_NAME}.service
             DESTINATION ${SYSTEMD_UNIT_DIR})
 INSTALL(FILES mcs
+            PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
+            DESTINATION ${BIN_DIR})
+INSTALL(FILES mcs_aws
+            PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
+            DESTINATION ${BIN_DIR})
+INSTALL(FILES mcs_gsutil
             PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
             DESTINATION ${BIN_DIR})
 

--- a/cmapi/mcs_aws.template
+++ b/cmapi/mcs_aws.template
@@ -1,0 +1,1 @@
+PYTHONPATH="${CMAPI_DIR}:${CMAPI_DIR}/deps" ${CMAPI_DIR}/python/bin/python3 ${CMAPI_DIR}/deps/bin/aws $@

--- a/cmapi/mcs_gsutil.template
+++ b/cmapi/mcs_gsutil.template
@@ -1,0 +1,1 @@
+PYTHONPATH="${CMAPI_DIR}:${CMAPI_DIR}/deps" ${CMAPI_DIR}/python/bin/python3 ${CMAPI_DIR}/deps/bin/gsutil $@


### PR DESCRIPTION
- [x] [add] mcs_aws and mcs_gsutil template files
- [x] [fix] cmapi CMakeLists to add mcs_aws and mcs_gsutil tools to usr/bin folder