### PR TITLE
Fix/mcol 4886 dev23.02

### DIFF
--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -372,7 +372,17 @@ fi
 if [ $(running_systemd) -eq 0 ]; then
     chown -R @DEFAULT_USER@:@DEFAULT_GROUP@ @ENGINE_LOGDIR@
     chown -R @DEFAULT_USER@:@DEFAULT_GROUP@ /etc/columnstore
-    chown -R @DEFAULT_USER@:@DEFAULT_GROUP@ @ENGINE_DATADIR@
+    findcmd=`which find 2>/dev/null`
+    if [ -n "$findcmd" ]; then
+        if [[ $($findcmd @ENGINE_DATADIR@ -maxdepth 3 -type f ! -user @DEFAULT_USER@ -exec echo {} \; -quit 2>/dev/null) ]]; then
+            echo "At least one file is not owned by @DEFAULT_USER@ in @ENGINE_DATADIR@. Running chown..."
+            chown -R @DEFAULT_USER@:@DEFAULT_GROUP@ @ENGINE_DATADIR@
+        else
+            echo "Confirmed top @ENGINE_DATADIR@ folders owned by @DEFAULT_USER@"
+        fi  
+    else
+        chown -R @DEFAULT_USER@:@DEFAULT_GROUP@ @ENGINE_DATADIR@
+    fi
     chown -R @DEFAULT_USER@:@DEFAULT_GROUP@ $tmpDir
     chmod 777 /dev/shm
 fi

--- a/oam/install_scripts/columnstore-post-install.in
+++ b/oam/install_scripts/columnstore-post-install.in
@@ -374,7 +374,7 @@ if [ $(running_systemd) -eq 0 ]; then
     chown -R @DEFAULT_USER@:@DEFAULT_GROUP@ /etc/columnstore
     findcmd=`which find 2>/dev/null`
     if [ -n "$findcmd" ]; then
-        if [[ $($findcmd @ENGINE_DATADIR@ -maxdepth 3 -type f ! -user @DEFAULT_USER@ -exec echo {} \; -quit 2>/dev/null) ]]; then
+        if [[ $($findcmd @ENGINE_DATADIR@ -maxdepth 3 ! -user @DEFAULT_USER@ -exec echo {} \; -quit 2>/dev/null) ]]; then
             echo "At least one file is not owned by @DEFAULT_USER@ in @ENGINE_DATADIR@. Running chown..."
             chown -R @DEFAULT_USER@:@DEFAULT_GROUP@ @ENGINE_DATADIR@
         else


### PR DESCRIPTION
This patch calls chown on datadir /var/lib/columnstore only if needed to reduce upgrade timing.