### PR TITLE
MCOL-5618: Testing fix + script minor fixes.

### DIFF
--- a/cmapi/mcs_cluster_tool/__main__.py
+++ b/cmapi/mcs_cluster_tool/__main__.py
@@ -21,9 +21,9 @@ app = typer.Typer(
 app.add_typer(cluster_app.app, name='cluster')
 app.add_typer(cmapi_app.app, name='cmapi')
 app.command()(backup_commands.backup)
-app.command('backup-dbrm')(backup_commands.backup_dbrm)
+app.command('backup-dbrm')(backup_commands.dbrm_backup)
 app.command()(restore_commands.restore)
-app.command('restore-dbrm')(restore_commands.restore_dbrm)
+app.command('restore-dbrm')(restore_commands.dbrm_restore)
 
 
 if __name__ == '__main__':

--- a/cmapi/mcs_cluster_tool/backup_commands.py
+++ b/cmapi/mcs_cluster_tool/backup_commands.py
@@ -248,13 +248,13 @@ def backup(
         if sh_arg is None:
             continue
         arguments.append(sh_arg)
-    cmd = f'{MCS_BACKUP_MANAGER_SH} {" ".join(arguments)}'
+    cmd = f'{MCS_BACKUP_MANAGER_SH} backup {" ".join(arguments)}'
     success, _ = BaseDispatcher.exec_command(cmd, stdout=sys.stdout)
     return {'success': success}
 
 
 @handle_output
-def backup_dbrm(
+def dbrm_backup(
     m: Annotated[
         str,
         typer.Option(
@@ -320,6 +320,6 @@ def backup_dbrm(
         if sh_arg is None:
             continue
         arguments.append(sh_arg)
-    cmd = f'{MCS_BACKUP_MANAGER_SH} {" ".join(arguments)}'
+    cmd = f'{MCS_BACKUP_MANAGER_SH} dbrm_backup {" ".join(arguments)}'
     success, _ = BaseDispatcher.exec_command(cmd, stdout=sys.stdout)
     return {'success': success}

--- a/cmapi/mcs_cluster_tool/restore_commands.py
+++ b/cmapi/mcs_cluster_tool/restore_commands.py
@@ -256,13 +256,13 @@ def restore(
         if sh_arg is None:
             continue
         arguments.append(sh_arg)
-    cmd = f'{MCS_BACKUP_MANAGER_SH} {" ".join(arguments)}'
+    cmd = f'{MCS_BACKUP_MANAGER_SH} restore {" ".join(arguments)}'
     success, _ = BaseDispatcher.exec_command(cmd, stdout=sys.stdout)
     return {'success': success}
 
 
 @handle_output
-def restore_dbrm(
+def dbrm_restore(
     p: Annotated[
         str,
         typer.Option(
@@ -290,6 +290,6 @@ def restore_dbrm(
         if sh_arg is None:
             continue
         arguments.append(sh_arg)
-    cmd = f'{MCS_BACKUP_MANAGER_SH} {" ".join(arguments)}'
+    cmd = f'{MCS_BACKUP_MANAGER_SH} dbrm_restore {" ".join(arguments)}'
     success, _ = BaseDispatcher.exec_command(cmd, stdout=sys.stdout)
     return {'success': success}

--- a/cmapi/scripts/mcs_backup_manager.sh
+++ b/cmapi/scripts/mcs_backup_manager.sh
@@ -1984,7 +1984,7 @@ validation_prechecks_for_restore() {
     esac
 
     if eval $cmapi_installed_command ; then
-        if [ -z $(pidof /usr/share/columnstore/cmapi/python/bin/python3) ]; then 
+        if ! sudo mcs cmapi is-ready ; then
             printf " - Columnstore Management API Status .. Offline\n"; 
         else 
             handle_early_exit_on_restore "\n[X] Cmapi is ONLINE - please turn off \n\n"; 


### PR DESCRIPTION
- [x]  [fix] wrong cooking of .sh invoke string
- [x] [fix] restore_dbrm -> dbrm_restore, backup_dbrm -> dbrm_backup to use same naming in both python wrapper and mcs_backup_manager.sh
- [x] [fix] mathod of checking cmapi online or not in mcs_backup_manager.sh