### PR TITLE
[DUPLICATE STABLE-23.10] MCOL-5526: CLI rename "mcs CLUSTER" commands to just mcs.

### DIFF
--- a/cmapi/CMakeLists.txt
+++ b/cmapi/CMakeLists.txt
@@ -48,6 +48,7 @@ SET(CMAPI_DIR "${SHARE_DIR}/cmapi")
 SET(SYSTEMD_UNIT_DIR "/usr/lib/systemd/system")
 SET(SYSTEMD_ENGINE_UNIT_NAME "mariadb-columnstore")
 SET(CMAPI_CONF_FILEPATH "${ETC_DIR}/cmapi_server.conf")
+SET(MAN_DIR "/usr/share/man/man1")
 
 STRING(TOLOWER ${CPACK_PACKAGE_NAME} SYSTEMD_UNIT_NAME)
 
@@ -65,7 +66,8 @@ INSTALL(DIRECTORY python deps mcs_node_control failover cmapi_server engine_file
             DESTINATION ${CMAPI_DIR}
             USE_SOURCE_PERMISSIONS
             PATTERN "test" EXCLUDE
-            PATTERN "cmapi_server.conf" EXCLUDE)
+            PATTERN "cmapi_server.conf" EXCLUDE
+            PATTERN "README" EXCLUDE)
 INSTALL(FILES LICENSE.GPL2 VERSION
             DESTINATION ${CMAPI_DIR})
 INSTALL(FILES check_ready.sh
@@ -87,6 +89,7 @@ INSTALL(FILES mcs_gsutil
 INSTALL(FILES scripts/mcs_backup_manager.sh scripts/cs_package_manager.sh
             PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
             DESTINATION ${BIN_DIR})
+INSTALL(FILES mcs_cluster_tool/mcs.1 DESTINATION ${MAN_DIR})
 
 OPTION(RPM "Build an RPM" OFF)
 IF(RPM)

--- a/cmapi/mcs_cluster_tool/README.md
+++ b/cmapi/mcs_cluster_tool/README.md
@@ -1,0 +1,576 @@
+# `mcs`
+
+The  MCS  Command  Line  Interface is a unified tool to manage your MCS services
+
+**Usage**:
+
+```console
+$ mcs [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `backup`: Backup Columnstore and/or MariDB data.
+* `dbrm_backup`: Columnstore DBRM Backup.
+* `restore`: Restore Columnstore (and/or MariaDB) data.
+* `dbrm_restore`: Restore Columnstore DBRM data.
+* `help-all`: Show help for all commands in man page style.
+* `status`: Get status information.
+* `stop`: Stop the Columnstore cluster.
+* `start`: Start the Columnstore cluster.
+* `restart`: Restart the Columnstore cluster.
+* `node`: Cluster nodes management.
+* `set`: Set cluster parameters.
+* `cluster`: MariaDB Columnstore cluster management...
+* `cmapi`: CMAPI itself related commands.
+
+## `mcs backup`
+
+Backup Columnstore and/or MariDB data.
+
+**Usage**:
+
+```console
+$ mcs backup [OPTIONS]
+```
+
+**Options**:
+
+* `-bl, --backup-location TEXT`: What directory to store the backups on this machine or the target machine.
+Consider write permissions of the scp user and the user running this script.
+Mariadb-backup will use this location as a tmp dir for S3 and remote backups temporarily.
+Example: /mnt/backups/  [default: /tmp/backups/]
+* `-bd, --backup-destination TEXT`: Are the backups going to be stored on the same machine this script is running on or another server - if Remote you need to setup scp=Options: &quot;Local&quot; or &quot;Remote&quot;  [default: Local]
+* `-scp TEXT`: Used only if --backup-destination=&quot;Remote&quot;.
+The user/credentials that will be used to scp the backup files
+Example: &quot;centos@10.14.51.62&quot;
+* `-bb, --backup-bucket TEXT`: Only used if --storage=S3
+Name of the bucket to store the columnstore backups.
+Example: &quot;s3://my-cs-backups&quot;
+* `-url, --endpoint-url TEXT`: Used by on premise S3 vendors.
+Example: &quot;http://127.0.0.1:8000&quot;
+* `-nv-ssl, --no-verify-ssl / -v-ssl, --verify-ssl`: Skips verifying ssl certs, useful for onpremise s3 storage.  [default: v-ssl]
+* `-s, --storage TEXT`: What storage topogoly is being used by Columnstore - found in /etc/columnstore/storagemanager.cnf.
+Options: &quot;LocalStorage&quot; or &quot;S3&quot;  [default: LocalStorage]
+* `-i, --incremental TEXT`: Adds columnstore deltas to an existing full backup. Backup folder to apply increment could be a value or &quot;auto_most_recent&quot; - the incremental backup applies to last full backup.
+* `-ha, --highavilability / -no-ha, --no-highavilability`: Hint wether shared storage is attached @ below on all nodes to see all data
+HA LocalStorage ( /var/lib/columnstore/dataX/ )
+HA S3           ( /var/lib/columnstore/storagemanager/ )  [default: no-ha]
+* `-f, --config-file TEXT`: Path to backup configuration file to load variables from.
+* `-sbrm, --skip-save-brm / -no-sbrm, --no-skip-save-brm`: Skip saving brm prior to running a backup - ideal for dirty backups.  [default: no-sbrm]
+* `-spoll, --skip-polls / -no-spoll, --no-skip-polls`: Skip sql checks confirming no write/cpimports running.  [default: no-spoll]
+* `-slock, --skip-locks / -no-slock, --no-skip-locks`: Skip issuing write locks - ideal for dirty backups.  [default: no-slock]
+* `-smdb, --skip-mariadb-backup / -no-smdb, --no-skip-mariadb-backup`: Skip running a mariadb-backup for innodb data - ideal for incremental dirty backups.  [default: no-smdb]
+* `-sb, --skip-bucket-data / -no-sb, --no-skip-bucket-data`: Skip taking a copy of the columnstore data in the bucket.  [default: no-sb]
+* `-pi, --poll-interval INTEGER`: Number of seconds between poll checks for active writes &amp; cpimports.  [default: 5]
+* `-pmw, --poll-max-wait INTEGER`: Max number of minutes for polling checks for writes to wait before exiting as a failed backup attempt.  [default: 60]
+* `-q, --quiet / -no-q, --no-quiet`: Silence verbose copy command outputs.  [default: no-q]
+* `-c, --compress TEXT`: Compress backup in X format - Options: [ pigz ].
+* `-P, --parallel INTEGER`: Determines if columnstore data directories will have multiple rsync running at the same time for different subfolders to parallelize writes. Ignored if &quot;-c/--compress&quot; argument not set.  [default: 4]
+* `-nb, --name-backup TEXT`: Define the name of the backup - default: $(date +%m-%d-%Y)  [default: 03-06-2025]
+* `-r, --retention-days INTEGER`: Retain backups created within the last X days, default 0 == keep all backups.  [default: 0]
+* `--help`: Show this message and exit.
+
+## `mcs dbrm_backup`
+
+Columnstore DBRM Backup.
+
+**Usage**:
+
+```console
+$ mcs dbrm_backup [OPTIONS]
+```
+
+**Options**:
+
+* `-m, --mode TEXT`: &quot;loop&quot; or &quot;once&quot; ; Determines if this script runs in a forever loop sleeping -i minutes or just once.  [default: once]
+* `-i, --interval INTEGER`: Number of minutes to sleep when --mode=loop.  [default: 90]
+* `-r, --retention-days INTEGER`: Retain dbrm backups created within the last X days, the rest are deleted  [default: 7]
+* `-p, --path TEXT`: Path of where to save the dbrm backups on disk.  [default: /tmp/dbrm_backups]
+* `-nb, --name-backup TEXT`: Custom name to prefex dbrm backups with.  [default: dbrm_backup]
+* `-q, --quiet / -no-q, --no-quiet`: Silence verbose copy command outputs.  [default: no-q]
+* `-ssm, --skip-storage-manager / -no-ssm, --no-skip-storage-manager`: Skip backing up storagemanager directory.  [default: no-ssm]
+* `--help`: Show this message and exit.
+
+## `mcs restore`
+
+Restore Columnstore (and/or MariaDB) data.
+
+**Usage**:
+
+```console
+$ mcs restore [OPTIONS]
+```
+
+**Options**:
+
+* `-l, --load TEXT`: What date folder to load from the backup_location.
+* `-bl, --backup-location TEXT`: Where the backup to load is found.
+Example: /mnt/backups/  [default: /tmp/backups/]
+* `-bd, --backup_destination TEXT`: Is this backup on the same or remote server compared to where this script is running.
+Options: &quot;Local&quot; or &quot;Remote&quot;  [default: Local]
+* `-scp, --secure-copy-protocol TEXT`: Used only if --backup-destination=RemoteThe user/credentials that will be used to scp the backup files.Example: &quot;centos@10.14.51.62&quot;
+* `-bb, --backup-bucket TEXT`: Only used if --storage=S3
+Name of the bucket to store the columnstore backups.
+Example: &quot;s3://my-cs-backups&quot;
+* `-url, --endpoint-url TEXT`: Used by on premise S3 vendors.
+Example: &quot;http://127.0.0.1:8000&quot;
+* `-s, --storage TEXT`: What storage topogoly is being used by Columnstore - found in /etc/columnstore/storagemanager.cnf.
+Options: &quot;LocalStorage&quot; or &quot;S3&quot;  [default: LocalStorage]
+* `-dbs, --dbroots INTEGER`: Number of database roots in the backup.  [default: 1]
+* `-pm, --nodeid TEXT`: Forces the handling of the restore as this node as opposed to whats detected on disk.
+* `-nb, --new-bucket TEXT`: Defines the new bucket to copy the s3 data to from the backup bucket. Use -nb if the new restored cluster should use a different bucket than the backup bucket itself.
+* `-nr, --new-region TEXT`: Defines the region of the new bucket to copy the s3 data to from the backup bucket.
+* `-nk, --new-key TEXT`: Defines the aws key to connect to the new_bucket.
+* `-ns, --new-secret TEXT`: Defines the aws secret of the aws key to connect to the new_bucket.
+* `-ha, --highavilability / -no-ha, --no-highavilability`: Flag for high available systems (meaning shared storage exists supporting the topology so that each node sees all data)  [default: no-ha]
+* `-cont, --continue / -no-cont, --no-continue`: This acknowledges data in your --new_bucket is ok to delete when restoring S3. When set to true skips the enforcement that new_bucket should be empty prior to starting a restore.  [default: no-cont]
+* `-f, --config-file TEXT`: Path to backup configuration file to load variables from.
+* `-smdb, --skip-mariadb-backup / -no-smdb, --no-skip-mariadb-backup`: Skip restoring mariadb server via mariadb-backup - ideal for only restoring columnstore.  [default: no-smdb]
+* `-sb, --skip-bucket-data / -no-sb, --no-skip-bucket-data`: Skip restoring columnstore data in the bucket - ideal if looking to only restore mariadb server.  [default: no-sb]
+* `-c, --compress TEXT`: Hint that the backup is compressed in X format. Options: [ pigz ].
+* `-P, --parallel INTEGER`: Determines number of decompression and mdbstream threads. Ignored if &quot;-c/--compress&quot; argument not set.  [default: 4]
+* `-q, --quiet / -no-q, --no-quiet`: Silence verbose copy command outputs.  [default: no-q]
+* `-nv-ssl, --no-verify-ssl / -v-ssl, --verify-ssl`: Skips verifying ssl certs, useful for onpremise s3 storage.  [default: v-ssl]
+* `--help`: Show this message and exit.
+
+## `mcs dbrm_restore`
+
+Restore Columnstore DBRM data.
+
+**Usage**:
+
+```console
+$ mcs dbrm_restore [OPTIONS]
+```
+
+**Options**:
+
+* `-p, --path TEXT`: Path of where dbrm backups stored on disk.  [default: /tmp/dbrm_backups]
+* `-d, --directory TEXT`: Date or directory chose to restore from.
+* `-ns, --no-start`: Do not attempt columnstore startup post dbrm_restore.
+* `-sdbk, --skip-dbrm-backup / -no-sdbk, --no-skip-dbrm-backup`: Skip backing up dbrms before restoring.  [default: sdbk]
+* `-ssm, --skip-storage-manager / -no-ssm, --no-skip-storage-manager`: Skip backing up storagemanager directory.  [default: ssm]
+* `--help`: Show this message and exit.
+
+## `mcs help-all`
+
+Show help for all commands in man page style.
+
+**Usage**:
+
+```console
+$ mcs help-all [OPTIONS]
+```
+
+## `mcs status`
+
+Get status information.
+
+**Usage**:
+
+```console
+$ mcs status [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+## `mcs stop`
+
+Stop the Columnstore cluster.
+
+**Usage**:
+
+```console
+$ mcs stop [OPTIONS]
+```
+
+**Options**:
+
+* `-i, --interactive / -no-i, --no-interactive`: Use this option on active cluster as interactive stop waits for current writes to complete in DMLProc before shutting down. Ensuring consistency, preventing data loss of active writes.  [default: no-interactive]
+* `-t, --timeout INTEGER`: Time in seconds to wait for DMLproc to gracefully stop.Warning: Low wait timeout values could result in data loss if the cluster is very active.In interactive mode means delay time between promts.  [default: 15]
+* `--help`: Show this message and exit.
+
+## `mcs start`
+
+Start the Columnstore cluster.
+
+**Usage**:
+
+```console
+$ mcs start [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+## `mcs restart`
+
+Restart the Columnstore cluster.
+
+**Usage**:
+
+```console
+$ mcs restart [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+## `mcs node`
+
+Cluster nodes management.
+
+**Usage**:
+
+```console
+$ mcs node [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `add`: Add nodes to the Columnstore cluster.
+* `remove`: Remove nodes from the Columnstore cluster.
+
+### `mcs node add`
+
+Add nodes to the Columnstore cluster.
+
+**Usage**:
+
+```console
+$ mcs node add [OPTIONS]
+```
+
+**Options**:
+
+* `--node TEXT`: node IP, name or FQDN. Can be used multiple times to add several nodes at a time.  [required]
+* `--help`: Show this message and exit.
+
+### `mcs node remove`
+
+Remove nodes from the Columnstore cluster.
+
+**Usage**:
+
+```console
+$ mcs node remove [OPTIONS]
+```
+
+**Options**:
+
+* `--node TEXT`: node IP, name or FQDN. Can be used multiple times to remove several nodes at a time.  [required]
+* `--help`: Show this message and exit.
+
+## `mcs set`
+
+Set cluster parameters.
+
+**Usage**:
+
+```console
+$ mcs set [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `mode`: Set Columnstore cluster mode.
+* `api-key`: Set API key for communication with cluster...
+* `log-level`: Set logging level on all cluster nodes for...
+
+### `mcs set mode`
+
+Set Columnstore cluster mode.
+
+**Usage**:
+
+```console
+$ mcs set mode [OPTIONS]
+```
+
+**Options**:
+
+* `--mode TEXT`: cluster mode to set. &quot;readonly&quot; or &quot;readwrite&quot; are the only acceptable values.  [required]
+* `--help`: Show this message and exit.
+
+### `mcs set api-key`
+
+Set API key for communication with cluster nodes via API.
+
+WARNING: this command will affect API key value on all cluster nodes.
+
+**Usage**:
+
+```console
+$ mcs set api-key [OPTIONS]
+```
+
+**Options**:
+
+* `--key TEXT`: API key to set.  [required]
+* `--help`: Show this message and exit.
+
+### `mcs set log-level`
+
+Set logging level on all cluster nodes for develop purposes.
+
+WARNING: this could dramatically affect the number of log lines.
+
+**Usage**:
+
+```console
+$ mcs set log-level [OPTIONS]
+```
+
+**Options**:
+
+* `--level TEXT`: Logging level to set.  [required]
+* `--help`: Show this message and exit.
+
+## `mcs cluster`
+
+MariaDB Columnstore cluster management command line tool.
+
+**Usage**:
+
+```console
+$ mcs cluster [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `status`: Get status information.
+* `stop`: Stop the Columnstore cluster.
+* `start`: Start the Columnstore cluster.
+* `restart`: Restart the Columnstore cluster.
+* `node`: Cluster nodes management.
+* `set`: Set cluster parameters.
+
+### `mcs cluster status`
+
+Get status information.
+
+**Usage**:
+
+```console
+$ mcs cluster status [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+### `mcs cluster stop`
+
+Stop the Columnstore cluster.
+
+**Usage**:
+
+```console
+$ mcs cluster stop [OPTIONS]
+```
+
+**Options**:
+
+* `-i, --interactive / -no-i, --no-interactive`: Use this option on active cluster as interactive stop waits for current writes to complete in DMLProc before shutting down. Ensuring consistency, preventing data loss of active writes.  [default: no-interactive]
+* `-t, --timeout INTEGER`: Time in seconds to wait for DMLproc to gracefully stop.Warning: Low wait timeout values could result in data loss if the cluster is very active.In interactive mode means delay time between promts.  [default: 15]
+* `--help`: Show this message and exit.
+
+### `mcs cluster start`
+
+Start the Columnstore cluster.
+
+**Usage**:
+
+```console
+$ mcs cluster start [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+### `mcs cluster restart`
+
+Restart the Columnstore cluster.
+
+**Usage**:
+
+```console
+$ mcs cluster restart [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+### `mcs cluster node`
+
+Cluster nodes management.
+
+**Usage**:
+
+```console
+$ mcs cluster node [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `add`: Add nodes to the Columnstore cluster.
+* `remove`: Remove nodes from the Columnstore cluster.
+
+#### `mcs cluster node add`
+
+Add nodes to the Columnstore cluster.
+
+**Usage**:
+
+```console
+$ mcs cluster node add [OPTIONS]
+```
+
+**Options**:
+
+* `--node TEXT`: node IP, name or FQDN. Can be used multiple times to add several nodes at a time.  [required]
+* `--help`: Show this message and exit.
+
+#### `mcs cluster node remove`
+
+Remove nodes from the Columnstore cluster.
+
+**Usage**:
+
+```console
+$ mcs cluster node remove [OPTIONS]
+```
+
+**Options**:
+
+* `--node TEXT`: node IP, name or FQDN. Can be used multiple times to remove several nodes at a time.  [required]
+* `--help`: Show this message and exit.
+
+### `mcs cluster set`
+
+Set cluster parameters.
+
+**Usage**:
+
+```console
+$ mcs cluster set [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `mode`: Set Columnstore cluster mode.
+* `api-key`: Set API key for communication with cluster...
+* `log-level`: Set logging level on all cluster nodes for...
+
+#### `mcs cluster set mode`
+
+Set Columnstore cluster mode.
+
+**Usage**:
+
+```console
+$ mcs cluster set mode [OPTIONS]
+```
+
+**Options**:
+
+* `--mode TEXT`: cluster mode to set. &quot;readonly&quot; or &quot;readwrite&quot; are the only acceptable values.  [required]
+* `--help`: Show this message and exit.
+
+#### `mcs cluster set api-key`
+
+Set API key for communication with cluster nodes via API.
+
+WARNING: this command will affect API key value on all cluster nodes.
+
+**Usage**:
+
+```console
+$ mcs cluster set api-key [OPTIONS]
+```
+
+**Options**:
+
+* `--key TEXT`: API key to set.  [required]
+* `--help`: Show this message and exit.
+
+#### `mcs cluster set log-level`
+
+Set logging level on all cluster nodes for develop purposes.
+
+WARNING: this could dramatically affect the number of log lines.
+
+**Usage**:
+
+```console
+$ mcs cluster set log-level [OPTIONS]
+```
+
+**Options**:
+
+* `--level TEXT`: Logging level to set.  [required]
+* `--help`: Show this message and exit.
+
+## `mcs cmapi`
+
+CMAPI itself related commands.
+
+**Usage**:
+
+```console
+$ mcs cmapi [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `is-ready`: Check CMAPI is ready to handle requests.
+
+### `mcs cmapi is-ready`
+
+Check CMAPI is ready to handle requests.
+
+**Usage**:
+
+```console
+$ mcs cmapi is-ready [OPTIONS]
+```
+
+**Options**:
+
+* `--node TEXT`: Which node to check the CMAPI is ready to handle requests.  [default: 127.0.0.1]
+* `--help`: Show this message and exit.

--- a/cmapi/mcs_cluster_tool/README_DEV.md
+++ b/cmapi/mcs_cluster_tool/README_DEV.md
@@ -1,0 +1,19 @@
+# Generating documentation for MCS cli tool
+- install cmapi requirements
+    ```bash
+    pip install -r requirements.txt
+    ```
+- generate markdown
+    ```bash
+    typer mcs_cluster_tool/__main__.py utils docs --name mcs --output README.md
+    ```
+- install `md2man` (for now it's the only one tool that make convertation without any issues)
+    ```bash
+    sudo yum install -y ruby ruby-devel
+    gem install md2man
+    ```
+- convert to perfect `.roff` file (`man` page)
+    ```bash
+    md2man README.md > mcs.1
+    ```
+- enjoy =)

--- a/cmapi/mcs_cluster_tool/__main__.py
+++ b/cmapi/mcs_cluster_tool/__main__.py
@@ -1,4 +1,5 @@
 import logging
+import subprocess
 import sys
 
 import typer
@@ -17,13 +18,25 @@ app = typer.Typer(
         'The  MCS  Command  Line  Interface is a unified tool to manage your '
         'MCS services'
     ),
+    rich_markup_mode='rich',
 )
-app.add_typer(cluster_app.app, name='cluster')
+app.add_typer(cluster_app.app)
+# TODO: keep this only for potential backward compatibility
+app.add_typer(cluster_app.app, name='cluster', hidden=True)
 app.add_typer(cmapi_app.app, name='cmapi')
-app.command()(backup_commands.backup)
-app.command('backup-dbrm')(backup_commands.dbrm_backup)
-app.command()(restore_commands.restore)
-app.command('restore-dbrm')(restore_commands.dbrm_restore)
+app.command('backup')(backup_commands.backup)
+app.command('dbrm_backup')(backup_commands.dbrm_backup)
+app.command('restore')(restore_commands.restore)
+app.command('dbrm_restore')(restore_commands.dbrm_restore)
+
+
+@app.command(
+        name='help-all', help='Show help for all commands in man page style.',
+        add_help_option=False
+)
+def help_all():
+    # Open the man page in interactive mode
+    subprocess.run(['man', 'mcs'])
 
 
 if __name__ == '__main__':

--- a/cmapi/mcs_cluster_tool/cluster_app.py
+++ b/cmapi/mcs_cluster_tool/cluster_app.py
@@ -35,14 +35,14 @@ set_app = typer.Typer(help='Set cluster parameters.')
 app.add_typer(set_app, name='set')
 
 
-@app.command()
+@app.command(rich_help_panel='cluster and single node commands')
 @handle_output
 def status():
     """Get status information."""
     return ClusterHandler.status(logger=logger)
 
 
-@app.command()
+@app.command(rich_help_panel='cluster and single node commands')
 @handle_output
 @TransactionManager(
     timeout=timedelta(days=1).total_seconds(), handle_signals=True
@@ -161,14 +161,14 @@ def stop(
     return {'timestamp': start_time}
 
 
-@app.command()
+@app.command(rich_help_panel='cluster and single node commands')
 @handle_output
 def start():
     """Start the Columnstore cluster."""
     return ClusterHandler.start(logger=logger)
 
 
-@app.command()
+@app.command(rich_help_panel='cluster and single node commands')
 @handle_output
 def restart():
     """Restart the Columnstore cluster."""
@@ -180,7 +180,7 @@ def restart():
     return result
 
 
-@node_app.command()
+@node_app.command(rich_help_panel='cluster node commands')
 @handle_output
 def add(
     nodes: Optional[List[str]] = typer.Option(
@@ -199,7 +199,7 @@ def add(
     return result
 
 
-@node_app.command()
+@node_app.command(rich_help_panel='cluster node commands')
 @handle_output
 def remove(nodes: Optional[List[str]] = typer.Option(
         ...,

--- a/cmapi/mcs_cluster_tool/mcs.1
+++ b/cmapi/mcs_cluster_tool/mcs.1
@@ -1,0 +1,776 @@
+.TH \fB\fCmcs\fR
+.PP
+The  MCS  Command  Line  Interface is a unified tool to manage your MCS services
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs [OPTIONS] COMMAND [ARGS]...
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.PP
+\fBCommands\fP:
+.RS
+.IP \(bu 2
+\fB\fCbackup\fR: Backup Columnstore and/or MariDB data.
+.IP \(bu 2
+\fB\fCdbrm_backup\fR: Columnstore DBRM Backup.
+.IP \(bu 2
+\fB\fCrestore\fR: Restore Columnstore (and/or MariaDB) data.
+.IP \(bu 2
+\fB\fCdbrm_restore\fR: Restore Columnstore DBRM data.
+.IP \(bu 2
+\fB\fChelp\-all\fR: Show help for all commands in man page style.
+.IP \(bu 2
+\fB\fCstatus\fR: Get status information.
+.IP \(bu 2
+\fB\fCstop\fR: Stop the Columnstore cluster.
+.IP \(bu 2
+\fB\fCstart\fR: Start the Columnstore cluster.
+.IP \(bu 2
+\fB\fCrestart\fR: Restart the Columnstore cluster.
+.IP \(bu 2
+\fB\fCnode\fR: Cluster nodes management.
+.IP \(bu 2
+\fB\fCset\fR: Set cluster parameters.
+.IP \(bu 2
+\fB\fCcluster\fR: MariaDB Columnstore cluster management...
+.IP \(bu 2
+\fB\fCcmapi\fR: CMAPI itself related commands.
+.RE
+.SH \fB\fCmcs backup\fR
+.PP
+Backup Columnstore and/or MariDB data.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs backup [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-bl, \-\-backup\-location TEXT\fR: What directory to store the backups on this machine or the target machine.
+Consider write permissions of the scp user and the user running this script.
+Mariadb\-backup will use this location as a tmp dir for S3 and remote backups temporarily.
+Example: /mnt/backups/  [default: /tmp/backups/]
+.IP \(bu 2
+\fB\fC\-bd, \-\-backup\-destination TEXT\fR: Are the backups going to be stored on the same machine this script is running on or another server \- if Remote you need to setup scp=Options: \[dq]Local\[dq] or \[dq]Remote\[dq]  [default: Local]
+.IP \(bu 2
+\fB\fC\-scp TEXT\fR: Used only if \-\-backup\-destination=\[dq]Remote\[dq]\&.
+The user/credentials that will be used to scp the backup files
+Example: \[dq]\[la]centos@10.14.51.62\[ra]\[dq]
+.IP \(bu 2
+\fB\fC\-bb, \-\-backup\-bucket TEXT\fR: Only used if \-\-storage=S3
+Name of the bucket to store the columnstore backups.
+Example: \[dq]s3://my\-cs\-backups\[dq]
+.IP \(bu 2
+\fB\fC\-url, \-\-endpoint\-url TEXT\fR: Used by on premise S3 vendors.
+Example: \[dq]\[la]http://127.0.0.1:8000\[ra]\[dq]
+.IP \(bu 2
+\fB\fC\-nv\-ssl, \-\-no\-verify\-ssl / \-v\-ssl, \-\-verify\-ssl\fR: Skips verifying ssl certs, useful for onpremise s3 storage.  [default: v\-ssl]
+.IP \(bu 2
+\fB\fC\-s, \-\-storage TEXT\fR: What storage topogoly is being used by Columnstore \- found in /etc/columnstore/storagemanager.cnf.
+Options: \[dq]LocalStorage\[dq] or \[dq]S3\[dq]  [default: LocalStorage]
+.IP \(bu 2
+\fB\fC\-i, \-\-incremental TEXT\fR: Adds columnstore deltas to an existing full backup. Backup folder to apply increment could be a value or \[dq]auto\fImost\fPrecent\[dq] \- the incremental backup applies to last full backup.
+.IP \(bu 2
+\fB\fC\-ha, \-\-highavilability / \-no\-ha, \-\-no\-highavilability\fR: Hint wether shared storage is attached @ below on all nodes to see all data
+HA LocalStorage ( /var/lib/columnstore/dataX/ )
+HA S3           ( /var/lib/columnstore/storagemanager/ )  [default: no\-ha]
+.IP \(bu 2
+\fB\fC\-f, \-\-config\-file TEXT\fR: Path to backup configuration file to load variables from.
+.IP \(bu 2
+\fB\fC\-sbrm, \-\-skip\-save\-brm / \-no\-sbrm, \-\-no\-skip\-save\-brm\fR: Skip saving brm prior to running a backup \- ideal for dirty backups.  [default: no\-sbrm]
+.IP \(bu 2
+\fB\fC\-spoll, \-\-skip\-polls / \-no\-spoll, \-\-no\-skip\-polls\fR: Skip sql checks confirming no write/cpimports running.  [default: no\-spoll]
+.IP \(bu 2
+\fB\fC\-slock, \-\-skip\-locks / \-no\-slock, \-\-no\-skip\-locks\fR: Skip issuing write locks \- ideal for dirty backups.  [default: no\-slock]
+.IP \(bu 2
+\fB\fC\-smdb, \-\-skip\-mariadb\-backup / \-no\-smdb, \-\-no\-skip\-mariadb\-backup\fR: Skip running a mariadb\-backup for innodb data \- ideal for incremental dirty backups.  [default: no\-smdb]
+.IP \(bu 2
+\fB\fC\-sb, \-\-skip\-bucket\-data / \-no\-sb, \-\-no\-skip\-bucket\-data\fR: Skip taking a copy of the columnstore data in the bucket.  [default: no\-sb]
+.IP \(bu 2
+\fB\fC\-pi, \-\-poll\-interval INTEGER\fR: Number of seconds between poll checks for active writes & cpimports.  [default: 5]
+.IP \(bu 2
+\fB\fC\-pmw, \-\-poll\-max\-wait INTEGER\fR: Max number of minutes for polling checks for writes to wait before exiting as a failed backup attempt.  [default: 60]
+.IP \(bu 2
+\fB\fC\-q, \-\-quiet / \-no\-q, \-\-no\-quiet\fR: Silence verbose copy command outputs.  [default: no\-q]
+.IP \(bu 2
+\fB\fC\-c, \-\-compress TEXT\fR: Compress backup in X format \- Options: [ pigz ].
+.IP \(bu 2
+\fB\fC\-P, \-\-parallel INTEGER\fR: Determines if columnstore data directories will have multiple rsync running at the same time for different subfolders to parallelize writes. Ignored if \[dq]\-c/\-\-compress\[dq] argument not set.  [default: 4]
+.IP \(bu 2
+\fB\fC\-nb, \-\-name\-backup TEXT\fR: Define the name of the backup \- default: $(date +%m\-%d\-%Y)  [default: 03\-06\-2025]
+.IP \(bu 2
+\fB\fC\-r, \-\-retention\-days INTEGER\fR: Retain backups created within the last X days, default 0 == keep all backups.  [default: 0]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SH \fB\fCmcs dbrm_backup\fR
+.PP
+Columnstore DBRM Backup.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs dbrm_backup [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-m, \-\-mode TEXT\fR: \[dq]loop\[dq] or \[dq]once\[dq] ; Determines if this script runs in a forever loop sleeping \-i minutes or just once.  [default: once]
+.IP \(bu 2
+\fB\fC\-i, \-\-interval INTEGER\fR: Number of minutes to sleep when \-\-mode=loop.  [default: 90]
+.IP \(bu 2
+\fB\fC\-r, \-\-retention\-days INTEGER\fR: Retain dbrm backups created within the last X days, the rest are deleted  [default: 7]
+.IP \(bu 2
+\fB\fC\-p, \-\-path TEXT\fR: Path of where to save the dbrm backups on disk.  [default: /tmp/dbrm_backups]
+.IP \(bu 2
+\fB\fC\-nb, \-\-name\-backup TEXT\fR: Custom name to prefex dbrm backups with.  [default: dbrm_backup]
+.IP \(bu 2
+\fB\fC\-q, \-\-quiet / \-no\-q, \-\-no\-quiet\fR: Silence verbose copy command outputs.  [default: no\-q]
+.IP \(bu 2
+\fB\fC\-ssm, \-\-skip\-storage\-manager / \-no\-ssm, \-\-no\-skip\-storage\-manager\fR: Skip backing up storagemanager directory.  [default: no\-ssm]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SH \fB\fCmcs restore\fR
+.PP
+Restore Columnstore (and/or MariaDB) data.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs restore [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-l, \-\-load TEXT\fR: What date folder to load from the backup_location.
+.IP \(bu 2
+\fB\fC\-bl, \-\-backup\-location TEXT\fR: Where the backup to load is found.
+Example: /mnt/backups/  [default: /tmp/backups/]
+.IP \(bu 2
+\fB\fC\-bd, \-\-backup_destination TEXT\fR: Is this backup on the same or remote server compared to where this script is running.
+Options: \[dq]Local\[dq] or \[dq]Remote\[dq]  [default: Local]
+.IP \(bu 2
+\fB\fC\-scp, \-\-secure\-copy\-protocol TEXT\fR: Used only if \-\-backup\-destination=RemoteThe user/credentials that will be used to scp the backup files.Example: \[dq]\[la]centos@10.14.51.62\[ra]\[dq]
+.IP \(bu 2
+\fB\fC\-bb, \-\-backup\-bucket TEXT\fR: Only used if \-\-storage=S3
+Name of the bucket to store the columnstore backups.
+Example: \[dq]s3://my\-cs\-backups\[dq]
+.IP \(bu 2
+\fB\fC\-url, \-\-endpoint\-url TEXT\fR: Used by on premise S3 vendors.
+Example: \[dq]\[la]http://127.0.0.1:8000\[ra]\[dq]
+.IP \(bu 2
+\fB\fC\-s, \-\-storage TEXT\fR: What storage topogoly is being used by Columnstore \- found in /etc/columnstore/storagemanager.cnf.
+Options: \[dq]LocalStorage\[dq] or \[dq]S3\[dq]  [default: LocalStorage]
+.IP \(bu 2
+\fB\fC\-dbs, \-\-dbroots INTEGER\fR: Number of database roots in the backup.  [default: 1]
+.IP \(bu 2
+\fB\fC\-pm, \-\-nodeid TEXT\fR: Forces the handling of the restore as this node as opposed to whats detected on disk.
+.IP \(bu 2
+\fB\fC\-nb, \-\-new\-bucket TEXT\fR: Defines the new bucket to copy the s3 data to from the backup bucket. Use \-nb if the new restored cluster should use a different bucket than the backup bucket itself.
+.IP \(bu 2
+\fB\fC\-nr, \-\-new\-region TEXT\fR: Defines the region of the new bucket to copy the s3 data to from the backup bucket.
+.IP \(bu 2
+\fB\fC\-nk, \-\-new\-key TEXT\fR: Defines the aws key to connect to the new_bucket.
+.IP \(bu 2
+\fB\fC\-ns, \-\-new\-secret TEXT\fR: Defines the aws secret of the aws key to connect to the new_bucket.
+.IP \(bu 2
+\fB\fC\-ha, \-\-highavilability / \-no\-ha, \-\-no\-highavilability\fR: Flag for high available systems (meaning shared storage exists supporting the topology so that each node sees all data)  [default: no\-ha]
+.IP \(bu 2
+\fB\fC\-cont, \-\-continue / \-no\-cont, \-\-no\-continue\fR: This acknowledges data in your \-\-new\fIbucket is ok to delete when restoring S3. When set to true skips the enforcement that new\fPbucket should be empty prior to starting a restore.  [default: no\-cont]
+.IP \(bu 2
+\fB\fC\-f, \-\-config\-file TEXT\fR: Path to backup configuration file to load variables from.
+.IP \(bu 2
+\fB\fC\-smdb, \-\-skip\-mariadb\-backup / \-no\-smdb, \-\-no\-skip\-mariadb\-backup\fR: Skip restoring mariadb server via mariadb\-backup \- ideal for only restoring columnstore.  [default: no\-smdb]
+.IP \(bu 2
+\fB\fC\-sb, \-\-skip\-bucket\-data / \-no\-sb, \-\-no\-skip\-bucket\-data\fR: Skip restoring columnstore data in the bucket \- ideal if looking to only restore mariadb server.  [default: no\-sb]
+.IP \(bu 2
+\fB\fC\-c, \-\-compress TEXT\fR: Hint that the backup is compressed in X format. Options: [ pigz ].
+.IP \(bu 2
+\fB\fC\-P, \-\-parallel INTEGER\fR: Determines number of decompression and mdbstream threads. Ignored if \[dq]\-c/\-\-compress\[dq] argument not set.  [default: 4]
+.IP \(bu 2
+\fB\fC\-q, \-\-quiet / \-no\-q, \-\-no\-quiet\fR: Silence verbose copy command outputs.  [default: no\-q]
+.IP \(bu 2
+\fB\fC\-nv\-ssl, \-\-no\-verify\-ssl / \-v\-ssl, \-\-verify\-ssl\fR: Skips verifying ssl certs, useful for onpremise s3 storage.  [default: v\-ssl]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SH \fB\fCmcs dbrm_restore\fR
+.PP
+Restore Columnstore DBRM data.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs dbrm_restore [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-p, \-\-path TEXT\fR: Path of where dbrm backups stored on disk.  [default: /tmp/dbrm_backups]
+.IP \(bu 2
+\fB\fC\-d, \-\-directory TEXT\fR: Date or directory chose to restore from.
+.IP \(bu 2
+\fB\fC\-ns, \-\-no\-start\fR: Do not attempt columnstore startup post dbrm_restore.
+.IP \(bu 2
+\fB\fC\-sdbk, \-\-skip\-dbrm\-backup / \-no\-sdbk, \-\-no\-skip\-dbrm\-backup\fR: Skip backing up dbrms before restoring.  [default: sdbk]
+.IP \(bu 2
+\fB\fC\-ssm, \-\-skip\-storage\-manager / \-no\-ssm, \-\-no\-skip\-storage\-manager\fR: Skip backing up storagemanager directory.  [default: ssm]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SH \fB\fCmcs help\-all\fR
+.PP
+Show help for all commands in man page style.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs help\-all [OPTIONS]
+.fi
+.RE
+.SH \fB\fCmcs status\fR
+.PP
+Get status information.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs status [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SH \fB\fCmcs stop\fR
+.PP
+Stop the Columnstore cluster.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs stop [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-i, \-\-interactive / \-no\-i, \-\-no\-interactive\fR: Use this option on active cluster as interactive stop waits for current writes to complete in DMLProc before shutting down. Ensuring consistency, preventing data loss of active writes.  [default: no\-interactive]
+.IP \(bu 2
+\fB\fC\-t, \-\-timeout INTEGER\fR: Time in seconds to wait for DMLproc to gracefully stop.Warning: Low wait timeout values could result in data loss if the cluster is very active.In interactive mode means delay time between promts.  [default: 15]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SH \fB\fCmcs start\fR
+.PP
+Start the Columnstore cluster.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs start [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SH \fB\fCmcs restart\fR
+.PP
+Restart the Columnstore cluster.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs restart [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SH \fB\fCmcs node\fR
+.PP
+Cluster nodes management.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs node [OPTIONS] COMMAND [ARGS]...
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.PP
+\fBCommands\fP:
+.RS
+.IP \(bu 2
+\fB\fCadd\fR: Add nodes to the Columnstore cluster.
+.IP \(bu 2
+\fB\fCremove\fR: Remove nodes from the Columnstore cluster.
+.RE
+.SS \fB\fCmcs node add\fR
+.PP
+Add nodes to the Columnstore cluster.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs node add [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-node TEXT\fR: node IP, name or FQDN. Can be used multiple times to add several nodes at a time.  [required]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SS \fB\fCmcs node remove\fR
+.PP
+Remove nodes from the Columnstore cluster.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs node remove [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-node TEXT\fR: node IP, name or FQDN. Can be used multiple times to remove several nodes at a time.  [required]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SH \fB\fCmcs set\fR
+.PP
+Set cluster parameters.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs set [OPTIONS] COMMAND [ARGS]...
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.PP
+\fBCommands\fP:
+.RS
+.IP \(bu 2
+\fB\fCmode\fR: Set Columnstore cluster mode.
+.IP \(bu 2
+\fB\fCapi\-key\fR: Set API key for communication with cluster...
+.IP \(bu 2
+\fB\fClog\-level\fR: Set logging level on all cluster nodes for...
+.RE
+.SS \fB\fCmcs set mode\fR
+.PP
+Set Columnstore cluster mode.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs set mode [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-mode TEXT\fR: cluster mode to set. \[dq]readonly\[dq] or \[dq]readwrite\[dq] are the only acceptable values.  [required]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SS \fB\fCmcs set api\-key\fR
+.PP
+Set API key for communication with cluster nodes via API.
+.PP
+WARNING: this command will affect API key value on all cluster nodes.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs set api\-key [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-key TEXT\fR: API key to set.  [required]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SS \fB\fCmcs set log\-level\fR
+.PP
+Set logging level on all cluster nodes for develop purposes.
+.PP
+WARNING: this could dramatically affect the number of log lines.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs set log\-level [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-level TEXT\fR: Logging level to set.  [required]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SH \fB\fCmcs cluster\fR
+.PP
+MariaDB Columnstore cluster management command line tool.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cluster [OPTIONS] COMMAND [ARGS]...
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.PP
+\fBCommands\fP:
+.RS
+.IP \(bu 2
+\fB\fCstatus\fR: Get status information.
+.IP \(bu 2
+\fB\fCstop\fR: Stop the Columnstore cluster.
+.IP \(bu 2
+\fB\fCstart\fR: Start the Columnstore cluster.
+.IP \(bu 2
+\fB\fCrestart\fR: Restart the Columnstore cluster.
+.IP \(bu 2
+\fB\fCnode\fR: Cluster nodes management.
+.IP \(bu 2
+\fB\fCset\fR: Set cluster parameters.
+.RE
+.SS \fB\fCmcs cluster status\fR
+.PP
+Get status information.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cluster status [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SS \fB\fCmcs cluster stop\fR
+.PP
+Stop the Columnstore cluster.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cluster stop [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-i, \-\-interactive / \-no\-i, \-\-no\-interactive\fR: Use this option on active cluster as interactive stop waits for current writes to complete in DMLProc before shutting down. Ensuring consistency, preventing data loss of active writes.  [default: no\-interactive]
+.IP \(bu 2
+\fB\fC\-t, \-\-timeout INTEGER\fR: Time in seconds to wait for DMLproc to gracefully stop.Warning: Low wait timeout values could result in data loss if the cluster is very active.In interactive mode means delay time between promts.  [default: 15]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SS \fB\fCmcs cluster start\fR
+.PP
+Start the Columnstore cluster.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cluster start [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SS \fB\fCmcs cluster restart\fR
+.PP
+Restart the Columnstore cluster.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cluster restart [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SS \fB\fCmcs cluster node\fR
+.PP
+Cluster nodes management.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cluster node [OPTIONS] COMMAND [ARGS]...
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.PP
+\fBCommands\fP:
+.RS
+.IP \(bu 2
+\fB\fCadd\fR: Add nodes to the Columnstore cluster.
+.IP \(bu 2
+\fB\fCremove\fR: Remove nodes from the Columnstore cluster.
+.RE
+.SS \fB\fCmcs cluster node add\fR
+.PP
+Add nodes to the Columnstore cluster.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cluster node add [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-node TEXT\fR: node IP, name or FQDN. Can be used multiple times to add several nodes at a time.  [required]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SS \fB\fCmcs cluster node remove\fR
+.PP
+Remove nodes from the Columnstore cluster.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cluster node remove [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-node TEXT\fR: node IP, name or FQDN. Can be used multiple times to remove several nodes at a time.  [required]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SS \fB\fCmcs cluster set\fR
+.PP
+Set cluster parameters.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cluster set [OPTIONS] COMMAND [ARGS]...
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.PP
+\fBCommands\fP:
+.RS
+.IP \(bu 2
+\fB\fCmode\fR: Set Columnstore cluster mode.
+.IP \(bu 2
+\fB\fCapi\-key\fR: Set API key for communication with cluster...
+.IP \(bu 2
+\fB\fClog\-level\fR: Set logging level on all cluster nodes for...
+.RE
+.SS \fB\fCmcs cluster set mode\fR
+.PP
+Set Columnstore cluster mode.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cluster set mode [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-mode TEXT\fR: cluster mode to set. \[dq]readonly\[dq] or \[dq]readwrite\[dq] are the only acceptable values.  [required]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SS \fB\fCmcs cluster set api\-key\fR
+.PP
+Set API key for communication with cluster nodes via API.
+.PP
+WARNING: this command will affect API key value on all cluster nodes.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cluster set api\-key [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-key TEXT\fR: API key to set.  [required]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SS \fB\fCmcs cluster set log\-level\fR
+.PP
+Set logging level on all cluster nodes for develop purposes.
+.PP
+WARNING: this could dramatically affect the number of log lines.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cluster set log\-level [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-level TEXT\fR: Logging level to set.  [required]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.SH \fB\fCmcs cmapi\fR
+.PP
+CMAPI itself related commands.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cmapi [OPTIONS] COMMAND [ARGS]...
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE
+.PP
+\fBCommands\fP:
+.RS
+.IP \(bu 2
+\fB\fCis\-ready\fR: Check CMAPI is ready to handle requests.
+.RE
+.SS \fB\fCmcs cmapi is\-ready\fR
+.PP
+Check CMAPI is ready to handle requests.
+.PP
+\fBUsage\fP:
+.PP
+.RS
+.nf
+$ mcs cmapi is\-ready [OPTIONS]
+.fi
+.RE
+.PP
+\fBOptions\fP:
+.RS
+.IP \(bu 2
+\fB\fC\-\-node TEXT\fR: Which node to check the CMAPI is ready to handle requests.  [default: 127.0.0.1]
+.IP \(bu 2
+\fB\fC\-\-help\fR: Show this message and exit.
+.RE

--- a/cmapi/requirements.txt
+++ b/cmapi/requirements.txt
@@ -7,7 +7,8 @@ lxml==4.7.1
 psutil==5.9.1
 pyotp==2.6.0
 requests==2.27.1
-typer==0.9.0
+typer==0.15.1
+
 
 # indirect dependencies
 aiohttp==3.8.1
@@ -24,7 +25,7 @@ certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.12
 cheroot==8.6.0
-click==8.1.7
+click==8.1.8
 colorama==0.4.4
 crcmod==1.7
 docutils==0.16
@@ -44,6 +45,8 @@ jaraco.context==4.1.1
 jaraco.functools==3.5.0
 jaraco.text==3.7.0
 jmespath==1.0.1
+markdown-it-py==3.0.0
+mdurl==0.1.2
 monotonic==1.6
 more-itertools==8.12.0
 multidict==6.0.2
@@ -53,20 +56,23 @@ portend==3.1.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pycparser==2.21
+Pygments==2.19.1
 pyOpenSSL==22.0.0
 pyparsing==3.0.9
 python-dateutil==2.8.2
 pytz==2021.3
 pyu2f==0.1.5
 PyYAML==5.4.1
+rich==13.9.4
 repoze.lru==0.7
 retry-decorator==1.1.1
 Routes==2.5.1
 rsa==4.7.2
 s3transfer==0.6.0
+shellingham==1.5.4
 six==1.16.0
 tempora==5.0.1
-typing-extensions==4.8.0
+typing_extensions==4.12.2
 urllib3==1.26.8
 yarl==1.8.1
 zc.lockfile==2.0


### PR DESCRIPTION
[add] now all 'cluster' subcommand commands working without using 'cluster' subcommand itself [fix] 'cluster' command hidding its help message
[add] explicit names for commands
[add] help-all command to list all nested help messages in man page view [add] rich colored tabled help
[add] table panels for cluster commands
[upd] typer dependency version and some extra indirect dependencies [add] README.md for mcs cli tool with all command reference [add] mcs.1 man page
[add] README_DEV.md for mcs cli tool
[fix] cmapi/CMakeLists.txt to install mcs.1 man page

For reference #3399 