### PR TITLE
perf(primproc) MCOL-5601: Initilize two fields once in ctor instead of calling makeConfig

### DIFF
--- a/utils/rowgroup/rowaggregation.cpp
+++ b/utils/rowgroup/rowaggregation.cpp
@@ -675,19 +675,16 @@ void RowAggregation::initialize(bool hasGroupConcat)
     }
   }
 
-  config::Config* config = config::Config::makeConfig();
-  string tmpDir = config->getTempFileDir(config::Config::TempDirPurpose::Aggregates);
-  string compStr = config->getConfig("RowAggregation", "Compression");
-  auto* compressor = compress::getCompressInterfaceByName(compStr);
+  auto* compressor = compress::getCompressInterfaceByName(fCompStr);
 
   if (fKeyOnHeap)
   {
-    fRowAggStorage.reset(new RowAggStorage(tmpDir, fRowGroupOut, &fKeyRG, fAggMapKeyCount, fRm,
+    fRowAggStorage.reset(new RowAggStorage(fTmpDir, fRowGroupOut, &fKeyRG, fAggMapKeyCount, fRm,
                                            fSessionMemLimit, disk_agg, allow_gen, compressor));
   }
   else
   {
-    fRowAggStorage.reset(new RowAggStorage(tmpDir, fRowGroupOut, fAggMapKeyCount, fRm, fSessionMemLimit,
+    fRowAggStorage.reset(new RowAggStorage(fTmpDir, fRowGroupOut, fAggMapKeyCount, fRm, fSessionMemLimit,
                                            disk_agg, allow_gen, compressor));
   }
 
@@ -768,19 +765,16 @@ void RowAggregation::aggReset()
     }
   }
 
-  config::Config* config = config::Config::makeConfig();
-  string tmpDir = config->getTempFileDir(config::Config::TempDirPurpose::Aggregates);
-  string compStr = config->getConfig("RowAggregation", "Compression");
-  auto* compressor = compress::getCompressInterfaceByName(compStr);
+  auto* compressor = compress::getCompressInterfaceByName(fCompStr);
 
   if (fKeyOnHeap)
   {
-    fRowAggStorage.reset(new RowAggStorage(tmpDir, fRowGroupOut, &fKeyRG, fAggMapKeyCount, fRm,
+    fRowAggStorage.reset(new RowAggStorage(fTmpDir, fRowGroupOut, &fKeyRG, fAggMapKeyCount, fRm,
                                            fSessionMemLimit, disk_agg, allow_gen, compressor));
   }
   else
   {
-    fRowAggStorage.reset(new RowAggStorage(tmpDir, fRowGroupOut, fAggMapKeyCount, fRm, fSessionMemLimit,
+    fRowAggStorage.reset(new RowAggStorage(fTmpDir, fRowGroupOut, fAggMapKeyCount, fRm, fSessionMemLimit,
                                            disk_agg, allow_gen, compressor));
   }
   fRowGroupOut->getRow(0, &fRow);

--- a/utils/rowgroup/rowaggregation.h
+++ b/utils/rowgroup/rowaggregation.h
@@ -635,6 +635,10 @@ class RowAggregation : public messageqcpp::Serializeable
   boost::shared_ptr<int64_t> fSessionMemLimit;
   std::unique_ptr<RGData> fCurRGData;
   bool fRollupFlag = false;
+
+  std::string fTmpDir = config::Config::makeConfig()->getTempFileDir(config::Config::TempDirPurpose::Aggregates);
+  std::string fCompStr = config::Config::makeConfig()->getConfig("RowAggregation", "Compression");
+
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
```
std::string fTmpDir = config::Config::makeConfig()->getTempFileDir(config::Config::TempDirPurpose::Aggregates); 
std::string fCompStr = config::Config::makeConfig()->getConfig("RowAggregation", "Compression");
```