### PR TITLE
fix(dbcon): MCOL-4756: having not() provokes an ERROR 2013

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -2158,7 +2158,8 @@ bool buildPredicateItem(Item_func* ifp, gp_walk_info* gwip)
 
     idbassert(ifp->argument_count() == 1);
     ParseTree* ptp = 0;
-    if (((Item_func*)(ifp->arguments()[0]))->functype() == Item_func::EQUAL_FUNC)
+    Item_func* argfp = dynamic_cast<Item_func*>(ifp->arguments()[0]);
+    if (argfp && argfp->functype() == Item_func::EQUAL_FUNC)
     {
       // negate it in place
       // Note that an EQUAL_FUNC ( a <=> b) was converted to

--- a/mysql-test/columnstore/bugfixes/mcol-4756.result
+++ b/mysql-test/columnstore/bugfixes/mcol-4756.result
@@ -1,0 +1,9 @@
+DROP DATABASE IF EXISTS `mcol_4756`;
+CREATE DATABASE `mcol_4756`;
+USE `mcol_4756`;
+CREATE TABLE `manu_test` (id tinyint unsigned NOT NULL, test tinyint default null) ENGINE=Columnstore DEFAULT CHARSET=utf8;
+INSERT INTO `manu_test` (`id`, `test`) VALUES (1,0), (2,1), (3,null);
+SELECT id, test FROM manu_test HAVING NOT(test);
+id	test
+1	0
+DROP DATABASE `mcol_4756`;

--- a/mysql-test/columnstore/bugfixes/mcol-4756.test
+++ b/mysql-test/columnstore/bugfixes/mcol-4756.test
@@ -1,0 +1,15 @@
+--source ../include/have_columnstore.inc
+--disable_warnings
+DROP DATABASE IF EXISTS `mcol_4756`;
+--enable_warnings
+CREATE DATABASE `mcol_4756`;
+USE `mcol_4756`;
+
+CREATE TABLE `manu_test` (id tinyint unsigned NOT NULL, test tinyint default null) ENGINE=Columnstore DEFAULT CHARSET=utf8;
+
+INSERT INTO `manu_test` (`id`, `test`) VALUES (1,0), (2,1), (3,null);
+
+SELECT id, test FROM manu_test HAVING NOT(test);
+
+# cleanup
+DROP DATABASE `mcol_4756`;


### PR DESCRIPTION
    The `NOT()` function in the HAVING clause was handled
    incorrectly, which caused the server to crash.