### PR TITLE
Allow packagers to use system Thrift library

### DIFF
--- a/cmake/thrift.cmake
+++ b/cmake/thrift.cmake
@@ -1,3 +1,19 @@
+set(WITH_THRIFT "auto" CACHE STRING
+  "Which Thrift to use (possible values are 'bundled', 'system', or 'auto')")
+
+if(WITH_THRIFT STREQUAL "system" OR WITH_THRIFT STREQUAL "auto")
+  FIND_PACKAGE(Thrift)
+
+  if (Thrift_FOUND)
+    add_custom_target(external_thrift)
+    set(THRIFT_INCLUDE_DIR "${THRIFT_INCLUDE_DIR}")
+    set(THRIFT_LIBRARY "${THRIFT_LIBRARIES}")
+    return()
+  elseif(WITH_THRIFT STREQUAL "system")
+    message(FATAL_ERROR "System Thrift requested but not found!")
+  endif()
+endif()
+
 include(ExternalProject)
 
 set(INSTALL_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/external/thrift)


### PR DESCRIPTION
The commit introduces a new CMake configuration option, `WITH_THRIFT`, which accepts "auto", "system", or "bundled". In "auto" mode (the default), the build system attempts to use the system-installed Thrift library and falls back to the bundled version if the system library is not available. Setting `WITH_THRIFT` to "system" enforces the use of the system Thrift, causing the configuration to fail if it isn't found, while "bundled" forces the use of the bundled version.

The change mainly useful for downstream maintainers as it gives them flexibility over dependency management.

Downstream-issue: https://bugs.gentoo.org/949680

---

I would ideally like to have this backported to Mariadb 11.4 as a packager of MariaDB in Gentoo, which means `stable-23.10` branch in this repo.