### PR TITLE
Boost1.84[stable-23.10]

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -37,8 +37,8 @@ ENDFOREACH()
 
 ExternalProject_Add(external_boost
   PREFIX .boost
-  URL https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2
-  URL_HASH SHA256=71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa
+  URL https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.gz
+  URL_HASH SHA256=a5800f405508f5df8114558ca9855d2640a2de8f0445f051fa1c7c3383045724
   CONFIGURE_COMMAND ./bootstrap.sh
   UPDATE_COMMAND ""
   BUILD_COMMAND ./b2 -q ${_b2args}

--- a/tests/mcs_decimal-tests.cpp
+++ b/tests/mcs_decimal-tests.cpp
@@ -1349,10 +1349,10 @@ TEST(Decimal, DecimalToStringCheckScale0)
   datatypes::Decimal dec(0, scale, precision, res);
 
   // test simple values
-  expected = "0";
+  expected = std::string("0");
   EXPECT_EQ(dec.toString(), expected);
   res = 2;
-  expected = "2";
+  expected = std::string("2");
   dec.setTSInt128Value(res);
   EXPECT_EQ(dec.toString(), expected);
   res = -2;

--- a/utils/funcexp/func_truncate.cpp
+++ b/utils/funcexp/func_truncate.cpp
@@ -19,7 +19,6 @@
 //  $Id: func_truncate.cpp 3921 2013-06-19 18:59:56Z bwilkinson $
 
 #include <cstdlib>
-#include <iomanip>
 #include <string>
 using namespace std;
 
@@ -560,7 +559,7 @@ IDB_Decimal Func_truncate::getDecimalVal(Row& row, FunctionParm& parm, bool& isN
         else
         {
           if (-s >= (int32_t)value.size())
-            value = "0";
+            value = std::string("0");
           else
           {
             value = value.substr(0, value.size() + s);
@@ -661,7 +660,7 @@ int64_t Func_truncate::getTimestampIntVal(rowgroup::Row& row, FunctionParm& parm
   if (isNull)
     return 0;
   s = (s > MAX_MICROSECOND_PRECISION) ? MAX_MICROSECOND_PRECISION : s;
-  if (s < 0) 
+  if (s < 0)
   {
     s = 0;
   }
@@ -677,7 +676,7 @@ int64_t Func_truncate::getDatetimeIntVal(Row& row, FunctionParm& parm, bool& isN
   if (isNull)
     return 0;
   s = (s > MAX_MICROSECOND_PRECISION) ? MAX_MICROSECOND_PRECISION : s;
-  if (s < 0) 
+  if (s < 0)
   {
     s = 0;
   }
@@ -693,7 +692,7 @@ int64_t Func_truncate::getTimeIntVal(rowgroup::Row& row, FunctionParm& parm, boo
   if (isNull)
     return 0;
   s = (s > MAX_MICROSECOND_PRECISION) ? MAX_MICROSECOND_PRECISION : s;
-  if (s < 0) 
+  if (s < 0)
   {
     s = 0;
   }


### PR DESCRIPTION
Something happened with boost 1.81 we used
```
-- SHA256 hash of
    /mdb/verylongdirnameforverystrangecpackbehavior/storage/columnstore/columnstore/.boost/src/boost_1_81_0.tar.bz2
  does not match expected value
    expected: '71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa'
      actual: '5e89103d9b70bba5c91a794126b169cb67654be2051f90cf7c22ba6893ede0ff'
-- Hash mismatch, removing...
CMake Error at external_boost-stamp/download-external_boost.cmake:159 (message):
  Each download failed!
```
IMHO it's time to update