### PR TITLE
MCOL-5618: Minor fixes to sync after PR #1398.

### DIFF
--- a/cmapi/mcs_cluster_tool/backup_commands.py
+++ b/cmapi/mcs_cluster_tool/backup_commands.py
@@ -13,6 +13,7 @@ from mcs_cluster_tool.helpers import cook_sh_arg
 
 
 logger = logging.getLogger('mcs_cli')
+# pylint: disable=unused-argument
 
 
 @handle_output
@@ -287,7 +288,8 @@ def dbrm_backup(
         typer.Option(
             '-r', '--retention-days',
             help=(
-                'Retain dbrm backups created within the last X days.'
+                'Retain dbrm backups created within the last X days, '
+                'the rest are deleted'
             )
         )
     ] = 7,
@@ -311,7 +313,14 @@ def dbrm_backup(
             '-q/-no-q', '--quiet/--no-quiet',
             help='Silence verbose copy command outputs.'
         )
-    ] = False
+    ] = False,
+    ssm: Annotated[
+        bool,
+        typer.Option(
+            '-ssm/-no-ssm', '--skip-storage-manager/--no-skip-storage-manager',
+            help='Skip backing up storagemanager directory.'
+        )
+    ] = False,
 ):
     """Columnstore DBRM Backup."""
 

--- a/cmapi/mcs_cluster_tool/restore_commands.py
+++ b/cmapi/mcs_cluster_tool/restore_commands.py
@@ -12,6 +12,7 @@ from mcs_cluster_tool.helpers import cook_sh_arg
 
 
 logger = logging.getLogger('mcs_cli')
+# pylint: disable=unused-argument
 
 
 @handle_output
@@ -286,7 +287,22 @@ def dbrm_restore(
             )
         )
     ] = False,
-
+    sdbk: Annotated[
+        bool,
+        typer.Option(
+            '-sdbk/-no-sdbk', '--skip-dbrm-backup/--no-skip-dbrm-backup',
+            help=(
+                'Skip backing up dbrms before restoring.'
+            )
+        )
+    ] = True,
+    ssm: Annotated[
+        bool,
+        typer.Option(
+            '-ssm/-no-ssm', '--skip-storage-manager/--no-skip-storage-manager',
+            help='Skip backing up storagemanager directory.'
+        )
+    ] = True,
 ):
     """Restore Columnstore DBRM data."""
 


### PR DESCRIPTION
- [x] [add] -ssm argument for dbrm backup
- [x] [add] -sdbk -ssm arguments for dbrm restore
- [x] [add] silenece annoying pylint warning unused argument for bachup_commands.py and restore_commnads.py