### PR TITLE
MCOL-5587: Fix columnstore.cnf.

### DIFF
--- a/dbcon/mysql/columnstore.cnf
+++ b/dbcon/mysql/columnstore.cnf
@@ -1,4 +1,4 @@
-[client]
+[mariadb-client]
 quick
 
 [mysqld]


### PR DESCRIPTION
fix(client): Fix columnstore.cnf file

This fix changes option file to apply '--quick' option only for 'mariadb' and 'mysql' clients instead of all MariaDB clients. Otherwise 'mysqladmin' uses this option, but it doesn't exist. As a result broken CI multinode MTR stage.