### PR TITLE
MCOL-5630: fix multi node MTR. Add "cmapi is-ready" cli command [develop-23.02]

### DIFF
--- a/cmapi/mcs_cluster_tool/__main__.py
+++ b/cmapi/mcs_cluster_tool/__main__.py
@@ -4,7 +4,7 @@ import sys
 import typer
 
 from cmapi_server.logging_management import dict_config, add_logging_level
-from mcs_cluster_tool import cluster_app
+from mcs_cluster_tool import cluster_app, cmapi_app
 from mcs_cluster_tool.constants import MCS_CLI_LOG_CONF_PATH
 
 
@@ -17,6 +17,7 @@ app = typer.Typer(
     ),
 )
 app.add_typer(cluster_app.app, name="cluster")
+app.add_typer(cmapi_app.app, name="cmapi")
 
 
 if __name__ == "__main__":

--- a/cmapi/mcs_cluster_tool/cmapi_app.py
+++ b/cmapi/mcs_cluster_tool/cmapi_app.py
@@ -1,0 +1,50 @@
+"""Cmapi typer application.
+
+Formally this module contains all subcommands for "mcs cmapi" cli command.
+"""
+import logging
+from typing_extensions import Annotated
+
+import requests
+import typer
+
+from cmapi_server.exceptions import CMAPIBasicError
+from mcs_cluster_tool.decorators import handle_output
+
+
+logger = logging.getLogger('mcs_cli')
+app = typer.Typer(
+    help='CMAPI itself related commands.'
+)
+
+
+@app.command()
+@handle_output
+def is_ready(
+    node: Annotated[
+        str,
+        typer.Option(
+            '--node',
+            help=('Which node to check the CMAPI is ready to handle requests.')
+        )
+    ] = '127.0.0.1'
+):
+    """Check CMAPI is ready to handle requests."""
+    url = f'https://{node}:8640/cmapi/ready'
+    try:
+        resp = requests.get(url, verify=False, timeout=15)
+        resp.raise_for_status()
+        r_json = resp.json()
+    except requests.exceptions.HTTPError as err:
+        if err.response.status_code == 503:
+            raise CMAPIBasicError('CMAPI is not ready.') from err
+        else:
+            raise CMAPIBasicError(
+                'Got unexpected HTTP return code '
+                f'"{err.response.status_code}" while getting CMAPI ready '
+                'state.'
+            ) from err
+    except Exception as err:
+        raise CMAPIBasicError('Got an error getting CMAPI ready state.') from err
+    logger.debug('Successfully get CMAPI ready state.')
+    return r_json

--- a/cmapi/requirements.txt
+++ b/cmapi/requirements.txt
@@ -7,7 +7,7 @@ lxml==4.7.1
 psutil==5.9.1
 pyotp==2.6.0
 requests==2.27.1
-typer==0.4.1
+typer==0.9.0
 
 # indirect dependencies
 aiohttp==3.8.1
@@ -24,7 +24,7 @@ certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.12
 cheroot==8.6.0
-click==8.1.3
+click==8.1.7
 colorama==0.4.4
 crcmod==1.7
 docutils==0.16
@@ -66,7 +66,7 @@ rsa==4.7.2
 s3transfer==0.6.0
 six==1.16.0
 tempora==5.0.1
-typing-extensions==4.3.0
+typing-extensions==4.8.0
 urllib3==1.26.8
 yarl==1.8.1
 zc.lockfile==2.0


### PR DESCRIPTION
The docker repo is isolated from engine, so we need duplicates to all branches we use

This task is a next logical part of MCOL-5470 that implements AppManager and API endpoint
to check if CMAPI ready or not.

- [x] [add] cmapi_app.py with is-ready command implementation
- [x] [fix] add cmapi is-ready command to main typer app