### PR TITLE
MCOL-4480: TEXT type added

### DIFF
--- a/dbcon/ddlpackageproc/altertableprocessor.cpp
+++ b/dbcon/ddlpackageproc/altertableprocessor.cpp
@@ -47,6 +47,7 @@ using namespace logging;
 
 #include "we_messages.h"
 #include "we_ddlcommandclient.h"
+#include "we_ddlcommon.h"
 using namespace WriteEngine;
 
 #include "oamcache.h"
@@ -685,10 +686,13 @@ void AlterTableProcessor::addColumn(uint32_t sessionID, execplan::CalpontSystemC
     throw std::runtime_error(err);
   }
 
-  if ((columnDefPtr->fType->fType == CalpontSystemCatalog::CHAR && columnDefPtr->fType->fLength > 8) ||
-      (columnDefPtr->fType->fType == CalpontSystemCatalog::VARCHAR && columnDefPtr->fType->fLength > 7) ||
-      (columnDefPtr->fType->fType == CalpontSystemCatalog::VARBINARY && columnDefPtr->fType->fLength > 7) ||
-      (columnDefPtr->fType->fType == CalpontSystemCatalog::BLOB))
+  int dataType = WriteEngine::convertDataType(columnDefPtr->fType->fType);
+
+  if ((dataType == CalpontSystemCatalog::CHAR && columnDefPtr->fType->fLength > 8) ||
+      (dataType == CalpontSystemCatalog::VARCHAR && columnDefPtr->fType->fLength > 7) ||
+      (dataType == CalpontSystemCatalog::VARBINARY && columnDefPtr->fType->fLength > 7) ||
+      (dataType == CalpontSystemCatalog::TEXT) ||
+      (dataType == CalpontSystemCatalog::BLOB))
   {
     isDict = true;
   }

--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -401,6 +401,7 @@ int fetchNextRow(uchar* buf, cal_table_info& ti, cal_connection_info* ci, long t
         // @2835. Handle empty string and null confusion. store empty string for string column
         if (colType.colDataType == CalpontSystemCatalog::CHAR ||
             colType.colDataType == CalpontSystemCatalog::VARCHAR ||
+            colType.colDataType == CalpontSystemCatalog::TEXT ||
             colType.colDataType == CalpontSystemCatalog::VARBINARY)
         {
           (*f)->reset();

--- a/dbcon/mysql/ha_pseudocolumn.cpp
+++ b/dbcon/mysql/ha_pseudocolumn.cpp
@@ -428,6 +428,7 @@ execplan::ReturnedColumn* buildPseudoColumn(Item* item, gp_walk_info& gwi, bool&
 
   if ((pseudoType == PSEUDO_EXTENTMIN || pseudoType == PSEUDO_EXTENTMAX) &&
       (sc->colType().colDataType == CalpontSystemCatalog::VARBINARY ||
+       (sc->colType().colDataType == CalpontSystemCatalog::TEXT) ||
        (sc->colType().colDataType == CalpontSystemCatalog::VARCHAR && sc->colType().colWidth > 7) ||
        (sc->colType().colDataType == CalpontSystemCatalog::CHAR && sc->colType().colWidth > 8)))
     return nullOnError(gwi, funcName);

--- a/mysql-test/columnstore/bugfixes/MCOL_5175.result
+++ b/mysql-test/columnstore/bugfixes/MCOL_5175.result
@@ -1,0 +1,21 @@
+DROP DATABASE IF EXISTS MCOL_5175;
+CREATE DATABASE MCOL_5175;
+USE MCOL_5175;
+create table testtext2 ( myvalue varchar(100) )engine=Columnstore CHARSET=utf8;
+show create table testtext2;
+Table	Create Table
+testtext2	CREATE TABLE `testtext2` (
+  `myvalue` varchar(100) DEFAULT NULL
+) ENGINE=Columnstore DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+alter table testtext2 add column myvalue2 text;
+show create table testtext2;
+Table	Create Table
+testtext2	CREATE TABLE `testtext2` (
+  `myvalue` varchar(100) DEFAULT NULL,
+  `myvalue2` text DEFAULT NULL
+) ENGINE=Columnstore DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+insert into testtext2 (myvalue2) VALUES ('myvalue');
+select * from testtext2;
+myvalue	myvalue2
+NULL	myvalue
+DROP DATABASE MCOL_5175;

--- a/mysql-test/columnstore/bugfixes/MCOL_5175.test
+++ b/mysql-test/columnstore/bugfixes/MCOL_5175.test
@@ -1,0 +1,22 @@
+#
+# Alter table add column
+# Author: Bharath, bharath.bokka@mariadb.com
+#
+-- source include/have_innodb.inc
+-- source ../include/have_columnstore.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS MCOL_5175;
+--enable_warnings
+
+CREATE DATABASE MCOL_5175;
+USE MCOL_5175;
+
+create table testtext2 ( myvalue varchar(100) )engine=Columnstore CHARSET=utf8;
+show create table testtext2;
+alter table testtext2 add column myvalue2 text;
+show create table testtext2;
+insert into testtext2 (myvalue2) VALUES ('myvalue');
+select * from testtext2;
+
+DROP DATABASE MCOL_5175;

--- a/mysql-test/columnstore/bugfixes/mcol-4758.result
+++ b/mysql-test/columnstore/bugfixes/mcol-4758.result
@@ -11,4 +11,9 @@ INSERT INTO src VALUES (1, "Pretty Bloby Thing", "This is some text");
 select * from src where c0=1 and substr(cLT, 1, 4)="This";
 c0	cLB	cLT
 1	Pretty Bloby Thing	This is some text
+ALTER TABLE src ADD COLUMN (cLT2 LONGTEXT);
+UPDATE src SET cLT2="My Friday Night" where c0=1;
+select * from src where c0=1 and substr(cLT, 1, 4)="This";
+c0	cLB	cLT	cLT2
+1	Pretty Bloby Thing	This is some text	My Friday Night
 DROP DATABASE `mcol_4758`;

--- a/mysql-test/columnstore/bugfixes/mcol-4758.test
+++ b/mysql-test/columnstore/bugfixes/mcol-4758.test
@@ -11,9 +11,9 @@ INSERT INTO src VALUES (1, "Pretty Bloby Thing", "This is some text");
 select * from src where c0=1 and substr(cLT, 1, 4)="This";
 
 # To be uncommented when MCOL-4480 is fixed
-#ALTER TABLE src ADD COLUMN (cLT2 LONGTEXT);
-#UPDATE src SET cLT2="My Friday Night" where c0=1;
-#select * from src where c0=1 and substr(cLT, 1, 4)="This";
+ALTER TABLE src ADD COLUMN (cLT2 LONGTEXT);
+UPDATE src SET cLT2="My Friday Night" where c0=1;
+select * from src where c0=1 and substr(cLT, 1, 4)="This";
 
 # cleanup
 DROP DATABASE `mcol_4758`;


### PR DESCRIPTION
the field `columnDefPtr->fType->fType` in `AlterTableProcessor::addColumn` is written as `enum DDL_DATATYPES` and was compared with values from `enum ColDataType` 
`CalpontSystemCatalog::TEXT` was missed in the same function and in two more or less similar cases