### PR TITLE
MCOL-5624: dont force columnstore_use_import_for_batchinsert 

### DIFF
--- a/dbcon/mysql/columnstore.cnf
+++ b/dbcon/mysql/columnstore.cnf
@@ -4,4 +4,4 @@ plugin-load-add=ha_columnstore.so
 collation_server = utf8_general_ci
 character_set_server = utf8
 
-columnstore_use_import_for_batchinsert = ON
+loose-columnstore_use_import_for_batchinsert = ON


### PR DESCRIPTION
option to be required to start mariadb server