### PR TITLE
remove boost from deps, add procsps, due without ps installation halts

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -837,8 +837,8 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
              commands: [
                "echo -e '\\e]8;;" + publish_pkg_url + '\\e\\\\' + publish_pkg_url + "\\e]8;;\\e\\\\'",
                "echo 'for installation run:'",
-               "export OS="+result,
-               "export PACKAGES_URL="+packages_url,
+               "echo 'export OS="+result+"'",
+               "echo 'export PACKAGES_URL="+packages_url+"'",
              ],
            },
          ] +

--- a/cmake/cpackEngineDEB.cmake
+++ b/cmake/cpackEngineDEB.cmake
@@ -55,13 +55,8 @@ if (EXISTS "/etc/debian_version")
     string(REGEX MATCH "([0-9]+).[0-9]+" DEBIAN "${DEBIAN_VERSION}")
     set(DEBIAN_VERSION_NUMBER "${CMAKE_MATCH_1}")
 endif ()
-if ("${DEBIAN_VERSION_NUMBER}" EQUAL "8")
-    SET(CPACK_DEBIAN_PLATFORM_PACKAGE_DEPENDS "openssl, file, libdbi-perl, rsync, net-tools, libboost-all-dev, libsnappy1, MariaDB-server, python3")
-elseif ("${DEBIAN_VERSION_NUMBER}" EQUAL "9")
-    SET(CPACK_DEBIAN_PLATFORM_PACKAGE_DEPENDS "openssl, file, libdbi-perl, rsync, net-tools, libboost-all-dev, libsnappy1v5, MariaDB-server, python3")
-else()
-    SET(CPACK_DEBIAN_PLATFORM_PACKAGE_DEPENDS "openssl, file, libdbi-perl, libboost-all-dev, rsync, libsnappy1v5, net-tools, MariaDB-server, python3")
-endif ()
+
+SET(CPACK_DEBIAN_PLATFORM_PACKAGE_DEPENDS "openssl, file, libdbi-perl, rsync, libsnappy1v5, net-tools, MariaDB-server, python3, procps")
 
 set(CPACK_DEBIAN_COLUMNSTORE-ENGINE_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_SOURCE_DIR}/build/debian/storageEngine/postinst;${CMAKE_CURRENT_SOURCE_DIR}/build/debian/storageEngine/prerm;")
 

--- a/cmake/cpackEngineRPM.cmake
+++ b/cmake/cpackEngineRPM.cmake
@@ -46,7 +46,7 @@ It is GPL v2 licensed, which means you can use the it free of charge under the
 conditions of the GNU General Public License Version 2 (http://www.gnu.org/licenses/).
 
 MariaDB documentation can be found at https://mariadb.com/kb
-MariaDB bug reports should be submitted through https://jira.mariadb.org 
+MariaDB bug reports should be submitted through https://jira.mariadb.org
 
 ")
 
@@ -71,20 +71,14 @@ IF (EXISTS "/etc/redhat-release")
     string(REGEX MATCH "release ([0-9]+)" CENTOS "${REDHAT_VERSION}")
     set(REDHAT_VERSION_NUMBER "${CMAKE_MATCH_1}")
 ENDIF ()
+
 IF (EXISTS "/etc/SuSE-release")
     file (READ "/etc/SuSE-release" SUSE_VERSION)
     string(REGEX MATCH "VERSION = ([0-9]+)" SUSE "${SUSE_VERSION}")
     set(SUSE_VERSION_NUMBER "${CMAKE_MATCH_1}")
 ENDIF ()
-if (${REDHAT_VERSION_NUMBER} EQUAL 6)
-    SETA(CPACK_RPM_columnstore-engine_PACKAGE_REQUIRES "MariaDB-columnstore-shared" "snappy" "net-tools" "MariaDB-server" "python3")
-    # Disable auto require as this will also try to pull Boost via RPM
-    SET(CPACK_RPM_PACKAGE_AUTOREQPROV " no")
-elseif (${SUSE_VERSION_NUMBER} EQUAL 12)
-    SETA(CPACK_RPM_columnstore-engine_PACKAGE_REQUIRES "boost-devel >= 1.54.0" "libsnappy1" "net-tools" "MariaDB-server" "python3" "jemalloc")
-else ()
-    SETA(CPACK_RPM_columnstore-engine_PACKAGE_REQUIRES "boost >= 1.53.0" "snappy" "net-tools" "MariaDB-server" "python3" "jemalloc")
-endif()
+
+SETA(CPACK_RPM_columnstore-engine_PACKAGE_REQUIRES "snappy" "net-tools" "MariaDB-server" "python3" "jemalloc" "procps-ng")
 
 SET(CPACK_RPM_columnstore-engine_PRE_INSTALL_SCRIPT_FILE ${CMAKE_SOURCE_DIR}/build/preInstall_storage_engine.sh)
 SET(CPACK_RPM_columnstore-engine_POST_INSTALL_SCRIPT_FILE ${CMAKE_SOURCE_DIR}/build/postInstall_storage_engine.sh)

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Depends: binutils,
          libmariadb3 (= ${server:Version}),
          net-tools,
          python3,
+         procps,
          ${misc:Depends},
          ${shlibs:Depends}
 Breaks: mariadb-columnstore-libs,


### PR DESCRIPTION
columstore install scripts use `ps` and pure docker images could miss this useful util and package installation will halt