### PR TITLE
Fixes MCOL-5056, an error of joining TEXT column from InnoDB

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -3180,7 +3180,15 @@ CalpontSystemCatalog::ColType colType_MysqlToIDB(const Item* item)
 
         if (item->field_type() == MYSQL_TYPE_BLOB)
         {
+          // We default to BLOB, but then try to correct type,
+	  // because many textual types in server have type_handler_blob
+	  // (and variants) as their type.
           ct.colDataType = CalpontSystemCatalog::BLOB;
+          const Item_result_field* irf = dynamic_cast<const Item_result_field*>(item);
+	  if (irf && irf->result_field && !irf->result_field->binary())
+          {
+            ct.colDataType = CalpontSystemCatalog::TEXT;
+	  }
         }
       }
 

--- a/mysql-test/columnstore/basic/r/MCOL-5056-text-is-not-blob.result
+++ b/mysql-test/columnstore/basic/r/MCOL-5056-text-is-not-blob.result
@@ -1,0 +1,22 @@
+DROP DATABASE IF EXISTS MCOL5056;
+CREATE DATABASE MCOL5056;
+USE MCOL5056;
+CREATE USER IF NOT EXISTS'cejuser'@'localhost' IDENTIFIED BY 'Vagrant1|0000001';
+GRANT ALL PRIVILEGES ON *.* TO 'cejuser'@'localhost';
+FLUSH PRIVILEGES;
+CREATE TABLE foo5 (a TEXT);
+CREATE TABLE bar5 (b TEXT) ENGINE=COLUMNSTORE;
+SELECT * FROM foo5, bar5 WHERE foo5.a=bar5.b;
+a	b
+CREATE TABLE t3i (ai TEXT, bi INTEGER, ci TEXT);
+CREATE TABLE t3c (ac TEXT, bc INTEGER, cc TEXT) ENGINE=COLUMNSTORE;
+SELECT * FROM t3i, t3c WHERE t3i.ai=t3c.ac;
+ai	bi	ci	ac	bc	cc
+SELECT * FROM t3i, t3c WHERE t3i.ci=t3c.ac;
+ai	bi	ci	ac	bc	cc
+SELECT * FROM t3i, t3c WHERE t3i.ai=t3c.cc;
+ai	bi	ci	ac	bc	cc
+SELECT * FROM t3i, t3c WHERE t3i.ci=t3c.cc;
+ai	bi	ci	ac	bc	cc
+DROP USER 'cejuser'@'localhost';
+DROP DATABASE MCOL5056;

--- a/mysql-test/columnstore/basic/t/MCOL-5056-text-is-not-blob.test
+++ b/mysql-test/columnstore/basic/t/MCOL-5056-text-is-not-blob.test
@@ -1,0 +1,42 @@
+-- source include/have_innodb.inc
+-- source ../include/have_columnstore.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS MCOL5056;
+--enable_warnings
+
+CREATE DATABASE MCOL5056;
+
+USE MCOL5056;
+
+if (!$MASTER_MYPORT)
+{
+  # Running with --extern
+  let $MASTER_MYPORT=`SELECT @@port`;
+}
+
+--exec $MCS_MCSSETCONFIG CrossEngineSupport User 'cejuser'
+--exec $MCS_MCSSETCONFIG CrossEngineSupport Password 'Vagrant1|0000001'
+--exec $MCS_MCSSETCONFIG CrossEngineSupport Port $MASTER_MYPORT
+--disable_warnings
+CREATE USER IF NOT EXISTS'cejuser'@'localhost' IDENTIFIED BY 'Vagrant1|0000001';
+--enable_warnings
+GRANT ALL PRIVILEGES ON *.* TO 'cejuser'@'localhost';
+FLUSH PRIVILEGES;
+
+CREATE TABLE foo5 (a TEXT);
+CREATE TABLE bar5 (b TEXT) ENGINE=COLUMNSTORE;
+# no data, just the fact that we can run this SELECT without errors.
+SELECT * FROM foo5, bar5 WHERE foo5.a=bar5.b;
+
+CREATE TABLE t3i (ai TEXT, bi INTEGER, ci TEXT);
+CREATE TABLE t3c (ac TEXT, bc INTEGER, cc TEXT) ENGINE=COLUMNSTORE;
+SELECT * FROM t3i, t3c WHERE t3i.ai=t3c.ac;
+SELECT * FROM t3i, t3c WHERE t3i.ci=t3c.ac;
+SELECT * FROM t3i, t3c WHERE t3i.ai=t3c.cc;
+SELECT * FROM t3i, t3c WHERE t3i.ci=t3c.cc;
+
+
+DROP USER 'cejuser'@'localhost';
+DROP DATABASE MCOL5056;
+


### PR DESCRIPTION
We incorrectly identified TEXT columns from external tables as BLOB. Alexander Barkov suggested a way to discriminate them which I implemented here.