### PR TITLE
Migration for Boost 1.85

### DIFF
--- a/oamapps/columnstoreSupport/columnstoreSupport.cpp
+++ b/oamapps/columnstoreSupport/columnstoreSupport.cpp
@@ -30,6 +30,7 @@
 #include <readline.h>
 #include <boost/filesystem.hpp>
 
+#include "boost_copy_options_compat.hpp"
 #include "mcsconfig.h"
 #include "liboamcpp.h"
 #include "configcpp.h"
@@ -256,11 +257,11 @@ void* reportThread(string* reporttype)
       boost::filesystem::path configFile =
           std::string(MCSSYSCONFDIR) + std::string("/columnstore/Columnstore.xml");
       boost::filesystem::copy_file(configFile, "./Columnstore.xml",
-                                   boost::filesystem::copy_option::overwrite_if_exists);
+                                   boost::filesystem::copy_options::overwrite_existing);
       boost::filesystem::path SMconfigFile =
           std::string(MCSSYSCONFDIR) + std::string("/columnstore/storagemanager.cnf");
       boost::filesystem::copy_file(SMconfigFile, "./storagemanager.cnf",
-                                   boost::filesystem::copy_option::overwrite_if_exists);
+                                   boost::filesystem::copy_options::overwrite_existing);
       system("sed -i 's/.*aws_access_key_id.*/aws_access_key_id={PRIVATE}/' ./storagemanager.cnf");
       system("sed -i 's/.*aws_secret_access_key.*/aws_secret_access_key={PRIVATE}/' ./storagemanager.cnf");
       fclose(pOutputFile);
@@ -858,7 +859,7 @@ int main(int argc, char* argv[])
 
     boost::filesystem::path configFile = std::string(MCSMYCNFDIR) + "/columnstore.cnf";
     boost::filesystem::copy_file(configFile, "./columnstore.cnf",
-                                 boost::filesystem::copy_option::overwrite_if_exists);
+                                 boost::filesystem::copy_options::overwrite_existing);
   }
 
   int wait = 0;

--- a/storage-manager/src/LocalStorage.cpp
+++ b/storage-manager/src/LocalStorage.cpp
@@ -21,6 +21,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <time.h>
+#include "boost_copy_options_compat.hpp"
 #include "LocalStorage.h"
 #include "Config.h"
 
