### PR TITLE
fix(bootstrap_mcs): Check directory existence before `cp`

### DIFF
--- a/build/bootstrap_mcs.sh
+++ b/build/bootstrap_mcs.sh
@@ -501,6 +501,7 @@ socket=/run/mysqld/mysqld.sock" > $CONFIG_DIR/socket.cnf
 
     fix_config_files
 
+    make_dir /etc/my.cnf.d
     if [ -d "/etc/mysql/mariadb.conf.d/" ]; then
         message "Copying configs from /etc/mysql/mariadb.conf.d/ to /etc/my.cnf.d"
         cp -rp /etc/mysql/mariadb.conf.d/* /etc/my.cnf.d


### PR DESCRIPTION
On some distributions, directories may not exist by default, causing the `cp` to fail and interrupt the bootstrap_mcs.
- **Change:** `mkdir -p ...` before the `cp`.
- **OS:** Aws EC2 (Ubuntu 24.04 LTS).
- **Reproduce:**
![image](https://github.com/mariadb-corporation/mariadb-columnstore-engine/assets/49604965/a0a3cc4b-93aa-4f99-9cdb-ee1ac1dab456)
