### PR TITLE
MCOL-5630: fix multi node MTR. Add "cmapi is-ready" cli command.

### DIFF
--- a/cmapi/mcs_cluster_tool/__main__.py
+++ b/cmapi/mcs_cluster_tool/__main__.py
@@ -4,7 +4,7 @@ import sys
 import typer
 
 from cmapi_server.logging_management import dict_config, add_logging_level
-from mcs_cluster_tool import cluster_app
+from mcs_cluster_tool import cluster_app, cmapi_app
 from mcs_cluster_tool.constants import MCS_CLI_LOG_CONF_PATH
 
 
@@ -17,6 +17,7 @@ app = typer.Typer(
     ),
 )
 app.add_typer(cluster_app.app, name="cluster")
+app.add_typer(cmapi_app.app, name="cmapi")
 
 
 if __name__ == "__main__":

--- a/cmapi/mcs_cluster_tool/cmapi_app.py
+++ b/cmapi/mcs_cluster_tool/cmapi_app.py
@@ -1,0 +1,50 @@
+"""Cmapi typer application.
+
+Formally this module contains all subcommands for "mcs cmapi" cli command.
+"""
+import logging
+from typing_extensions import Annotated
+
+import requests
+import typer
+
+from cmapi_server.exceptions import CMAPIBasicError
+from mcs_cluster_tool.decorators import handle_output
+
+
+logger = logging.getLogger('mcs_cli')
+app = typer.Typer(
+    help='CMAPI itself related commands.'
+)
+
+
+@app.command()
+@handle_output
+def is_ready(
+    node: Annotated[
+        str,
+        typer.Option(
+            '--node',
+            help=('Which node to check the CMAPI is ready to handle requests.')
+        )
+    ] = '127.0.0.1'
+):
+    """Check CMAPI is ready to handle requests."""
+    url = f'https://{node}:8640/cmapi/ready'
+    try:
+        resp = requests.get(url, verify=False, timeout=15)
+        resp.raise_for_status()
+        r_json = resp.json()
+    except requests.exceptions.HTTPError as err:
+        if err.response.status_code == 503:
+            raise CMAPIBasicError('CMAPI is not ready.') from err
+        else:
+            raise CMAPIBasicError(
+                'Got unexpected HTTP return code '
+                f'"{err.response.status_code}" while getting CMAPI ready '
+                'state.'
+            ) from err
+    except Exception as err:
+        raise CMAPIBasicError('Got an error getting CMAPI ready state.') from err
+    logger.debug('Successfully get CMAPI ready state.')
+    return r_json


### PR DESCRIPTION
This task is a next logical part of MCOL-5470 that implements AppManager and API endpoint to check if CMAPI ready or not.

- [x] [add] cmapi_app.py with is-ready command implementation
- [x] [fix] add cmapi is-ready command to main typer app