### PR TITLE
MCOL-5597: large side read errors

### DIFF
--- a/utils/joiner/joinpartition.cpp
+++ b/utils/joiner/joinpartition.cpp
@@ -849,7 +849,15 @@ uint64_t JoinPartition::writeByteStream(int which, ByteStream& bs)
   bs.advance(len);
 
   offset = fs.tellp();
+
   fs.close();
+
+  if (fs.fail())
+  {
+    ostringstream os;
+    os << "Disk join file " << filename << ": close() failure, probable exhaustion of disk space." << endl;
+    throw IDBExcept(os.str().c_str(), ERR_DBJ_FILE_IO_ERROR);
+  }
   return ret;
 }
 


### PR DESCRIPTION
The large side read errors mentioned there can be due to failure to close file stream properly. Some of the data may still reside in the file stream buffers, closing must flush it. The flush is an I/O operation and can fail, leading to partial write and subsequent partial read.

This patch tries to provide better diagnostics.