### PR TITLE
MCOL-5618: Fix after testing

### DIFF
--- a/cmapi/mcs_cluster_tool/backup_commands.py
+++ b/cmapi/mcs_cluster_tool/backup_commands.py
@@ -13,7 +13,8 @@ from mcs_cluster_tool.helpers import cook_sh_arg
 
 
 logger = logging.getLogger('mcs_cli')
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument, too-many-arguments, too-many-locals
+# pylint: disable=invalid-name, line-too-long
 
 
 @handle_output
@@ -94,23 +95,18 @@ def backup(
         )
     ] = 'LocalStorage',
     i: Annotated[
-        bool,
+        str,
         typer.Option(
-            '-i/-no-i', '--incremental/--no--incremental',
-            help='Adds columnstore deltas to an existing full backup.'
-        )
-    ] = False,
-    P: Annotated[
-        int,
-        typer.Option(
-            '-P', '--parallel',
+            '-i', '--incremental',
             help=(
-                'Determines if columnstore data directories will have '
-                'multiple rsync running at the same time for different '
-                'subfolders to parallelize writes.'
-            )
+                'Adds columnstore deltas to an existing full backup. '
+                'Backup folder to apply increment could be a value or '
+                '"auto_most_recent" - the incremental backup applies to '
+                'last full backup.'   
+            ),
+            show_default=False
         )
-    ] = 4,
+    ] = '',
     ha: Annotated[
         bool,
         typer.Option(
@@ -127,9 +123,10 @@ def backup(
         str,
         typer.Option(
             '-f', '--config-file',
-            help='Path to backup configuration file to load variables from.'
+            help='Path to backup configuration file to load variables from.',
+            show_default=False
         )
-    ] = '.cs-backup-config',
+    ] = '',
     sbrm: Annotated[
         bool,
         typer.Option(
@@ -202,9 +199,22 @@ def backup(
         str,
         typer.Option(
             '-c', '--compress',
-            help='Compress backup in X format - Options: [ pigz ].'
+            help='Compress backup in X format - Options: [ pigz ].',
+            show_default=False
         )
     ] = '',
+    P: Annotated[
+        int,
+        typer.Option(
+            '-P', '--parallel',
+            help=(
+                'Determines if columnstore data directories will have '
+                'multiple rsync running at the same time for different '
+                'subfolders to parallelize writes. '
+                'Ignored if "-c/--compress" argument not set.'
+            )
+        )
+    ] = 4,
     nb: Annotated[
         str,
         typer.Option(

--- a/cmapi/mcs_cluster_tool/restore_commands.py
+++ b/cmapi/mcs_cluster_tool/restore_commands.py
@@ -12,7 +12,8 @@ from mcs_cluster_tool.helpers import cook_sh_arg
 
 
 logger = logging.getLogger('mcs_cli')
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument, too-many-arguments, too-many-locals
+# pylint: disable=invalid-name, line-too-long
 
 
 @handle_output
@@ -143,17 +144,6 @@ def restore(
             )
         )
     ] = '',
-    P: Annotated[
-        int,
-        typer.Option(
-            '-P', '--parallel',
-            help=(
-                'Determines if columnstore data directories will have '
-                'multiple rsync running at the same time for different '
-                'subfolders to parallelize writes.'
-            )
-        )
-    ] = 4,
     ha: Annotated[
         bool,
         typer.Option(
@@ -180,9 +170,10 @@ def restore(
         str,
         typer.Option(
             '-f', '--config-file',
-            help='Path to backup configuration file to load variables from.'
+            help='Path to backup configuration file to load variables from.',
+            show_default=False
         )
-    ] = '.cs-backup-config',
+    ] = '',
     smdb: Annotated[
         bool,
         typer.Option(
@@ -223,9 +214,20 @@ def restore(
             help=(
                 'Hint that the backup is compressed in X format. '
                 'Options: [ pigz ].'
-            )
+            ),
+            show_default=False
         )
     ] = '',
+    P: Annotated[
+        int,
+        typer.Option(
+            '-P', '--parallel',
+            help=(
+                'Determines number of decompression and mdbstream threads. '
+                'Ignored if "-c/--compress" argument not set.'
+            )
+        )
+    ] = 4,
     q: Annotated[
         bool,
         typer.Option(

--- a/cmapi/scripts/mcs_backup_manager.sh
+++ b/cmapi/scripts/mcs_backup_manager.sh
@@ -2003,6 +2003,7 @@ print_restore_help_text()
         -sb  | --skip-bucket-data       Skip restoring columnstore data in the bucket - ideal if looking to only restore mariadb server
         -q   | --quiet                  Silence verbose copy command outputs
         -c   | --compress               Hint that the backup is compressed in X format - Options: [ pigz ]
+        -P   | --parallel               Number of parallel decompression and mbstream threads to run
         -ha  | --highavilability        Hint for if shared storage is attached @ below on all nodes to see all data
                                             HA LocalStorage ( /var/lib/columnstore/dataX/ )
                                             HA S3           ( /var/lib/columnstore/storagemanager/ )
@@ -2038,6 +2039,7 @@ print_restore_variables()
     if [[ -n "$compress_format" ]]; then
         echo "Compression:        true"
         echo "Compression Format: $compress_format";
+        echo "Decompression Threads:" "$PARALLEL_THREADS";
     else
         echo "Compression:        false"
     fi


### PR DESCRIPTION
- [x] [add] -P to restore help in mcs_backup_restore.sh
- [x] [fix] -f argument default value in both backup and restore wrapper commands
- [x] [fix] -i argument behaviour and type + default value
- [x] [fix] -P argument position and help for both backup and restore wrapper commands
- [x] [fix] disable some pylint warning for both backup and restore wrapper files