### PR TITLE
MCOL-4499: Filters [NOT] LIKE NULL stop filtering

### DIFF
--- a/mysql-test/columnstore/bugfixes/mcol-4499-float-null.result
+++ b/mysql-test/columnstore/bugfixes/mcol-4499-float-null.result
@@ -1,0 +1,13 @@
+DROP DATABASE IF EXISTS `doubles_and_nulls`;
+CREATE DATABASE `doubles_and_nulls`;
+USE `doubles_and_nulls`;
+DROP TABLE IF EXISTS qatablefloat;
+CREATE TABLE qatablefloat (col float) engine=columnstore;
+INSERT INTO qatablefloat VALUES (null);
+INSERT INTO qatablefloat VALUES (null);
+INSERT INTO qatablefloat VALUES (null);
+DELETE FROM qatablefloat WHERE col IS NULL;
+SELECT * FROM qatablefloat;
+col
+DROP TABLE qatablefloat;
+DROP DATABASE `doubles_and_nulls`;

--- a/mysql-test/columnstore/bugfixes/mcol-4499-float-null.result
+++ b/mysql-test/columnstore/bugfixes/mcol-4499-float-null.result
@@ -6,8 +6,14 @@ CREATE TABLE qatablefloat (col float) engine=columnstore;
 INSERT INTO qatablefloat VALUES (null);
 INSERT INTO qatablefloat VALUES (null);
 INSERT INTO qatablefloat VALUES (null);
+INSERT INTO qatablefloat VALUES (3.14);
+INSERT INTO qatablefloat VALUES (0);
+INSERT INTO qatablefloat VALUES (1.44);
 DELETE FROM qatablefloat WHERE col IS NULL;
 SELECT * FROM qatablefloat;
 col
+3.14
+0
+1.44
 DROP TABLE qatablefloat;
 DROP DATABASE `doubles_and_nulls`;

--- a/mysql-test/columnstore/bugfixes/mcol-4499-float-null.test
+++ b/mysql-test/columnstore/bugfixes/mcol-4499-float-null.test
@@ -1,0 +1,19 @@
+-- source ../include/have_columnstore.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS `doubles_and_nulls`;
+CREATE DATABASE `doubles_and_nulls`;
+USE `doubles_and_nulls`;
+
+DROP TABLE IF EXISTS qatablefloat;
+--enable_warnings
+
+CREATE TABLE qatablefloat (col float) engine=columnstore;
+INSERT INTO qatablefloat VALUES (null);
+INSERT INTO qatablefloat VALUES (null);
+INSERT INTO qatablefloat VALUES (null);
+DELETE FROM qatablefloat WHERE col IS NULL;
+SELECT * FROM qatablefloat;
+
+DROP TABLE qatablefloat;
+DROP DATABASE `doubles_and_nulls`;

--- a/mysql-test/columnstore/bugfixes/mcol-4499-float-null.test
+++ b/mysql-test/columnstore/bugfixes/mcol-4499-float-null.test
@@ -12,6 +12,9 @@ CREATE TABLE qatablefloat (col float) engine=columnstore;
 INSERT INTO qatablefloat VALUES (null);
 INSERT INTO qatablefloat VALUES (null);
 INSERT INTO qatablefloat VALUES (null);
+INSERT INTO qatablefloat VALUES (3.14);
+INSERT INTO qatablefloat VALUES (0);
+INSERT INTO qatablefloat VALUES (1.44);
 DELETE FROM qatablefloat WHERE col IS NULL;
 SELECT * FROM qatablefloat;
 

--- a/mysql-test/columnstore/bugfixes/mcol-4499.result
+++ b/mysql-test/columnstore/bugfixes/mcol-4499.result
@@ -1,0 +1,20 @@
+DROP DATABASE IF EXISTS `mcol_4499`;
+CREATE DATABASE `mcol_4499`;
+USE `mcol_4499`;
+DROP TABLE IF EXISTS twidevarchar;
+DROP TABLE IF EXISTS twidechar;
+CREATE TABLE twidevarchar (col VARCHAR(4)) ENGINE=ColumnStore;
+INSERT INTO twidevarchar VALUES (NULL),('a');
+SELECT col FROM twidevarchar WHERE col LIKE NULL;
+col
+SELECT col FROM twidevarchar WHERE col NOT LIKE NULL;
+col
+DROP TABLE twidevarchar;
+CREATE TABLE twidechar (col CHAR(5)) ENGINE=ColumnStore;
+INSERT INTO twidechar VALUES (NULL),('a');
+SELECT col FROM twidechar WHERE col LIKE NULL;
+col
+SELECT col FROM twidechar WHERE col NOT LIKE NULL;
+col
+DROP TABLE twidechar;
+DROP DATABASE `mcol_4499`;

