### PR TITLE
MCOL-5618: Sync with PR3410.

### DIFF
--- a/cmapi/mcs_cluster_tool/backup_commands.py
+++ b/cmapi/mcs_cluster_tool/backup_commands.py
@@ -102,7 +102,7 @@ def backup(
                 'Adds columnstore deltas to an existing full backup. '
                 'Backup folder to apply increment could be a value or '
                 '"auto_most_recent" - the incremental backup applies to '
-                'last full backup.'   
+                'last full backup.'
             ),
             show_default=False
         )
@@ -123,7 +123,10 @@ def backup(
         str,
         typer.Option(
             '-f', '--config-file',
-            help='Path to backup configuration file to load variables from.',
+            help=(
+                'Path to backup configuration file to load variables from - '
+                'relative or full path accepted.'
+            ),
             show_default=False
         )
     ] = '',
@@ -245,6 +248,13 @@ def backup(
             )
         )
     ] = 0,
+    list: Annotated[
+        bool,
+        typer.Option(
+            'list',
+            help='List backups.'
+        )
+    ] = False
 ):
     """Backup Columnstore and/or MariDB data."""
 
@@ -303,10 +313,10 @@ def dbrm_backup(
             )
         )
     ] = 7,
-    p: Annotated[
+    bl: Annotated[
         str,
         typer.Option(
-            '-p', '--path',
+            '-bl', '--backup-location',
             help='Path of where to save the dbrm backups on disk.'
         )
     ] = '/tmp/dbrm_backups',
@@ -314,7 +324,10 @@ def dbrm_backup(
         str,
         typer.Option(
             '-nb', '--name-backup',
-            help='Custom name to prefex dbrm backups with.'
+            help=(
+                'Define the prefix of the backup - '
+                'default: dbrm_backup+date +%Y%m%d_%H%M%S'
+            )
         )
     ] = 'dbrm_backup',
     q: Annotated[
@@ -334,14 +347,15 @@ def dbrm_backup(
 ):
     """Columnstore DBRM Backup."""
 
-    # Default: ./$0 dbrm_backup -m once --retention-days 7 --path /tmp/dbrm_backups
+    # Default: ./$0 dbrm_backup -m once --retention-days 0 --backup-location /tmp/dbrm_backups
 
     #     Examples:
-    #         ./$0 dbrm_backup --mode loop --interval 90 --retention-days 7 --path /mnt/dbrm_backups
-    #         ./$0 dbrm_backup --mode once --retention-days 7 --path /mnt/dbrm_backups -nb my-one-off-backup
+    #         ./$0 dbrm_backup --backup-location /mnt/columnstore/dbrm_backups
+    #         ./$0 dbrm_backup --retention-days 7 --backup-location /mnt/dbrm_backups --mode once -nb my-one-off-backup-before-upgrade
+    #         ./$0 dbrm_backup --retention-days 7 --backup-location /mnt/dbrm_backups --mode loop --interval 90brm_backup --mode once --retention-days 7 --path /mnt/dbrm_backups -nb my-one-off-backup
 
     #     Cron Example:
-    #     */60 */3 * * * root  bash /root/$0 dbrm_backup -m once --retention-days 7 --path /tmp/dbrm_backups  >> /tmp/dbrm_backups/cs_backup.log  2>&1
+    #         */60 */3 * * * root bash /root/$0 dbrm_backup -m once --retention-days 7 --backup-location /tmp/dbrm_backups >> /tmp/dbrm_backups/cs_backup.log 2>&1
     arguments = []
     for arg_name, value in locals().items():
         sh_arg = cook_sh_arg(arg_name, value)

--- a/cmapi/mcs_cluster_tool/restore_commands.py
+++ b/cmapi/mcs_cluster_tool/restore_commands.py
@@ -170,7 +170,10 @@ def restore(
         str,
         typer.Option(
             '-f', '--config-file',
-            help='Path to backup configuration file to load variables from.',
+            help=(
+                'Path to backup configuration file to load variables from - '
+                'relative or full path accepted.'
+            ),
             show_default=False
         )
     ] = '',
@@ -242,6 +245,13 @@ def restore(
             help='Skips verifying ssl certs, useful for onpremise s3 storage.'
         )
     ] = False,
+    list: Annotated[
+        bool,
+        typer.Option(
+            'list',
+            help='List backups.'
+        )
+    ] = False
 ):
     """Restore Columnstore (and/or MariaDB) data."""
 
@@ -266,18 +276,18 @@ def restore(
 
 @handle_output
 def dbrm_restore(
-    p: Annotated[
+    bl: Annotated[
         str,
         typer.Option(
-            '-p', '--path',
-            help='Path of where dbrm backups stored on disk.'
+            '-bl', '--backup-location',
+            help='Path of where dbrm backups exist on disk.'
         )
     ] = '/tmp/dbrm_backups',
-    d: Annotated[
+    l: Annotated[
         str,
         typer.Option(
-            '-d', '--directory',
-            help='Date or directory chose to restore from.'
+            '-l', '--load',
+            help='Name of the directory to restore from -bl'
         )
     ] = '',
     ns: Annotated[
@@ -305,14 +315,21 @@ def dbrm_restore(
             help='Skip backing up storagemanager directory.'
         )
     ] = True,
+    list: Annotated[
+        bool,
+        typer.Option(
+            'list',
+            help='List backups.'
+        )
+    ] = False
 ):
     """Restore Columnstore DBRM data."""
 
-    # Default: ./$0 dbrm_restore --path /tmp/dbrm_backups
+    # Default: ./$0 dbrm_restore --backup-location /tmp/dbrm_backups
 
     # Examples:
-    #   ./$0 dbrm_restore --path /tmp/dbrm_backups --directory dbrm_backup_20240318_172842
-    #   ./$0 dbrm_restore --path /tmp/dbrm_backups --directory dbrm_backup_20240318_172842 --no-start
+    #       ./$0 dbrm_restore --backup-location /tmp/dbrm_backups --load dbrm_backup_20240318_172842
+    #       ./$0 dbrm_restore --backup-location /tmp/dbrm_backups --load dbrm_backup_20240318_172842 --no-startdbrm_restore --path /tmp/dbrm_backups --directory dbrm_backup_20240318_172842 --no-start
     arguments = []
     for arg_name, value in locals().items():
         sh_arg = cook_sh_arg(arg_name, value)


### PR DESCRIPTION
 - [x] [add] list option but in argument notation "list" for backup, restore, dbrm_restore
 - [x] [fix] help messages for --config-file
 - [x] [fix] -p/--path > -bl/--backup-location option for dbrm_backup and dbrm_restore
 - [x] [fix] -d/--directory > '-l', '--load' option for dbrm_restore

More details about changes in original script: #3410 
