### PR TITLE
MCOL-5881 set/getThreadName use FreeBSD API

### DIFF
--- a/utils/common/threadnaming.cpp
+++ b/utils/common/threadnaming.cpp
@@ -22,13 +22,21 @@ namespace utils
 {
 void setThreadName(const char* threadName)
 {
+#ifdef __FreeBSD__
+  pthread_set_name_np(pthread_self(), threadName);
+#else
   prctl(PR_SET_NAME, threadName, 0, 0, 0);
+#endif
 }
 
 std::string getThreadName()
 {
   char buf[32];
+#ifdef __FreeBSD__
+  pthread_get_name_np(pthread_self(), buf, sizeof(buf));
+#else
   prctl(PR_GET_NAME, buf, 0, 0, 0);
+#endif
   return std::string(buf);
 }
 }  // namespace utils


### PR DESCRIPTION
Taken from FreeBSD ports, this uses the FreeBSD
APIs rather than the Linux specific prctl to change and retreive the thread names.