### PR TITLE
fix(BRM): MCOL-5879 DBRM::clearShm runs crit sections w/o sync mechanism

### DIFF
--- a/dbcon/mysql/ha_mcs_partition.cpp
+++ b/dbcon/mysql/ha_mcs_partition.cpp
@@ -330,7 +330,7 @@ void partitionByValue_common(UDF_ARGS* args,                              // inp
                              string functionName)                         // input
 {
   // identify partitions by the range
-  BRM::DBRM::refreshShm();
+  BRM::DBRM::refreshShmWithLock();
   DBRM em;
   vector<struct EMEntry> entries;
   vector<struct EMEntry>::iterator iter;
@@ -575,7 +575,7 @@ extern "C"
       const char* calshowpartitions(UDF_INIT* initid, UDF_ARGS* args, char* result, unsigned long* length,
                                     char* is_null, char* error)
   {
-    BRM::DBRM::refreshShm();
+    BRM::DBRM::refreshShmWithLock();
     DBRM em;
     vector<struct EMEntry> entries;
     vector<struct EMEntry>::iterator iter;
@@ -1170,7 +1170,7 @@ extern "C"
       const char* calshowpartitionsbyvalue(UDF_INIT* initid, UDF_ARGS* args, char* result,
                                            unsigned long* length, char* is_null, char* error)
   {
-    BRM::DBRM::refreshShm();
+    BRM::DBRM::refreshShmWithLock();
     DBRM em;
     vector<struct EMEntry> entries;
     vector<struct EMEntry>::iterator iter;

--- a/dbcon/mysql/is_columnstore_extents.cpp
+++ b/dbcon/mysql/is_columnstore_extents.cpp
@@ -202,7 +202,7 @@ static int is_columnstore_extents_fill(THD* thd, TABLE_LIST* tables, COND* cond)
   BRM::OID_t cond_oid = 0;
   TABLE* table = tables->table;
 
-  BRM::DBRM::refreshShm();
+  BRM::DBRM::refreshShmWithLock();
   BRM::DBRM* emp = new BRM::DBRM();
 
   if (!emp || !emp->isDBRMReady())

--- a/dbcon/mysql/is_columnstore_files.cpp
+++ b/dbcon/mysql/is_columnstore_files.cpp
@@ -215,7 +215,7 @@ static int generate_result(BRM::OID_t oid, BRM::DBRM* emp, TABLE* table, THD* th
 
 static int is_columnstore_files_fill(THD* thd, TABLE_LIST* tables, COND* cond)
 {
-  BRM::DBRM::refreshShm();
+  BRM::DBRM::refreshShmWithLock();
   BRM::DBRM* emp = new BRM::DBRM();
   BRM::OID_t cond_oid = 0;
   TABLE* table = tables->table;

--- a/versioning/BRM/dbrm.h
+++ b/versioning/BRM/dbrm.h
@@ -101,11 +101,11 @@ class DBRM
   EXPORT DBRM(bool noBRMFcns = false);
   EXPORT ~DBRM();
 
-  EXPORT static void refreshShm()
+  static void refreshShmWithLock()
   {
-    MasterSegmentTableImpl::refreshShm();
-    ExtentMapRBTreeImpl::refreshShm();
-    FreeListImpl::refreshShm();
+    MasterSegmentTableImpl::refreshShmWithLock();
+    ExtentMapRBTreeImpl::refreshShmWithLock();
+    FreeListImpl::refreshShmWithLock();
   }
 
   // @bug 1055+ - Added functions below for multiple files per OID enhancement.

--- a/versioning/BRM/extentmap.h
+++ b/versioning/BRM/extentmap.h
@@ -256,6 +256,12 @@ class ExtentMapRBTreeImpl
   static ExtentMapRBTreeImpl* makeExtentMapRBTreeImpl(unsigned key, off_t size, bool readOnly, bool& emLocked,
                                                       const MasterSegmentTable* emSegTable = nullptr);
 
+  static void refreshShmWithLock()
+  {
+    boost::mutex::scoped_lock lk(fInstanceMutex);
+    return refreshShm();
+  }
+
   static void refreshShm()
   {
     if (fInstance)
@@ -308,6 +314,13 @@ class FreeListImpl
   ~FreeListImpl(){};
 
   static FreeListImpl* makeFreeListImpl(unsigned key, off_t size, bool readOnly = false);
+  
+  static void refreshShmWithLock()
+  {
+    boost::mutex::scoped_lock lk(fInstanceMutex);
+    return refreshShm();
+  }
+  
   static void refreshShm()
   {
     if (fInstance)

--- a/versioning/BRM/mastersegmenttable.h
+++ b/versioning/BRM/mastersegmenttable.h
@@ -61,6 +61,12 @@ class MasterSegmentTableImpl
   ~MasterSegmentTableImpl(){};
   static MasterSegmentTableImpl* makeMasterSegmentTableImpl(int key, int size);
 
+  static void refreshShmWithLock()
+  {
+    boost::mutex::scoped_lock lk(fInstanceMutex);
+    return refreshShm();
+  }
+
   static void refreshShm()
   {
     if (fInstance)


### PR DESCRIPTION
This patch teaches DBRM to access shared resources using mutexes.