### PR TITLE
MCOL-5463. [stable-23-10] Same columns fom diffeernt views in GROUP BY do not produce errors

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -8173,23 +8173,31 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, SCSEP& csep, bool i
         ReturnedColumn* rc = buildSimpleColumn(ifp, gwi);
         SimpleColumn* sc = dynamic_cast<SimpleColumn*>(rc);
 
-        for (uint32_t j = 0; j < gwi.returnedCols.size(); j++)
-        {
-          if (sc)
+	if (sc)
+	{
+	  bool found = false;
+          for (uint32_t j = 0; j < gwi.returnedCols.size(); j++)
           {
             if (sc->sameColumn(gwi.returnedCols[j].get()))
             {
               sc->orderPos(j);
+	      found = true;
               break;
             }
-            else if (strcasecmp(sc->alias().c_str(), gwi.returnedCols[j]->alias().c_str()) == 0)
+	  }
+          for (uint32_t j = 0; !found && j < gwi.returnedCols.size(); j++)
+          {
+            if (strcasecmp(sc->alias().c_str(), gwi.returnedCols[j]->alias().c_str()) == 0)
             {
               rc = gwi.returnedCols[j].get()->clone();
               rc->orderPos(j);
               break;
             }
           }
-          else
+	}
+	else
+	{
+          for (uint32_t j = 0; j < gwi.returnedCols.size(); j++)
           {
             if (ifp->name.length && string(ifp->name.str) == gwi.returnedCols[j].get()->alias())
             {
@@ -8198,7 +8206,7 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, SCSEP& csep, bool i
               break;
             }
           }
-        }
+	}
 
         if (!rc)
         {
@@ -9920,7 +9928,7 @@ int getGroupPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, SCSEP& csep, cal_gro
             }
           }
 
-          srcp->orderPos(groupcol->counter - 1);
+	  srcp->orderPos(groupcol->counter - 1);
           gwi.groupByCols.push_back(srcp);
           continue;
         }

--- a/mysql-test/columnstore/basic/r/MCOL-5643-views-group-by-same-columns.result
+++ b/mysql-test/columnstore/basic/r/MCOL-5643-views-group-by-same-columns.result
@@ -1,0 +1,26 @@
+drop database if exists MCOL_5643;
+create database MCOL_5643;
+use MCOL_5643;
+create table t1
+(
+id int,
+someStr varchar(100)
+) ENGINE=Columnstore;
+create table t2
+(
+id int,
+fk_t1 int,
+someStr varchar(100)
+) ENGINE=Columnstore;
+insert into t1 values (1, 'bla');
+insert into t2 values (1, 1, 'xyz');
+create view view_on_t1 as select id, someStr from t1;
+create view view_on_t2 as select id, fk_t1, someStr from t2;
+select max(view_on_t1.id), view_on_t1.someStr, view_on_t2.someStr
+from view_on_t1
+left outer join view_on_t2
+on view_on_t1.id = view_on_t2.fk_t1
+group by view_on_t1.someStr, view_on_t2.someStr;
+max(view_on_t1.id)	someStr	someStr
+1	bla	xyz
+drop database MCOL_5643;

--- a/mysql-test/columnstore/basic/t/MCOL-5643-views-group-by-same-columns.test
+++ b/mysql-test/columnstore/basic/t/MCOL-5643-views-group-by-same-columns.test
@@ -1,0 +1,36 @@
+--disable_warnings
+drop database if exists MCOL_5643;
+--enable_warnings
+create database MCOL_5643;
+
+use MCOL_5643;
+
+create table t1
+(
+        id int,
+        someStr varchar(100)
+) ENGINE=Columnstore;
+
+create table t2
+(
+        id int,
+        fk_t1 int,
+        someStr varchar(100)
+) ENGINE=Columnstore;
+
+insert into t1 values (1, 'bla');
+insert into t2 values (1, 1, 'xyz');
+
+create view view_on_t1 as select id, someStr from t1;
+create view view_on_t2 as select id, fk_t1, someStr from t2;
+
+# ERROR !!!
+select max(view_on_t1.id), view_on_t1.someStr, view_on_t2.someStr
+from view_on_t1
+left outer join view_on_t2
+on view_on_t1.id = view_on_t2.fk_t1
+group by view_on_t1.someStr, view_on_t2.someStr;
+# ==> All non-aggregate columns in the SELECT and ORDER BY clause must be included in the GROUP BY clause. 0.063 sec
+
+drop database MCOL_5643;
+


### PR DESCRIPTION
Fixes MCOL-5643.

The problem was that different views with same column names in GROUP BY and on the SELECT clause produced an error about "projection column is not an aggergate neither in GROUP BY list."

This was due to incorrect search in expressions's list that lead to duplicate columns in GROUP BY list.