### PR TITLE
fix(MCOL-5842): Fix JSON_OBJECT's handling of empty strings

### DIFF
--- a/mysql-test/columnstore/bugfixes/MCOL-5842-group-concat-json-object.result
+++ b/mysql-test/columnstore/bugfixes/MCOL-5842-group-concat-json-object.result
@@ -1,0 +1,12 @@
+DROP DATABASE IF EXISTS MCOL5842;
+CREATE DATABASE MCOL5842;
+USE MCOL5842;
+CREATE TABLE tcs(t TEXT) ENGINE=Columnstore;
+INSERT INTO tcs(t) VALUES ('');
+SELECT JSON_OBJECT('t', t, 'a', 'b') FROM tcs;
+JSON_OBJECT('t', t, 'a', 'b')
+{"t": "", "a": "b"}
+SELECT GROUP_CONCAT(JSON_OBJECT('t', t, 'a', 'b')) FROM tcs;
+GROUP_CONCAT(JSON_OBJECT('t', t, 'a', 'b'))
+{"t": "", "a": "b"}
+DROP DATABASE MCOL5842;

--- a/mysql-test/columnstore/bugfixes/MCOL-5842-group-concat-json-object.test
+++ b/mysql-test/columnstore/bugfixes/MCOL-5842-group-concat-json-object.test
@@ -1,0 +1,12 @@
+--disable_warnings
+DROP DATABASE IF EXISTS MCOL5842;
+--enable_warnings
+CREATE DATABASE MCOL5842;
+USE MCOL5842;
+
+CREATE TABLE tcs(t TEXT) ENGINE=Columnstore;
+INSERT INTO tcs(t) VALUES ('');
+SELECT JSON_OBJECT('t', t, 'a', 'b') FROM tcs;
+SELECT GROUP_CONCAT(JSON_OBJECT('t', t, 'a', 'b')) FROM tcs;
+
+DROP DATABASE MCOL5842;

--- a/utils/funcexp/jsonhelpers.cpp
+++ b/utils/funcexp/jsonhelpers.cpp
@@ -32,7 +32,7 @@ bool appendEscapedJS(string& ret, const CHARSET_INFO* retCS, const utils::NullSt
   int strLen = jsLen * 12 * jsCS->mbmaxlen / jsCS->mbminlen;
   char* buf = (char*)alloca(strLen);
   if ((strLen = json_escape(retCS, (const uchar*)rawJS, (const uchar*)rawJS + jsLen, jsCS, (uchar*)buf,
-                            (uchar*)buf + strLen)) > 0)
+                            (uchar*)buf + strLen)) >= 0)
   {
     buf[strLen] = '\0';
     ret.append(buf, strLen);


### PR DESCRIPTION
JSON_OBJECT() (and probably some other JSON functions) now properly handle empty strings in their arguments - JSON_OBJECT used to return NULL, now it returns empty string.