### PR TITLE
Docker multinode provision script expects container names in the cli

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -688,7 +688,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
       'sed -i "/^MCS_IMAGE_NAME=/s/=.*/=${MCS_IMAGE_NAME}/" .env',
       'sed -i "/^MAXSCALE=/s/=.*/=false/" .env',
       'docker-compose up -d',
-      'docker exec mcs1 provision',
+      'docker exec mcs1 provision mcs1 mcs2 mcs3',
       'docker cp ../mysql-test/columnstore mcs1:' + mtr_path + '/suite/',
       'docker exec -t mcs1 chown mysql:mysql -R ' + mtr_path,
       'docker exec -t mcs1 mariadb -e "create database if not exists test;"',


### PR DESCRIPTION
For multi-node setup, docker provision [script](https://github.com/mariadb-corporation/mariadb-columnstore-docker/blob/86c9c28ebef027c18d56d0236bdbb43b6c5c353d/scripts/provision)  expects all container names to be passed in the cli, otherwise it only provisions the localhost (the present behavior). So, pass container names in the provision script cli.