### PR TITLE
fix(cmapi): handle an exception seen in CMAPI at RHEL 8

### DIFF
--- a/cmapi/cmapi_server/managers/process.py
+++ b/cmapi/cmapi_server/managers/process.py
@@ -170,7 +170,7 @@ class MCSProcessManager:
                             workernodes[name]['Port']
                         )
                     )
-                except socket.timeout:
+                except (ConnectionRefusedError, socket.timeout):
                     logging.debug(
                         f'"{name}" {workernodes[name]["IPAddr"]}:'
                         f'{workernodes[name]["Port"]} not started yet.'


### PR DESCRIPTION
This is a permanent fix for a online workaround made during debug session with a client.