@@ -94,7 +95,7 @@ inline void LocalStorage::addLatency()
 int LocalStorage::copy(const bf::path& source, const bf::path& dest)
 {
   boost::system::error_code err;
-  bf::copy_file(source, dest, bf::copy_option::fail_if_exists, err);
+  bf::copy_file(source, dest, bf::copy_options::none, err);
   if (err)
   {
     errno = err.value();

--- a/storage-manager/src/Ownership.cpp
+++ b/storage-manager/src/Ownership.cpp
@@ -77,7 +77,13 @@ bf::path Ownership::get(const bf::path& p, bool getOwnership)
   bf::path::const_iterator pit;
   int i, levels;
 
+#if BOOST_VERSION >= 106000
+  // available since 1.60.0 released 2015-12-17
+  normalizedPath.lexically_normal();
+#else
+  // removed in 1.85.0 release 2024-04-15
   normalizedPath.normalize();
+#endif
   // cerr << "Ownership::get() param = " << normalizedPath.string() << endl;
   if (prefixDepth > 0)
   {

--- a/utils/common/boost_copy_options_compat.hpp
+++ b/utils/common/boost_copy_options_compat.hpp
@@ -1,0 +1,28 @@
+#ifndef COMPAT_BOOST_FILESYSTEM_HPP
+#define COMPAT_BOOST_FILESYSTEM_HPP
+
+#include <boost/version.hpp>
+
+// copy_option was replaced with copy_options in version 1.74.0 released 2020-08-14
+// copy_option was removed in version 1.85.0 released 2024-04-15
+#if BOOST_VERSION < 107400
+
+#include <boost/filesystem/operations.hpp>
+
+namespace boost
+{
+namespace filesystem
+{
+namespace copy_options
+{
+
+constexpr copy_option::enum_type overwrite_existing = copy_option::overwrite_if_exists;
+constexpr copy_option::enum_type none = copy_option::fail_if_exists;
+
+}
+}
+}
+
+#endif
+
+#endif

--- a/utils/configcpp/configcpp.cpp
+++ b/utils/configcpp/configcpp.cpp
@@ -54,6 +54,7 @@ namespace fs = boost::filesystem;
 
 #include "configcpp.h"
 
+#include "boost_copy_options_compat.hpp"
 #include "exceptclasses.h"
 #include "installdir.h"
 #ifdef _MSC_VER
@@ -401,7 +402,7 @@ void Config::writeConfig(const string& configFile) const
       {
       }
 
-      fs::copy_file(dcf, scft, fs::copy_option::overwrite_if_exists);
+      fs::copy_file(dcf, scft, fs::copy_options::overwrite_existing);
 
       try
       {

--- a/utils/idbdatafile/IDBPolicy.cpp
+++ b/utils/idbdatafile/IDBPolicy.cpp
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <sstream>
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem/operations.hpp>
 #include <boost/thread/thread.hpp>
 
 #include "configcpp.h"  // for Config

--- a/utils/idbdatafile/PosixFileSystem.cpp
+++ b/utils/idbdatafile/PosixFileSystem.cpp
@@ -24,8 +24,7 @@
 #include <stdio.h>
 #include <iostream>
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem.hpp>
 
 using namespace std;
 

--- a/writeengine/bulk/we_bulkload.cpp
+++ b/writeengine/bulk/we_bulkload.cpp
@@ -34,8 +34,7 @@
 #include <string.h>
 #include <vector>
 #include <sstream>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <pwd.h>

--- a/writeengine/redistribute/we_redistributeworkerthread.cpp
+++ b/writeengine/redistribute/we_redistributeworkerthread.cpp
@@ -32,8 +32,7 @@ using namespace std;
 #include "boost/scoped_ptr.hpp"
 #include "boost/scoped_array.hpp"
 #include "boost/thread/mutex.hpp"
-#include "boost/filesystem/path.hpp"
-#include "boost/filesystem/operations.hpp"
+#include "boost/filesystem.hpp"
 using namespace boost;
 
 #include "installdir.h"

--- a/writeengine/server/we_ddlcommandproc.cpp
+++ b/writeengine/server/we_ddlcommandproc.cpp
@@ -19,8 +19,7 @@
 // $Id: we_ddlcommandproc.cpp 3082 2011-09-26 22:00:38Z chao $
 
 #include <unistd.h>
-#include "boost/filesystem/operations.hpp"
-#include "boost/filesystem/path.hpp"
+#include "boost/filesystem.hpp"
 #include "boost/scoped_ptr.hpp"
 using namespace std;
 

--- a/writeengine/shared/we_bulkrollbackfilecompressed.cpp
+++ b/writeengine/shared/we_bulkrollbackfilecompressed.cpp
@@ -24,7 +24,6 @@
 #include <sstream>
 #include <boost/scoped_array.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
 
 #include "we_define.h"
 #include "we_fileop.h"

--- a/writeengine/shared/we_bulkrollbackfilecompressedhdfs.cpp
+++ b/writeengine/shared/we_bulkrollbackfilecompressedhdfs.cpp
@@ -20,7 +20,6 @@
 #include <sstream>
 #include <boost/scoped_array.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
 
 #include "we_define.h"
 #include "we_fileop.h"

--- a/writeengine/shared/we_bulkrollbackmgr.cpp
+++ b/writeengine/shared/we_bulkrollbackmgr.cpp
@@ -30,7 +30,6 @@
 #include <boost/scoped_array.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
 
 #include "we_bulkrollbackmgr.h"
 

--- a/writeengine/shared/we_rbmetawriter.cpp
+++ b/writeengine/shared/we_rbmetawriter.cpp
@@ -26,7 +26,6 @@
 #include <sstream>
 #include <unistd.h>
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
 
 #include "we_config.h"
 #include "we_convertor.h"

--- a/writeengine/xml/we_xmljob.cpp
+++ b/writeengine/xml/we_xmljob.cpp
@@ -36,8 +36,7 @@
 #include "we_convertor.h"
 #include "dataconvert.h"
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem.hpp>
 
 #include <sys/time.h>
 


### PR DESCRIPTION
Gentoo users cannot compile MariaDB with columnstore because the oldest available Boost version in Gentoo is 1.85, see https://bugs.gentoo.org/932735. Migration seems to be straightforward, however, I noticed PR #3394, therefore, I am not sure, if this change is feasible for others.

I have set the base to `develop-6` because I did the migration for Mariadb 10.6.21 and 10.11.11, both versions compile and pass tests. The change seems to apply to `develop` cleanly as well, but I didn't test it properly yet.

---

Boost 1.85 removed some deprecated code in filesystem module which is still used in columnstore:

- The boost/filesystem/convenience.hpp was removed but columnstore does not use any functionality from that file except indirect includes. Therefore this include is removed or replaced with more general boost/filesystem.hpp. The convenience.hpp header file was deprecated in filesystem V3 introduced in Boost 1.46.0.
- `normalize` method was removed and users are suggested to replace it with `lexically_normal` method, which was introduced in Boost 1.60.0.
- The `copy_option` was removed in favor of `copy_options` (note the trailing 's'), but enum values were renamed. Namely, `fail_if_exists` is replaced with `none` and `overwrite_if_exists` is replaced with `overwrite_existing`. The `copy_options` was introduced in Boost 1.74.0