### PR TITLE
MCOL-5772: incorrect ORDER BY ordering for a columns not in GROUP BY

### DIFF
--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -1770,7 +1770,7 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(JobInfo& jobInfo, vector<Ro
       {
         case ROWAGG_MIN:
         case ROWAGG_MAX:
-	case ROWAGG_SELECT_SOME:
+        case ROWAGG_SELECT_SOME:
         {
           oidsAgg.push_back(oidsProj[colProj]);
           keysAgg.push_back(aggKey);
@@ -2181,6 +2181,7 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(JobInfo& jobInfo, vector<Ro
         case ROWAGG_BIT_AND:
         case ROWAGG_BIT_OR:
         case ROWAGG_BIT_XOR:
+        case ROWAGG_SELECT_SOME:
         default:
         {
           AGG_MAP::iterator it = aggFuncMap.find(
@@ -2837,7 +2838,7 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(JobInfo& jobInfo, vector<Ro
                     f->fAggFunction == ROWAGG_STATS || f->fAggFunction == ROWAGG_BIT_AND ||
                     f->fAggFunction == ROWAGG_BIT_OR || f->fAggFunction == ROWAGG_BIT_XOR ||
                     f->fAggFunction == ROWAGG_CONSTANT || f->fAggFunction == ROWAGG_GROUP_CONCAT ||
-                    f->fAggFunction == ROWAGG_JSON_ARRAY))
+                    f->fAggFunction == ROWAGG_JSON_ARRAY || f->fAggFunction == ROWAGG_SELECT_SOME))
           {
             funct.reset(new RowAggFunctionCol(f->fAggFunction, f->fStatsFunction, f->fInputColumnIndex,
                                               f->fOutputColumnIndex, f->fAuxColumnIndex - multiParms));
@@ -3132,7 +3133,7 @@ void TupleAggregateStep::prep2PhasesAggregate(JobInfo& jobInfo, vector<RowGroup>
       {
         case ROWAGG_MIN:
         case ROWAGG_MAX:
-	case ROWAGG_SELECT_SOME:
+        case ROWAGG_SELECT_SOME:
         {
           oidsAggPm.push_back(oidsProj[colProj]);
           keysAggPm.push_back(aggKey);
@@ -4050,7 +4051,7 @@ void TupleAggregateStep::prep2PhasesDistinctAggregate(JobInfo& jobInfo, vector<R
       {
         case ROWAGG_MIN:
         case ROWAGG_MAX:
-	case ROWAGG_SELECT_SOME:
+        case ROWAGG_SELECT_SOME:
         {
           oidsAggPm.push_back(oidsProj[colProj]);
           keysAggPm.push_back(aggKey);
@@ -5086,7 +5087,7 @@ void TupleAggregateStep::prep2PhasesDistinctAggregate(JobInfo& jobInfo, vector<R
                      f->fAggFunction == ROWAGG_MIN || f->fAggFunction == ROWAGG_MAX ||
                      f->fAggFunction == ROWAGG_STATS || f->fAggFunction == ROWAGG_BIT_AND ||
                      f->fAggFunction == ROWAGG_BIT_OR || f->fAggFunction == ROWAGG_BIT_XOR ||
-                     f->fAggFunction == ROWAGG_CONSTANT)
+                     f->fAggFunction == ROWAGG_CONSTANT || f->fAggFunction == ROWAGG_SELECT_SOME)
             {
               funct.reset(new RowAggFunctionCol(f->fAggFunction, f->fStatsFunction, f->fInputColumnIndex,
                                                 f->fOutputColumnIndex, f->fAuxColumnIndex - multiParms));

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -4977,11 +4977,15 @@ ReturnedColumn* wrapIntoAggregate(ReturnedColumn* rc, gp_walk_info& gwi, SELECT_
     groupcol = groupcol->next;
   }
 
+  cal_connection_info* ci = static_cast<cal_connection_info*>(get_fe_conn_info_ptr());
+
   AggregateColumn* ac = new AggregateColumn(gwi.sessionid);
   ac->timeZone(gwi.timeZone);
   ac->alias(rc->alias());
   ac->aggOp(AggregateColumn::SELECT_SOME);
   ac->asc(rc->asc());
+  ac->charsetNumber(rc->charsetNumber());
+  ac->expressionId(ci->expressionId++);
 
   ac->aggParms().push_back(SRCP(rc));
   return ac;

--- a/mysql-test/columnstore/basic/r/MCOL-5772-hidden-order-by.result
+++ b/mysql-test/columnstore/basic/r/MCOL-5772-hidden-order-by.result
@@ -1,0 +1,23 @@
+DROP DATABASE IF EXISTS MCOL5772;
+CREATE DATABASE MCOL5772;
+USE MCOL5772;
+CREATE TABLE products (
+product_id INT,
+product_name VARCHAR(100),
+category VARCHAR(50),
+unit_price DECIMAL(10, 2),
+stock_quantity INT
+) ENGINE=Columnstore;
+INSERT INTO products VALUES
+(1, 'Laptop', 'Electronics', 1200.00, 50),
+(2, 'Smartphone', 'Electronics', 800.00, 100),
+(3, 'Coffee Maker', 'Appliances', 50.00, 30),
+(4, 'Backpack', 'Fashion', 40.00, 80),
+(5, 'Desk Chair', 'Furniture', 150.00, 20);
+SELECT product_name, SUM(stock_quantity) AS total_stock FROM products GROUP BY category ORDER BY stock_quantity;
+product_name	total_stock
+Desk Chair	20
+Coffee Maker	30
+Backpack	80
+Smartphone	150
+DROP DATABASE MCOL5772;

--- a/mysql-test/columnstore/basic/t/MCOL-5772-hidden-order-by.test
+++ b/mysql-test/columnstore/basic/t/MCOL-5772-hidden-order-by.test
@@ -1,0 +1,28 @@
+# Order by a column that is not in GROUP BY and SELECT parts
+# should be correct.
+--disable_warnings
+DROP DATABASE IF EXISTS MCOL5772;
+--enable_warnings
+
+CREATE DATABASE MCOL5772;
+
+USE MCOL5772;
+
+CREATE TABLE products (
+product_id INT,
+product_name VARCHAR(100),
+category VARCHAR(50),
+unit_price DECIMAL(10, 2),
+stock_quantity INT
+) ENGINE=Columnstore;
+
+INSERT INTO products VALUES
+(1, 'Laptop', 'Electronics', 1200.00, 50),
+(2, 'Smartphone', 'Electronics', 800.00, 100),
+(3, 'Coffee Maker', 'Appliances', 50.00, 30),
+(4, 'Backpack', 'Fashion', 40.00, 80),
+(5, 'Desk Chair', 'Furniture', 150.00, 20);
+
+SELECT product_name, SUM(stock_quantity) AS total_stock FROM products GROUP BY category ORDER BY stock_quantity;
+
+DROP DATABASE MCOL5772;


### PR DESCRIPTION
When ORDER BY column is not in GROUP BY, is not an aggregate and there is a SELECT column that is also not an aggregate, there was a problem: ordering happened on the SELECTed column, not ORDERed one.

This patch fixes that particular problem and also performs some tidying around newly added aggregate.