### PR TITLE
compilation

### DIFF
--- a/storage-manager/src/Ownership.cpp
+++ b/storage-manager/src/Ownership.cpp
@@ -77,7 +77,7 @@ bf::path Ownership::get(const bf::path& p, bool getOwnership)
   bf::path::const_iterator pit;
   int i, levels;
 
-  normalizedPath.lexically_normal();
+  normalizedPath.normalize();
   // cerr << "Ownership::get() param = " << normalizedPath.string() << endl;
   if (prefixDepth > 0)
   {


### PR DESCRIPTION
storage-manager/src/Ownership.cpp:80:18: error: ‘class boost::filesystem::path’ has no member named ‘lexically_normal’

Boost 1.53.0