### PR TITLE
Containers memory limits for CI

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -475,7 +475,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
       'cd mariadb-columnstore-regression-test',
       'git rev-parse --abbrev-ref HEAD && git rev-parse HEAD',
       'cd ..',
-      'docker run --shm-size=500m --memory 8g --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --name regression$${DRONE_BUILD_NUMBER} --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target']
+      'docker run --shm-size=500m --memory 12g --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --name regression$${DRONE_BUILD_NUMBER} --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target']
       + prepareTestStage(dockerImage('regression'), pkg_format, result, true) + [
 
       if (platform == 'centos:7') then

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -300,8 +300,6 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
       },
     },
     commands: [
-      'apk add bash',
-      'bash -c "RUNNERPID=`pidof drone-runner-docker`; if [[ $RUNNERPID ]]; then echo \"drone docker runner pid is $RUNNERPID\"; echo -n \"-999\" > /proc/$RUNNERPID/oom_score_adj; fi"',
       execInnerDocker("mkdir -p reg-logs", dockerImage("regression"), "--workdir /mariadb-columnstore-regression-test/mysql/queries/nightly/alltest"),
       execInnerDocker("bash -c 'sleep 4800 && bash /save_stack.sh /mariadb-columnstore-regression-test/mysql/queries/nightly/alltest/reg-logs/' & ",
                       dockerImage("regresion")),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -251,6 +251,18 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
     if (pkg_format == 'deb')
       then execInnerDocker('sed -i "s/exit 101/exit 0/g" /usr/sbin/policy-rc.d', dockerImage),
 
+    'echo "Docker CGroups opts here"',
+    'ls -al /sys/fs/cgroup/cgroup.controllers || true ',
+    'ls -al /sys/fs/cgroup/ || true ',
+    'ls -al /sys/fs/cgroup/memory || true',
+    "docker ps --filter=name=" + dockerImage,
+
+    execInnerDocker('echo "Inner Docker CGroups opts here"', dockerImage),
+    execInnerDocker('ls -al /sys/fs/cgroup/cgroup.controllers || true', dockerImage),
+    execInnerDocker('ls -al /sys/fs/cgroup/ || true', dockerImage),
+    execInnerDocker('ls -al /sys/fs/cgroup/memory || true', dockerImage),
+    execInnerDocker("docker ps --filter=name=" + dockerImage, dockerImage),
+
     execInnerDocker('mkdir core', dockerImage),
     execInnerDocker('chmod 777 core', dockerImage),
     'docker cp core_dumps/. ' + dockerImage  +  ':/',

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -300,6 +300,8 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
       },
     },
     commands: [
+      'apk add bash',
+      'bash -c "RUNNERPID=`pidof drone-runner-docker`; if [[ $RUNNERPID ]]; then echo \"drone docker runner pid is $RUNNERPID\"; echo -n \"-999\" > /proc/$RUNNERPID/oom_score_adj; fi"',
       execInnerDocker("mkdir -p reg-logs", dockerImage("regression"), "--workdir /mariadb-columnstore-regression-test/mysql/queries/nightly/alltest"),
       execInnerDocker("bash -c 'sleep 4800 && bash /save_stack.sh /mariadb-columnstore-regression-test/mysql/queries/nightly/alltest/reg-logs/' & ",
                       dockerImage("regresion")),
@@ -475,7 +477,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
       'cd mariadb-columnstore-regression-test',
       'git rev-parse --abbrev-ref HEAD && git rev-parse HEAD',
       'cd ..',
-      'docker run --shm-size=500m --memory 12g --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --name regression$${DRONE_BUILD_NUMBER} --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target']
+      'docker run --shm-size=500m --memory 10g --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --name regression$${DRONE_BUILD_NUMBER} --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target']
       + prepareTestStage(dockerImage('regression'), pkg_format, result, true) + [
 
       if (platform == 'centos:7') then

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -318,7 +318,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
       'sleep $${SMOKE_DELAY_SECONDS:-1s}',
       // start mariadb and mariadb-columnstore services and run simple query
       execInnerDocker('systemctl start mariadb', dockerImage("smoke")),
-      execInnerDocker("/usr/bin/mcsSetConfig SystemConfig CGroup $(docker ps --filter=name=mtr$${DRONE_BUILD_NUMBER} --quiet --no-trunc)", dockerImage("smoke")),
+      execInnerDocker("/usr/bin/mcsSetConfig SystemConfig CGroup $(docker ps --filter=name=" + dockerImage("smoke") + " --quiet --no-trunc)", dockerImage("smoke")),
       execInnerDocker('systemctl restart mariadb-columnstore', dockerImage("smoke")),
       execInnerDocker('mariadb -e "create database if not exists test; create table test.t1 (a int) engine=Columnstore; insert into test.t1 values (1); select * from test.t1"',
                       dockerImage("smoke")),
@@ -378,7 +378,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
       MTR_FULL_SUITE: '${MTR_FULL_SUITE:-false}',
     },
     commands: [
-      'docker run --shm-size=500m --env MYSQL_TEST_DIR=' + mtr_path + ' --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --name mtr$${DRONE_BUILD_NUMBER} --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target']
+      'docker run --shm-size=500m --memory 8g --env MYSQL_TEST_DIR=' + mtr_path + ' --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --name mtr$${DRONE_BUILD_NUMBER} --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target']
       + prepareTestStage('mtr$${DRONE_BUILD_NUMBER}', pkg_format, result, true) + [
       installEngine(dockerImage("mtr"), pkg_format),
       'docker cp mysql-test/columnstore mtr$${DRONE_BUILD_NUMBER}:' + mtr_path + '/suite/',
@@ -387,13 +387,10 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
       execInnerDocker("bash -c 'sed -i /ProtectSystem/d $(systemctl show --property FragmentPath mariadb | sed s/FragmentPath=//)'", dockerImage('mtr')),
       execInnerDocker('systemctl daemon-reload', dockerImage("mtr")),
       execInnerDocker('systemctl start mariadb', dockerImage("mtr")),
+      // Set RAM consumption limits to avoid RAM contention b/w mtr and regression steps.
+      execInnerDocker("/usr/bin/mcsSetConfig SystemConfig CGroup $(docker ps --filter=name=" + dockerImage("mtr") + " --quiet --no-trunc)", dockerImage("mtr")),
       execInnerDocker('mariadb -e "create database if not exists test;"', dockerImage("mtr")),
       execInnerDocker('systemctl restart mariadb-columnstore', dockerImage("mtr")),
-
-      // Set RAM consumption limits to avoid RAM contention b/w mtr and regression steps.
-      //'docker exec -t mtr$${DRONE_BUILD_NUMBER} bash -c "/usr/bin/mcsSetConfig HashJoin TotalUmMemory 4G"',
-      //'docker exec -t mtr$${DRONE_BUILD_NUMBER} bash -c "/usr/bin/mcsSetConfig DBBC NumBlocksPct 1G"',
-      //'docker exec -t mtr$${DRONE_BUILD_NUMBER} bash -c "/usr/bin/mcsSetConfig SystemConfig CGroup $(docker ps --filter=name=mtr$${DRONE_BUILD_NUMBER} --quiet --no-trunc)"',
 
       // delay mtr for manual debugging on live instance
       'sleep $${MTR_DELAY_SECONDS:-1s}',
@@ -465,7 +462,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
       'cd mariadb-columnstore-regression-test',
       'git rev-parse --abbrev-ref HEAD && git rev-parse HEAD',
       'cd ..',
-      'docker run --shm-size=500m --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --name regression$${DRONE_BUILD_NUMBER} --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target']
+      'docker run --shm-size=500m --memory 8g --env OS=' + result + ' --env PACKAGES_URL=' + packages_url + ' --env DEBIAN_FRONTEND=noninteractive --env MCS_USE_S3_STORAGE=0 --name regression$${DRONE_BUILD_NUMBER} --ulimit core=-1 --privileged --detach ' + img + ' ' + init + ' --unit=basic.target']
       + prepareTestStage(dockerImage('regression'), pkg_format, result, true) + [
 
       if (platform == 'centos:7') then
@@ -485,11 +482,10 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
       execInnerDocker('sed -i "/^.mariadb.$/a lower_case_table_names=1" ' + config_path_prefix + 'server.cnf', dockerImage('regression')),
       // set default client character set to utf-8
       execInnerDocker('sed -i "/^.client.$/a default-character-set=utf8" ' + config_path_prefix + 'client.cnf',dockerImage('regression')),
+
       // Set RAM consumption limits to avoid RAM contention b/w mtr andregression steps.
-      //'docker exec -t regression$${DRONE_BUILD_NUMBER} bash -c "/usr/bin/mcsSetConfig HashJoin TotalUmMemory 5G"',
-      //'docker exec -t regressin$${DRONE_BUILD_NUMBER} bash -c "/usr/bin/mcsSetConfig DBBC NumBlocksPct 2G"',
-      //'docker exec -t regression$${DRONE_BUILD_NUMBER} bash -c "/usr/bin/mcsSetConfig SystemConfig CGroup $(docker ps --filter=name=regression$${DRONE_BUILD_NUMBER} --quiet --no-trunc)"',
-      // start mariadb and mariadb-columnstore services
+      execInnerDocker("/usr/bin/mcsSetConfig SystemConfig CGroup $(docker ps --filter=name=" + dockerImage("regression") + " --quiet --no-trunc)", dockerImage("regression")),
+
       execInnerDocker('systemctl start mariadb',dockerImage('regression')),
       execInnerDocker('systemctl restart mariadb-columnstore',dockerImage('regression')),
       // delay regression for manual debugging on live instance

--- a/build/bootstrap_mcs.sh
+++ b/build/bootstrap_mcs.sh
@@ -199,6 +199,7 @@ clean_old_installation()
     rm -rf /var/lib/columnstore/local/
     rm -rf /var/lib/columnstore/storagemanager/*
     rm -rf /var/log/mariadb/columnstore/*
+    rm -rf /etc/mysql/mariadb.conf.d/columnstore.cnf /etc/my.cnf.d/columnstore.cnf
     rm -rf /tmp/*
     rm -rf $REPORT_PATH
     rm -rf /var/lib/mysql

--- a/mysql-test/columnstore/basic/disabled.def
+++ b/mysql-test/columnstore/basic/disabled.def
@@ -6,3 +6,4 @@ mcs118_charset_negative : mcs error code has changed 2022-07-07 roman.navrotskiy
 mcs16_functions_define_call_drop : 2022-07-08 roman.navrotskiy@mariadb.com
 udf_calshowpartitions : unstable values for min/max in the output(sometimes N/A, sometimes numbers) 2022-07-26 roman.nozdrin@mariadb.com
 mcs3_create_table_charset_collations : 10.6 vs 10.9 show create table difference
+pron : pron is not threadsfe and doesn't work with PrimProc TDB: leonid.fedorov@mariadb.com

--- a/utils/common/cgroupconfigurator.cpp
+++ b/utils/common/cgroupconfigurator.cpp
@@ -79,11 +79,11 @@ CGroupConfigurator::CGroupConfigurator()
   else
     cGroupDefined = true;
 
+  if (cGroupName == "just_no_group_use_local")
+    cGroupName = std::string{};
 
   ifstream v2Check("/sys/fs/cgroup/cgroup.controllers");
   cGroupVersion_ = (v2Check) ? v2 : v1;
-
-
 }
 
 CGroupConfigurator::~CGroupConfigurator()


### PR DESCRIPTION
We could see the limits work, as large-volume parquet tests fails. This patch rewrites parquet tests to limit memory consumption as well