--- a/mysql-test/columnstore/bugfixes/mcol-4499.result
+++ b/mysql-test/columnstore/bugfixes/mcol-4499.result
@@ -1,20 +1,132 @@
 DROP DATABASE IF EXISTS `mcol_4499`;
 CREATE DATABASE `mcol_4499`;
 USE `mcol_4499`;
-DROP TABLE IF EXISTS twidevarchar;
-DROP TABLE IF EXISTS twidechar;
-CREATE TABLE twidevarchar (col VARCHAR(4)) ENGINE=ColumnStore;
-INSERT INTO twidevarchar VALUES (NULL),('a');
-SELECT col FROM twidevarchar WHERE col LIKE NULL;
+DROP TABLE IF EXISTS t_char_2;
+DROP TABLE IF EXISTS t_char_3;
+DROP TABLE IF EXISTS t_char_4;
+DROP TABLE IF EXISTS t_char_5;
+DROP TABLE IF EXISTS t_char_6;
+DROP TABLE IF EXISTS t_char_7;
+DROP TABLE IF EXISTS t_char_8;
+DROP TABLE IF EXISTS t_char_9;
+DROP TABLE IF EXISTS t_varchar_2;
+DROP TABLE IF EXISTS t_varchar_3;
+DROP TABLE IF EXISTS t_varchar_4;
+DROP TABLE IF EXISTS t_varchar_5;
+DROP TABLE IF EXISTS t_varchar_6;
+DROP TABLE IF EXISTS t_varchar_7;
+DROP TABLE IF EXISTS t_varchar_8;
+DROP TABLE IF EXISTS t_varchar_9;
+CREATE TABLE t_char_2 (col CHAR(2)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_2 VALUES (NULL),('a');
+SELECT col FROM t_char_2 WHERE col LIKE NULL;
 col
-SELECT col FROM twidevarchar WHERE col NOT LIKE NULL;
+SELECT col FROM t_char_2 WHERE col NOT LIKE NULL;
 col
-DROP TABLE twidevarchar;
-CREATE TABLE twidechar (col CHAR(5)) ENGINE=ColumnStore;
-INSERT INTO twidechar VALUES (NULL),('a');
-SELECT col FROM twidechar WHERE col LIKE NULL;
+DROP TABLE t_char_2;
+CREATE TABLE t_char_3 (col CHAR(3)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_3 VALUES (NULL),('a');
+SELECT col FROM t_char_3 WHERE col LIKE NULL;
 col
-SELECT col FROM twidechar WHERE col NOT LIKE NULL;
+SELECT col FROM t_char_3 WHERE col NOT LIKE NULL;
 col
-DROP TABLE twidechar;
+DROP TABLE t_char_3;
+CREATE TABLE t_char_4 (col CHAR(4)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_4 VALUES (NULL),('abcd');
+SELECT col FROM t_char_4 WHERE col LIKE NULL;
+col
+SELECT col FROM t_char_4 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_char_4;
+CREATE TABLE t_char_5 (col CHAR(5)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_5 VALUES (NULL),('abcde');
+SELECT col FROM t_char_5 WHERE col LIKE NULL;
+col
+SELECT col FROM t_char_5 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_char_5;
+CREATE TABLE t_char_6 (col CHAR(6)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_6 VALUES (NULL),('abcdef');
+SELECT col FROM t_char_6 WHERE col LIKE NULL;
+col
+SELECT col FROM t_char_6 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_char_6;
+CREATE TABLE t_char_7 (col CHAR(7)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_7 VALUES (NULL),('abcdefg');
+SELECT col FROM t_char_7 WHERE col LIKE NULL;
+col
+SELECT col FROM t_char_7 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_char_7;
+CREATE TABLE t_char_8 (col CHAR(8)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_8 VALUES (NULL),('abcdefgh');
+SELECT col FROM t_char_8 WHERE col LIKE NULL;
+col
+SELECT col FROM t_char_8 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_char_8;
+CREATE TABLE t_char_9 (col CHAR(9)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_9 VALUES (NULL),('abcdefghi');
+SELECT col FROM t_char_9 WHERE col LIKE NULL;
+col
+SELECT col FROM t_char_9 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_char_9;
+CREATE TABLE t_varchar_2 (col VARCHAR(2)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_2 VALUES (NULL),('a');
+SELECT col FROM t_varchar_2 WHERE col LIKE NULL;
+col
+SELECT col FROM t_varchar_2 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_varchar_2;
+CREATE TABLE t_varchar_3 (col VARCHAR(3)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_3 VALUES (NULL),('a');
+SELECT col FROM t_varchar_3 WHERE col LIKE NULL;
+col
+SELECT col FROM t_varchar_3 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_varchar_3;
+CREATE TABLE t_varchar_4 (col VARCHAR(4)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_4 VALUES (NULL),('abcd');
+SELECT col FROM t_varchar_4 WHERE col LIKE NULL;
+col
+SELECT col FROM t_varchar_4 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_varchar_4;
+CREATE TABLE t_varchar_5 (col VARCHAR(5)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_5 VALUES (NULL),('abcde');
+SELECT col FROM t_varchar_5 WHERE col LIKE NULL;
+col
+SELECT col FROM t_varchar_5 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_varchar_5;
+CREATE TABLE t_varchar_6 (col VARCHAR(6)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_6 VALUES (NULL),('abcdef');
+SELECT col FROM t_varchar_6 WHERE col LIKE NULL;
+col
+SELECT col FROM t_varchar_6 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_varchar_6;
+CREATE TABLE t_varchar_7 (col VARCHAR(7)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_7 VALUES (NULL),('abcdefg');
+SELECT col FROM t_varchar_7 WHERE col LIKE NULL;
+col
+SELECT col FROM t_varchar_7 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_varchar_7;
+CREATE TABLE t_varchar_8 (col VARCHAR(8)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_8 VALUES (NULL),('abcdefgh');
+SELECT col FROM t_varchar_8 WHERE col LIKE NULL;
+col
+SELECT col FROM t_varchar_8 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_varchar_8;
+CREATE TABLE t_varchar_9 (col VARCHAR(9)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_9 VALUES (NULL),('abcdefghi');
+SELECT col FROM t_varchar_9 WHERE col LIKE NULL;
+col
+SELECT col FROM t_varchar_9 WHERE col NOT LIKE NULL;
+col
+DROP TABLE t_varchar_9;
 DROP DATABASE `mcol_4499`;

--- a/mysql-test/columnstore/bugfixes/mcol-4499.test
+++ b/mysql-test/columnstore/bugfixes/mcol-4499.test
@@ -8,20 +8,120 @@
 DROP DATABASE IF EXISTS `mcol_4499`;
 CREATE DATABASE `mcol_4499`;
 USE `mcol_4499`;
-DROP TABLE IF EXISTS twidevarchar;
-DROP TABLE IF EXISTS twidechar;
+
+DROP TABLE IF EXISTS t_char_2;
+DROP TABLE IF EXISTS t_char_3;
+DROP TABLE IF EXISTS t_char_4;
+DROP TABLE IF EXISTS t_char_5;
+DROP TABLE IF EXISTS t_char_6;
+DROP TABLE IF EXISTS t_char_7;
+DROP TABLE IF EXISTS t_char_8;
+DROP TABLE IF EXISTS t_char_9;
+
+DROP TABLE IF EXISTS t_varchar_2;
+DROP TABLE IF EXISTS t_varchar_3;
+DROP TABLE IF EXISTS t_varchar_4;
+DROP TABLE IF EXISTS t_varchar_5;
+DROP TABLE IF EXISTS t_varchar_6;
+DROP TABLE IF EXISTS t_varchar_7;
+DROP TABLE IF EXISTS t_varchar_8;
+DROP TABLE IF EXISTS t_varchar_9;
 --enable_warnings
 
-CREATE TABLE twidevarchar (col VARCHAR(4)) ENGINE=ColumnStore;
-INSERT INTO twidevarchar VALUES (NULL),('a');
-SELECT col FROM twidevarchar WHERE col LIKE NULL;
-SELECT col FROM twidevarchar WHERE col NOT LIKE NULL;
-DROP TABLE twidevarchar;
+CREATE TABLE t_char_2 (col CHAR(2)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_2 VALUES (NULL),('a');
+SELECT col FROM t_char_2 WHERE col LIKE NULL;
+SELECT col FROM t_char_2 WHERE col NOT LIKE NULL;
+DROP TABLE t_char_2;
 
-CREATE TABLE twidechar (col CHAR(5)) ENGINE=ColumnStore;
-INSERT INTO twidechar VALUES (NULL),('a');
-SELECT col FROM twidechar WHERE col LIKE NULL;
-SELECT col FROM twidechar WHERE col NOT LIKE NULL;
-DROP TABLE twidechar;
+CREATE TABLE t_char_3 (col CHAR(3)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_3 VALUES (NULL),('a');
+SELECT col FROM t_char_3 WHERE col LIKE NULL;
+SELECT col FROM t_char_3 WHERE col NOT LIKE NULL;
+DROP TABLE t_char_3;
+
+CREATE TABLE t_char_4 (col CHAR(4)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_4 VALUES (NULL),('abcd');
+SELECT col FROM t_char_4 WHERE col LIKE NULL;
+SELECT col FROM t_char_4 WHERE col NOT LIKE NULL;
+DROP TABLE t_char_4;
+
+CREATE TABLE t_char_5 (col CHAR(5)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_5 VALUES (NULL),('abcde');
+SELECT col FROM t_char_5 WHERE col LIKE NULL;
+SELECT col FROM t_char_5 WHERE col NOT LIKE NULL;
+DROP TABLE t_char_5;
+
+CREATE TABLE t_char_6 (col CHAR(6)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_6 VALUES (NULL),('abcdef');
+SELECT col FROM t_char_6 WHERE col LIKE NULL;
+SELECT col FROM t_char_6 WHERE col NOT LIKE NULL;
+DROP TABLE t_char_6;
+
+CREATE TABLE t_char_7 (col CHAR(7)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_7 VALUES (NULL),('abcdefg');
+SELECT col FROM t_char_7 WHERE col LIKE NULL;
+SELECT col FROM t_char_7 WHERE col NOT LIKE NULL;
+DROP TABLE t_char_7;
+
+CREATE TABLE t_char_8 (col CHAR(8)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_8 VALUES (NULL),('abcdefgh');
+SELECT col FROM t_char_8 WHERE col LIKE NULL;
+SELECT col FROM t_char_8 WHERE col NOT LIKE NULL;
+DROP TABLE t_char_8;
+
+CREATE TABLE t_char_9 (col CHAR(9)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_char_9 VALUES (NULL),('abcdefghi');
+SELECT col FROM t_char_9 WHERE col LIKE NULL;
+SELECT col FROM t_char_9 WHERE col NOT LIKE NULL;
+DROP TABLE t_char_9;
+
+CREATE TABLE t_varchar_2 (col VARCHAR(2)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_2 VALUES (NULL),('a');
+SELECT col FROM t_varchar_2 WHERE col LIKE NULL;
+SELECT col FROM t_varchar_2 WHERE col NOT LIKE NULL;
+DROP TABLE t_varchar_2;
+
+CREATE TABLE t_varchar_3 (col VARCHAR(3)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_3 VALUES (NULL),('a');
+SELECT col FROM t_varchar_3 WHERE col LIKE NULL;
+SELECT col FROM t_varchar_3 WHERE col NOT LIKE NULL;
+DROP TABLE t_varchar_3;
+
+CREATE TABLE t_varchar_4 (col VARCHAR(4)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_4 VALUES (NULL),('abcd');
+SELECT col FROM t_varchar_4 WHERE col LIKE NULL;
+SELECT col FROM t_varchar_4 WHERE col NOT LIKE NULL;
+DROP TABLE t_varchar_4;
+
+CREATE TABLE t_varchar_5 (col VARCHAR(5)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_5 VALUES (NULL),('abcde');
+SELECT col FROM t_varchar_5 WHERE col LIKE NULL;
+SELECT col FROM t_varchar_5 WHERE col NOT LIKE NULL;
+DROP TABLE t_varchar_5;
+
+CREATE TABLE t_varchar_6 (col VARCHAR(6)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_6 VALUES (NULL),('abcdef');
+SELECT col FROM t_varchar_6 WHERE col LIKE NULL;
+SELECT col FROM t_varchar_6 WHERE col NOT LIKE NULL;
+DROP TABLE t_varchar_6;
+
+CREATE TABLE t_varchar_7 (col VARCHAR(7)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_7 VALUES (NULL),('abcdefg');
+SELECT col FROM t_varchar_7 WHERE col LIKE NULL;
+SELECT col FROM t_varchar_7 WHERE col NOT LIKE NULL;
+DROP TABLE t_varchar_7;
+
+CREATE TABLE t_varchar_8 (col VARCHAR(8)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_8 VALUES (NULL),('abcdefgh');
+SELECT col FROM t_varchar_8 WHERE col LIKE NULL;
+SELECT col FROM t_varchar_8 WHERE col NOT LIKE NULL;
+DROP TABLE t_varchar_8;
+
+CREATE TABLE t_varchar_9 (col VARCHAR(9)) ENGINE=ColumnStore CHARACTER SET ascii;
+INSERT INTO t_varchar_9 VALUES (NULL),('abcdefghi');
+SELECT col FROM t_varchar_9 WHERE col LIKE NULL;
+SELECT col FROM t_varchar_9 WHERE col NOT LIKE NULL;
+DROP TABLE t_varchar_9;
 
 DROP DATABASE `mcol_4499`;

--- a/mysql-test/columnstore/bugfixes/mcol-4499.test
+++ b/mysql-test/columnstore/bugfixes/mcol-4499.test
@@ -1,0 +1,27 @@
+#
+# MCOL-4499 NOT LIKE NULL must not return any rows
+#
+
+-- source ../include/have_columnstore.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS `mcol_4499`;
+CREATE DATABASE `mcol_4499`;
+USE `mcol_4499`;
+DROP TABLE IF EXISTS twidevarchar;
+DROP TABLE IF EXISTS twidechar;
+--enable_warnings
+
+CREATE TABLE twidevarchar (col VARCHAR(4)) ENGINE=ColumnStore;
+INSERT INTO twidevarchar VALUES (NULL),('a');
+SELECT col FROM twidevarchar WHERE col LIKE NULL;
+SELECT col FROM twidevarchar WHERE col NOT LIKE NULL;
+DROP TABLE twidevarchar;
+
+CREATE TABLE twidechar (col CHAR(5)) ENGINE=ColumnStore;
+INSERT INTO twidechar VALUES (NULL),('a');
+SELECT col FROM twidechar WHERE col LIKE NULL;
+SELECT col FROM twidechar WHERE col NOT LIKE NULL;
+DROP TABLE twidechar;
+
+DROP DATABASE `mcol_4499`;

--- a/primitives/linux-port/column.cpp
+++ b/primitives/linux-port/column.cpp
@@ -1754,6 +1754,14 @@ void filterColumnData(NewColRequestHeader* in, ColResultHeader* out, uint16_t* r
   if (parsedColumnFilter.get() == nullptr && filterCount > 0)
     parsedColumnFilter = _parseColumnFilter<T>(in->getFilterStringPtr(), dataType, filterCount, in->BOP);
 
+  // If the filter is always false, return an empty result
+  // TODO how can parsedColumnFilter be nullptr here?
+  if (parsedColumnFilter.get() != nullptr && parsedColumnFilter->columnFilterMode == ALWAYS_FALSE)
+  {
+    out->NVALS = 0;
+    return;
+  }
+
   // Cache parsedColumnFilter fields in local vars
   auto columnFilterMode = filterCount == 0 ? ALWAYS_TRUE : parsedColumnFilter->columnFilterMode;
   FT* filterValues = filterCount == 0 ? nullptr : parsedColumnFilter->getFilterVals<FT>();


### PR DESCRIPTION
Varchars with width > 7 are dictionary objects that keep the value in the blob, and the position of value inside the blob is stored in the token structure. 
Here we introduce columnFilterMode == ALWAYS_FALSE that means "don't even start filtering, the query won't find anything" (because LIKE NULL will never match anything). We enable it if operation is LIKE/NOT LIKE and the right hand value is NULL.
The hardest part here is to determine the NULL value. There are many implementation of getting the null value (I found six of them). Now getNullValue<T> in primitiveprocessor.h also takes width argument that we use to check if VARCHAR is wide enough to use dictionary format