### PR TITLE
fix(TNS): fix for duplicate DISTINCT output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,7 @@ ENDIF()
 MY_CHECK_AND_SET_COMPILER_FLAG("-Wno-deprecated-copy" DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
 MY_CHECK_AND_SET_COMPILER_FLAG("-Wno-deprecated-declarations" DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
 
-MY_CHECK_AND_SET_COMPILER_FLAG("-Wall -Wextra")
+MY_CHECK_AND_SET_COMPILER_FLAG("-Werror -Wall -Wextra")
 SET (ENGINE_LDFLAGS    "-Wl,--no-as-needed -Wl,--add-needed")
 SET (ENGINE_DT_LIB datatypes)
 SET (ENGINE_COMMON_LIBS     messageqcpp loggingcpp configcpp idbboot boost_thread xml2 pthread rt ${ENGINE_DT_LIB})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,7 @@ ENDIF()
 MY_CHECK_AND_SET_COMPILER_FLAG("-Wno-deprecated-copy" DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
 MY_CHECK_AND_SET_COMPILER_FLAG("-Wno-deprecated-declarations" DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
 
-MY_CHECK_AND_SET_COMPILER_FLAG("-Werror -Wall -Wextra")
+MY_CHECK_AND_SET_COMPILER_FLAG("-Wall -Wextra")
 SET (ENGINE_LDFLAGS    "-Wl,--no-as-needed -Wl,--add-needed")
 SET (ENGINE_DT_LIB datatypes)
 SET (ENGINE_COMMON_LIBS     messageqcpp loggingcpp configcpp idbboot boost_thread xml2 pthread rt ${ENGINE_DT_LIB})

--- a/dbcon/joblist/batchprimitiveprocessor-jl.cpp
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.cpp
@@ -1413,7 +1413,7 @@ bool BatchPrimitiveProcessorJL::pickNextJoinerNum()
   for (i = 0; i < PMJoinerCount; i++)
   {
     joinerNum = (joinerNum + 1) % PMJoinerCount;
-    if (posByJoinerNum[joinerNum] != tJoiners[joinerNum]->getSmallSide()->size())
+    if (posByJoinerNum[joinerNum] != tJoiners[joinerNum]->getSmallSide().size())
       break;
   }
   if (i == PMJoinerCount)
@@ -1426,10 +1426,9 @@ bool BatchPrimitiveProcessorJL::pickNextJoinerNum()
 /* XXXPAT: Going to interleave across joiners to take advantage of the new locking env in PrimProc */
 bool BatchPrimitiveProcessorJL::nextTupleJoinerMsg(ByteStream& bs)
 {
-  uint32_t size = 0, toSend, i, j;
+  uint32_t toSend, i, j;
   ISMPacketHeader ism;
   Row r;
-  vector<Row::Pointer>* tSmallSide;
   joiner::TypelessData tlData;
   uint32_t smallKeyCol;
   uint32_t largeKeyCol;
@@ -1452,8 +1451,8 @@ bool BatchPrimitiveProcessorJL::nextTupleJoinerMsg(ByteStream& bs)
   }
 
   memset((void*)&ism, 0, sizeof(ism));
-  tSmallSide = tJoiners[joinerNum]->getSmallSide();
-  size = tSmallSide->size();
+  auto& tSmallSide = tJoiners[joinerNum]->getSmallSide();
+  auto size = tSmallSide.size();
 
 #if 0
     if (joinerNum == PMJoinerCount - 1 && pos == size)
@@ -1503,7 +1502,7 @@ bool BatchPrimitiveProcessorJL::nextTupleJoinerMsg(ByteStream& bs)
 
     for (i = pos; i < pos + toSend; i++)
     {
-      r.setPointer((*tSmallSide)[i]);
+      r.setPointer(tSmallSide[i]);
       isNull = false;
       bSignedUnsigned = tJoiners[joinerNum]->isSignedUnsignedJoin();
 
@@ -1570,7 +1569,7 @@ bool BatchPrimitiveProcessorJL::nextTupleJoinerMsg(ByteStream& bs)
 
     for (i = pos, j = 0; i < pos + toSend; ++i, ++j)
     {
-      r.setPointer((*tSmallSide)[i]);
+      r.setPointer(tSmallSide[i]);
 
       if (r.getColType(smallKeyCol) == CalpontSystemCatalog::LONGDOUBLE)
       {
@@ -1643,7 +1642,7 @@ bool BatchPrimitiveProcessorJL::nextTupleJoinerMsg(ByteStream& bs)
 
     for (i = pos; i < pos + toSend; i++, tmpRow.nextRow())
     {
-      r.setPointer((*tSmallSide)[i]);
+      r.setPointer(tSmallSide[i]);
       copyRow(r, &tmpRow);
     }
 

--- a/dbcon/joblist/batchprimitiveprocessor-jl.cpp
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.cpp
@@ -54,7 +54,7 @@ using namespace joiner;
 
 namespace joblist
 {
-BatchPrimitiveProcessorJL::BatchPrimitiveProcessorJL(const ResourceManager* rm)
+BatchPrimitiveProcessorJL::BatchPrimitiveProcessorJL(ResourceManager* rm)
  : ot(BPS_ELEMENT_TYPE)
  , needToSetLBID(true)
  , count(1)
@@ -81,6 +81,7 @@ BatchPrimitiveProcessorJL::BatchPrimitiveProcessorJL(const ResourceManager* rm)
  , fJoinerChunkSize(rm->getJlJoinerChunkSize())
  , hasSmallOuterJoin(false)
  , _priority(1)
+ , rm_(rm)
 {
   PMJoinerCount = 0;
   uuid = bu::nil_generator()();
@@ -1497,7 +1498,8 @@ bool BatchPrimitiveProcessorJL::nextTupleJoinerMsg(ByteStream& bs)
 
   if (tJoiners[joinerNum]->isTypelessJoin())
   {
-    utils::FixedAllocator fa(tlKeyLens[joinerNum], true);
+    auto alloc = rm_->getAllocator<utils::FixedAllocatorBufType>();
+    utils::FixedAllocator fa(alloc, tlKeyLens[joinerNum], true);
 
     for (i = pos; i < pos + toSend; i++)
     {

--- a/dbcon/joblist/batchprimitiveprocessor-jl.cpp
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.cpp
@@ -791,7 +791,7 @@ void BatchPrimitiveProcessorJL::getRowGroupData(ByteStream& in, vector<RGData>* 
   if (in.length() == 0)
   {
     // done, return an empty RG
-    rgData = RGData(org, 0);
+    rgData = RGData(org, 0U);
     org.setData(&rgData);
     org.resetRowGroup(0);
     out->push_back(rgData);
@@ -926,7 +926,7 @@ RGData BatchPrimitiveProcessorJL::getErrorRowGroupData(uint16_t error) const
   RGData ret;
   rowgroup::RowGroup rg(projectionRG);
 
-  ret = RGData(rg, 0);
+  ret = RGData(rg, 0U);
   rg.setData(&ret);
   // rg.convertToInlineDataInPlace();
   rg.resetRowGroup(0);

--- a/dbcon/joblist/batchprimitiveprocessor-jl.cpp
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.cpp
@@ -1497,6 +1497,7 @@ bool BatchPrimitiveProcessorJL::nextTupleJoinerMsg(ByteStream& bs)
 
   if (tJoiners[joinerNum]->isTypelessJoin())
   {
+    // TODO: change RM ptr to ref b/c its scope and lifetime lasts till the end of the program.
     auto alloc = rm_->getAllocator<utils::FixedAllocatorBufType>();
     utils::FixedAllocator fa(alloc, tlKeyLens[joinerNum], true);
 

--- a/dbcon/joblist/batchprimitiveprocessor-jl.h
+++ b/dbcon/joblist/batchprimitiveprocessor-jl.h
@@ -59,7 +59,7 @@ class BatchPrimitiveProcessorJL
 {
  public:
   /* Constructor used by the JobStep */
-  explicit BatchPrimitiveProcessorJL(const ResourceManager* rm);
+  explicit BatchPrimitiveProcessorJL(ResourceManager* rm);
   ~BatchPrimitiveProcessorJL();
 
   /* Interface used by the JobStep */
@@ -384,6 +384,8 @@ class BatchPrimitiveProcessorJL
   uint32_t _priority;
 
   boost::uuids::uuid uuid;
+
+  joblist::ResourceManager* rm_ = nullptr;
 
   friend class CommandJL;
   friend class ColumnCommandJL;

--- a/dbcon/joblist/diskjoinstep.cpp
+++ b/dbcon/joblist/diskjoinstep.cpp
@@ -481,10 +481,10 @@ void DiskJoinStep::joinFcn()
               // cout << "inserting a full RG" << endl;
               if (thjs)
               {
-                if (!thjs->getMemory(l_outputRG.getMaxDataSize()))
+                if (!thjs->getMemory(l_outputRG.getMaxDataSizeWithStrings()))
                 {
                   // calculate guess of size required for error message
-                  uint64_t memReqd = (unmatched.size() * outputRG.getDataSize(1)) / 1048576;
+                  uint64_t memReqd = (l_outputRG.getMaxDataSizeWithStrings()) / 1048576;
                   Message::Args args;
                   args.add(memReqd);
                   args.add(thjs->resourceManager->getConfiguredUMMemLimit() / 1048576);

--- a/dbcon/joblist/distributedenginecomm.cpp
+++ b/dbcon/joblist/distributedenginecomm.cpp
@@ -414,7 +414,7 @@ Error:
   // eventually let jobstep error out.
   std::unique_lock lk(fMlock);
   MessageQueueMap::iterator map_tok;
-  sbs.reset(new ByteStream(0));
+  sbs.reset(new ByteStream(0U));
 
   for (map_tok = fSessionMessages.begin(); map_tok != fSessionMessages.end(); ++map_tok)
   {
@@ -1097,7 +1097,7 @@ int DistributedEngineComm::writeToClient(size_t aPMIndex, const SBS& bs, uint32_
     std::unique_lock lk(fMlock);
     // std::cout << "WARNING: DEC WRITE BROKEN PIPE. PMS index = " << index << std::endl;
     MessageQueueMap::iterator map_tok;
-    sbs.reset(new ByteStream(0));
+    sbs.reset(new ByteStream(0U));
 
     for (map_tok = fSessionMessages.begin(); map_tok != fSessionMessages.end(); ++map_tok)
     {

--- a/dbcon/joblist/groupconcat.cpp
+++ b/dbcon/joblist/groupconcat.cpp
@@ -769,6 +769,7 @@ void GroupConcatOrderBy::processRow(const rowgroup::Row& row)
   if (concatColIsNull(row))
     return;
 
+  auto& orderByQueue = getQueue();
   // if the row count is less than the limit
   if (fCurrentLength < fGroupConcatLen)
   {
@@ -777,7 +778,7 @@ void GroupConcatOrderBy::processRow(const rowgroup::Row& row)
     int16_t estLen = lengthEstimate(fRow0);
     fRow0.setRid(estLen);
     OrderByRow newRow(fRow0, fRule);
-    fOrderByQueue.push(newRow);
+    orderByQueue.push(newRow);
     fCurrentLength += estLen;
 
     // add to the distinct map
@@ -807,11 +808,11 @@ void GroupConcatOrderBy::processRow(const rowgroup::Row& row)
     }
   }
 
-  else if (fOrderByCond.size() > 0 && fRule.less(row.getPointer(), fOrderByQueue.top().fData))
+  else if (fOrderByCond.size() > 0 && fRule.less(row.getPointer(), orderByQueue.top().fData))
   {
-    OrderByRow swapRow = fOrderByQueue.top();
+    OrderByRow swapRow = orderByQueue.top();
     fRow1.setData(swapRow.fData);
-    fOrderByQueue.pop();
+    orderByQueue.pop();
     fCurrentLength -= fRow1.getRelRid();
     fRow2.setData(swapRow.fData);
 
@@ -831,7 +832,7 @@ void GroupConcatOrderBy::processRow(const rowgroup::Row& row)
     fRow2.setRid(estLen);
     fCurrentLength += estLen;
 
-    fOrderByQueue.push(swapRow);
+    orderByQueue.push(swapRow);
   }
 }
 
@@ -839,9 +840,12 @@ void GroupConcatOrderBy::merge(GroupConcator* gc)
 {
   GroupConcatOrderBy* go = dynamic_cast<GroupConcatOrderBy*>(gc);
 
-  while (go->fOrderByQueue.empty() == false)
+  auto& orderByQueue = getQueue();
+  auto mergeQueue = go->getQueue();
+
+  while (mergeQueue.empty() == false)
   {
-    const OrderByRow& row = go->fOrderByQueue.top();
+    const OrderByRow& row = mergeQueue.top();
 
     // check if the distinct row already exists
     if (fDistinct && fDistinctMap->find(row.fData) != fDistinctMap->end())
@@ -852,7 +856,7 @@ void GroupConcatOrderBy::merge(GroupConcator* gc)
     // if the row count is less than the limit
     else if (fCurrentLength < fGroupConcatLen)
     {
-      fOrderByQueue.push(row);
+      orderByQueue.push(row);
       row1.setData(row.fData);
       fCurrentLength += row1.getRelRid();
 
@@ -861,11 +865,11 @@ void GroupConcatOrderBy::merge(GroupConcator* gc)
         fDistinctMap->insert(row.fData);
     }
 
-    else if (fOrderByCond.size() > 0 && fRule.less(row.fData, fOrderByQueue.top().fData))
+    else if (fOrderByCond.size() > 0 && fRule.less(row.fData, orderByQueue.top().fData))
     {
-      OrderByRow swapRow = fOrderByQueue.top();
+      OrderByRow swapRow = orderByQueue.top();
       row1.setData(swapRow.fData);
-      fOrderByQueue.pop();
+      orderByQueue.pop();
       fCurrentLength -= row1.getRelRid();
 
       if (fDistinct)
@@ -877,10 +881,10 @@ void GroupConcatOrderBy::merge(GroupConcator* gc)
       row1.setData(row.fData);
       fCurrentLength += row1.getRelRid();
 
-      fOrderByQueue.push(row);
+      orderByQueue.push(row);
     }
 
-    go->fOrderByQueue.pop();
+    mergeQueue.pop();
   }
 }
 
@@ -891,10 +895,12 @@ uint8_t* GroupConcatOrderBy::getResultImpl(const string& sep)
 
   // need to reverse the order
   stack<OrderByRow> rowStack;
-  while (fOrderByQueue.size() > 0)
+  auto& orderByQueue = getQueue();
+
+  while (orderByQueue.size() > 0)
   {
-    rowStack.push(fOrderByQueue.top());
-    fOrderByQueue.pop();
+    rowStack.push(orderByQueue.top());
+    orderByQueue.pop();
   }
 
   size_t prevResultSize = 0;

--- a/dbcon/joblist/groupconcat.cpp
+++ b/dbcon/joblist/groupconcat.cpp
@@ -841,7 +841,7 @@ void GroupConcatOrderBy::merge(GroupConcator* gc)
   GroupConcatOrderBy* go = dynamic_cast<GroupConcatOrderBy*>(gc);
 
   auto& orderByQueue = getQueue();
-  auto mergeQueue = go->getQueue();
+  auto& mergeQueue = go->getQueue();
 
   while (mergeQueue.empty() == false)
   {

--- a/dbcon/joblist/jobstep.cpp
+++ b/dbcon/joblist/jobstep.cpp
@@ -217,6 +217,12 @@ void JobStep::handleException(std::exception_ptr e, const int errorCode, const u
   {
     std::rethrow_exception(e);
   }
+  // Add it here for now to handle potential bad_alloc exceptions
+  catch (std::bad_alloc& exc)
+  {
+   std::cerr << methodName << " caught a bad_alloc exception. " << std::endl;
+    catchHandler(methodName + " caught " + exc.what(), errorCode, fErrorInfo, fSessionId);
+  }
   catch (const IDBExcept& iex)
   {
     std::cerr << methodName << " caught a internal exception. " << std::endl;

--- a/dbcon/joblist/jsonarrayagg.cpp
+++ b/dbcon/joblist/jsonarrayagg.cpp
@@ -767,6 +767,8 @@ void JsonArrayAggOrderBy::processRow(const rowgroup::Row& row)
   if (concatColIsNull(row))
     return;
 
+  auto& orderByQueue = getQueue();
+  
   // if the row count is less than the limit
   if (fCurrentLength < fGroupConcatLen)
   {
@@ -775,7 +777,7 @@ void JsonArrayAggOrderBy::processRow(const rowgroup::Row& row)
     int16_t estLen = lengthEstimate(fRow0);
     fRow0.setRid(estLen);
     OrderByRow newRow(fRow0, fRule);
-    fOrderByQueue.push(newRow);
+    orderByQueue.push(newRow);
     fCurrentLength += estLen;
 
     // add to the distinct map
@@ -805,11 +807,11 @@ void JsonArrayAggOrderBy::processRow(const rowgroup::Row& row)
     }
   }
 
-  else if (fOrderByCond.size() > 0 && fRule.less(row.getPointer(), fOrderByQueue.top().fData))
+  else if (fOrderByCond.size() > 0 && fRule.less(row.getPointer(), orderByQueue.top().fData))
   {
-    OrderByRow swapRow = fOrderByQueue.top();
+    OrderByRow swapRow = orderByQueue.top();
     fRow1.setData(swapRow.fData);
-    fOrderByQueue.pop();
+    orderByQueue.pop();
     fCurrentLength -= fRow1.getRelRid();
     fRow2.setData(swapRow.fData);
 
@@ -829,7 +831,7 @@ void JsonArrayAggOrderBy::processRow(const rowgroup::Row& row)
     fRow2.setRid(estLen);
     fCurrentLength += estLen;
 
-    fOrderByQueue.push(swapRow);
+    orderByQueue.push(swapRow);
   }
 }
 
@@ -837,9 +839,12 @@ void JsonArrayAggOrderBy::merge(GroupConcator* gc)
 {
   JsonArrayAggOrderBy* go = dynamic_cast<JsonArrayAggOrderBy*>(gc);
 
-  while (go->fOrderByQueue.empty() == false)
+  auto& orderByQueue = getQueue();
+  auto mergeQueue = go->getQueue();
+
+  while (mergeQueue.empty() == false)
   {
-    const OrderByRow& row = go->fOrderByQueue.top();
+    const OrderByRow& row = mergeQueue.top();
 
     // check if the distinct row already exists
     if (fDistinct && fDistinctMap->find(row.fData) != fDistinctMap->end())
@@ -850,7 +855,7 @@ void JsonArrayAggOrderBy::merge(GroupConcator* gc)
     // if the row count is less than the limit
     else if (fCurrentLength < fGroupConcatLen)
     {
-      fOrderByQueue.push(row);
+      orderByQueue.push(row);
       row1.setData(row.fData);
       fCurrentLength += row1.getRelRid();
 
@@ -859,11 +864,11 @@ void JsonArrayAggOrderBy::merge(GroupConcator* gc)
         fDistinctMap->insert(row.fData);
     }
 
-    else if (fOrderByCond.size() > 0 && fRule.less(row.fData, fOrderByQueue.top().fData))
+    else if (fOrderByCond.size() > 0 && fRule.less(row.fData, orderByQueue.top().fData))
     {
-      OrderByRow swapRow = fOrderByQueue.top();
+      OrderByRow swapRow = orderByQueue.top();
       row1.setData(swapRow.fData);
-      fOrderByQueue.pop();
+      orderByQueue.pop();
       fCurrentLength -= row1.getRelRid();
 
       if (fDistinct)
@@ -875,10 +880,10 @@ void JsonArrayAggOrderBy::merge(GroupConcator* gc)
       row1.setData(row.fData);
       fCurrentLength += row1.getRelRid();
 
-      fOrderByQueue.push(row);
+      orderByQueue.push(row);
     }
 
-    go->fOrderByQueue.pop();
+    mergeQueue.pop();
   }
 }
 
@@ -889,11 +894,12 @@ uint8_t* JsonArrayAggOrderBy::getResultImpl(const string&)
 
   // need to reverse the order
   stack<OrderByRow> rowStack;
+  auto& orderByQueue = getQueue();
 
-  while (fOrderByQueue.size() > 0)
+  while (orderByQueue.size() > 0)
   {
-    rowStack.push(fOrderByQueue.top());
-    fOrderByQueue.pop();
+    rowStack.push(orderByQueue.top());
+    orderByQueue.pop();
   }
   if (rowStack.size() > 0)
   {

--- a/dbcon/joblist/jsonarrayagg.cpp
+++ b/dbcon/joblist/jsonarrayagg.cpp
@@ -840,7 +840,7 @@ void JsonArrayAggOrderBy::merge(GroupConcator* gc)
   JsonArrayAggOrderBy* go = dynamic_cast<JsonArrayAggOrderBy*>(gc);
 
   auto& orderByQueue = getQueue();
-  auto mergeQueue = go->getQueue();
+  auto& mergeQueue = go->getQueue();
 
   while (mergeQueue.empty() == false)
   {

--- a/dbcon/joblist/limitedorderby.cpp
+++ b/dbcon/joblist/limitedorderby.cpp
@@ -54,7 +54,7 @@ void LimitedOrderBy::initialize(const RowGroup& rg, const JobInfo& jobInfo, bool
 {
   fRm = jobInfo.rm;
   fSessionMemLimit = jobInfo.umMemLimit;
-  fErrorCode = ERR_LIMIT_TOO_BIG;
+  fErrorCode = ERR_ORDERBY_TOO_BIG;
 
   // locate column position in the rowgroup
   map<uint32_t, uint32_t> keyToIndexMap;

--- a/dbcon/joblist/resourcemanager.cpp
+++ b/dbcon/joblist/resourcemanager.cpp
@@ -347,23 +347,23 @@ bool ResourceManager::userPriorityEnabled() const
 // If both have space, return true.
 bool ResourceManager::getMemory(int64_t amount, boost::shared_ptr<int64_t>& sessionLimit, bool patience)
 {
-  bool ret1 = (totalUmMemLimit.fetch_sub(amount, std::memory_order_relaxed) >= 0);
+  bool ret1 = (atomicops::atomicSubRef(totalUmMemLimit, amount) >= 0);
   bool ret2 = sessionLimit ? (atomicops::atomicSub(sessionLimit.get(), amount) >= 0) : ret1;
 
   uint32_t retryCounter = 0, maxRetries = 20;  // 10s delay
 
   while (patience && !(ret1 && ret2) && retryCounter++ < maxRetries)
   {
-    totalUmMemLimit.fetch_add(amount, std::memory_order_relaxed);
+    atomicops::atomicAddRef(totalUmMemLimit, amount);
     sessionLimit ? atomicops::atomicAdd(sessionLimit.get(), amount) : 0;
     usleep(500000);
-    ret1 = (totalUmMemLimit.fetch_sub(amount, std::memory_order_relaxed) >= 0);
+    ret1 = (atomicops::atomicSubRef(totalUmMemLimit, amount) >= 0);
     ret2 = sessionLimit ? (atomicops::atomicSub(sessionLimit.get(), amount) >= 0) : ret1;
   }
   if (!(ret1 && ret2))
   {
     // If  we  didn't  get any memory, restore the counters.
-    totalUmMemLimit.fetch_add(amount, std::memory_order_relaxed);
+    atomicops::atomicAddRef(totalUmMemLimit, amount);
     sessionLimit ? atomicops::atomicAdd(sessionLimit.get(), amount) : 0;
   }
   return (ret1 && ret2);
@@ -371,20 +371,20 @@ bool ResourceManager::getMemory(int64_t amount, boost::shared_ptr<int64_t>& sess
 // Don't care about session memory
 bool ResourceManager::getMemory(int64_t amount, bool patience)
 {
-  bool ret1 = (totalUmMemLimit.fetch_sub(amount, std::memory_order_relaxed) >= 0);
+  bool ret1 = (atomicops::atomicSubRef(totalUmMemLimit, amount) >= 0);
 
   uint32_t retryCounter = 0, maxRetries = 20;  // 10s delay
 
   while (patience && !ret1 && retryCounter++ < maxRetries)
   {
-    totalUmMemLimit.fetch_add(amount, std::memory_order_relaxed);
+    atomicops::atomicAddRef(totalUmMemLimit, amount);
     usleep(500000);
-    ret1 = (totalUmMemLimit.fetch_sub(amount, std::memory_order_relaxed) >= 0);
+    ret1 = (atomicops::atomicSubRef(totalUmMemLimit, amount) >= 0);
   }
   if (!ret1)
   {
     // If  we  didn't  get any memory, restore the counters.
-    totalUmMemLimit.fetch_add(amount, std::memory_order_relaxed);
+    atomicops::atomicAddRef(totalUmMemLimit, amount);
   }
   return ret1;
 }

--- a/dbcon/joblist/resourcemanager.cpp
+++ b/dbcon/joblist/resourcemanager.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************************/
 
 #include <unistd.h>
+#include <atomic>
 #include <string>
 #include <stdexcept>
 #include <iostream>
@@ -346,23 +347,23 @@ bool ResourceManager::userPriorityEnabled() const
 // If both have space, return true.
 bool ResourceManager::getMemory(int64_t amount, boost::shared_ptr<int64_t>& sessionLimit, bool patience)
 {
-  bool ret1 = (atomicops::atomicSub(&totalUmMemLimit, amount) >= 0);
+  bool ret1 = (totalUmMemLimit.fetch_sub(amount, std::memory_order_relaxed) >= 0);
   bool ret2 = sessionLimit ? (atomicops::atomicSub(sessionLimit.get(), amount) >= 0) : ret1;
 
   uint32_t retryCounter = 0, maxRetries = 20;  // 10s delay
 
   while (patience && !(ret1 && ret2) && retryCounter++ < maxRetries)
   {
-    atomicops::atomicAdd(&totalUmMemLimit, amount);
+    totalUmMemLimit.fetch_add(amount, std::memory_order_relaxed);
     sessionLimit ? atomicops::atomicAdd(sessionLimit.get(), amount) : 0;
     usleep(500000);
-    ret1 = (atomicops::atomicSub(&totalUmMemLimit, amount) >= 0);
+    ret1 = (totalUmMemLimit.fetch_sub(amount, std::memory_order_relaxed) >= 0);
     ret2 = sessionLimit ? (atomicops::atomicSub(sessionLimit.get(), amount) >= 0) : ret1;
   }
   if (!(ret1 && ret2))
   {
     // If  we  didn't  get any memory, restore the counters.
-    atomicops::atomicAdd(&totalUmMemLimit, amount);
+    totalUmMemLimit.fetch_add(amount, std::memory_order_relaxed);
     sessionLimit ? atomicops::atomicAdd(sessionLimit.get(), amount) : 0;
   }
   return (ret1 && ret2);
@@ -370,20 +371,20 @@ bool ResourceManager::getMemory(int64_t amount, boost::shared_ptr<int64_t>& sess
 // Don't care about session memory
 bool ResourceManager::getMemory(int64_t amount, bool patience)
 {
-  bool ret1 = (atomicops::atomicSub(&totalUmMemLimit, amount) >= 0);
+  bool ret1 = (totalUmMemLimit.fetch_sub(amount, std::memory_order_relaxed) >= 0);
 
   uint32_t retryCounter = 0, maxRetries = 20;  // 10s delay
 
   while (patience && !ret1 && retryCounter++ < maxRetries)
   {
-    atomicops::atomicAdd(&totalUmMemLimit, amount);
+    totalUmMemLimit.fetch_add(amount, std::memory_order_relaxed);
     usleep(500000);
-    ret1 = (atomicops::atomicSub(&totalUmMemLimit, amount) >= 0);
+    ret1 = (totalUmMemLimit.fetch_sub(amount, std::memory_order_relaxed) >= 0);
   }
   if (!ret1)
   {
     // If  we  didn't  get any memory, restore the counters.
-    atomicops::atomicAdd(&totalUmMemLimit, amount);
+    totalUmMemLimit.fetch_add(amount, std::memory_order_relaxed);
   }
   return ret1;
 }

--- a/dbcon/joblist/resourcemanager.h
+++ b/dbcon/joblist/resourcemanager.h
@@ -329,11 +329,11 @@ class ResourceManager
   bool getMemory(int64_t amount, bool patience = true);
   inline void returnMemory(int64_t amount)
   {
-    totalUmMemLimit.fetch_add(amount, std::memory_order_relaxed);
+    atomicops::atomicAddRef(totalUmMemLimit, amount);
   }
   inline void returnMemory(int64_t amount, boost::shared_ptr<int64_t>& sessionLimit)
   {
-    totalUmMemLimit.fetch_add(amount, std::memory_order_relaxed);
+    atomicops::atomicAddRef(totalUmMemLimit, amount);
     sessionLimit ? atomicops::atomicAdd(sessionLimit.get(), amount) : 0;
   }
   inline int64_t availableMemory() const

--- a/dbcon/joblist/resourcemanager.h
+++ b/dbcon/joblist/resourcemanager.h
@@ -461,7 +461,7 @@ class ResourceManager
   template<typename T>
   allocators::CountingAllocator<T> getAllocator()
   {
-    return allocators::CountingAllocator<T>(totalUmMemLimit);
+    return allocators::CountingAllocator<T>(&totalUmMemLimit);
   }
 
  private:

--- a/dbcon/joblist/resourcemanager.h
+++ b/dbcon/joblist/resourcemanager.h
@@ -458,10 +458,12 @@ class ResourceManager
     return configuredUmMemLimit;
   }
 
-  template<typename T>
-  allocators::CountingAllocator<T> getAllocator()
+  template <typename T>
+  allocators::CountingAllocator<T> getAllocator(
+      const int64_t checkPointStepSize = allocators::CheckPointStepSize,
+      const int64_t memoryLimitLowerBound = allocators::MemoryLimitLowerBound)
   {
-    return allocators::CountingAllocator<T>(&totalUmMemLimit);
+    return allocators::CountingAllocator<T>(&totalUmMemLimit, checkPointStepSize, memoryLimitLowerBound);
   }
 
  private:

--- a/dbcon/joblist/subquerystep.cpp
+++ b/dbcon/joblist/subquerystep.cpp
@@ -239,7 +239,7 @@ uint32_t SubAdapterStep::nextBand(messageqcpp::ByteStream& bs)
   if (fEndOfResult)
   {
     // send an empty / error band
-    RGData rgData(fRowGroupDeliver, 0);
+    RGData rgData(fRowGroupDeliver, 0U);
     fRowGroupDeliver.setData(&rgData);
     fRowGroupDeliver.resetRowGroup(0);
     fRowGroupDeliver.setStatus(status());

--- a/dbcon/joblist/tuple-bps.cpp
+++ b/dbcon/joblist/tuple-bps.cpp
@@ -273,9 +273,10 @@ uint64_t TupleBPS::JoinLocalData::generateJoinResultSet(const uint32_t depth,
         uint64_t baseRid = local_outputRG.getBaseRid();
         outputData.push_back(joinedData);
         // Don't let the join results buffer get out of control.
-        if (tbps->resourceManager()->getMemory(local_outputRG.getMaxDataSize(), false))
+        auto outputDataSize = local_outputRG.getMaxDataSizeWithStrings();
+        if (tbps->resourceManager()->getMemory(outputDataSize, false))
         {
-          memSizeForOutputRG += local_outputRG.getMaxDataSize();
+          memSizeForOutputRG += outputDataSize;
         }
         else
         {

--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -611,7 +611,7 @@ uint32_t TupleAggregateStep::nextBand_singleThread(messageqcpp::ByteStream& bs)
     postStepSummaryTele(sts);
 
     // send an empty / error band
-    RGData rgData(fRowGroupOut, 0);
+    RGData rgData(fRowGroupOut, 0U);
     fRowGroupOut.setData(&rgData);
     fRowGroupOut.resetRowGroup(0);
     fRowGroupOut.setStatus(status());
@@ -5857,7 +5857,7 @@ uint64_t TupleAggregateStep::doThreadedAggregate(ByteStream& bs, RowGroupDL* dlp
     else
     {
       // send an empty / error band
-      RGData rgData(fRowGroupOut, 0);
+      RGData rgData(fRowGroupOut, 0U);
       fRowGroupOut.setData(&rgData);
       fRowGroupOut.resetRowGroup(0);
       fRowGroupOut.setStatus(status());

--- a/dbcon/joblist/tupleannexstep.cpp
+++ b/dbcon/joblist/tupleannexstep.cpp
@@ -22,7 +22,7 @@
 #include <cassert>
 #include <sstream>
 #include <iomanip>
-#include <tr1/unordered_set>
+#include <unordered_set>
 using namespace std;
 
 #include <boost/shared_ptr.hpp>
@@ -83,8 +83,7 @@ struct TAEq
   bool operator()(const rowgroup::Row::Pointer&, const rowgroup::Row::Pointer&) const;
 };
 // TODO:  Generalize these and put them back in utils/common/hasher.h
-typedef tr1::unordered_set<rowgroup::Row::Pointer, TAHasher, TAEq, STLPoolAllocator<rowgroup::Row::Pointer> >
-    DistinctMap_t;
+using TNSDistinctMap_t = std::unordered_set<rowgroup::Row::Pointer, TAHasher, TAEq, allocators::CountingAllocator<rowgroup::Row::Pointer> >;
 };  // namespace
 
 inline uint64_t TAHasher::operator()(const Row::Pointer& p) const
@@ -466,7 +465,6 @@ void TupleAnnexStep::executeNoOrderBy()
 void TupleAnnexStep::executeNoOrderByWithDistinct()
 {
   utils::setThreadName("TNSwoOrdDist");
-  scoped_ptr<DistinctMap_t> distinctMap(new DistinctMap_t(10, TAHasher(this), TAEq(this)));
   vector<RGData> dataVec;
   vector<RGData> dataVecSkip;
   RGData rgDataIn;
@@ -475,6 +473,9 @@ void TupleAnnexStep::executeNoOrderByWithDistinct()
   RowGroup rowGroupSkip;
   Row rowSkip;
   bool more = false;
+
+  auto alloc = fRm->getAllocator<rowgroup::Row::Pointer>();
+  std::unique_ptr<TNSDistinctMap_t> distinctMap(new TNSDistinctMap_t(10, TAHasher(this), TAEq(this), alloc));
 
   rgDataOut.reinit(fRowGroupOut);
   fRowGroupOut.setData(&rgDataOut);
@@ -512,7 +513,7 @@ void TupleAnnexStep::executeNoOrderByWithDistinct()
 
       for (uint64_t i = 0; i < fRowGroupIn.getRowCount() && !cancelled() && !fLimitHit; ++i)
       {
-        pair<DistinctMap_t::iterator, bool> inserted;
+        pair<TNSDistinctMap_t::iterator, bool> inserted;
         Row* rowPtr;
 
         if (distinctMap->size() < fLimitStart)
@@ -548,6 +549,8 @@ void TupleAnnexStep::executeNoOrderByWithDistinct()
               // allocate new RGData for skipped rows below the fLimitStart
               // offset (do not take it into account in RM assuming there
               // are few skipped rows
+              checkAndAllocateMemory4RGData(rowGroupSkip);
+
               dataVecSkip.push_back(rgDataSkip);
               rgDataSkip.reinit(rowGroupSkip);
               rowGroupSkip.setData(&rgDataSkip);
@@ -564,6 +567,7 @@ void TupleAnnexStep::executeNoOrderByWithDistinct()
 
           if (UNLIKELY(fRowGroupOut.getRowCount() >= rowgroup::rgCommonSize))
           {
+            checkAndAllocateMemory4RGData(fRowGroupOut);
             dataVec.push_back(rgDataOut);
             rgDataOut.reinit(fRowGroupOut);
             fRowGroupOut.setData(&rgDataOut);
@@ -576,6 +580,9 @@ void TupleAnnexStep::executeNoOrderByWithDistinct()
       more = fInputDL->next(fInputIterator, &rgDataIn);
     }
 
+    // to reduce memory consumption
+    dataVecSkip.clear();
+
     if (fRowGroupOut.getRowCount() > 0)
       dataVec.push_back(rgDataOut);
 
@@ -584,6 +591,14 @@ void TupleAnnexStep::executeNoOrderByWithDistinct()
       rgDataOut = *i;
       fRowGroupOut.setData(&rgDataOut);
       fOutputDL->insert(rgDataOut);
+    }
+    while (!dataVec.empty())
+    {
+      auto& rgData = dataVec.back();
+      fRowGroupOut.setData(&rgData);
+      fRm->returnMemory(fRowGroupOut.getSizeWithStrings() - fRowGroupOut.getHeaderSize());
+      fOutputDL->insert(rgData);
+      dataVec.pop_back();
     }
   }
   catch (...)
@@ -597,6 +612,16 @@ void TupleAnnexStep::executeNoOrderByWithDistinct()
 
   // Bug 3136, let mini stats to be formatted if traceOn.
   fOutputDL->endOfInput();
+}
+
+void TupleAnnexStep::checkAndAllocateMemory4RGData(const rowgroup::RowGroup& rowGroup)
+{
+    uint64_t size = rowGroup.getSizeWithStrings() - rowGroup.getHeaderSize();
+    if (!fRm->getMemory(size, false))
+    {
+        cerr << IDBErrorInfo::instance()->errorMsg(ERR_TNS_DISTINCT_IS_TOO_BIG) << " @" << __FILE__ << ":" << __LINE__;
+        throw IDBExcept(ERR_TNS_DISTINCT_IS_TOO_BIG);
+    }
 }
 
 void TupleAnnexStep::executeWithOrderBy()
@@ -673,6 +698,10 @@ void TupleAnnexStep::executeWithOrderBy()
         {
           fRowsReturned += fRowGroupOut.getRowCount();
           fOutputDL->insert(rgDataOut);
+
+          // release RGData memory
+          size_t rgDataSize = fRowGroupOut.getSizeWithStrings() - fRowGroupOut.getHeaderSize();
+          fOrderBy->returnRGDataMemory2RM(rgDataSize);
         }
       }
     }
@@ -716,9 +745,10 @@ void TupleAnnexStep::finalizeParallelOrderByDistinct()
   // Calculate offset here
   fRowGroupOut.getRow(0, &fRowOut);
 
-  auto alloc = fRm->getAllocator<ordering::OrderByRow>();
-  ordering::SortingPQ finalPQ(rowgroup::rgCommonSize, alloc);
-  scoped_ptr<DistinctMap_t> distinctMap(new DistinctMap_t(10, TAHasher(this), TAEq(this)));
+  auto allocSorting = fRm->getAllocator<ordering::OrderByRow>();
+  ordering::SortingPQ finalPQ(rowgroup::rgCommonSize, allocSorting);
+  auto allocDistinct = fRm->getAllocator<rowgroup::Row::Pointer>();
+  std::unique_ptr<TNSDistinctMap_t> distinctMap(new TNSDistinctMap_t(10, TAHasher(this), TAEq(this), allocDistinct));
   fRowGroupIn.initRow(&row1);
   fRowGroupIn.initRow(&row2);
 
@@ -735,7 +765,7 @@ void TupleAnnexStep::finalizeParallelOrderByDistinct()
       fOrderByList[id]->getRule().revertRules();
       ordering::SortingPQ& currentPQ = fOrderByList[id]->getQueue();
       finalPQ.reserve(finalPQ.size() + currentPQ.size());
-      pair<DistinctMap_t::iterator, bool> inserted;
+      pair<TNSDistinctMap_t::iterator, bool> inserted;
       while (currentPQ.size())
       {
         ordering::OrderByRow& topOBRow = const_cast<ordering::OrderByRow&>(currentPQ.top());
@@ -872,14 +902,6 @@ void TupleAnnexStep::finalizeParallelOrderByDistinct()
 
   fOutputDL->endOfInput();
 
-  StepTeleStats sts;
-  sts.query_uuid = fQueryUuid;
-  sts.step_uuid = fStepUuid;
-  sts.msg_type = StepTeleStats::ST_SUMMARY;
-  sts.total_units_of_work = sts.units_of_work_completed = 1;
-  sts.rows = fRowsReturned;
-  postStepSummaryTele(sts);
-
   if (traceOn())
   {
     if (dlTimes.FirstReadTime().tv_sec == 0)
@@ -889,6 +911,20 @@ void TupleAnnexStep::finalizeParallelOrderByDistinct()
     dlTimes.setEndOfInputTime();
     printCalTrace();
   }
+
+  // Release memory before ctor
+  for (uint64_t id = 1; id <= fMaxThreads; id++)
+  {
+    fOrderByList[id]->returnAllRGDataMemory2RM();
+  }
+
+  StepTeleStats sts;
+  sts.query_uuid = fQueryUuid;
+  sts.step_uuid = fStepUuid;
+  sts.msg_type = StepTeleStats::ST_SUMMARY;
+  sts.total_units_of_work = sts.units_of_work_completed = 1;
+  sts.rows = fRowsReturned;
+  postStepSummaryTele(sts);
 }
 
 /*
@@ -1060,14 +1096,6 @@ void TupleAnnexStep::finalizeParallelOrderBy()
 
   fOutputDL->endOfInput();
 
-  StepTeleStats sts;
-  sts.query_uuid = fQueryUuid;
-  sts.step_uuid = fStepUuid;
-  sts.msg_type = StepTeleStats::ST_SUMMARY;
-  sts.total_units_of_work = sts.units_of_work_completed = 1;
-  sts.rows = fRowsReturned;
-  postStepSummaryTele(sts);
-
   if (traceOn())
   {
     if (dlTimes.FirstReadTime().tv_sec == 0)
@@ -1077,6 +1105,20 @@ void TupleAnnexStep::finalizeParallelOrderBy()
     dlTimes.setEndOfInputTime();
     printCalTrace();
   }
+
+  // Release memory before ctor
+  for (uint64_t id = 1; id <= fMaxThreads; id++)
+  {
+    fOrderByList[id]->returnAllRGDataMemory2RM();
+  }
+
+  StepTeleStats sts;
+  sts.query_uuid = fQueryUuid;
+  sts.step_uuid = fStepUuid;
+  sts.msg_type = StepTeleStats::ST_SUMMARY;
+  sts.total_units_of_work = sts.units_of_work_completed = 1;
+  sts.rows = fRowsReturned;
+  postStepSummaryTele(sts);
 }
 
 void TupleAnnexStep::executeParallelOrderBy(uint64_t id)

--- a/dbcon/joblist/tupleannexstep.cpp
+++ b/dbcon/joblist/tupleannexstep.cpp
@@ -165,6 +165,8 @@ void TupleAnnexStep::setOutputRowGroup(const rowgroup::RowGroup& rg)
 
 void TupleAnnexStep::initialize(const RowGroup& rgIn, const JobInfo& jobInfo)
 {
+  // Initialize ResourceManager to acount memory usage. 
+  fRm = jobInfo.rm;
   // Initialize structures used by separate workers
   uint64_t id = 1;
   fRowGroupIn = rgIn;
@@ -713,7 +715,9 @@ void TupleAnnexStep::finalizeParallelOrderByDistinct()
   fRowGroupOut.resetRowGroup(0);
   // Calculate offset here
   fRowGroupOut.getRow(0, &fRowOut);
-  ordering::SortingPQ finalPQ;
+
+  auto alloc = fRm->getAllocator<ordering::OrderByRow>();
+  ordering::SortingPQ finalPQ(rowgroup::rgCommonSize, alloc);
   scoped_ptr<DistinctMap_t> distinctMap(new DistinctMap_t(10, TAHasher(this), TAEq(this)));
   fRowGroupIn.initRow(&row1);
   fRowGroupIn.initRow(&row2);
@@ -907,7 +911,8 @@ void TupleAnnexStep::finalizeParallelOrderBy()
   uint32_t rowSize = 0;
 
   rowgroup::RGData rgDataOut;
-  ordering::SortingPQ finalPQ;
+  auto alloc = fRm->getAllocator<ordering::OrderByRow>();
+  ordering::SortingPQ finalPQ(rowgroup::rgCommonSize, alloc);
   rgDataOut.reinit(fRowGroupOut, rowgroup::rgCommonSize);
   fRowGroupOut.setData(&rgDataOut);
   fRowGroupOut.resetRowGroup(0);

--- a/dbcon/joblist/tupleannexstep.cpp
+++ b/dbcon/joblist/tupleannexstep.cpp
@@ -399,69 +399,53 @@ void TupleAnnexStep::executeNoOrderBy()
     sts.total_units_of_work = 1;
     postStepStartTele(sts);
 
-    if (!fConstant && fLimitCount == std::numeric_limits<uint64_t>::max())
+    while (more && !cancelled() && !fLimitHit)
     {
-      while (more && !cancelled())
+      fRowGroupIn.setData(&rgDataIn);
+      fRowGroupIn.getRow(0, &fRowIn);
+      // Get a new output rowgroup for each input rowgroup to preserve the rids
+      rgDataOut.reinit(fRowGroupOut, fRowGroupIn.getRowCount());
+      fRowGroupOut.setData(&rgDataOut);
+      fRowGroupOut.resetRowGroup(fRowGroupIn.getBaseRid());
+      fRowGroupOut.setDBRoot(fRowGroupIn.getDBRoot());
+      fRowGroupOut.getRow(0, &fRowOut);
+
+      for (uint64_t i = 0; i < fRowGroupIn.getRowCount() && !cancelled() && !fLimitHit; ++i)
       {
-        fRowGroupIn.setData(&rgDataIn);
-        if (fRowGroupIn.getRowCount() > 0)
+        // skip first limit-start rows
+        if (fRowsProcessed++ < fLimitStart)
         {
-          fOutputDL->insert(rgDataIn);
+          fRowIn.nextRow();
+          continue;
         }
 
-        more = fInputDL->next(fInputIterator, &rgDataIn);
+        if (UNLIKELY(fRowsReturned >= fLimitCount))
+        {
+          fLimitHit = true;
+          fJobList->abortOnLimit((JobStep*)this);
+          continue;
+        }
+
+        if (fConstant)
+          fConstant->fillInConstants(fRowIn, fRowOut);
+        else
+          copyRow(fRowIn, &fRowOut);
+
+        fRowGroupOut.incRowCount();
+
+        if (++fRowsReturned < fLimitCount)
+        {
+          fRowOut.nextRow();
+          fRowIn.nextRow();
+        }
       }
-    }
-    else
-    {
-      while (more && !cancelled() && !fLimitHit)
+
+      if (fRowGroupOut.getRowCount() > 0)
       {
-        fRowGroupIn.setData(&rgDataIn);
-        fRowGroupIn.getRow(0, &fRowIn);
-        // Get a new output rowgroup for each input rowgroup to preserve the rids
-        rgDataOut.reinit(fRowGroupOut, fRowGroupIn.getRowCount());
-        fRowGroupOut.setData(&rgDataOut);
-        fRowGroupOut.resetRowGroup(fRowGroupIn.getBaseRid());
-        fRowGroupOut.setDBRoot(fRowGroupIn.getDBRoot());
-        fRowGroupOut.getRow(0, &fRowOut);
-
-        for (uint64_t i = 0; i < fRowGroupIn.getRowCount() && !cancelled() && !fLimitHit; ++i)
-        {
-          // skip first limit-start rows
-          if (fRowsProcessed++ < fLimitStart)
-          {
-            fRowIn.nextRow();
-            continue;
-          }
-
-          if (UNLIKELY(fRowsReturned >= fLimitCount))
-          {
-            fLimitHit = true;
-            fJobList->abortOnLimit((JobStep*)this);
-            continue;
-          }
-
-          if (fConstant)
-            fConstant->fillInConstants(fRowIn, fRowOut);
-          else
-            copyRow(fRowIn, &fRowOut);
-
-          fRowGroupOut.incRowCount();
-
-          if (++fRowsReturned < fLimitCount)
-          {
-            fRowOut.nextRow();
-            fRowIn.nextRow();
-          }
-        }
-
-        if (fRowGroupOut.getRowCount() > 0)
-        {
-          fOutputDL->insert(rgDataOut);
-        }
-
-        more = fInputDL->next(fInputIterator, &rgDataIn);
+        fOutputDL->insert(rgDataOut);
       }
+
+      more = fInputDL->next(fInputIterator, &rgDataIn);
     }
   }
   catch (...)

--- a/dbcon/joblist/tupleannexstep.cpp
+++ b/dbcon/joblist/tupleannexstep.cpp
@@ -586,12 +586,6 @@ void TupleAnnexStep::executeNoOrderByWithDistinct()
     if (fRowGroupOut.getRowCount() > 0)
       dataVec.push_back(rgDataOut);
 
-    for (vector<RGData>::iterator i = dataVec.begin(); i != dataVec.end(); i++)
-    {
-      rgDataOut = *i;
-      fRowGroupOut.setData(&rgDataOut);
-      fOutputDL->insert(rgDataOut);
-    }
     while (!dataVec.empty())
     {
       auto& rgData = dataVec.back();

--- a/dbcon/joblist/tupleannexstep.h
+++ b/dbcon/joblist/tupleannexstep.h
@@ -109,6 +109,7 @@ class TupleAnnexStep : public JobStep, public TupleDeliveryStep
   void executeWithOrderBy();
   void executeParallelOrderBy(uint64_t id);
   void executeNoOrderByWithDistinct();
+  void checkAndAllocateMemory4RGData(const rowgroup::RowGroup& rowGroup);
   void formatMiniStats();
   void printCalTrace();
   void finalizeParallelOrderBy();

--- a/dbcon/joblist/tupleannexstep.h
+++ b/dbcon/joblist/tupleannexstep.h
@@ -171,25 +171,7 @@ class TupleAnnexStep : public JobStep, public TupleDeliveryStep
   std::vector<uint64_t> fRunnersList;
   uint16_t fFinishedThreads;
   boost::mutex fParallelFinalizeMutex;
-};
-
-template <class T>
-class reservablePQ : private std::priority_queue<T>
-{
- public:
-  typedef typename std::priority_queue<T>::size_type size_type;
-  reservablePQ(size_type capacity = 0)
-  {
-    reserve(capacity);
-  };
-  void reserve(size_type capacity)
-  {
-    this->c.reserve(capacity);
-  }
-  size_type capacity() const
-  {
-    return this->c.capacity();
-  }
+  joblist::ResourceManager* fRm;
 };
 
 }  // namespace joblist

--- a/dbcon/joblist/tupleconstantstep.cpp
+++ b/dbcon/joblist/tupleconstantstep.cpp
@@ -362,7 +362,7 @@ uint32_t TupleConstantStep::nextBand(messageqcpp::ByteStream& bs)
   if (fEndOfResult)
   {
     // send an empty / error band
-    RGData rgData(fRowGroupOut, 0);
+    RGData rgData(fRowGroupOut, 0U);
     fRowGroupOut.setData(&rgData);
     fRowGroupOut.resetRowGroup(0);
     fRowGroupOut.setStatus(status());
@@ -720,7 +720,7 @@ uint32_t TupleConstantOnlyStep::nextBand(messageqcpp::ByteStream& bs)
   else
   {
     // send an empty / error band
-    RGData rgData(fRowGroupOut, 0);
+    RGData rgData(fRowGroupOut, 0U);
     fRowGroupOut.setData(&rgData);
     fRowGroupOut.resetRowGroup(0);
     fRowGroupOut.setStatus(status());
@@ -809,7 +809,7 @@ void TupleConstantBooleanStep::run()
 uint32_t TupleConstantBooleanStep::nextBand(messageqcpp::ByteStream& bs)
 {
   // send an empty band
-  RGData rgData(fRowGroupOut, 0);
+  RGData rgData(fRowGroupOut, 0U);
   fRowGroupOut.setData(&rgData);
   fRowGroupOut.resetRowGroup(0);
   fRowGroupOut.setStatus(status());

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -1684,8 +1684,8 @@ void TupleHashJoinStep::joinOneRG(
   if (!smallNullMem)
     smallNullMem = &smallNullMemory;
 
-  auto alloc = resourceManager->getAllocator<RGDataBufType>(10 * 1024 * 1024);
-  RGData joinedData(alloc);
+  // auto alloc = resourceManager->getAllocator<RGDataBufType>(10 * 1024 * 1024);
+  RGData joinedData;
   uint32_t matchCount, smallSideCount = tjoiners->size();
   uint32_t j, k;
 

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -205,60 +205,6 @@ void TupleHashJoinStep::join()
   }
 }
 
-// simple sol'n.  Poll mem usage of Joiner once per second.  Request mem
-// increase after the fact.  Failure to get mem will be detected and handled by
-// the threads inserting into Joiner.
-void TupleHashJoinStep::trackMem(uint index)
-{
-  auto joiner = joiners[index];
-  ssize_t memBefore = 0, memAfter = 0;
-  bool gotMem;
-
-  boost::unique_lock<boost::mutex> scoped(memTrackMutex);
-  while (!stopMemTracking)
-  {
-    memAfter = joiner->getMemUsage();
-    if (memAfter != memBefore)
-    {
-      gotMem = resourceManager->getMemory(memAfter - memBefore, sessionMemLimit, true);
-      if (gotMem)
-        atomicops::atomicAdd(&memUsedByEachJoin[index], memAfter - memBefore);
-      else
-        return;
-
-      memBefore = memAfter;
-    }
-    memTrackDone.timed_wait(scoped, boost::posix_time::seconds(1));
-  }
-
-  // one more iteration to capture mem usage since last poll, for this one
-  // raise an error if mem went over the limit
-  memAfter = joiner->getMemUsage();
-  if (memAfter == memBefore)
-    return;
-  gotMem = resourceManager->getMemory(memAfter - memBefore, sessionMemLimit, true);
-  if (gotMem)
-  {
-    atomicops::atomicAdd(&memUsedByEachJoin[index], memAfter - memBefore);
-  }
-  else
-  {
-    if (!joinIsTooBig &&
-        (isDML || !allowDJS || (fSessionId & 0x80000000) || (tableOid() < 3000 && tableOid() >= 1000)))
-    {
-      joinIsTooBig = true;
-      ostringstream oss;
-      oss << "(" << __LINE__ << ") "
-          << logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_JOIN_TOO_BIG);
-      fLogger->logMessage(logging::LOG_TYPE_INFO, oss.str());
-      errorMessage(oss.str());
-      status(logging::ERR_JOIN_TOO_BIG);
-      cout << "Join is too big, raise the UM join limit for now (monitor thread)" << endl;
-      abort();
-    }
-  }
-}
-
 void TupleHashJoinStep::startSmallRunners(uint index)
 {
   utils::setThreadName("HJSStartSmall");
@@ -296,7 +242,6 @@ void TupleHashJoinStep::startSmallRunners(uint index)
 
   stopMemTracking = false;
   utils::VLArray<uint64_t> jobs(numCores);
-  // uint64_t memMonitor = jobstepThreadPool.invoke([this, index] { this->trackMem(index); });
   // starting 1 thread when in PM mode, since it's only inserting into a
   // vector of rows.  The rest will be started when converted to UM mode.
   if (joiners[index]->inUM())

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -1360,13 +1360,16 @@ void TupleHashJoinStep::finishSmallOuterJoin()
   uint32_t smallSideCount = smallDLs.size();
   uint32_t i, j, k;
   std::shared_ptr<uint8_t[]> largeNullMemory;
-  RGData joinedData;
   Row joinedBaseRow, fe2InRow, fe2OutRow;
   std::shared_ptr<Row[]> smallRowTemplates;
   std::shared_ptr<Row[]> smallNullRows;
   Row largeNullRow;
   RowGroup l_outputRG = outputRG;
   RowGroup l_fe2Output = fe2Output;
+
+  // auto alloc = resourceManager->getAllocator<RGDataBufType>(10 * 1024 * 1024);
+  // RGData joinedData(alloc);
+  RGData joinedData;
 
   joiners[lastSmallOuterJoiner]->getUnmarkedRows(&unmatched);
 
@@ -1681,7 +1684,8 @@ void TupleHashJoinStep::joinOneRG(
   if (!smallNullMem)
     smallNullMem = &smallNullMemory;
 
-  RGData joinedData;
+  auto alloc = resourceManager->getAllocator<RGDataBufType>(10 * 1024 * 1024);
+  RGData joinedData(alloc);
   uint32_t matchCount, smallSideCount = tjoiners->size();
   uint32_t j, k;
 
@@ -1814,13 +1818,13 @@ void TupleHashJoinStep::generateJoinResultSet(const vector<vector<Row::Pointer> 
     {
       smallRow.setPointer(joinerOutput[depth][i]);
 
-      if (UNLIKELY(l_outputRG.getRowCount() == 8192))
+      if (UNLIKELY(l_outputRG.getRowCount() == rowgroup::rgCommonSize))
       {
         uint32_t dbRoot = l_outputRG.getDBRoot();
         uint64_t baseRid = l_outputRG.getBaseRid();
         outputData.push_back(rgData);
         // Count the memory
-        if (UNLIKELY(!getMemory(l_outputRG.getMaxDataSize())))
+        if (UNLIKELY(!getMemory(l_outputRG.getSizeWithStrings())))
         {
           // MCOL-5512
           if (fe2)
@@ -1833,6 +1837,9 @@ void TupleHashJoinStep::generateJoinResultSet(const vector<vector<Row::Pointer> 
             l_outputRG.initRow(&fe2InRow);
             l_fe2RG.initRow(&fe2OutRow);
 
+            // WIP do we remove previosuly pushed(line 1824) rgData
+            // replacing it with a new FE2 rgdata added by processFE2?
+            // Generates a new RGData w/o accounting its memory consumption
             processFE2(l_outputRG, l_fe2RG, fe2InRow, fe2OutRow, &outputData, fe2.get());
           }
           // Don't let the join results buffer get out of control.

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -296,7 +296,7 @@ void TupleHashJoinStep::startSmallRunners(uint index)
 
   stopMemTracking = false;
   utils::VLArray<uint64_t> jobs(numCores);
-  uint64_t memMonitor = jobstepThreadPool.invoke([this, index] { this->trackMem(index); });
+  // uint64_t memMonitor = jobstepThreadPool.invoke([this, index] { this->trackMem(index); });
   // starting 1 thread when in PM mode, since it's only inserting into a
   // vector of rows.  The rest will be started when converted to UM mode.
   if (joiners[index]->inUM())
@@ -325,7 +325,7 @@ void TupleHashJoinStep::startSmallRunners(uint index)
   stopMemTracking = true;
   memTrackDone.notify_one();
   memTrackMutex.unlock();
-  jobstepThreadPool.join(memMonitor);
+  // jobstepThreadPool.join(memMonitor);
 
   /* If there was an error or an abort, drain the input DL,
       do endOfInput on the output */
@@ -461,6 +461,22 @@ void TupleHashJoinStep::smallRunnerFcn(uint32_t index, uint threadID, uint64_t* 
       dlMutex.lock();
       more = smallDL->next(smallIt, &oneRG);
       dlMutex.unlock();
+    }
+  }
+  catch (std::bad_alloc& exc)
+  {
+    if (!joinIsTooBig &&
+        (isDML || !allowDJS || (fSessionId & 0x80000000) || (tableOid() < 3000 && tableOid() >= 1000)))
+    {
+      joinIsTooBig = true;
+      ostringstream oss;
+      oss << "(" << __LINE__ << ") "
+          << logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_JOIN_TOO_BIG);
+      fLogger->logMessage(logging::LOG_TYPE_INFO, oss.str());
+      errorMessage(oss.str());
+      status(logging::ERR_JOIN_TOO_BIG);
+      cout << "Join is too big, raise the UM join limit for now" << endl;
+      abort();
     }
   }
   catch (...)
@@ -2018,6 +2034,9 @@ void TupleHashJoinStep::abort()
 {
   JobStep::abort();
   boost::mutex::scoped_lock sl(djsLock);
+
+  for (auto& joiner : joiners)
+    joiner->abort();
 
   if (djs)
   {

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -1367,8 +1367,6 @@ void TupleHashJoinStep::finishSmallOuterJoin()
   RowGroup l_outputRG = outputRG;
   RowGroup l_fe2Output = fe2Output;
 
-  // auto alloc = resourceManager->getAllocator<RGDataBufType>(10 * 1024 * 1024);
-  // RGData joinedData(alloc);
   RGData joinedData;
 
   joiners[lastSmallOuterJoiner]->getUnmarkedRows(&unmatched);
@@ -1684,7 +1682,6 @@ void TupleHashJoinStep::joinOneRG(
   if (!smallNullMem)
     smallNullMem = &smallNullMemory;
 
-  // auto alloc = resourceManager->getAllocator<RGDataBufType>(10 * 1024 * 1024);
   RGData joinedData;
   uint32_t matchCount, smallSideCount = tjoiners->size();
   uint32_t j, k;
@@ -1837,7 +1834,7 @@ void TupleHashJoinStep::generateJoinResultSet(const vector<vector<Row::Pointer> 
             l_outputRG.initRow(&fe2InRow);
             l_fe2RG.initRow(&fe2OutRow);
 
-            // WIP do we remove previosuly pushed(line 1824) rgData
+            // WIP do we remove previosuly pushed(line 1825) rgData
             // replacing it with a new FE2 rgdata added by processFE2?
             // Generates a new RGData w/o accounting its memory consumption
             processFE2(l_outputRG, l_fe2RG, fe2InRow, fe2OutRow, &outputData, fe2.get());
@@ -1977,6 +1974,7 @@ void TupleHashJoinStep::abort()
   JobStep::abort();
   boost::mutex::scoped_lock sl(djsLock);
 
+  // To prevent potential endless loop in bucketsToTables()
   for (auto& joiner : joiners)
     joiner->abort();
 

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -276,8 +276,8 @@ void TupleHashJoinStep::startSmallRunners(uint index)
   }
   else
   {
-    joiners[index].reset(new TupleJoiner(smallRGs[index], largeRG, smallSideKeys[index][0], largeSideKeys[index][0],
-                                 jt, &jobstepThreadPool, resourceManager));
+    joiners[index].reset(new TupleJoiner(smallRGs[index], largeRG, smallSideKeys[index][0],
+                                         largeSideKeys[index][0], jt, &jobstepThreadPool, resourceManager));
   }
 
   joiners[index]->setUniqueLimit(uniqueLimit);
@@ -380,6 +380,30 @@ void TupleHashJoinStep::startSmallRunners(uint index)
   formatMiniStats(index);
 }
 
+void TupleHashJoinStep::outOfMemoryHandler(std::shared_ptr<joiner::TupleJoiner> joiner)
+{
+  boost::unique_lock<boost::mutex> sl(saneErrMsg);
+
+  if (cancelled())
+    return;
+  if (!allowDJS || isDML || (fSessionId & 0x80000000) || (tableOid() < 3000 && tableOid() >= 1000))
+  {
+    joinIsTooBig = true;
+    ostringstream oss;
+    oss << "(" << __LINE__ << ") " << logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_JOIN_TOO_BIG);
+    fLogger->logMessage(logging::LOG_TYPE_INFO, oss.str());
+    errorMessage(oss.str());
+    status(logging::ERR_JOIN_TOO_BIG);
+    cout << "Join is too big, raise the UM join limit for now (small runner)" << endl;
+    abort();
+  }
+  else if (allowDJS)
+  {
+    joiner->setConvertToDiskJoin();
+    // TODO RGData that triggers this path is lost. Need to store it to pass it future.
+  }
+}
+
 /* Index is which small input to read. */
 void TupleHashJoinStep::smallRunnerFcn(uint32_t index, uint threadID, uint64_t* jobs)
 {
@@ -402,6 +426,7 @@ void TupleHashJoinStep::smallRunnerFcn(uint32_t index, uint threadID, uint64_t* 
     ssize_t rgSize;
     bool gotMem;
     goto next;
+    // TODO need to quit this loop early of on-disk flag is set by any of the small size threads.
     while (more && !cancelled())
     {
       smallRG.setData(&oneRG);
@@ -426,25 +451,28 @@ void TupleHashJoinStep::smallRunnerFcn(uint32_t index, uint threadID, uint64_t* 
             if disk join is enabled, use it.
             else abort.
         */
-        boost::unique_lock<boost::mutex> sl(saneErrMsg);
-        if (cancelled())
-          return;
-        if (!allowDJS || isDML || (fSessionId & 0x80000000) || (tableOid() < 3000 && tableOid() >= 1000))
-        {
-          joinIsTooBig = true;
-          ostringstream oss;
-          oss << "(" << __LINE__ << ") "
-              << logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_JOIN_TOO_BIG);
-          fLogger->logMessage(logging::LOG_TYPE_INFO, oss.str());
-          errorMessage(oss.str());
-          status(logging::ERR_JOIN_TOO_BIG);
-          cout << "Join is too big, raise the UM join limit for now (small runner)" << endl;
-          abort();
-        }
-        else if (allowDJS)
-          joiner->setConvertToDiskJoin();
+        // boost::unique_lock<boost::mutex> sl(saneErrMsg);
 
-        return;
+        // if (cancelled())
+        //   return;
+        // if (!allowDJS || isDML || (fSessionId & 0x80000000) || (tableOid() < 3000 && tableOid() >= 1000))
+        // {
+        //   joinIsTooBig = true;
+        //   ostringstream oss;
+        //   oss << "(" << __LINE__ << ") "
+        //       << logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_JOIN_TOO_BIG);
+        //   fLogger->logMessage(logging::LOG_TYPE_INFO, oss.str());
+        //   errorMessage(oss.str());
+        //   status(logging::ERR_JOIN_TOO_BIG);
+        //   cout << "Join is too big, raise the UM join limit for now (small runner)" << endl;
+        //   abort();
+        // }
+        // else if (allowDJS)
+        // {
+        //   joiner->setConvertToDiskJoin();
+        //   // TODO RGData that triggers this path is lost. Need to store it to pass it future.
+        // }
+        return outOfMemoryHandler(joiner);
       }
       joiner->insertRGData(smallRG, threadID);
       if (!joiner->inUM() && (memUsedByEachJoin[index] > pmMemLimit))
@@ -465,19 +493,38 @@ void TupleHashJoinStep::smallRunnerFcn(uint32_t index, uint threadID, uint64_t* 
   }
   catch (std::bad_alloc& exc)
   {
-    if (!joinIsTooBig &&
-        (isDML || !allowDJS || (fSessionId & 0x80000000) || (tableOid() < 3000 && tableOid() >= 1000)))
-    {
-      joinIsTooBig = true;
-      ostringstream oss;
-      oss << "(" << __LINE__ << ") "
-          << logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_JOIN_TOO_BIG);
-      fLogger->logMessage(logging::LOG_TYPE_INFO, oss.str());
-      errorMessage(oss.str());
-      status(logging::ERR_JOIN_TOO_BIG);
-      cout << "Join is too big, raise the UM join limit for now" << endl;
-      abort();
-    }
+    // boost::unique_lock<boost::mutex> sl(saneErrMsg);
+
+    // if (!joinIsTooBig &&
+    //     (isDML || !allowDJS || (fSessionId & 0x80000000) || (tableOid() < 3000 && tableOid() >= 1000)))
+    // {
+    //   joinIsTooBig = true;
+    //   ostringstream oss;
+    //   oss << "(" << __LINE__ << ") "
+    //       << logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_JOIN_TOO_BIG);
+    //   fLogger->logMessage(logging::LOG_TYPE_INFO, oss.str());
+    //   errorMessage(oss.str());
+    //   status(logging::ERR_JOIN_TOO_BIG);
+    //   cout << "Join is too big, raise the UM join limit for now" << endl;
+    //   abort();
+    // }
+    // else if (allowDJS)
+    // {
+    //   joiner->setConvertToDiskJoin();
+    //   // RGData that triggers OOM is saved but the hash table is too big.
+    //   // TBD need to store RGData if counting allocator will be used for RGData.
+
+    //   // Need to clean hash tables and vec.
+    //   // joiner->clearData(); // `finished` flag can implicitly interfere.
+    // }
+    // return;
+
+    // RGData that triggers OOM is saved but the hash table is too big.
+    // TBD need to store RGData if counting allocator will be used for RGData.
+
+    // Need to clean hash tables and vec.
+    // joiner->clearData(); // `finished` flag can implicitly interfere.
+    return outOfMemoryHandler(joiner);
   }
   catch (...)
   {
@@ -1293,15 +1340,11 @@ void TupleHashJoinStep::formatMiniStats(uint32_t index)
   else
     oss << "- ";
 
-  oss << " "
-      << "- "
-      << "- "
-      << "- "
+  oss << " " << "- " << "- " << "- "
       << "- "
       //		<< JSTimeStamp::tsdiffstr(dlTimes.EndOfInputTime(), dlTimes.FirstReadTime()) << " "
       //		dlTimes are not timed in this step, using '--------' instead.
-      << "-------- "
-      << "-\n";
+      << "-------- " << "-\n";
   fMiniInfo += oss.str();
 }
 

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -270,7 +270,6 @@ void TupleHashJoinStep::startSmallRunners(uint index)
   stopMemTracking = true;
   memTrackDone.notify_one();
   memTrackMutex.unlock();
-  // jobstepThreadPool.join(memMonitor);
 
   /* If there was an error or an abort, drain the input DL,
       do endOfInput on the output */
@@ -396,27 +395,6 @@ void TupleHashJoinStep::smallRunnerFcn(uint32_t index, uint threadID, uint64_t* 
             if disk join is enabled, use it.
             else abort.
         */
-        // boost::unique_lock<boost::mutex> sl(saneErrMsg);
-
-        // if (cancelled())
-        //   return;
-        // if (!allowDJS || isDML || (fSessionId & 0x80000000) || (tableOid() < 3000 && tableOid() >= 1000))
-        // {
-        //   joinIsTooBig = true;
-        //   ostringstream oss;
-        //   oss << "(" << __LINE__ << ") "
-        //       << logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_JOIN_TOO_BIG);
-        //   fLogger->logMessage(logging::LOG_TYPE_INFO, oss.str());
-        //   errorMessage(oss.str());
-        //   status(logging::ERR_JOIN_TOO_BIG);
-        //   cout << "Join is too big, raise the UM join limit for now (small runner)" << endl;
-        //   abort();
-        // }
-        // else if (allowDJS)
-        // {
-        //   joiner->setConvertToDiskJoin();
-        //   // TODO RGData that triggers this path is lost. Need to store it to pass it future.
-        // }
         return outOfMemoryHandler(joiner);
       }
       joiner->insertRGData(smallRG, threadID);
@@ -438,37 +416,6 @@ void TupleHashJoinStep::smallRunnerFcn(uint32_t index, uint threadID, uint64_t* 
   }
   catch (std::bad_alloc& exc)
   {
-    // boost::unique_lock<boost::mutex> sl(saneErrMsg);
-
-    // if (!joinIsTooBig &&
-    //     (isDML || !allowDJS || (fSessionId & 0x80000000) || (tableOid() < 3000 && tableOid() >= 1000)))
-    // {
-    //   joinIsTooBig = true;
-    //   ostringstream oss;
-    //   oss << "(" << __LINE__ << ") "
-    //       << logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_JOIN_TOO_BIG);
-    //   fLogger->logMessage(logging::LOG_TYPE_INFO, oss.str());
-    //   errorMessage(oss.str());
-    //   status(logging::ERR_JOIN_TOO_BIG);
-    //   cout << "Join is too big, raise the UM join limit for now" << endl;
-    //   abort();
-    // }
-    // else if (allowDJS)
-    // {
-    //   joiner->setConvertToDiskJoin();
-    //   // RGData that triggers OOM is saved but the hash table is too big.
-    //   // TBD need to store RGData if counting allocator will be used for RGData.
-
-    //   // Need to clean hash tables and vec.
-    //   // joiner->clearData(); // `finished` flag can implicitly interfere.
-    // }
-    // return;
-
-    // RGData that triggers OOM is saved but the hash table is too big.
-    // TBD need to store RGData if counting allocator will be used for RGData.
-
-    // Need to clean hash tables and vec.
-    // joiner->clearData(); // `finished` flag can implicitly interfere.
     return outOfMemoryHandler(joiner);
   }
   catch (...)

--- a/dbcon/joblist/tuplehashjoin.h
+++ b/dbcon/joblist/tuplehashjoin.h
@@ -648,6 +648,7 @@ class TupleHashJoinStep : public JobStep, public TupleDeliveryStep
   bool stopMemTracking;
   void trackMem(uint index);
   void startSmallRunners(uint index);
+  void outOfMemoryHandler(std::shared_ptr<joiner::TupleJoiner> joiner);
 
   friend class DiskJoinStep;
 };

--- a/dbcon/joblist/tupleunion.cpp
+++ b/dbcon/joblist/tupleunion.cpp
@@ -1590,7 +1590,7 @@ uint32_t TupleUnion::nextBand(messageqcpp::ByteStream& bs)
     outputRG.setData(&mem);
   else
   {
-    mem = RGData(outputRG, 0);
+    mem = RGData(outputRG, 0U);
     outputRG.setData(&mem);
     outputRG.resetRowGroup(0);
     outputRG.setStatus(status());

--- a/mysql-test/columnstore/basic/r/mcol-5195.result
+++ b/mysql-test/columnstore/basic/r/mcol-5195.result
@@ -5,54 +5,54 @@ create table t1 (a int, b int) engine=columnstore;
 create table t2 (a int, b int) engine=columnstore;
 insert into t1 values (1, 2), (1, 3), (1, 4), (2, 5), (2, 6), (2, 7);
 insert into t2 values (1, 2), (1, 2), (1, 4), (2, 5), (2, 6), (2, 8);
-select * from t1, t2 where t1.a = t2.a and t2.b = (select max(b) from t2 where t1.a = t2.a) order by t2.b;
+select * from t1, t2 where t1.a = t2.a and t2.b = (select max(b) from t2 where t1.a = t2.a);
 a	b	a	b
-1	4	1	4
 1	2	1	4
 1	3	1	4
-2	7	2	8
+1	4	1	4
 2	5	2	8
 2	6	2	8
-select * from t1, t2 where t1.a = t2.a and t2.b < (select max(b) from t2 where t1.a = t2.a) order by t2.b;
+2	7	2	8
+select * from t1, t2 where t1.a = t2.a and t2.b < (select max(b) from t2 where t1.a = t2.a);
 a	b	a	b
-1	3	1	2
-1	4	1	2
 1	2	1	2
-1	4	1	2
 1	2	1	2
 1	3	1	2
-2	6	2	5
+1	3	1	2
+1	4	1	2
+1	4	1	2
 2	5	2	5
-2	7	2	5
 2	5	2	6
-2	6	2	6
-2	7	2	6
-select * from t1, t2 where t1.a = t2.a and t2.b > (select max(b) from t2 where t1.a = t2.a) order by t2.b;
-a	b	a	b
-select * from t1, t2 where t1.a = t2.a and t1.b = (select avg(t2.b) from t2 where t1.a = t2.a group by t2.a) order by t2.b;
-a	b	a	b
-select * from t1, t2 where t1.a = t2.a and t2.b < (select avg(t2.b) from t2 where t1.a = t2.a group by t2.a) order by t2.b;
-a	b	a	b
-1	3	1	2
-1	4	1	2
-1	2	1	2
-1	4	1	2
-1	2	1	2
-1	3	1	2
 2	6	2	5
-2	5	2	5
-2	7	2	5
-2	5	2	6
 2	6	2	6
+2	7	2	5
 2	7	2	6
-select * from t1, t2 where t1.a = t2.a and t2.b > (select avg(t2.b) from t2 where t1.a = t2.a group by t2.a) order by t2.b;
+select * from t1, t2 where t1.a = t2.a and t2.b > (select max(b) from t2 where t1.a = t2.a);
 a	b	a	b
-1	4	1	4
+select * from t1, t2 where t1.a = t2.a and t1.b = (select avg(t2.b) from t2 where t1.a = t2.a group by t2.a);
+a	b	a	b
+select * from t1, t2 where t1.a = t2.a and t2.b < (select avg(t2.b) from t2 where t1.a = t2.a group by t2.a);
+a	b	a	b
+1	2	1	2
+1	2	1	2
+1	3	1	2
+1	3	1	2
+1	4	1	2
+1	4	1	2
+2	5	2	5
+2	5	2	6
+2	6	2	5
+2	6	2	6
+2	7	2	5
+2	7	2	6
+select * from t1, t2 where t1.a = t2.a and t2.b > (select avg(t2.b) from t2 where t1.a = t2.a group by t2.a);
+a	b	a	b
 1	2	1	4
 1	3	1	4
-2	7	2	8
+1	4	1	4
 2	5	2	8
 2	6	2	8
+2	7	2	8
 drop table t1;
 drop table t2;
 DROP DATABASE mcol5195;

--- a/mysql-test/columnstore/basic/r/mcol_4617.result
+++ b/mysql-test/columnstore/basic/r/mcol_4617.result
@@ -112,7 +112,7 @@ a
 1
 2
 3
-select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a in (select b from cs2) order by 1,2,3;
+select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a in (select b from cs2);
 a	b	c
 1	1	100
 1	1	101
@@ -124,7 +124,7 @@ select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a in (select b from cs2) and c
 a	b	c
 1	1	100
 1	1	101
-select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a in (select t1.b from cs2 t1 join cs2 t2 on t1.b=t2.b and t1.b=1) order by 1,2,3;
+select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a in (select t1.b from cs2 t1 join cs2 t2 on t1.b=t2.b and t1.b=1);
 a	b	c
 1	1	100
 1	1	101
@@ -193,7 +193,7 @@ select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select b from cs2);
 a	b	c
 select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select b from cs2) and cs1.a=1;
 a	b	c
-select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select t1.b from cs2 t1 join cs2 t2 on t1.b=t2.b and t1.b=1) order by 1,2,3;
+select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select t1.b from cs2 t1 join cs2 t2 on t1.b=t2.b and t1.b=1);
 a	b	c
 2	2	200
 3	3	300
@@ -249,7 +249,7 @@ select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select b from cs2 wh
 a	b	c
 select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select b from cs2 where b is not null) and cs1.a=1;
 a	b	c
-select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select t1.b from (select b from cs2 where b is not null) t1 join cs2 t2 on t1.b=t2.b and t1.b=1) order by 1,2,3;
+select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select t1.b from (select b from cs2 where b is not null) t1 join cs2 t2 on t1.b=t2.b and t1.b=1);
 a	b	c
 2	2	200
 3	3	300
@@ -348,21 +348,21 @@ select * from cs1 where (a,d) in (select t1.b,t1.c from cs2 t1 join cs2 t2 on t1
 a	d
 1	100
 3	302
-select * from cs1 join cs2 on cs1.a=cs2.b and (cs1.a,cs1.d) in (select b,c from cs2) order by 1,2,3,4;
+select * from cs1 join cs2 on cs1.a=cs2.b and (cs1.a,cs1.d) in (select b,c from cs2);
 a	d	b	c
 1	100	1	100
 1	100	1	101
 3	302	3	300
 3	302	3	301
 3	302	3	302
-select * from cs1 join cs2 on cs1.a=cs2.b and (cs1.a,cs1.d) in (select b,c from cs2) and cs1.a=1 order by 1,2,3,4;
+select * from cs1 join cs2 on cs1.a=cs2.b and (cs1.a,cs1.d) in (select b,c from cs2) and cs1.a=1;
 a	d	b	c
 1	100	1	100
 1	100	1	101
 select * from cs1 join cs2 on cs1.a=cs2.b and (cs1.a,cs1.d) in (select t1.b,t1.c from cs2 t1 join cs2 t2 on t1.b=t2.b and t1.b=1);
 a	d	b	c
-1	100	1	100
 1	100	1	101
+1	100	1	100
 drop table cs1;
 create table cs1 (a int);
 insert into cs1 values (1), (2), (3), (4), (null);

--- a/mysql-test/columnstore/basic/t/mcol-5195.test
+++ b/mysql-test/columnstore/basic/t/mcol-5195.test
@@ -15,13 +15,19 @@ create table t2 (a int, b int) engine=columnstore;
 insert into t1 values (1, 2), (1, 3), (1, 4), (2, 5), (2, 6), (2, 7);
 insert into t2 values (1, 2), (1, 2), (1, 4), (2, 5), (2, 6), (2, 8);
 
-select * from t1, t2 where t1.a = t2.a and t2.b = (select max(b) from t2 where t1.a = t2.a) order by t2.b;
-select * from t1, t2 where t1.a = t2.a and t2.b < (select max(b) from t2 where t1.a = t2.a) order by t2.b;
-select * from t1, t2 where t1.a = t2.a and t2.b > (select max(b) from t2 where t1.a = t2.a) order by t2.b;
+--sorted_result
+select * from t1, t2 where t1.a = t2.a and t2.b = (select max(b) from t2 where t1.a = t2.a);
+--sorted_result
+select * from t1, t2 where t1.a = t2.a and t2.b < (select max(b) from t2 where t1.a = t2.a);
+--sorted_result
+select * from t1, t2 where t1.a = t2.a and t2.b > (select max(b) from t2 where t1.a = t2.a);
 
-select * from t1, t2 where t1.a = t2.a and t1.b = (select avg(t2.b) from t2 where t1.a = t2.a group by t2.a) order by t2.b;
-select * from t1, t2 where t1.a = t2.a and t2.b < (select avg(t2.b) from t2 where t1.a = t2.a group by t2.a) order by t2.b;
-select * from t1, t2 where t1.a = t2.a and t2.b > (select avg(t2.b) from t2 where t1.a = t2.a group by t2.a) order by t2.b;
+--sorted_result
+select * from t1, t2 where t1.a = t2.a and t1.b = (select avg(t2.b) from t2 where t1.a = t2.a group by t2.a);
+--sorted_result
+select * from t1, t2 where t1.a = t2.a and t2.b < (select avg(t2.b) from t2 where t1.a = t2.a group by t2.a);
+--sorted_result
+select * from t1, t2 where t1.a = t2.a and t2.b > (select avg(t2.b) from t2 where t1.a = t2.a group by t2.a);
 
 drop table t1;
 drop table t2;

--- a/mysql-test/columnstore/basic/t/mcol_4617.test
+++ b/mysql-test/columnstore/basic/t/mcol_4617.test
@@ -69,11 +69,13 @@ select * from cs1 where a in (select t1.b from cs2 t1, cs2 t2 where t1.b=t2.b an
 select * from cs1 where a in (select t1.b from cs2 t1 join cs2 t2 on t1.b=t2.b and t1.c=t2.c);
 
 ### Outer query containing joins
-select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a in (select b from cs2) order by 1,2,3;
+--sorted_result
+select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a in (select b from cs2);
 select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a in (select b from cs2) and cs1.a=1;
 
 ### Both IN subquery and outer queries containing joins
-select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a in (select t1.b from cs2 t1 join cs2 t2 on t1.b=t2.b and t1.b=1) order by 1,2,3;
+--sorted_result
+select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a in (select t1.b from cs2 t1 join cs2 t2 on t1.b=t2.b and t1.b=1);
 
 ## NOT IN subquery
 ### Basic tests
@@ -120,7 +122,8 @@ select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select b from cs2);
 select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select b from cs2) and cs1.a=1;
 
 ### Both IN subquery and outer queries containing joins
-select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select t1.b from cs2 t1 join cs2 t2 on t1.b=t2.b and t1.b=1) order by 1,2,3;
+--sorted_result
+select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select t1.b from cs2 t1 join cs2 t2 on t1.b=t2.b and t1.b=1);
 
 ## NOT IN subquery without NULLs
 ### Basic tests
@@ -158,7 +161,8 @@ select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select b from cs2 wh
 select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select b from cs2 where b is not null) and cs1.a=1;
 
 ### Both IN subquery and outer queries containing joins
-select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select t1.b from (select b from cs2 where b is not null) t1 join cs2 t2 on t1.b=t2.b and t1.b=1) order by 1,2,3;
+--sorted_result
+select * from cs1 join cs2 on cs1.a=cs2.b and cs1.a not in (select t1.b from (select b from cs2 where b is not null) t1 join cs2 t2 on t1.b=t2.b and t1.b=1);
 
 # Special cases involving NULLs
 select * from cs1 where a in (select b from cs2 where b is null);
@@ -213,8 +217,10 @@ select * from cs1 where (a,d) in (select t1.b,t1.c from cs2 t1, cs2 t2 where t1.
 select * from cs1 where (a,d) in (select t1.b,t1.c from cs2 t1 join cs2 t2 on t1.b=t2.b and t1.c=t2.c);
 
 ### Outer query containing joins
-select * from cs1 join cs2 on cs1.a=cs2.b and (cs1.a,cs1.d) in (select b,c from cs2) order by 1,2,3,4;
-select * from cs1 join cs2 on cs1.a=cs2.b and (cs1.a,cs1.d) in (select b,c from cs2) and cs1.a=1 order by 1,2,3,4;
+--sorted_result
+select * from cs1 join cs2 on cs1.a=cs2.b and (cs1.a,cs1.d) in (select b,c from cs2);
+--sorted_result
+select * from cs1 join cs2 on cs1.a=cs2.b and (cs1.a,cs1.d) in (select b,c from cs2) and cs1.a=1;
 
 ### Both IN subquery and outer queries containing joins
 select * from cs1 join cs2 on cs1.a=cs2.b and (cs1.a,cs1.d) in (select t1.b,t1.c from cs2 t1 join cs2 t2 on t1.b=t2.b and t1.b=1);

--- a/mysql-test/columnstore/basic/t/mcs26_insert_into_view.test
+++ b/mysql-test/columnstore/basic/t/mcs26_insert_into_view.test
@@ -27,7 +27,7 @@ CREATE VIEW v AS
     SELECT      a.id a_id, b.id b_id, b.ta_id, a.value v1, b.value v2
     FROM        table_a a
     INNER JOIN  table_b b ON (b.ta_id = a.id);
-
+--sorted_result
 SELECT * FROM v;
 
 #Can not modify more than one base table through a join view
@@ -41,6 +41,7 @@ INSERT INTO v (a_id, v1) VALUES (3, 30);
 --error 1178
 INSERT INTO v (b_id, ta_id, v2) VALUES (5, 3, 500);
 
+--sorted_result
 SELECT * FROM v;
 
 #Clean up

--- a/primitives/blockcache/stats.cpp
+++ b/primitives/blockcache/stats.cpp
@@ -176,7 +176,7 @@ class StatMon
     sigset_t sigset;
     sigemptyset(&sigset);
     sigaddset(&sigset, SIGPIPE);
-    sigaddset(&sigset, SIGUSR1);
+    // sigaddset(&sigset, SIGUSR1);
     sigaddset(&sigset, SIGUSR2);
     pthread_sigmask(SIG_BLOCK, &sigset, 0);
   }

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -331,8 +331,8 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
       {
         // storedKeyAllocators[j].setUseLock(true);
         // WIP use one copy of the allocator
-        auto allocator = exemgr::globServiceExeMgr->getRm().getAllocator<utils::PoolAllocatorBufType>();
-        storedKeyAllocators.emplace_back(PoolAllocator(&allocator, PoolAllocator::DEFAULT_WINDOW_SIZE, false, true));
+        auto alloc = exemgr::globServiceExeMgr->getRm().getAllocator<utils::PoolAllocatorBufType>();
+        storedKeyAllocators.emplace_back(PoolAllocator(alloc, PoolAllocator::DEFAULT_WINDOW_SIZE, false, true));
       }
 
       joinNullValues.reset(new uint64_t[joinerCount]);

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -326,12 +326,9 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
       typelessJoin.reset(new bool[joinerCount]);
       tlSmallSideKeyLengths.reset(new uint32_t[joinerCount]);
 
-      // storedKeyAllocators.reset(new PoolAllocator[joinerCount]);
+      auto alloc = exemgr::globServiceExeMgr->getRm().getAllocator<utils::PoolAllocatorBufType>();
       for (uint j = 0; j < joinerCount; ++j)
       {
-        // storedKeyAllocators[j].setUseLock(true);
-        // WIP use one copy of the allocator
-        auto alloc = exemgr::globServiceExeMgr->getRm().getAllocator<utils::PoolAllocatorBufType>();
         storedKeyAllocators.emplace_back(PoolAllocator(alloc, PoolAllocator::DEFAULT_WINDOW_SIZE, false, true));
       }
 

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -2210,8 +2210,9 @@ int BatchPrimitiveProcessor::operator()()
     validCPData = false;
     cpDataFromDictScan = false;
 
-    auto allocator = exemgr::globServiceExeMgr->getRm().getAllocator<messageqcpp::BSBufType>();
-    messageqcpp::SBS bs(new ByteStream(allocator));
+    // auto allocator = exemgr::globServiceExeMgr->getRm().getAllocator<messageqcpp::BSBufType>();
+    // messageqcpp::SBS bs(new ByteStream(allocator));
+    messageqcpp::SBS bs(new ByteStream());
 
 #ifdef PRIMPROC_STOPWATCH
     stopwatch->start("BPP() execute");

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -241,8 +241,6 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
   uint8_t tmp8;
   uint16_t tmp16;
   Command::CommandType type;
-  auto cnt = exemgr::globServiceExeMgr->getRm().availableMemory();
-  std::cout << "initBPP availableMemory: " << cnt << std::endl;
 
   bs.advance(sizeof(ISMPacketHeader));  // skip the header
   bs >> tmp8;
@@ -848,8 +846,6 @@ int BatchPrimitiveProcessor::endOfJoiner()
   {
     endOfJoinerRan = true;
     pthread_mutex_unlock(&objLock);
-    auto cnt = exemgr::globServiceExeMgr->getRm().availableMemory();
-    std::cout << "endOfJoiner availableMemory: " << cnt << std::endl;
     return 0;
   }
 
@@ -892,8 +888,6 @@ int BatchPrimitiveProcessor::endOfJoiner()
   endOfJoinerRan = true;
 
   pthread_mutex_unlock(&objLock);
-  auto cnt = exemgr::globServiceExeMgr->getRm().availableMemory();
-  std::cout << "endOfJoiner availableMemory: " << cnt << std::endl;
   return 0;
 }
 
@@ -2217,7 +2211,7 @@ int BatchPrimitiveProcessor::operator()()
     cpDataFromDictScan = false;
 
     auto allocator = exemgr::globServiceExeMgr->getRm().getAllocator<messageqcpp::BSBufType>();
-    messageqcpp::SBS bs(new ByteStream(&allocator));
+    messageqcpp::SBS bs(new ByteStream(allocator));
 
 #ifdef PRIMPROC_STOPWATCH
     stopwatch->start("BPP() execute");
@@ -2283,14 +2277,14 @@ void BatchPrimitiveProcessor::allocLargeBuffers()
   if (ot == ROW_GROUP && !outRowGroupData)
   {
     // outputRG.setUseStringTable(true);
-    outRowGroupData.reset(new RGData(outputRG, &allocator));
+    outRowGroupData.reset(new RGData(outputRG, allocator));
     outputRG.setData(outRowGroupData.get());
   }
 
   if (fe1 && !fe1Data)
   {
     // fe1Input.setUseStringTable(true);
-    fe1Data.reset(new RGData(fe1Input, &allocator));
+    fe1Data.reset(new RGData(fe1Input, allocator));
     // fe1Data.reset(new uint8_t[fe1Input.getMaxDataSize()]);
     fe1Input.setData(fe1Data.get());
   }
@@ -2298,14 +2292,14 @@ void BatchPrimitiveProcessor::allocLargeBuffers()
   if (fe2 && !fe2Data)
   {
     // fe2Output.setUseStringTable(true);
-    fe2Data.reset(new RGData(fe2Output, &allocator));
+    fe2Data.reset(new RGData(fe2Output, allocator));
     fe2Output.setData(fe2Data.get());
   }
 
   if (getTupleJoinRowGroupData && !joinedRGMem)
   {
     // joinedRG.setUseStringTable(true);
-    joinedRGMem.reset(new RGData(joinedRG, &allocator));
+    joinedRGMem.reset(new RGData(joinedRG, allocator));
     joinedRG.setData(joinedRGMem.get());
   }
 }

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -38,6 +38,7 @@
 #include <string>
 #include <sstream>
 #include <set>
+#include "rowgroup.h"
 #include "serviceexemgr.h"
 #include <cstdlib>
 using namespace std;
@@ -327,9 +328,14 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
       typelessJoin.reset(new bool[joinerCount]);
       tlSmallSideKeyLengths.reset(new uint32_t[joinerCount]);
 
-      storedKeyAllocators.reset(new PoolAllocator[joinerCount]);
+      // storedKeyAllocators.reset(new PoolAllocator[joinerCount]);
       for (uint j = 0; j < joinerCount; ++j)
-        storedKeyAllocators[j].setUseLock(true);
+      {
+        // storedKeyAllocators[j].setUseLock(true);
+        // WIP use one copy of the allocator
+        auto allocator = exemgr::globServiceExeMgr->getRm().getAllocator<utils::PoolAllocatorBufType>();
+        storedKeyAllocators.emplace_back(PoolAllocator(&allocator, PoolAllocator::DEFAULT_WINDOW_SIZE, false, true));
+      }
 
       joinNullValues.reset(new uint64_t[joinerCount]);
       doMatchNulls.reset(new bool[joinerCount]);
@@ -360,16 +366,16 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
 
         if (!typelessJoin[i])
         {
-          auto alloc = exemgr::globServiceExeMgr->getRm().getAllocator<TJoiner::value_type>();
+          auto allocator = exemgr::globServiceExeMgr->getRm().getAllocator<TJoiner::value_type>();
 
           bs >> joinNullValues[i];
           bs >> largeSideKeyColumns[i];
           for (uint j = 0; j < processorThreads; ++j)
-            tJoiners[i][j].reset(new TJoiner(10, TupleJoiner::hasher(), alloc));
+            tJoiners[i][j].reset(new TJoiner(10, TupleJoiner::hasher(), allocator));
         }
         else
         {
-          auto alloc = exemgr::globServiceExeMgr->getRm().getAllocator<TLJoiner::value_type>();
+          auto allocator = exemgr::globServiceExeMgr->getRm().getAllocator<TLJoiner::value_type>();
 
           deserializeVector<uint32_t>(bs, tlLargeSideKeyColumns[i]);
           bs >> tlSmallSideKeyLengths[i];
@@ -392,7 +398,7 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
                                                             mSmallSideKeyColumnsPtr, mSmallSideRGPtr);
             auto tlComparator = TupleJoiner::TypelessDataComparator(&outputRG, &tlLargeSideKeyColumns[i],
                                                                     mSmallSideKeyColumnsPtr, mSmallSideRGPtr);
-            tlJoiners[i][j].reset(new TLJoiner(10, tlHasher, tlComparator, alloc));
+            tlJoiners[i][j].reset(new TLJoiner(10, tlHasher, tlComparator, allocator));
           }
         }
       }
@@ -1375,7 +1381,7 @@ uint32_t BatchPrimitiveProcessor::executeTupleJoin(uint32_t startRid, RowGroup& 
 }
 
 #ifdef PRIMPROC_STOPWATCH
-void BatchPrimitiveProcessor::execute(StopWatch* stopwatch)
+void BatchPrimitiveProcessor::execute(StopWatch* stopwatch, messageqcpp::SBS& bs)
 #else
 void BatchPrimitiveProcessor::execute(messageqcpp::SBS& bs)
 #endif
@@ -1599,7 +1605,6 @@ void BatchPrimitiveProcessor::execute(messageqcpp::SBS& bs)
       {
         for (j = 0; j < projectCount; ++j)
         {
-          // 				cout << "projectionMap[" << j << "] = " << projectionMap[j] << endl;
           if (projectionMap[j] != -1)
           {
 #ifdef PRIMPROC_STOPWATCH
@@ -1610,11 +1615,6 @@ void BatchPrimitiveProcessor::execute(messageqcpp::SBS& bs)
             projectSteps[j]->projectIntoRowGroup(outputRG, projectionMap[j]);
 #endif
           }
-
-          //				else
-          //					cout << "   no target found for OID " <<
-          // projectSteps[j]->getOID()
-          //<< endl;
         }
         if (fe2)
         {
@@ -2216,8 +2216,8 @@ int BatchPrimitiveProcessor::operator()()
     validCPData = false;
     cpDataFromDictScan = false;
 
-    auto alloc = exemgr::globServiceExeMgr->getRm().getAllocator<messageqcpp::BSBufType>();
-    messageqcpp::SBS bs(new ByteStream(&alloc));
+    auto allocator = exemgr::globServiceExeMgr->getRm().getAllocator<messageqcpp::BSBufType>();
+    messageqcpp::SBS bs(new ByteStream(&allocator));
 
 #ifdef PRIMPROC_STOPWATCH
     stopwatch->start("BPP() execute");
@@ -2278,17 +2278,19 @@ int BatchPrimitiveProcessor::operator()()
 
 void BatchPrimitiveProcessor::allocLargeBuffers()
 {
+  auto allocator = exemgr::globServiceExeMgr->getRm().getAllocator<rowgroup::RGDataBufType>();
+  
   if (ot == ROW_GROUP && !outRowGroupData)
   {
     // outputRG.setUseStringTable(true);
-    outRowGroupData.reset(new RGData(outputRG));
+    outRowGroupData.reset(new RGData(outputRG, &allocator));
     outputRG.setData(outRowGroupData.get());
   }
 
   if (fe1 && !fe1Data)
   {
     // fe1Input.setUseStringTable(true);
-    fe1Data.reset(new RGData(fe1Input));
+    fe1Data.reset(new RGData(fe1Input, &allocator));
     // fe1Data.reset(new uint8_t[fe1Input.getMaxDataSize()]);
     fe1Input.setData(fe1Data.get());
   }
@@ -2296,14 +2298,14 @@ void BatchPrimitiveProcessor::allocLargeBuffers()
   if (fe2 && !fe2Data)
   {
     // fe2Output.setUseStringTable(true);
-    fe2Data.reset(new RGData(fe2Output));
+    fe2Data.reset(new RGData(fe2Output, &allocator));
     fe2Output.setData(fe2Data.get());
   }
 
   if (getTupleJoinRowGroupData && !joinedRGMem)
   {
     // joinedRG.setUseStringTable(true);
-    joinedRGMem.reset(new RGData(joinedRG));
+    joinedRGMem.reset(new RGData(joinedRG, &allocator));
     joinedRG.setData(joinedRGMem.get());
   }
 }
@@ -2470,73 +2472,6 @@ SBPP BatchPrimitiveProcessor::duplicate()
   bpp->initProcessor();
   return bpp;
 }
-
-#if 0
-bool BatchPrimitiveProcessor::operator==(const BatchPrimitiveProcessor& bpp) const
-{
-    uint32_t i;
-
-    if (ot != bpp.ot)
-        return false;
-
-    if (versionInfo != bpp.versionInfo)
-        return false;
-
-    if (txnID != bpp.txnID)
-        return false;
-
-    if (sessionID != bpp.sessionID)
-        return false;
-
-    if (stepID != bpp.stepID)
-        return false;
-
-    if (uniqueID != bpp.uniqueID)
-        return false;
-
-    if (gotValues != bpp.gotValues)
-        return false;
-
-    if (gotAbsRids != bpp.gotAbsRids)
-        return false;
-
-    if (needStrValues != bpp.needStrValues)
-        return false;
-
-    if (filterCount != bpp.filterCount)
-        return false;
-
-    if (projectCount != bpp.projectCount)
-        return false;
-
-    if (sendRidsAtDelivery != bpp.sendRidsAtDelivery)
-        return false;
-
-    if (hasScan != bpp.hasScan)
-        return false;
-
-    if (hasFilterStep != bpp.hasFilterStep)
-        return false;
-
-    if (filtOnString != bpp.filtOnString)
-        return false;
-
-    if (doJoin != bpp.doJoin)
-        return false;
-
-    if (doJoin)
-
-        /* Join equality test is a bit out of date */
-        if (joiner != bpp.joiner || joinerSize != bpp.joinerSize)
-            return false;
-
-    for (i = 0; i < filterCount; i++)
-        if (*filterSteps[i] != *bpp.filterSteps[i])
-            return false;
-
-    return true;
-}
-#endif
 
 void BatchPrimitiveProcessor::asyncLoadProjectColumns()
 {

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -213,13 +213,6 @@ BatchPrimitiveProcessor::BatchPrimitiveProcessor(ByteStream& b, double prefetch,
   initBPP(b);
 }
 
-#if 0
-BatchPrimitiveProcessor::BatchPrimitiveProcessor(const BatchPrimitiveProcessor& bpp)
-{
-    throw logic_error("copy BPP deprecated");
-}
-#endif
-
 BatchPrimitiveProcessor::~BatchPrimitiveProcessor()
 {
   // FIXME: just do a sync fetch
@@ -247,6 +240,8 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
   uint8_t tmp8;
   uint16_t tmp16;
   Command::CommandType type;
+  auto cnt = exemgr::globServiceExeMgr->getRm().availableMemory();
+  std::cout << "initBPP availableMemory: " << cnt << std::endl;
 
   bs.advance(sizeof(ISMPacketHeader));  // skip the header
   bs >> tmp8;
@@ -365,13 +360,17 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
 
         if (!typelessJoin[i])
         {
+          auto alloc = exemgr::globServiceExeMgr->getRm().getAllocator<TJoiner::value_type>();
+
           bs >> joinNullValues[i];
           bs >> largeSideKeyColumns[i];
           for (uint j = 0; j < processorThreads; ++j)
-            tJoiners[i][j].reset(new TJoiner(10, TupleJoiner::hasher()));
+            tJoiners[i][j].reset(new TJoiner(10, TupleJoiner::hasher(), alloc));
         }
         else
         {
+          auto alloc = exemgr::globServiceExeMgr->getRm().getAllocator<TLJoiner::value_type>();
+
           deserializeVector<uint32_t>(bs, tlLargeSideKeyColumns[i]);
           bs >> tlSmallSideKeyLengths[i];
           bs >> tmp8;
@@ -393,7 +392,7 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
                                                             mSmallSideKeyColumnsPtr, mSmallSideRGPtr);
             auto tlComparator = TupleJoiner::TypelessDataComparator(&outputRG, &tlLargeSideKeyColumns[i],
                                                                     mSmallSideKeyColumnsPtr, mSmallSideRGPtr);
-            tlJoiners[i][j].reset(new TLJoiner(10, tlHasher, tlComparator));
+            tlJoiners[i][j].reset(new TLJoiner(10, tlHasher, tlComparator, alloc));
           }
         }
       }
@@ -497,7 +496,7 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
       bs >> *(fAggregator.get());
 
       // If there's UDAF involved, set up for PM processing
-      for (const auto & pcol : fAggregator->getAggFunctions())
+      for (const auto& pcol : fAggregator->getAggFunctions())
       {
         auto* rowUDAF = dynamic_cast<RowUDAFFunctionCol*>(pcol.get());
 
@@ -843,6 +842,8 @@ int BatchPrimitiveProcessor::endOfJoiner()
   {
     endOfJoinerRan = true;
     pthread_mutex_unlock(&objLock);
+    auto cnt = exemgr::globServiceExeMgr->getRm().availableMemory();
+    std::cout << "endOfJoiner availableMemory: " << cnt << std::endl;
     return 0;
   }
 
@@ -885,6 +886,8 @@ int BatchPrimitiveProcessor::endOfJoiner()
   endOfJoinerRan = true;
 
   pthread_mutex_unlock(&objLock);
+  auto cnt = exemgr::globServiceExeMgr->getRm().availableMemory();
+  std::cout << "endOfJoiner availableMemory: " << cnt << std::endl;
   return 0;
 }
 
@@ -1218,7 +1221,7 @@ uint32_t BatchPrimitiveProcessor::executeTupleJoin(uint32_t startRid, RowGroup& 
             {
               bool hasNull = false;
 
-              for (unsigned int column: tlLargeSideKeyColumns[j])
+              for (unsigned int column : tlLargeSideKeyColumns[j])
                 if (oldRow.isNullValue(column))
                 {
                   hasNull = true;
@@ -1374,7 +1377,7 @@ uint32_t BatchPrimitiveProcessor::executeTupleJoin(uint32_t startRid, RowGroup& 
 #ifdef PRIMPROC_STOPWATCH
 void BatchPrimitiveProcessor::execute(StopWatch* stopwatch)
 #else
-void BatchPrimitiveProcessor::execute()
+void BatchPrimitiveProcessor::execute(messageqcpp::SBS& bs)
 #endif
 {
   uint8_t sendCount = 0;
@@ -1387,7 +1390,6 @@ void BatchPrimitiveProcessor::execute()
 #ifdef PRIMPROC_STOPWATCH
     stopwatch->start("BatchPrimitiveProcessor::execute first part");
 #endif
-
     // if only one scan step which has no predicate, async load all columns
     if (filterCount == 1 && hasScan)
     {
@@ -1508,7 +1510,7 @@ void BatchPrimitiveProcessor::execute()
       writeProjectionPreamble();
       stopwatch->stop("- writeProjectionPreamble");
 #else
-      writeProjectionPreamble();
+      writeProjectionPreamble(bs);
 #endif
     }
 
@@ -1535,7 +1537,7 @@ void BatchPrimitiveProcessor::execute()
     {
       for (j = 0; j < projectCount; ++j)
       {
-        projectSteps[j]->project();
+        projectSteps[j]->project(bs);
       }
     }
     else
@@ -1636,9 +1638,9 @@ void BatchPrimitiveProcessor::execute()
 
           if (!fAggregator)
           {
-            *serialized << (uint8_t)1;  // the "count this msg" var
+            *bs << (uint8_t)1;  // the "count this msg" var
             fe2Output.setDBRoot(dbRoot);
-            fe2Output.serializeRGData(*serialized);
+            fe2Output.serializeRGData(*bs);
             //*serialized << fe2Output.getDataSize();
             // serialized->append(fe2Output.getData(), fe2Output.getDataSize());
           }
@@ -1646,7 +1648,7 @@ void BatchPrimitiveProcessor::execute()
 
         if (fAggregator)
         {
-          *serialized << (uint8_t)1;  // the "count this msg" var
+          *bs << (uint8_t)1;  // the "count this msg" var
 
           RowGroup& toAggregate = (fe2 ? fe2Output : outputRG);
           // toAggregate.convertToInlineDataInPlace();
@@ -1660,25 +1662,25 @@ void BatchPrimitiveProcessor::execute()
 
           if ((currentBlockOffset + 1) == count)  // @bug4507, 8k
           {
-            fAggregator->loadResult(*serialized);            // @bug4507, 8k
-          }                                                  // @bug4507, 8k
+            fAggregator->loadResult(*bs);  // @bug4507, 8k
+          }  // @bug4507, 8k
           else if (utils::MonitorProcMem::isMemAvailable())  // @bug4507, 8k
           {
-            fAggregator->loadEmptySet(*serialized);  // @bug4507, 8k
-          }                                          // @bug4507, 8k
-          else                                       // @bug4507, 8k
+            fAggregator->loadEmptySet(*bs);  // @bug4507, 8k
+          }  // @bug4507, 8k
+          else  // @bug4507, 8k
           {
-            fAggregator->loadResult(*serialized);  // @bug4507, 8k
-            fAggregator->aggReset();               // @bug4507, 8k
-          }                                        // @bug4507, 8k
+            fAggregator->loadResult(*bs);  // @bug4507, 8k
+            fAggregator->aggReset();       // @bug4507, 8k
+          }  // @bug4507, 8k
         }
 
         if (!fAggregator && !fe2)
         {
-          *serialized << (uint8_t)1;  // the "count this msg" var
+          *bs << (uint8_t)1;  // the "count this msg" var
           outputRG.setDBRoot(dbRoot);
           // cerr << "serializing " << outputRG.toString() << endl;
-          outputRG.serializeRGData(*serialized);
+          outputRG.serializeRGData(*bs);
 
           //*serialized << outputRG.getDataSize();
           // serialized->append(outputRG.getData(), outputRG.getDataSize());
@@ -1691,7 +1693,7 @@ void BatchPrimitiveProcessor::execute()
       else  // Is doJoin
       {
         uint32_t startRid = 0;
-        ByteStream preamble = *serialized;
+        ByteStream preamble = *bs;
         origRidCount = ridCount;  // ridCount can get modified by executeTupleJoin(). We need to keep track of
                                   // the original val.
         /* project the key columns.  If there's the filter IN the join, project everything.
@@ -1772,7 +1774,7 @@ void BatchPrimitiveProcessor::execute()
               sendCount = (uint8_t)(!moreRGs && !startRid);
               //                            *serialized << (uint8_t)(!moreRGs && !startRid);   // the "count
               //                            this msg" var
-              *serialized << sendCount;
+              *bs << sendCount;
               if (fe2)
               {
                 /* functionize this -> processFE2()*/
@@ -1802,30 +1804,30 @@ void BatchPrimitiveProcessor::execute()
 
                 if ((currentBlockOffset + 1) == count && moreRGs == false && startRid == 0)  // @bug4507, 8k
                 {
-                  fAggregator->loadResult(*serialized);            // @bug4507, 8k
-                }                                                  // @bug4507, 8k
+                  fAggregator->loadResult(*bs);  // @bug4507, 8k
+                }  // @bug4507, 8k
                 else if (utils::MonitorProcMem::isMemAvailable())  // @bug4507, 8k
                 {
-                  fAggregator->loadEmptySet(*serialized);  // @bug4507, 8k
-                }                                          // @bug4507, 8k
-                else                                       // @bug4507, 8k
+                  fAggregator->loadEmptySet(*bs);  // @bug4507, 8k
+                }  // @bug4507, 8k
+                else  // @bug4507, 8k
                 {
-                  fAggregator->loadResult(*serialized);  // @bug4507, 8k
-                  fAggregator->aggReset();               // @bug4507, 8k
-                }                                        // @bug4507, 8k
+                  fAggregator->loadResult(*bs);  // @bug4507, 8k
+                  fAggregator->aggReset();       // @bug4507, 8k
+                }  // @bug4507, 8k
               }
               else
               {
                 // cerr <<" * serialzing " << nextRG.toString() << endl;
-                nextRG.serializeRGData(*serialized);
+                nextRG.serializeRGData(*bs);
               }
 
               /* send the msg & reinit the BS */
               if (moreRGs)
               {
-                sendResponse();
-                serialized.reset(new ByteStream());
-                *serialized = preamble;
+                sendResponse(bs);
+                bs.reset(new ByteStream());
+                *bs = preamble;
               }
             }
 
@@ -1833,16 +1835,16 @@ void BatchPrimitiveProcessor::execute()
             {
               // Should we happen to finish sending data rows right on the boundary of when moreRGs flips off,
               // then we need to start a new buffer. I.e., it needs the count this message byte pushed.
-              if (serialized->length() == preamble.length())
-                *serialized << (uint8_t)(startRid > 0 ? 0 : 1);  // the "count this msg" var
+              if (bs->length() == preamble.length())
+                *bs << (uint8_t)(startRid > 0 ? 0 : 1);  // the "count this msg" var
 
-              *serialized << ridCount;
+              *bs << ridCount;
 
               for (i = 0; i < joinerCount; i++)
               {
                 for (j = 0; j < ridCount; ++j)
                 {
-                  serializeInlineVector<uint32_t>(*serialized, tSmallSideMatches[i][j]);
+                  serializeInlineVector<uint32_t>(*bs, tSmallSideMatches[i][j]);
                   tSmallSideMatches[i][j].clear();
                 }
               }
@@ -1857,10 +1859,10 @@ void BatchPrimitiveProcessor::execute()
           }
           else
           {
-            *serialized << (uint8_t)(startRid > 0 ? 0 : 1);  // the "count this msg" var
+            *bs << (uint8_t)(startRid > 0 ? 0 : 1);  // the "count this msg" var
             outputRG.setDBRoot(dbRoot);
             // cerr << "serializing " << outputRG.toString() << endl;
-            outputRG.serializeRGData(*serialized);
+            outputRG.serializeRGData(*bs);
 
             //*serialized << outputRG.getDataSize();
             // serialized->append(outputRG.getData(), outputRG.getDataSize());
@@ -1868,16 +1870,16 @@ void BatchPrimitiveProcessor::execute()
             {
               for (j = 0; j < ridCount; ++j)
               {
-                serializeInlineVector<uint32_t>(*serialized, tSmallSideMatches[i][j]);
+                serializeInlineVector<uint32_t>(*bs, tSmallSideMatches[i][j]);
                 tSmallSideMatches[i][j].clear();
               }
             }
           }
           if (startRid > 0)
           {
-            sendResponse();
-            serialized.reset(new ByteStream());
-            *serialized = preamble;
+            sendResponse(bs);
+            bs.reset(new ByteStream());
+            *bs = preamble;
           }
         } while (startRid > 0);
       }
@@ -1890,11 +1892,11 @@ void BatchPrimitiveProcessor::execute()
     //        sendCount << std::endl;
     if (projectCount > 0 || ot == ROW_GROUP)
     {
-      *serialized << cachedIO;
+      *bs << cachedIO;
       cachedIO = 0;
-      *serialized << physIO;
+      *bs << physIO;
       physIO = 0;
-      *serialized << touchedBlocks;
+      *bs << touchedBlocks;
       touchedBlocks = 0;
       // 		cout << "sent physIO=" << physIO << " cachedIO=" << cachedIO <<
       // 			" touchedBlocks=" << touchedBlocks << endl;
@@ -1906,15 +1908,15 @@ void BatchPrimitiveProcessor::execute()
   }
   catch (logging::QueryDataExcept& qex)
   {
-    writeErrorMsg(qex.what(), qex.errorCode());
+    writeErrorMsg(bs, qex.what(), qex.errorCode());
   }
   catch (logging::DictionaryBufferOverflow& db)
   {
-    writeErrorMsg(db.what(), db.errorCode());
+    writeErrorMsg(bs, db.what(), db.errorCode());
   }
   catch (scalar_exception& se)
   {
-    writeErrorMsg(IDBErrorInfo::instance()->errorMsg(ERR_MORE_THAN_1_ROW), ERR_MORE_THAN_1_ROW, false);
+    writeErrorMsg(bs, IDBErrorInfo::instance()->errorMsg(ERR_MORE_THAN_1_ROW), ERR_MORE_THAN_1_ROW, false);
   }
   catch (NeedToRestartJob& n)
   {
@@ -1925,20 +1927,21 @@ void BatchPrimitiveProcessor::execute()
   }
   catch (IDBExcept& iex)
   {
-    writeErrorMsg(iex.what(), iex.errorCode(), true, false);
+    writeErrorMsg(bs, iex.what(), iex.errorCode(), true, false);
   }
   catch (const std::exception& ex)
   {
-    writeErrorMsg(ex.what(), logging::batchPrimitiveProcessorErr);
+    writeErrorMsg(bs, ex.what(), logging::batchPrimitiveProcessorErr);
   }
   catch (...)
   {
     string msg("BatchPrimitiveProcessor caught an unknown exception");
-    writeErrorMsg(msg, logging::batchPrimitiveProcessorErr);
+    writeErrorMsg(bs, msg, logging::batchPrimitiveProcessorErr);
   }
 }
 
-void BatchPrimitiveProcessor::writeErrorMsg(const string& error, uint16_t errCode, bool logIt, bool critical)
+void BatchPrimitiveProcessor::writeErrorMsg(messageqcpp::SBS& bs, const string& error, uint16_t errCode,
+                                            bool logIt, bool critical)
 {
   ISMPacketHeader ism;
   PrimitiveHeader ph;
@@ -1954,10 +1957,10 @@ void BatchPrimitiveProcessor::writeErrorMsg(const string& error, uint16_t errCod
   ph.UniqueID = uniqueID;
   ism.Status = errCode;
 
-  serialized.reset(new ByteStream());
-  serialized->append((uint8_t*)&ism, sizeof(ism));
-  serialized->append((uint8_t*)&ph, sizeof(ph));
-  *serialized << error;
+  bs.reset(new ByteStream());
+  bs->append((uint8_t*)&ism, sizeof(ism));
+  bs->append((uint8_t*)&ph, sizeof(ph));
+  *bs << error;
 
   if (logIt)
   {
@@ -1966,7 +1969,7 @@ void BatchPrimitiveProcessor::writeErrorMsg(const string& error, uint16_t errCod
   }
 }
 
-void BatchPrimitiveProcessor::writeProjectionPreamble()
+void BatchPrimitiveProcessor::writeProjectionPreamble(SBS& bs)
 {
   ISMPacketHeader ism;
   PrimitiveHeader ph;
@@ -1981,36 +1984,36 @@ void BatchPrimitiveProcessor::writeProjectionPreamble()
   ph.StepID = stepID;
   ph.UniqueID = uniqueID;
 
-  serialized.reset(new ByteStream());
-  serialized->append((uint8_t*)&ism, sizeof(ism));
-  serialized->append((uint8_t*)&ph, sizeof(ph));
+  bs.reset(new ByteStream());
+  bs->append((uint8_t*)&ism, sizeof(ism));
+  bs->append((uint8_t*)&ph, sizeof(ph));
 
   /* add-ons */
   if (hasScan)
   {
     if (validCPData)
     {
-      *serialized << (uint8_t)1;
-      *serialized << lbidForCP;
-      *serialized << ((uint8_t)cpDataFromDictScan);
+      *bs << (uint8_t)1;
+      *bs << lbidForCP;
+      *bs << ((uint8_t)cpDataFromDictScan);
       if (UNLIKELY(hasWideColumnOut))
       {
         // PSA width
-        *serialized << (uint8_t)wideColumnWidthOut;
-        *serialized << min128Val;
-        *serialized << max128Val;
+        *bs << (uint8_t)wideColumnWidthOut;
+        *bs << min128Val;
+        *bs << max128Val;
       }
       else
       {
-        *serialized << (uint8_t)utils::MAXLEGACYWIDTH;  // width of min/max value
-        *serialized << (uint64_t)minVal;
-        *serialized << (uint64_t)maxVal;
+        *bs << (uint8_t)utils::MAXLEGACYWIDTH;  // width of min/max value
+        *bs << (uint64_t)minVal;
+        *bs << (uint64_t)maxVal;
       }
     }
     else
     {
-      *serialized << (uint8_t)0;
-      *serialized << lbidForCP;
+      *bs << (uint8_t)0;
+      *bs << lbidForCP;
     }
   }
 
@@ -2019,34 +2022,34 @@ void BatchPrimitiveProcessor::writeProjectionPreamble()
 
   if (ot != ROW_GROUP)
   {
-    *serialized << ridCount;
+    *bs << ridCount;
 
     if (sendRidsAtDelivery)
     {
-      *serialized << baseRid;
-      serialized->append((uint8_t*)relRids, ridCount << 1);
+      *bs << baseRid;
+      bs->append((uint8_t*)relRids, ridCount << 1);
     }
   }
 }
 
-void BatchPrimitiveProcessor::serializeElementTypes()
+void BatchPrimitiveProcessor::serializeElementTypes(messageqcpp::SBS& bs)
 {
-  *serialized << baseRid;
-  *serialized << ridCount;
-  serialized->append((uint8_t*)relRids, ridCount << 1);
-  serialized->append((uint8_t*)values, ridCount << 3);
+  *bs << baseRid;
+  *bs << ridCount;
+  bs->append((uint8_t*)relRids, ridCount << 1);
+  bs->append((uint8_t*)values, ridCount << 3);
 }
 
-void BatchPrimitiveProcessor::serializeStrings()
+void BatchPrimitiveProcessor::serializeStrings(messageqcpp::SBS& bs)
 {
-  *serialized << ridCount;
-  serialized->append((uint8_t*)absRids.get(), ridCount << 3);
+  *bs << ridCount;
+  bs->append((uint8_t*)absRids.get(), ridCount << 3);
 
   for (uint32_t i = 0; i < ridCount; ++i)
-    *serialized << strValues[i];
+    *bs << strValues[i];
 }
 
-void BatchPrimitiveProcessor::sendResponse()
+void BatchPrimitiveProcessor::sendResponse(messageqcpp::SBS& bs)
 {
   // Here is the fast path for local EM to PM interaction. PM puts into the
   // input EM DEC queue directly.
@@ -2057,12 +2060,12 @@ void BatchPrimitiveProcessor::sendResponse()
     // is limited.
     if (sendThread->flowControlEnabled())
     {
-      sendThread->sendResult({serialized, sock, writelock, 0}, false);
+      sendThread->sendResult({bs, sock, writelock, 0}, false);
     }
     else
     {
-      sock->write(serialized);
-      serialized.reset();
+      sock->write(bs);
+      bs.reset();
     }
 
     return;
@@ -2072,20 +2075,20 @@ void BatchPrimitiveProcessor::sendResponse()
   {
     // newConnection should be set only for the first result of a batch job
     // it tells sendthread it should consider it for the connection array
-    sendThread->sendResult(BPPSendThread::Msg_t(serialized, sock, writelock, sockIndex), newConnection);
+    sendThread->sendResult(BPPSendThread::Msg_t(bs, sock, writelock, sockIndex), newConnection);
     newConnection = false;
   }
   else
   {
     boost::mutex::scoped_lock lk(*writelock);
-    sock->write(*serialized);
+    sock->write(*bs);
   }
 
-  serialized.reset();
+  bs.reset();
 }
 
 /* The output of a filter chain is either ELEMENT_TYPE or STRING_ELEMENT_TYPE */
-void BatchPrimitiveProcessor::makeResponse()
+void BatchPrimitiveProcessor::makeResponse(messageqcpp::SBS& bs)
 {
   ISMPacketHeader ism;
   PrimitiveHeader ph;
@@ -2100,39 +2103,39 @@ void BatchPrimitiveProcessor::makeResponse()
   ph.StepID = stepID;
   ph.UniqueID = uniqueID;
 
-  serialized.reset(new ByteStream());
-  serialized->append((uint8_t*)&ism, sizeof(ism));
-  serialized->append((uint8_t*)&ph, sizeof(ph));
+  bs.reset(new ByteStream());
+  bs->append((uint8_t*)&ism, sizeof(ism));
+  bs->append((uint8_t*)&ph, sizeof(ph));
 
   /* add-ons */
   if (hasScan)
   {
     if (validCPData)
     {
-      *serialized << (uint8_t)1;
-      *serialized << lbidForCP;
-      *serialized << ((uint8_t)cpDataFromDictScan);
+      *bs << (uint8_t)1;
+      *bs << lbidForCP;
+      *bs << ((uint8_t)cpDataFromDictScan);
 
       if (UNLIKELY(hasWideColumnOut))
       {
         // PSA width
         // Remove the assert for >16 bytes DTs.
         assert(wideColumnWidthOut == datatypes::MAXDECIMALWIDTH);
-        *serialized << (uint8_t)wideColumnWidthOut;
-        *serialized << min128Val;
-        *serialized << max128Val;
+        *bs << (uint8_t)wideColumnWidthOut;
+        *bs << min128Val;
+        *bs << max128Val;
       }
       else
       {
-        *serialized << (uint8_t)utils::MAXLEGACYWIDTH;  // width of min/max value
-        *serialized << (uint64_t)minVal;
-        *serialized << (uint64_t)maxVal;
+        *bs << (uint8_t)utils::MAXLEGACYWIDTH;  // width of min/max value
+        *bs << (uint64_t)minVal;
+        *bs << (uint64_t)maxVal;
       }
     }
     else
     {
-      *serialized << (uint8_t)0;
-      *serialized << lbidForCP;
+      *bs << (uint8_t)0;
+      *bs << lbidForCP;
     }
   }
 
@@ -2140,9 +2143,9 @@ void BatchPrimitiveProcessor::makeResponse()
   /* Take the rid and value arrays, munge into OutputType ot */
   switch (ot)
   {
-    case BPS_ELEMENT_TYPE: serializeElementTypes(); break;
+    case BPS_ELEMENT_TYPE: serializeElementTypes(bs); break;
 
-    case STRING_ELEMENT_TYPE: serializeStrings(); break;
+    case STRING_ELEMENT_TYPE: serializeStrings(bs); break;
 
     default:
     {
@@ -2150,15 +2153,13 @@ void BatchPrimitiveProcessor::makeResponse()
       oss << "BPP: makeResponse(): Bad output type: " << ot;
       throw logic_error(oss.str());
     }
-
-      // throw logic_error("BPP: makeResponse(): Bad output type");
   }
 
-  *serialized << cachedIO;
+  *bs << cachedIO;
   cachedIO = 0;
-  *serialized << physIO;
+  *bs << physIO;
   physIO = 0;
-  *serialized << touchedBlocks;
+  *bs << touchedBlocks;
   touchedBlocks = 0;
 
   // 	cout << "sent physIO=" << physIO << " cachedIO=" << cachedIO <<
@@ -2214,20 +2215,24 @@ int BatchPrimitiveProcessor::operator()()
 
     validCPData = false;
     cpDataFromDictScan = false;
+
+    auto alloc = exemgr::globServiceExeMgr->getRm().getAllocator<messageqcpp::BSBufType>();
+    messageqcpp::SBS bs(new ByteStream(&alloc));
+
 #ifdef PRIMPROC_STOPWATCH
     stopwatch->start("BPP() execute");
     execute(stopwatch);
     stopwatch->stop("BPP() execute");
 #else
-    execute();
+    execute(bs);
 #endif
 
     if (projectCount == 0 && ot != ROW_GROUP)
-      makeResponse();
+      makeResponse(bs);
 
     try
     {
-      sendResponse();
+      sendResponse(bs);
     }
     catch (std::exception& e)
     {
@@ -2701,7 +2706,7 @@ inline void BatchPrimitiveProcessor::getJoinResults(const Row& r, uint32_t jInde
     {
       bool hasNullValue = false;
 
-      for (unsigned int column: tlLargeSideKeyColumns[jIndex])
+      for (unsigned int column : tlLargeSideKeyColumns[jIndex])
       {
         if (r.isNullValue(column))
         {
@@ -2749,7 +2754,6 @@ void BatchPrimitiveProcessor::buildVSSCache(uint32_t loopCount)
   if (rc == 0)
     for (i = 0; i < vssData.size(); i++)
       vssCache.insert(make_pair(lbidList[i], vssData[i]));
-
 }
 
 }  // namespace primitiveprocessor

--- a/primitives/primproc/batchprimitiveprocessor.h
+++ b/primitives/primproc/batchprimitiveprocessor.h
@@ -270,7 +270,6 @@ class BatchPrimitiveProcessor
   uint32_t physIO, cachedIO, touchedBlocks;
 
   SP_UM_IOSOCK sock;
-  // messageqcpp::SBS serialized;
   SP_UM_MUTEX writelock;
 
   // MCOL-744 using pthread mutex instead of Boost mutex because
@@ -309,19 +308,10 @@ class BatchPrimitiveProcessor
   bool hasRowGroup;
 
   /* Rowgroups + join */
-  // typedef std::unordered_multimap<uint64_t, uint32_t, joiner::TupleJoiner::hasher,
-  //                                      std::equal_to<uint64_t>,
-  //                                      utils::STLPoolAllocator<std::pair<const uint64_t, uint32_t>>>
-  //     TJoiner;
   using TJoiner =
       std::unordered_multimap<uint64_t, uint32_t, joiner::TupleJoiner::hasher, std::equal_to<uint64_t>,
                               allocators::CountingAllocator<std::pair<const uint64_t, uint32_t>>>;
 
-  // typedef std::unordered_multimap<
-  //     joiner::TypelessData, uint32_t, joiner::TupleJoiner::TypelessDataHasher,
-  //     joiner::TupleJoiner::TypelessDataComparator,
-  //     utils::STLPoolAllocator<std::pair<const joiner::TypelessData, uint32_t>>>
-  //     TLJoiner;
   using TLJoiner =
       std::unordered_multimap<joiner::TypelessData, uint32_t, joiner::TupleJoiner::TypelessDataHasher,
                               joiner::TupleJoiner::TypelessDataComparator,
@@ -379,7 +369,6 @@ class BatchPrimitiveProcessor
 
   inline void getJoinResults(const rowgroup::Row& r, uint32_t jIndex, std::vector<uint32_t>& v);
   // these allocators hold the memory for the keys stored in tlJoiners
-  // WIP This was a shared vec of allocators originally but it might not be necessary.
   // This might give far memory allocations for keys used by JOIN hashmap.
   std::vector<utils::PoolAllocator> storedKeyAllocators;
 

--- a/primitives/primproc/batchprimitiveprocessor.h
+++ b/primitives/primproc/batchprimitiveprocessor.h
@@ -188,7 +188,7 @@ class BatchPrimitiveProcessor
 
   void initProcessor();
 #ifdef PRIMPROC_STOPWATCH
-  void execute(logging::StopWatch* stopwatch);
+  void execute(logging::StopWatch* stopwatch, messageqcpp::SBS& bs);
 #else
   void execute(messageqcpp::SBS& bs);
 #endif
@@ -379,14 +379,15 @@ class BatchPrimitiveProcessor
 
   inline void getJoinResults(const rowgroup::Row& r, uint32_t jIndex, std::vector<uint32_t>& v);
   // these allocators hold the memory for the keys stored in tlJoiners
-  std::shared_ptr<utils::PoolAllocator[]> storedKeyAllocators;
+  // WIP This was a shared vec of allocators originally but it might not be necessary.
+  // This might give far memory allocations for keys used by JOIN hashmap.
+  std::vector<utils::PoolAllocator> storedKeyAllocators;
 
   /* PM Aggregation */
   rowgroup::RowGroup joinedRG;  // if there's a join, the rows are formatted with this
   rowgroup::SP_ROWAGG_PM_t fAggregator;
   rowgroup::RowGroup fAggregateRG;
   rowgroup::RGData fAggRowGroupData;
-  // boost::scoped_array<uint8_t> fAggRowGroupData;
 
   /* OR hacks */
   uint8_t bop;  // BOP_AND or BOP_OR

--- a/primitives/primproc/batchprimitiveprocessor.h
+++ b/primitives/primproc/batchprimitiveprocessor.h
@@ -33,9 +33,10 @@
 #include <boost/scoped_array.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <tr1/unordered_map>
+#include <unordered_map>
 #include <boost/thread.hpp>
 
+#include "countingallocator.h"
 #include "errorcodes.h"
 #include "serializeable.h"
 #include "messagequeue.h"
@@ -189,20 +190,20 @@ class BatchPrimitiveProcessor
 #ifdef PRIMPROC_STOPWATCH
   void execute(logging::StopWatch* stopwatch);
 #else
-  void execute();
+  void execute(messageqcpp::SBS& bs);
 #endif
-  void writeProjectionPreamble();
-  void makeResponse();
-  void sendResponse();
+  void writeProjectionPreamble(messageqcpp::SBS& bs);
+  void makeResponse(messageqcpp::SBS& bs);
+  void sendResponse(messageqcpp::SBS& bs);
   /* Used by scan operations to increment the LBIDs in successive steps */
   void nextLBID();
 
   /* these send relative rids, should this be abs rids? */
-  void serializeElementTypes();
-  void serializeStrings();
+  void serializeElementTypes(messageqcpp::SBS& bs);
+  void serializeStrings(messageqcpp::SBS& bs);
 
   void asyncLoadProjectColumns();
-  void writeErrorMsg(const std::string& error, uint16_t errCode, bool logIt = true, bool critical = true);
+  void writeErrorMsg(messageqcpp::SBS& bs, const std::string& error, uint16_t errCode, bool logIt = true, bool critical = true);
 
   BPSOutputType ot;
 
@@ -231,7 +232,7 @@ class BatchPrimitiveProcessor
   /* Common space for primitive data */
   alignas(utils::MAXCOLUMNWIDTH) uint8_t blockData[BLOCK_SIZE * utils::MAXCOLUMNWIDTH];
   uint8_t blockDataAux[BLOCK_SIZE * execplan::AUX_COL_WIDTH];
-  std::unique_ptr<uint8_t[], utils::AlignedDeleter>  outputMsg;
+  std::unique_ptr<uint8_t[], utils::AlignedDeleter> outputMsg;
   uint32_t outMsgSize;
 
   std::vector<SCommand> filterSteps;
@@ -269,7 +270,7 @@ class BatchPrimitiveProcessor
   uint32_t physIO, cachedIO, touchedBlocks;
 
   SP_UM_IOSOCK sock;
-  messageqcpp::SBS serialized;
+  // messageqcpp::SBS serialized;
   SP_UM_MUTEX writelock;
 
   // MCOL-744 using pthread mutex instead of Boost mutex because
@@ -308,16 +309,23 @@ class BatchPrimitiveProcessor
   bool hasRowGroup;
 
   /* Rowgroups + join */
-  typedef std::tr1::unordered_multimap<uint64_t, uint32_t, joiner::TupleJoiner::hasher,
-                                       std::equal_to<uint64_t>,
-                                       utils::STLPoolAllocator<std::pair<const uint64_t, uint32_t>>>
-      TJoiner;
+  // typedef std::unordered_multimap<uint64_t, uint32_t, joiner::TupleJoiner::hasher,
+  //                                      std::equal_to<uint64_t>,
+  //                                      utils::STLPoolAllocator<std::pair<const uint64_t, uint32_t>>>
+  //     TJoiner;
+  using TJoiner =
+      std::unordered_multimap<uint64_t, uint32_t, joiner::TupleJoiner::hasher, std::equal_to<uint64_t>,
+                              allocators::CountingAllocator<std::pair<const uint64_t, uint32_t>>>;
 
-  typedef std::tr1::unordered_multimap<
-      joiner::TypelessData, uint32_t, joiner::TupleJoiner::TypelessDataHasher,
-      joiner::TupleJoiner::TypelessDataComparator,
-      utils::STLPoolAllocator<std::pair<const joiner::TypelessData, uint32_t>>>
-      TLJoiner;
+  // typedef std::unordered_multimap<
+  //     joiner::TypelessData, uint32_t, joiner::TupleJoiner::TypelessDataHasher,
+  //     joiner::TupleJoiner::TypelessDataComparator,
+  //     utils::STLPoolAllocator<std::pair<const joiner::TypelessData, uint32_t>>>
+  //     TLJoiner;
+  using TLJoiner =
+      std::unordered_multimap<joiner::TypelessData, uint32_t, joiner::TupleJoiner::TypelessDataHasher,
+                              joiner::TupleJoiner::TypelessDataComparator,
+                              allocators::CountingAllocator<std::pair<const joiner::TypelessData, uint32_t>>>;
 
   bool generateJoinedRowGroup(rowgroup::Row& baseRow, const uint32_t depth = 0);
   /* generateJoinedRowGroup helper fcns & vars */

--- a/primitives/primproc/columncommand.cpp
+++ b/primitives/primproc/columncommand.cpp
@@ -654,7 +654,7 @@ void ColumnCommand::fillInPrimitiveMessageHeader(const int8_t outputType, const 
 }
 
 /* Assumes OT_DATAVALUE */
-void ColumnCommand::projectResult()
+void ColumnCommand::projectResult(messageqcpp::SBS& bs)
 {
   auto nvals = outMsg->NVALS;
   if (primMsg->NVALS != nvals || nvals != bpp->ridCount)
@@ -687,8 +687,8 @@ void ColumnCommand::projectResult()
   idbassert(primMsg->NVALS == nvals);
   idbassert(bpp->ridCount == nvals);
   uint32_t valuesByteSize = nvals * colType.colWidth;
-  *bpp->serialized << valuesByteSize;
-  bpp->serialized->append(primitives::getFirstValueArrayPosition(outMsg), valuesByteSize);
+  *bs << valuesByteSize;
+  bs->append(primitives::getFirstValueArrayPosition(outMsg), valuesByteSize);
 }
 
 void ColumnCommand::removeRowsFromRowGroup(RowGroup& rg)
@@ -815,19 +815,19 @@ void ColumnCommand::projectResultRG(RowGroup& rg, uint32_t pos)
   }
 }
 
-void ColumnCommand::project()
+void ColumnCommand::project(messageqcpp::SBS& bs)
 {
   /* bpp->ridCount == 0 would signify a scan operation */
   if (bpp->ridCount == 0)
   {
-    *bpp->serialized << (uint32_t)0;
+    *bs << (uint32_t)0;
     blockCount += colType.colWidth;
     return;
   }
 
   makeStepMsg();
   issuePrimitive();
-  projectResult();
+  projectResult(bs);
 }
 
 void ColumnCommand::projectIntoRowGroup(RowGroup& rg, uint32_t pos)

--- a/primitives/primproc/columncommand.h
+++ b/primitives/primproc/columncommand.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <memory>
+#include "bytestream.h"
 #include "columnwidth.h"
 #include "command.h"
 #include "calpontsystemcatalog.h"
@@ -71,7 +72,7 @@ class ColumnCommand : public Command
   void execute();
   void execute(int64_t* vals);  // used by RTSCommand to redirect values
   virtual void prep(int8_t outputType, bool absRids);
-  void project();
+  void project(messageqcpp::SBS& bs);
   void projectIntoRowGroup(rowgroup::RowGroup& rg, uint32_t pos);
   void nextLBID();
   bool isScan()
@@ -151,7 +152,7 @@ class ColumnCommand : public Command
   template <int W>
   void _process_OT_DATAVALUE();
   void process_OT_ROWGROUP();
-  void projectResult();
+  void projectResult(messageqcpp::SBS& bs);
   template <typename T>
   void _projectResultRGLoop(rowgroup::Row& r, const T* valuesArray, const uint32_t offset);
   template <int W>

--- a/primitives/primproc/command.h
+++ b/primitives/primproc/command.h
@@ -54,7 +54,7 @@ class Command
   virtual ~Command();
 
   virtual void execute() = 0;
-  virtual void project() = 0;
+  virtual void project(messageqcpp::SBS& bs) = 0;
   virtual void projectIntoRowGroup(rowgroup::RowGroup& rg, uint32_t columnPosition) = 0;
   virtual uint64_t getLBID() = 0;
   virtual void getLBIDList(uint32_t loopCount, std::vector<int64_t>* out)

--- a/primitives/primproc/dictstep.cpp
+++ b/primitives/primproc/dictstep.cpp
@@ -407,7 +407,7 @@ void DictStep::_execute()
 }
 
 /* This will do the same thing as execute() but put the result in bpp->serialized */
-void DictStep::_project()
+void DictStep::_project(messageqcpp::SBS& bs)
 {
   /* Need to loop over bpp->values, issuing a primitive for each LBID */
   uint32_t i;
@@ -459,13 +459,13 @@ void DictStep::_project()
   }
 
   idbassert(tmpResultCounter == bpp->ridCount);
-  *bpp->serialized << totalResultLength;
+  *bs << totalResultLength;
 
   // cout << "_project() total length = " << totalResultLength << endl;
   for (i = 0; i < tmpResultCounter; i++)
   {
     // cout << "serializing " << tmpStrings[i] << endl;
-    *bpp->serialized << tmpStrings[i];
+    *bs << tmpStrings[i];
   }
 
   // cout << "DS: /_project() l: " << l_lbid << endl;
@@ -637,16 +637,16 @@ void DictStep::_projectToRG(RowGroup& rg, uint32_t col)
   //	<<  endl;
 }
 
-void DictStep::project()
+void DictStep::project(messageqcpp::SBS& bs)
 {
   values = bpp->values;
-  _project();
+  _project(bs);
 }
 
-void DictStep::project(int64_t* vals)
+void DictStep::project(messageqcpp::SBS& bs, int64_t* vals)
 {
   values = vals;
-  _project();
+  _project(bs);
 }
 
 void DictStep::projectIntoRowGroup(RowGroup& rg, uint32_t col)

--- a/primitives/primproc/dictstep.h
+++ b/primitives/primproc/dictstep.h
@@ -42,8 +42,8 @@ class DictStep : public Command
   virtual ~DictStep();
 
   void execute();
-  void project();
-  void project(int64_t* vals);  // used by RTSCommand to redirect input
+  void project(messageqcpp::SBS& bs);
+  void project(messageqcpp::SBS& bs, int64_t* vals);  // used by RTSCommand to redirect input
   void projectIntoRowGroup(rowgroup::RowGroup& rg, uint32_t row);
   void projectIntoRowGroup(rowgroup::RowGroup& rg, int64_t* vals, uint32_t col);
   uint64_t getLBID();
@@ -97,7 +97,7 @@ class DictStep : public Command
   void processResult();
   void projectResult(std::string* tmpStrings);
   void projectResult(StringPtr* tmpStrings);
-  void _project();
+  void _project(messageqcpp::SBS& bs);
   void _projectToRG(rowgroup::RowGroup& rg, uint32_t col);
 
   // struct used for scratch space

--- a/primitives/primproc/filtercommand.cpp
+++ b/primitives/primproc/filtercommand.cpp
@@ -201,7 +201,7 @@ void FilterCommand::prep(int8_t outputType, bool absRids)
 {
 }
 
-void FilterCommand::project()
+void FilterCommand::project(messageqcpp::SBS& bs)
 {
 }
 

--- a/primitives/primproc/filtercommand.h
+++ b/primitives/primproc/filtercommand.h
@@ -45,7 +45,7 @@ class FilterCommand : public Command
 
   // virtuals from base class -- Command
   void execute();
-  void project();
+  void project(messageqcpp::SBS& bs);
   void projectIntoRowGroup(rowgroup::RowGroup& rg, uint32_t col);
   uint64_t getLBID();
   void nextLBID();

--- a/primitives/primproc/passthrucommand.cpp
+++ b/primitives/primproc/passthrucommand.cpp
@@ -60,11 +60,11 @@ void PassThruCommand::execute()
   // 	throw logic_error("PassThruCommand isn't a filter step");
 }
 
-void PassThruCommand::project()
+void PassThruCommand::project(messageqcpp::SBS& bs)
 {
   uint32_t i;
 
-  *bpp->serialized << (uint32_t)(bpp->ridCount * colWidth);
+  *bs << (uint32_t)(bpp->ridCount * colWidth);
 #if 0
     cout << "pass thru serializing " << (uint32_t) (bpp->ridCount * colWidth) << " bytes:\n";
     cout << "at relative position " << bpp->serialized->length() - sizeof(ISMPacketHeader) - sizeof(PrimitiveHeader) - 4 << endl;
@@ -76,25 +76,25 @@ void PassThruCommand::project()
 
   switch (colWidth)
   {
-    case 16: bpp->serialized->append((uint8_t*)bpp->wide128Values, bpp->ridCount << 4); break;
+    case 16: bs->append((uint8_t*)bpp->wide128Values, bpp->ridCount << 4); break;
 
-    case 8: bpp->serialized->append((uint8_t*)bpp->values, bpp->ridCount << 3); break;
+    case 8: bs->append((uint8_t*)bpp->values, bpp->ridCount << 3); break;
 
     case 4:
       for (i = 0; i < bpp->ridCount; i++)
-        *bpp->serialized << (uint32_t)bpp->values[i];
+        *bs << (uint32_t)bpp->values[i];
 
       break;
 
     case 2:
       for (i = 0; i < bpp->ridCount; i++)
-        *bpp->serialized << (uint16_t)bpp->values[i];
+        *bs << (uint16_t)bpp->values[i];
 
       break;
 
     case 1:
       for (i = 0; i < bpp->ridCount; i++)
-        *bpp->serialized << (uint8_t)bpp->values[i];
+        *bs << (uint8_t)bpp->values[i];
 
       break;
 

--- a/primitives/primproc/passthrucommand.h
+++ b/primitives/primproc/passthrucommand.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "bytestream.h"
 #include "command.h"
 
 namespace primitiveprocessor
@@ -42,7 +43,7 @@ class PassThruCommand : public Command
 
   void prep(int8_t outputType, bool makeAbsRids);
   void execute();
-  void project();
+  void project(messageqcpp::SBS& bs);
   void projectIntoRowGroup(rowgroup::RowGroup& rg, uint32_t col);
   uint64_t getLBID();
   void nextLBID();

--- a/primitives/primproc/primproc.cpp
+++ b/primitives/primproc/primproc.cpp
@@ -220,7 +220,7 @@ class QszMonThd
 };
 #endif
 
-#define DUMP_CACHE_CONTENTS
+// #define DUMP_CACHE_CONTENTS
 #ifdef DUMP_CACHE_CONTENTS
 void* waitForSIGUSR1(void* p)
 {

--- a/primitives/primproc/rtscommand.cpp
+++ b/primitives/primproc/rtscommand.cpp
@@ -31,6 +31,7 @@
 #include <unistd.h>
 
 #include "bpp.h"
+#include "bytestream.h"
 #include "exceptclasses.h"
 
 using namespace std;
@@ -53,7 +54,7 @@ void RTSCommand::execute()
   throw logic_error("RTSCommand shouldn't be used for filter steps");
 }
 
-void RTSCommand::project()
+void RTSCommand::project(messageqcpp::SBS& bs)
 {
   uint32_t i;
 
@@ -70,7 +71,7 @@ void RTSCommand::project()
 
     // need something in values
 
-    dict.project();
+    dict.project(bs);
   }
   else
   {
@@ -99,7 +100,7 @@ void RTSCommand::project()
       }
     }
 
-    dict.project(tmpValues);
+    dict.project(bs, tmpValues);
   }
 }
 

--- a/primitives/primproc/rtscommand.h
+++ b/primitives/primproc/rtscommand.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "bytestream.h"
 #include "command.h"
 #include <boost/scoped_ptr.hpp>
 #include <memory>
@@ -43,7 +44,7 @@ class RTSCommand : public Command
   virtual ~RTSCommand();
 
   void execute();
-  void project();
+  void project(messageqcpp::SBS& bs);
   void projectIntoRowGroup(rowgroup::RowGroup& rg, uint32_t col);
   uint64_t getLBID();
   void nextLBID();

--- a/primitives/primproc/serviceexemgr.cpp
+++ b/primitives/primproc/serviceexemgr.cpp
@@ -89,22 +89,8 @@ void startRssMon(size_t maxPct, int pauseSeconds);
 
 void added_a_pm(int)
 {
-  logging::LoggingID logid(21, 0, 0);
-  logging::Message::Args args1;
-  logging::Message msg(1);
-  args1.add("exeMgr caught SIGHUP. Resetting connections");
-  msg.format(args1);
-  std::cout << msg.msg().c_str() << std::endl;
-  logging::Logger logger(logid.fSubsysID);
-  logger.logMessage(logging::LOG_TYPE_DEBUG, msg, logid);
-
-  auto* dec = exemgr::globServiceExeMgr->getDec();
-  if (dec)
-  {
-    oam::OamCache* oamCache = oam::OamCache::makeOamCache();
-    oamCache->forceReload();
-    dec->Setup();
-  }
+  int64_t num = globServiceExeMgr->getRm().availableMemory();
+  std::cout << "Total UM memory available: " << num << std::endl;
 }
 
 void printTotalUmMemory(int sig)

--- a/primitives/primproc/serviceexemgr.h
+++ b/primitives/primproc/serviceexemgr.h
@@ -94,6 +94,8 @@ namespace exemgr
     }
   };
 
+  void printTotalUmMemory(int sig);
+
   class ServiceExeMgr : public Service, public Opt
   {
     using SessionMemMap_t = std::map<uint32_t, size_t>;
@@ -111,16 +113,8 @@ namespace exemgr
     }
 
   public:
-    ServiceExeMgr(const Opt& opt) : Service("ExeMgr"), Opt(opt), msgLog_(logging::Logger(16))
-    {
-      bool runningWithExeMgr = true;
-      rm_ = joblist::ResourceManager::instance(runningWithExeMgr);
-    }
-    ServiceExeMgr(const Opt& opt, config::Config* aConfig) : Service("ExeMgr"), Opt(opt), msgLog_(logging::Logger(16))
-    {
-      bool runningWithExeMgr = true;
-      rm_ = joblist::ResourceManager::instance(runningWithExeMgr, aConfig);
-    }
+    ServiceExeMgr(const Opt& opt, joblist::ResourceManager* rm) : Service("ExeMgr"), Opt(opt), msgLog_(logging::Logger(16)), rm_(rm)
+    { }
     void LogErrno() override
     {
       log(logging::LOG_TYPE_CRITICAL, std::string(strerror(errno)));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,7 @@ if (WITH_UNITTESTS)
     target_link_libraries(counting_allocator ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} ${GTEST_LIBRARIES})
     gtest_add_tests(TARGET counting_allocator TEST_PREFIX columnstore:)
 
+    set_source_files_properties(poolallocator.cpp PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
     add_executable(poolallocator poolallocator.cpp)
     add_dependencies(poolallocator googletest)
     target_link_libraries(poolallocator ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} ${GTEST_LIBRARIES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ if (WITH_UNITTESTS)
     target_link_libraries(fair_threadpool_test ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} ${GTEST_LIBRARIES} processor dbbc)
     gtest_add_tests(TARGET fair_threadpool_test TEST_PREFIX columnstore:)
 
+    set_source_files_properties(counting_allocator.cpp PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
     add_executable(counting_allocator counting_allocator.cpp)
     add_dependencies(counting_allocator googletest)
     target_link_libraries(counting_allocator ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} ${GTEST_LIBRARIES})
@@ -88,7 +89,7 @@ if (WITH_UNITTESTS)
     add_test(NAME columnstore:brm_em_standalone COMMAND brm_em_standalone)
     set_tests_properties(columnstore:brm_em_standalone PROPERTIES DISABLED True)
 endif()
-
+# -Werror=sign-compare
 if (WITH_MICROBENCHMARKS AND (NOT CMAKE_BUILD_TYPE STREQUAL "Debug"))
     find_package(benchmark REQUIRED)
     add_executable(primitives_scan_bench primitives_scan_bench.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,11 @@ if (WITH_UNITTESTS)
     target_link_libraries(counting_allocator ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} ${GTEST_LIBRARIES})
     gtest_add_tests(TARGET counting_allocator TEST_PREFIX columnstore:)
 
+    add_executable(poolallocator poolallocator.cpp)
+    add_dependencies(poolallocator googletest)
+    target_link_libraries(poolallocator ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} ${GTEST_LIBRARIES})
+    gtest_add_tests(TARGET poolallocator TEST_PREFIX columnstore:)
+
     add_executable(comparators_tests comparators-tests.cpp)
     target_link_libraries(comparators_tests ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} ${CPPUNIT_LIBRARIES} cppunit)
     add_test(NAME columnstore:comparators_tests COMMAND comparators_tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,11 @@ if (WITH_UNITTESTS)
     target_link_libraries(fair_threadpool_test ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} ${GTEST_LIBRARIES} processor dbbc)
     gtest_add_tests(TARGET fair_threadpool_test TEST_PREFIX columnstore:)
 
+    add_executable(counting_allocator counting_allocator.cpp)
+    add_dependencies(counting_allocator googletest)
+    target_link_libraries(counting_allocator ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} ${GTEST_LIBRARIES})
+    gtest_add_tests(TARGET counting_allocator TEST_PREFIX columnstore:)
+
     add_executable(comparators_tests comparators-tests.cpp)
     target_link_libraries(comparators_tests ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} ${CPPUNIT_LIBRARIES} cppunit)
     add_test(NAME columnstore:comparators_tests COMMAND comparators_tests)

--- a/tests/counting_allocator.cpp
+++ b/tests/counting_allocator.cpp
@@ -1,0 +1,139 @@
+/* Copyright (C) 2024 MariaDB Corporation
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+   MA 02110-1301, USA. */
+#include <gtest/gtest.h>
+#include <memory>
+#include <atomic>
+#include <cstddef>
+#include "countingallocator.h"
+
+using namespace allocators;
+
+// Example class to be managed by the allocator
+struct TestClass {
+    int value;
+
+    TestClass(int val) : value(val) {}
+};
+
+static const constexpr int64_t MemoryAllowance =  10 * 1024 * 1024; 
+
+// Test Fixture for AtomicCounterAllocator
+class CountingAllocatorTest : public ::testing::Test {
+protected:
+    // Atomic counter to track allocated memory
+    std::atomic<int64_t> allocatedMemory{MemoryAllowance};
+
+    // Custom allocator instance
+    CountingAllocator<TestClass> allocator;
+
+    // Constructor
+    CountingAllocatorTest()
+        : allocatedMemory(MemoryAllowance), allocator(allocatedMemory, MemoryAllowance / 100) {}
+
+    // Destructor
+    ~CountingAllocatorTest() override = default;
+};
+
+// Test 1: Allocation increases the counter correctly
+TEST_F(CountingAllocatorTest, Allocation) {
+    const std::size_t numObjects = 5;
+    TestClass* ptr = allocator.allocate(numObjects);
+    EXPECT_NE(ptr, nullptr);
+    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance - numObjects * static_cast<int64_t>(sizeof(TestClass)));
+    allocator.deallocate(ptr, numObjects);
+}
+
+// Test 2: Deallocation decreases the counter correctly
+TEST_F(CountingAllocatorTest, Deallocation) {
+    const std::size_t numObjects = 3;
+    TestClass* ptr = allocator.allocate(numObjects);
+    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance - numObjects * static_cast<int64_t>(sizeof(TestClass)));
+
+    allocator.deallocate(ptr, numObjects);
+    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+}
+
+// Test 3: Allocator equality based on shared counter
+TEST_F(CountingAllocatorTest, AllocatorEquality) {
+    CountingAllocator<TestClass> allocator1(allocatedMemory);
+    CountingAllocator<TestClass> allocator2(allocatedMemory);
+    EXPECT_TRUE(allocator1 == allocator2);
+
+    std::atomic<int64_t> anotherCounter(0);
+    CountingAllocator<TestClass> allocator3(anotherCounter);
+    EXPECT_FALSE(allocator1 == allocator3);
+}
+
+// Test 4: Using allocator with std::allocate_shared
+TEST_F(CountingAllocatorTest, AllocateSharedUsesAllocator) {
+    // Create a shared_ptr using allocate_shared with the custom allocator
+    std::shared_ptr<TestClass> ptr = std::allocate_shared<TestClass>(allocator, 100);
+
+    // Check that the counter has increased by the size of TestClass plus control block
+    // Exact size depends on the implementation, so we verify it's at least sizeof(TestClass)
+    EXPECT_LE(allocatedMemory.load(), MemoryAllowance - static_cast<int64_t>(sizeof(TestClass)));
+
+    // Reset the shared_ptr and check that the counter decreases appropriately
+    ptr.reset();
+    // After deallocation, the counter should return to zero
+    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+
+    auto deleter = [this](TestClass* ptr) {
+        this->allocator.deallocate(ptr, 1);
+    };
+    ptr.reset(allocator.allocate(1), deleter);
+    EXPECT_LE(allocatedMemory.load(), MemoryAllowance - static_cast<int64_t>(sizeof(TestClass)));
+
+    ptr.reset();
+    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+}
+
+// Test 5: Thread Safety - Concurrent Allocations and Deallocations
+TEST_F(CountingAllocatorTest, ThreadSafety) {
+    const std::size_t numThreads = 100;
+    const std::size_t allocationsPerThread = 3;
+
+    auto worker = [this]() {
+        for (std::size_t i = 0; i < allocationsPerThread; ++i) {
+            TestClass* ptr = allocator.allocate(1);
+            allocator.deallocate(ptr, 1);
+        }
+    };
+
+    std::vector<std::thread> threads;
+    // Launch multiple threads performing allocations and deallocations
+    for (std::size_t i = 0; i < numThreads; ++i) {
+        threads.emplace_back(worker);
+    }
+
+    // Wait for all threads to finish
+    for (auto& th : threads) {
+        th.join();
+    }
+
+    // After all allocations and deallocations, the counter should be zero
+    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+}
+
+// Test 6: Allocating zero objects should not change the counter
+TEST_F(CountingAllocatorTest, AllocateZeroObjects) {
+    TestClass* ptr = allocator.allocate(0);
+    EXPECT_NE(ptr, nullptr);
+    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+    allocator.deallocate(ptr, 0);
+    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+}

--- a/tests/counting_allocator.cpp
+++ b/tests/counting_allocator.cpp
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <cstddef>
 #include "countingallocator.h"
+#include "rowgroup.h"
 
 using namespace allocators;
 
@@ -107,6 +108,13 @@ TEST_F(CountingAllocatorTest, AllocateSharedUsesAllocator)
   EXPECT_LE(allocatedMemory.load(), MemoryAllowance - static_cast<int64_t>(sizeof(TestClass)));
 
   ptr.reset();
+  EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+
+  size_t allocSize = 16ULL * rowgroup::rgCommonSize;
+  auto buf = boost::allocate_shared<rowgroup::RGDataBufType>(allocator, allocSize);
+  EXPECT_LE(allocatedMemory.load(), MemoryAllowance - allocSize);
+
+  buf.reset();
   EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 }
 

--- a/tests/counting_allocator.cpp
+++ b/tests/counting_allocator.cpp
@@ -17,25 +17,28 @@
 #include <gtest/gtest.h>
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <thread>
 
+#include <boost/smart_ptr/allocate_shared_array.hpp>
+
 #include "countingallocator.h"
-#include "rowgroup.h"
 
 using namespace allocators;
 
 // Example class to be managed by the allocator
 struct TestClass
 {
-  int value;
+  int value[1024];
 
   TestClass(int val) : value(val)
   {
   }
 };
 
-static const constexpr int64_t MemoryAllowance = 10 * 1024 * 1024;
+static const constexpr int64_t MemoryAllowance = 1 * 1024 * 1024;
+static const constexpr int64_t MemoryLimitStep = MemoryAllowance / 100;
 
 // Test Fixture for AtomicCounterAllocator
 class CountingAllocatorTest : public ::testing::Test
@@ -49,7 +52,8 @@ class CountingAllocatorTest : public ::testing::Test
 
   // Constructor
   CountingAllocatorTest()
-   : allocatedMemory(MemoryAllowance), allocator(&allocatedMemory, MemoryAllowance / 100)
+   : allocatedMemory(MemoryAllowance)
+   , allocator(&allocatedMemory, MemoryAllowance / 100, MemoryAllowance / 100)
   {
   }
 
@@ -63,7 +67,15 @@ TEST_F(CountingAllocatorTest, Allocation)
   const std::size_t numObjects = 5;
   TestClass* ptr = allocator.allocate(numObjects);
   EXPECT_NE(ptr, nullptr);
-  EXPECT_EQ(allocatedMemory.load(), MemoryAllowance - numObjects * static_cast<int64_t>(sizeof(TestClass)));
+  if (MemoryLimitStep > numObjects * static_cast<int64_t>(sizeof(TestClass)))
+  {
+    EXPECT_EQ(allocatedMemory.load() - allocator.getCurrentLocalMemoryUsage(),
+              MemoryAllowance - numObjects * static_cast<int64_t>(sizeof(TestClass)));
+  }
+  else
+  {
+    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance - numObjects * static_cast<int64_t>(sizeof(TestClass)));
+  }
   allocator.deallocate(ptr, numObjects);
 }
 
@@ -72,8 +84,15 @@ TEST_F(CountingAllocatorTest, Deallocation)
 {
   const std::size_t numObjects = 3;
   TestClass* ptr = allocator.allocate(numObjects);
-  EXPECT_EQ(allocatedMemory.load(), MemoryAllowance - numObjects * static_cast<int64_t>(sizeof(TestClass)));
-
+  if (MemoryLimitStep > numObjects * static_cast<int64_t>(sizeof(TestClass)))
+  {
+    EXPECT_EQ(allocatedMemory.load() - allocator.getCurrentLocalMemoryUsage(),
+              MemoryAllowance - numObjects * static_cast<int64_t>(sizeof(TestClass)));
+  }
+  else
+  {
+    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance - numObjects * static_cast<int64_t>(sizeof(TestClass)));
+  }
   allocator.deallocate(ptr, numObjects);
   EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 }
@@ -94,34 +113,42 @@ TEST_F(CountingAllocatorTest, AllocatorEquality)
 TEST_F(CountingAllocatorTest, AllocateSharedUsesAllocator)
 {
   // Create a shared_ptr using allocate_shared with the custom allocator
-  std::shared_ptr<TestClass> ptr = std::allocate_shared<TestClass>(allocator, 100);
+  CountingAllocator<TestClass> allocatorSmallerStep(&allocatedMemory, MemoryAllowance / 100,
+                                                    MemoryAllowance / 1000);
+  std::shared_ptr<TestClass> ptr1 = std::allocate_shared<TestClass>(allocatorSmallerStep, 100);
+  std::shared_ptr<TestClass> ptr2 = std::allocate_shared<TestClass>(allocatorSmallerStep, 100);
+  std::shared_ptr<TestClass> ptr3 = std::allocate_shared<TestClass>(allocatorSmallerStep, 100);
 
   // Check that the counter has increased by the size of TestClass plus control block
   // Exact size depends on the implementation, so we verify it's at least sizeof(TestClass)
-  EXPECT_LE(allocatedMemory.load(), MemoryAllowance - static_cast<int64_t>(sizeof(TestClass)));
+  EXPECT_LE(allocatedMemory.load(), MemoryAllowance - 3 * static_cast<int64_t>(sizeof(TestClass)));
 
   // Reset the shared_ptr and check that the counter decreases appropriately
-  ptr.reset();
+  ptr1.reset();
+  ptr2.reset();
+  ptr3.reset();
   // After deallocation, the counter should return to zero
   EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 
-  auto deleter = [this](TestClass* ptr) { this->allocator.deallocate(ptr, 1); };
-  ptr.reset(allocator.allocate(1), deleter);
-  EXPECT_LE(allocatedMemory.load(), MemoryAllowance - static_cast<int64_t>(sizeof(TestClass)));
+  // auto deleter = [&allocatorSmallerStep](TestClass* ptr) { allocatorSmallerStep.deallocate(ptr, 1); };
+  // ptr1.reset(allocatorSmallerStep.allocate(3), deleter);
+  // EXPECT_LE(allocatedMemory.load(), MemoryAllowance - static_cast<int64_t>(sizeof(TestClass)));
 
-  ptr.reset();
+  ptr1.reset();
   EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 
-  size_t allocSize = 16ULL * rowgroup::rgCommonSize;
-  auto buf = boost::allocate_shared<rowgroup::RGDataBufType>(allocator, allocSize);
+  using RGDataBufType = uint8_t[];
+  size_t allocSize = 16ULL * 8192;
+  auto buf = boost::allocate_shared<RGDataBufType>(allocator, allocSize);
+
   EXPECT_LE(allocatedMemory.load(), MemoryAllowance - allocSize);
 
   buf.reset();
   EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 
-  CountingAllocator<rowgroup::RGDataBufType> allocator1(&allocatedMemory, MemoryAllowance / 100);
-  std::optional<CountingAllocator<rowgroup::RGDataBufType>> allocator2(allocator1);
-  auto buf1 = boost::allocate_shared<rowgroup::RGDataBufType>(*allocator2, allocSize);
+  CountingAllocator<RGDataBufType> allocator1(&allocatedMemory, MemoryAllowance / 100, MemoryAllowance / 100);
+  std::optional<CountingAllocator<RGDataBufType>> allocator2(allocator1);
+  auto buf1 = boost::allocate_shared<RGDataBufType>(*allocator2, allocSize);
   EXPECT_LE(allocatedMemory.load(), MemoryAllowance - allocSize);
 
   buf1.reset();
@@ -136,11 +163,27 @@ TEST_F(CountingAllocatorTest, ThreadSafety)
 
   auto worker = [this]()
   {
+    std::vector<TestClass*> ptrs;
+    CountingAllocator<TestClass> allocatorLocal(&allocatedMemory, MemoryAllowance / 100,
+                                                MemoryAllowance / 1000);
     for (std::size_t i = 0; i < allocationsPerThread; ++i)
     {
-      TestClass* ptr = allocator.allocate(1);
-      allocator.deallocate(ptr, 1);
+      ptrs.push_back(allocatorLocal.allocate(1));
     }
+
+    int64_t usedMemory = allocationsPerThread * sizeof(TestClass);
+    EXPECT_EQ(allocatorLocal.getCurrentLocalMemoryUsage(), allocationsPerThread * sizeof(TestClass));
+    EXPECT_GE(usedMemory - allocatorLocal.getlastMemoryLimitCheckpoint(), 0LL);
+    EXPECT_LE(allocatedMemory.load(), MemoryAllowance - allocatorLocal.getlastMemoryLimitCheckpoint());
+
+    for (auto* ptr : ptrs)
+    {
+      allocatorLocal.deallocate(ptr, 1);
+    }
+
+    EXPECT_EQ(allocatorLocal.getCurrentLocalMemoryUsage(), 0);
+    EXPECT_EQ(allocatorLocal.getlastMemoryLimitCheckpoint(), 0);
+    EXPECT_GE(allocatedMemory.load(), allocationsPerThread * sizeof(TestClass));
   };
 
   std::vector<std::thread> threads;
@@ -156,7 +199,7 @@ TEST_F(CountingAllocatorTest, ThreadSafety)
     th.join();
   }
 
-  // After all allocations and deallocations, the counter should be zero
+  // After all allocations and deallocations, the counter should be zero minus the remainder
   EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 }
 
@@ -172,8 +215,8 @@ TEST_F(CountingAllocatorTest, AllocateZeroObjects)
 
 TEST_F(CountingAllocatorTest, CopyAssignable)
 {
-    CountingAllocator<TestClass> allocator1(&allocatedMemory);
-    CountingAllocator<TestClass> allocator2(&allocatedMemory);
-    allocator1 = allocator2;
-    EXPECT_EQ(allocator1, allocator2);
+  CountingAllocator<TestClass> allocator1(&allocatedMemory);
+  CountingAllocator<TestClass> allocator2(&allocatedMemory);
+  allocator1 = allocator2;
+  EXPECT_EQ(allocator1, allocator2);
 }

--- a/tests/counting_allocator.cpp
+++ b/tests/counting_allocator.cpp
@@ -113,8 +113,8 @@ TEST_F(CountingAllocatorTest, AllocatorEquality)
 TEST_F(CountingAllocatorTest, AllocateSharedUsesAllocator)
 {
   // Create a shared_ptr using allocate_shared with the custom allocator
-  CountingAllocator<TestClass> allocatorSmallerStep(&allocatedMemory, MemoryAllowance / 100,
-                                                    MemoryAllowance / 1000);
+  CountingAllocator<TestClass> allocatorSmallerStep(&allocatedMemory,
+                                                    MemoryAllowance / 1000, MemoryAllowance / 100);
   std::shared_ptr<TestClass> ptr1 = std::allocate_shared<TestClass>(allocatorSmallerStep, 100);
   std::shared_ptr<TestClass> ptr2 = std::allocate_shared<TestClass>(allocatorSmallerStep, 100);
   std::shared_ptr<TestClass> ptr3 = std::allocate_shared<TestClass>(allocatorSmallerStep, 100);
@@ -164,8 +164,8 @@ TEST_F(CountingAllocatorTest, ThreadSafety)
   auto worker = [this]()
   {
     std::vector<TestClass*> ptrs;
-    CountingAllocator<TestClass> allocatorLocal(&allocatedMemory, MemoryAllowance / 100,
-                                                MemoryAllowance / 1000);
+    CountingAllocator<TestClass> allocatorLocal(&allocatedMemory, MemoryAllowance / 1000,
+                                                MemoryAllowance / 100);
     for (std::size_t i = 0; i < allocationsPerThread; ++i)
     {
       ptrs.push_back(allocatorLocal.allocate(1));

--- a/tests/counting_allocator.cpp
+++ b/tests/counting_allocator.cpp
@@ -23,117 +23,131 @@
 using namespace allocators;
 
 // Example class to be managed by the allocator
-struct TestClass {
-    int value;
+struct TestClass
+{
+  int value;
 
-    TestClass(int val) : value(val) {}
+  TestClass(int val) : value(val)
+  {
+  }
 };
 
-static const constexpr int64_t MemoryAllowance =  10 * 1024 * 1024; 
+static const constexpr int64_t MemoryAllowance = 10 * 1024 * 1024;
 
 // Test Fixture for AtomicCounterAllocator
-class CountingAllocatorTest : public ::testing::Test {
-protected:
-    // Atomic counter to track allocated memory
-    std::atomic<int64_t> allocatedMemory{MemoryAllowance};
+class CountingAllocatorTest : public ::testing::Test
+{
+ protected:
+  // Atomic counter to track allocated memory
+  std::atomic<int64_t> allocatedMemory{MemoryAllowance};
 
-    // Custom allocator instance
-    CountingAllocator<TestClass> allocator;
+  // Custom allocator instance
+  CountingAllocator<TestClass> allocator;
 
-    // Constructor
-    CountingAllocatorTest()
-        : allocatedMemory(MemoryAllowance), allocator(allocatedMemory, MemoryAllowance / 100) {}
+  // Constructor
+  CountingAllocatorTest()
+   : allocatedMemory(MemoryAllowance), allocator(allocatedMemory, MemoryAllowance / 100)
+  {
+  }
 
-    // Destructor
-    ~CountingAllocatorTest() override = default;
+  // Destructor
+  ~CountingAllocatorTest() override = default;
 };
 
 // Test 1: Allocation increases the counter correctly
-TEST_F(CountingAllocatorTest, Allocation) {
-    const std::size_t numObjects = 5;
-    TestClass* ptr = allocator.allocate(numObjects);
-    EXPECT_NE(ptr, nullptr);
-    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance - numObjects * static_cast<int64_t>(sizeof(TestClass)));
-    allocator.deallocate(ptr, numObjects);
+TEST_F(CountingAllocatorTest, Allocation)
+{
+  const std::size_t numObjects = 5;
+  TestClass* ptr = allocator.allocate(numObjects);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ(allocatedMemory.load(), MemoryAllowance - numObjects * static_cast<int64_t>(sizeof(TestClass)));
+  allocator.deallocate(ptr, numObjects);
 }
 
 // Test 2: Deallocation decreases the counter correctly
-TEST_F(CountingAllocatorTest, Deallocation) {
-    const std::size_t numObjects = 3;
-    TestClass* ptr = allocator.allocate(numObjects);
-    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance - numObjects * static_cast<int64_t>(sizeof(TestClass)));
+TEST_F(CountingAllocatorTest, Deallocation)
+{
+  const std::size_t numObjects = 3;
+  TestClass* ptr = allocator.allocate(numObjects);
+  EXPECT_EQ(allocatedMemory.load(), MemoryAllowance - numObjects * static_cast<int64_t>(sizeof(TestClass)));
 
-    allocator.deallocate(ptr, numObjects);
-    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+  allocator.deallocate(ptr, numObjects);
+  EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 }
 
 // Test 3: Allocator equality based on shared counter
-TEST_F(CountingAllocatorTest, AllocatorEquality) {
-    CountingAllocator<TestClass> allocator1(allocatedMemory);
-    CountingAllocator<TestClass> allocator2(allocatedMemory);
-    EXPECT_TRUE(allocator1 == allocator2);
+TEST_F(CountingAllocatorTest, AllocatorEquality)
+{
+  CountingAllocator<TestClass> allocator1(allocatedMemory);
+  CountingAllocator<TestClass> allocator2(allocatedMemory);
+  EXPECT_TRUE(allocator1 == allocator2);
 
-    std::atomic<int64_t> anotherCounter(0);
-    CountingAllocator<TestClass> allocator3(anotherCounter);
-    EXPECT_FALSE(allocator1 == allocator3);
+  std::atomic<int64_t> anotherCounter(0);
+  CountingAllocator<TestClass> allocator3(anotherCounter);
+  EXPECT_FALSE(allocator1 == allocator3);
 }
 
 // Test 4: Using allocator with std::allocate_shared
-TEST_F(CountingAllocatorTest, AllocateSharedUsesAllocator) {
-    // Create a shared_ptr using allocate_shared with the custom allocator
-    std::shared_ptr<TestClass> ptr = std::allocate_shared<TestClass>(allocator, 100);
+TEST_F(CountingAllocatorTest, AllocateSharedUsesAllocator)
+{
+  // Create a shared_ptr using allocate_shared with the custom allocator
+  std::shared_ptr<TestClass> ptr = std::allocate_shared<TestClass>(allocator, 100);
 
-    // Check that the counter has increased by the size of TestClass plus control block
-    // Exact size depends on the implementation, so we verify it's at least sizeof(TestClass)
-    EXPECT_LE(allocatedMemory.load(), MemoryAllowance - static_cast<int64_t>(sizeof(TestClass)));
+  // Check that the counter has increased by the size of TestClass plus control block
+  // Exact size depends on the implementation, so we verify it's at least sizeof(TestClass)
+  EXPECT_LE(allocatedMemory.load(), MemoryAllowance - static_cast<int64_t>(sizeof(TestClass)));
 
-    // Reset the shared_ptr and check that the counter decreases appropriately
-    ptr.reset();
-    // After deallocation, the counter should return to zero
-    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+  // Reset the shared_ptr and check that the counter decreases appropriately
+  ptr.reset();
+  // After deallocation, the counter should return to zero
+  EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 
-    auto deleter = [this](TestClass* ptr) {
-        this->allocator.deallocate(ptr, 1);
-    };
-    ptr.reset(allocator.allocate(1), deleter);
-    EXPECT_LE(allocatedMemory.load(), MemoryAllowance - static_cast<int64_t>(sizeof(TestClass)));
+  auto deleter = [this](TestClass* ptr) { this->allocator.deallocate(ptr, 1); };
+  ptr.reset(allocator.allocate(1), deleter);
+  EXPECT_LE(allocatedMemory.load(), MemoryAllowance - static_cast<int64_t>(sizeof(TestClass)));
 
-    ptr.reset();
-    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+  ptr.reset();
+  EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 }
 
 // Test 5: Thread Safety - Concurrent Allocations and Deallocations
-TEST_F(CountingAllocatorTest, ThreadSafety) {
-    const std::size_t numThreads = 100;
-    const std::size_t allocationsPerThread = 3;
+TEST_F(CountingAllocatorTest, ThreadSafety)
+{
+  const std::size_t numThreads = 100;
+  const std::size_t allocationsPerThread = 3;
 
-    auto worker = [this]() {
-        for (std::size_t i = 0; i < allocationsPerThread; ++i) {
-            TestClass* ptr = allocator.allocate(1);
-            allocator.deallocate(ptr, 1);
-        }
-    };
-
-    std::vector<std::thread> threads;
-    // Launch multiple threads performing allocations and deallocations
-    for (std::size_t i = 0; i < numThreads; ++i) {
-        threads.emplace_back(worker);
+  auto worker = [this]()
+  {
+    for (std::size_t i = 0; i < allocationsPerThread; ++i)
+    {
+      TestClass* ptr = allocator.allocate(1);
+      allocator.deallocate(ptr, 1);
     }
+  };
 
-    // Wait for all threads to finish
-    for (auto& th : threads) {
-        th.join();
-    }
+  std::vector<std::thread> threads;
+  // Launch multiple threads performing allocations and deallocations
+  for (std::size_t i = 0; i < numThreads; ++i)
+  {
+    threads.emplace_back(worker);
+  }
 
-    // After all allocations and deallocations, the counter should be zero
-    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+  // Wait for all threads to finish
+  for (auto& th : threads)
+  {
+    th.join();
+  }
+
+  // After all allocations and deallocations, the counter should be zero
+  EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 }
 
 // Test 6: Allocating zero objects should not change the counter
-TEST_F(CountingAllocatorTest, AllocateZeroObjects) {
-    TestClass* ptr = allocator.allocate(0);
-    EXPECT_NE(ptr, nullptr);
-    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
-    allocator.deallocate(ptr, 0);
-    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+TEST_F(CountingAllocatorTest, AllocateZeroObjects)
+{
+  TestClass* ptr = allocator.allocate(0);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+  allocator.deallocate(ptr, 0);
+  EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 }

--- a/tests/counting_allocator.cpp
+++ b/tests/counting_allocator.cpp
@@ -47,7 +47,7 @@ class CountingAllocatorTest : public ::testing::Test
 
   // Constructor
   CountingAllocatorTest()
-   : allocatedMemory(MemoryAllowance), allocator(allocatedMemory, MemoryAllowance / 100)
+   : allocatedMemory(MemoryAllowance), allocator(&allocatedMemory, MemoryAllowance / 100)
   {
   }
 
@@ -79,12 +79,12 @@ TEST_F(CountingAllocatorTest, Deallocation)
 // Test 3: Allocator equality based on shared counter
 TEST_F(CountingAllocatorTest, AllocatorEquality)
 {
-  CountingAllocator<TestClass> allocator1(allocatedMemory);
-  CountingAllocator<TestClass> allocator2(allocatedMemory);
+  CountingAllocator<TestClass> allocator1(&allocatedMemory);
+  CountingAllocator<TestClass> allocator2(&allocatedMemory);
   EXPECT_TRUE(allocator1 == allocator2);
 
   std::atomic<int64_t> anotherCounter(0);
-  CountingAllocator<TestClass> allocator3(anotherCounter);
+  CountingAllocator<TestClass> allocator3(&anotherCounter);
   EXPECT_FALSE(allocator1 == allocator3);
 }
 

--- a/tests/poolallocator.cpp
+++ b/tests/poolallocator.cpp
@@ -1,0 +1,287 @@
+/* Copyright (C) 2024 MariaDB Corporation
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+   MA 02110-1301, USA. */
+#include <gtest/gtest.h>
+#include <sys/types.h>
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <thread>
+
+#include "countingallocator.h"
+#include "poolallocator.h"
+
+using namespace allocators;
+using namespace utils;
+
+/**
+ * Тест явного задания windowSize при создании:
+ */
+TEST(PoolAllocatorTest, CustomWindowSize)
+{
+  const unsigned CUSTOM_SIZE = 1024;
+  PoolAllocator pa(CUSTOM_SIZE);
+  EXPECT_EQ(pa.getWindowSize(), CUSTOM_SIZE);
+  EXPECT_EQ(pa.getMemUsage(), 0ULL);
+}
+
+/**
+ * Тест базового выделения небольшого блока памяти:
+ *  - Выделяем блок меньше, чем windowSize.
+ *  - Проверяем, что memUsage увеличился на размер выделенного блока.
+ *  - Указатель не должен быть равен nullptr.
+ */
+TEST(PoolAllocatorTest, AllocateSmallBlock)
+{
+  PoolAllocator pa;
+  uint64_t initialUsage = pa.getMemUsage();
+  const uint64_t ALLOC_SIZE = 128;
+
+  void* ptr = pa.allocate(ALLOC_SIZE);
+
+  ASSERT_NE(ptr, nullptr);
+  EXPECT_EQ(pa.getMemUsage(), initialUsage + ALLOC_SIZE);
+}
+
+/**
+ * Тест выделения блока памяти больше, чем windowSize (Out-Of-Band - OOB):
+ *  - Проверяем, что memUsage увеличился на нужное количество байт.
+ *  - Указатель не nullptr.
+ */
+TEST(PoolAllocatorTest, AllocateOOBBlock)
+{
+  // Выбираем размер гарантированно больше, чем окно по умолчанию
+  const uint64_t BIG_BLOCK_SIZE = PoolAllocator::DEFAULT_WINDOW_SIZE + 1024;
+  PoolAllocator pa;
+  uint64_t initialUsage = pa.getMemUsage();
+
+  void* ptr = pa.allocate(BIG_BLOCK_SIZE);
+  ASSERT_NE(ptr, nullptr);
+  EXPECT_EQ(pa.getMemUsage(), initialUsage + BIG_BLOCK_SIZE);
+}
+
+/**
+ * Тест деаллокации (deallocate) Out-Of-Band блока:
+ *  - Убеждаемся, что после deallocate memUsage возвращается к исходному значению.
+ */
+TEST(PoolAllocatorTest, DeallocateOOBBlock)
+{
+  PoolAllocator pa;
+  // Блок больше windowSize
+  const uint64_t BIG_BLOCK_SIZE = pa.getWindowSize() + 1024;
+
+  uint64_t initialUsage = pa.getMemUsage();
+  void* ptr = pa.allocate(BIG_BLOCK_SIZE);
+  ASSERT_NE(ptr, nullptr);
+  EXPECT_EQ(pa.getMemUsage(), initialUsage + BIG_BLOCK_SIZE);
+
+  pa.deallocate(ptr);
+  EXPECT_EQ(pa.getMemUsage(), initialUsage);
+}
+
+/**
+ * Тест деаллокации блока, который был выделен внутри "windowSize".
+ * По текущей логике PoolAllocator::deallocate для "маленьких" блоков ничего не делает.
+ * Основная проверка – что код не падает и не меняет memUsage.
+ */
+TEST(PoolAllocatorTest, DeallocateSmallBlock)
+{
+  PoolAllocator pa;
+  const uint64_t ALLOC_SIZE = 128;
+
+  uint64_t initialUsage = pa.getMemUsage();
+  void* ptr = pa.allocate(ALLOC_SIZE);
+  ASSERT_NE(ptr, nullptr);
+  EXPECT_EQ(pa.getMemUsage(), initialUsage + ALLOC_SIZE);
+
+  // Попытка деаллокации "маленького" блока – в текущей реализации
+  // код его не возвращает в пул, следовательно memUsage не уменьшится.
+  pa.deallocate(ptr);
+  EXPECT_EQ(pa.getMemUsage(), initialUsage + ALLOC_SIZE);
+}
+
+/**
+ * Тест полного освобождения памяти (deallocateAll):
+ *  - Выделяем несколько блоков: и маленький, и большой.
+ *  - После вызова deallocateAll всё должно освободиться, memUsage вернётся к 0.
+ */
+TEST(PoolAllocatorTest, DeallocateAll)
+{
+  PoolAllocator pa;
+  // Блок в пределах windowSize
+  const uint64_t SMALL_BLOCK = 256;
+  // Блок Out-Of-Band
+  const uint64_t LARGE_BLOCK = pa.getWindowSize() + 1024;
+
+  pa.allocate(SMALL_BLOCK);
+  pa.allocate(LARGE_BLOCK);
+  // Убедимся, что memUsage > 0
+  EXPECT_GT(pa.getMemUsage(), 0ULL);
+
+  // Освобождаем всё
+  pa.deallocateAll();
+  EXPECT_EQ(pa.getMemUsage(), 0ULL);
+}
+
+/**
+ * Тест копирующего оператора присваивания:
+ *  - Проверяем, что параметры (allocSize, tmpSpace, useLock) копируются.
+ *  - Однако выделенная память не копируется (т.к. после operator= вызывается deallocateAll).
+ */
+TEST(PoolAllocatorTest, AssignmentOperator)
+{
+  PoolAllocator pa1(2048, true, true);  // windowSize=2048, tmpSpace=true, useLock=true
+  // Выделяем немного памяти
+  pa1.allocate(100);
+  pa1.allocate(200);
+
+  EXPECT_EQ(pa1.getWindowSize(), 2048U);
+  EXPECT_TRUE(pa1.getMemUsage() > 0);
+
+  // С помощью оператора присваивания: pa2 = pa1
+  PoolAllocator pa2;
+  pa2 = pa1;  // После этого deallocateAll() вызывается внутри operator= (в нашем коде)
+
+  // Проверяем скопированные поля:
+  EXPECT_EQ(pa2.getWindowSize(), 2048U);
+  // tmpSpace и useLock также должны совпасть
+  // (В данном коде напрямую нет геттеров для них,
+  //  но, если нужно, можете добавить соответствующие методы или рефлексировать код.)
+
+  // Проверяем, что у pa2 memUsage == 0 после deallocateAll
+  EXPECT_EQ(pa2.getMemUsage(), 0ULL);
+  // А у pa1 осталась прежняя статистика использования памяти,
+  // т.к. operator= сделал deallocateAll только внутри pa2.
+  EXPECT_TRUE(pa1.getMemUsage() > 0);
+}
+
+TEST(PoolAllocatorTest, MultithreadedAllocationWithLock)
+{
+  PoolAllocator pa(PoolAllocator::DEFAULT_WINDOW_SIZE, false, true);
+  // useLock = true
+
+  const int THREAD_COUNT = 4;
+  const uint64_t ALLOC_PER_THREAD = 1024;
+  std::vector<std::thread> threads;
+
+  // Стартовое значение
+  uint64_t initialUsage = pa.getMemUsage();
+
+  // Запускаем несколько потоков, каждый сделает небольшое кол-во аллокаций
+  for (int i = 0; i < THREAD_COUNT; i++)
+  {
+    threads.emplace_back(
+        [&pa]()
+        {
+          for (int j = 0; j < 10; j++)
+          {
+            pa.allocate(ALLOC_PER_THREAD);
+          }
+        });
+  }
+
+  for (auto& th : threads)
+    th.join();
+
+  uint64_t expected = initialUsage + THREAD_COUNT * 10ULL * ALLOC_PER_THREAD;
+  EXPECT_GE(pa.getMemUsage(), expected);
+}
+
+static const constexpr int64_t MemoryAllowance = 10 * 1024 * 1024;
+
+// Test Fixture for AtomicCounterAllocator
+class PoolallocatorTest : public ::testing::Test
+{
+ protected:
+  // Atomic counter to track allocated memory
+  std::atomic<int64_t> allocatedMemory{MemoryAllowance};
+
+  // Custom allocator instance
+  CountingAllocator<PoolAllocatorBufType> allocator;
+
+  // Constructor
+  PoolallocatorTest() : allocatedMemory(MemoryAllowance), allocator(&allocatedMemory, MemoryAllowance / 100)
+  {
+  }
+
+  // Destructor
+  ~PoolallocatorTest() override = default;
+};
+
+// Тест для проверки учёта потребления памяти в PoolAllocator.
+TEST_F(PoolallocatorTest, AllocationWithAccounting)
+{
+  int bufSize = 512;
+  const unsigned CUSTOM_SIZE = 1024;
+  PoolAllocator pa(allocator, CUSTOM_SIZE, false, true);
+  EXPECT_EQ(pa.getWindowSize(), CUSTOM_SIZE);
+  EXPECT_EQ(pa.getMemUsage(), 0ULL);
+  auto* ptr = pa.allocate(bufSize);
+
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_LE(allocatedMemory.load(), MemoryAllowance - bufSize);
+  EXPECT_LE(allocatedMemory.load(), MemoryAllowance - CUSTOM_SIZE);
+  pa.deallocate(ptr);
+  // B/c this PoolAllocator frees memory only when it's destroyed.
+  EXPECT_LE(allocatedMemory.load(), MemoryAllowance - bufSize);
+  EXPECT_LE(allocatedMemory.load(), MemoryAllowance - CUSTOM_SIZE);
+
+  bufSize = 64536;
+  auto* ptr1 = pa.allocate(bufSize);
+
+  EXPECT_NE(ptr1, nullptr);
+  EXPECT_LE(allocatedMemory.load(), MemoryAllowance - bufSize);
+
+  pa.deallocate(ptr1);
+  EXPECT_LE(allocatedMemory.load(), MemoryAllowance - CUSTOM_SIZE);
+  EXPECT_GE(allocatedMemory.load(), MemoryAllowance - bufSize);
+}
+
+TEST_F(PoolallocatorTest, MultithreadedAccountedAllocationWithLock)
+{
+  const unsigned CUSTOM_SIZE = 1024;
+  PoolAllocator pa(allocator, CUSTOM_SIZE, false, true);
+
+  const int THREAD_COUNT = 4;
+  const uint64_t ALLOC_PER_THREAD = 1024;
+  const uint64_t NUM_ALLOCS_PER_THREAD = 10;
+  std::vector<std::thread> threads;
+
+  // Стартовое значение
+  uint64_t initialUsage = pa.getMemUsage();
+
+  // Запускаем несколько потоков, каждый сделает небольшое кол-во аллокаций
+  for (int i = 0; i < THREAD_COUNT; i++)
+  {
+    threads.emplace_back(
+        [&pa]()
+        {
+          for (uint64_t j = 0; j < NUM_ALLOCS_PER_THREAD; j++)
+          {
+            pa.allocate(ALLOC_PER_THREAD);
+          }
+        });
+  }
+
+  for (auto& th : threads)
+    th.join();
+
+  uint64_t expected = initialUsage + THREAD_COUNT * 10ULL * ALLOC_PER_THREAD;
+  EXPECT_GE(pa.getMemUsage(), expected);
+  // 2 * CUSTOM_SIZE semantics is structs allocation overhead.
+  EXPECT_GE(allocatedMemory.load(),
+            MemoryAllowance - (THREAD_COUNT * ALLOC_PER_THREAD * NUM_ALLOCS_PER_THREAD) - 2 * CUSTOM_SIZE);
+}

--- a/tests/poolallocator.cpp
+++ b/tests/poolallocator.cpp
@@ -200,7 +200,7 @@ TEST(PoolAllocatorTest, MultithreadedAllocationWithLock)
   EXPECT_GE(pa.getMemUsage(), expected);
 }
 
-static const constexpr int64_t MemoryAllowance = 10 * 1024 * 1024;
+static const constexpr int64_t MemoryAllowance = 1 * 1024 * 1024;
 
 // Test Fixture for AtomicCounterAllocator
 class PoolallocatorTest : public ::testing::Test
@@ -213,7 +213,7 @@ class PoolallocatorTest : public ::testing::Test
   CountingAllocator<PoolAllocatorBufType> allocator;
 
   // Constructor
-  PoolallocatorTest() : allocatedMemory(MemoryAllowance), allocator(&allocatedMemory, MemoryAllowance / 100)
+  PoolallocatorTest() : allocatedMemory(MemoryAllowance), allocator(&allocatedMemory, MemoryAllowance / 100, MemoryAllowance / 1000)
   {
   }
 
@@ -283,5 +283,5 @@ TEST_F(PoolallocatorTest, MultithreadedAccountedAllocationWithLock)
   EXPECT_GE(pa.getMemUsage(), expected);
   // 2 * CUSTOM_SIZE semantics is structs allocation overhead.
   EXPECT_GE(allocatedMemory.load(),
-            MemoryAllowance - (THREAD_COUNT * ALLOC_PER_THREAD * NUM_ALLOCS_PER_THREAD) - 2 * CUSTOM_SIZE);
+            MemoryAllowance - (THREAD_COUNT * ALLOC_PER_THREAD * NUM_ALLOCS_PER_THREAD) - 3 * CUSTOM_SIZE);
 }

--- a/tests/poolallocator.cpp
+++ b/tests/poolallocator.cpp
@@ -213,7 +213,9 @@ class PoolallocatorTest : public ::testing::Test
   CountingAllocator<PoolAllocatorBufType> allocator;
 
   // Constructor
-  PoolallocatorTest() : allocatedMemory(MemoryAllowance), allocator(&allocatedMemory, MemoryAllowance / 100, MemoryAllowance / 1000)
+  PoolallocatorTest()
+   : allocatedMemory(MemoryAllowance)
+   , allocator(&allocatedMemory, MemoryAllowance / 1000, MemoryAllowance / 100)
   {
   }
 

--- a/tests/rowgroup-tests.cpp
+++ b/tests/rowgroup-tests.cpp
@@ -357,7 +357,7 @@ class RGDataTest : public ::testing::Test
 {
  protected:
   RGDataTest()
-    : allocatedMemory(MemoryAllowance), alloc(allocatedMemory, MemoryAllowance / 100) {}
+    : allocatedMemory(MemoryAllowance), alloc(&allocatedMemory, MemoryAllowance / 100) {}
   void SetUp() override
   {
     rg = setupRG({execplan::CalpontSystemCatalog::VARCHAR, execplan::CalpontSystemCatalog::UDECIMAL,

--- a/tests/rowgroup-tests.cpp
+++ b/tests/rowgroup-tests.cpp
@@ -377,42 +377,31 @@ class RGDataTest : public ::testing::Test
   // bool useStringTable = true;
 TEST_F(RGDataTest, AllocData)
 {
-    std::cout << " test  allocatedMemery " << allocatedMemory.load() << " rowsize " << rg.getRowSize() << " " << rg.getMaxDataSize() << std::endl;
     rgD = rowgroup::RGData(rg, alloc);
     rg.setData(&rgD);
     rg.initRow(&r);
     rg.getRow(0, &r);
-    std::cout << " test inStringTable(colIndex) " << r.inStringTable(0) << std::endl;
 
-    std::cout << " test  allocatedMemery " << allocatedMemory.load() << std::endl;
     auto currentAllocation = allocatedMemory.load();
     EXPECT_LE(currentAllocation, MemoryAllowance - rg.getMaxDataSize());
 
     r.setStringField(utils::ConstString{"testaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, 0);
-    std::cout << " test  allocatedMemery " << allocatedMemory.load() << std::endl;
-    std::cout << " test  inStringTable " << r.getColumnWidth(0) << std::endl;
     EXPECT_LE(allocatedMemory.load(), currentAllocation);
 
     currentAllocation = allocatedMemory.load();
     r.nextRow();
     r.setStringField(utils::ConstString{"testaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, 0);
-    std::cout << " test  allocatedMemery " << allocatedMemory.load() << std::endl;
-    std::cout << " test  inStringTable " << r.getColumnWidth(0) << std::endl;
     EXPECT_EQ(allocatedMemory.load(), currentAllocation);
 
     currentAllocation = allocatedMemory.load();
     r.nextRow();
     std::string longString(64 * 1024 + 1000, 'a');
     auto cs = utils::ConstString(longString);
-    std::cout << "test longString " << longString.size() << " cs len " << cs.length()<< std::endl;
 
     r.setStringField(cs, 0);
-    std::cout << " test  allocatedMemery " << allocatedMemory.load() << std::endl;
-    std::cout << " test  inStringTable " << r.getColumnWidth(0) << std::endl;
     EXPECT_LE(allocatedMemory.load(), currentAllocation);
 
     rgD = rowgroup::RGData(rg);
-    std::cout << " test  allocatedMemery " << allocatedMemory.load() << std::endl;
 
     EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 

--- a/tests/rowgroup-tests.cpp
+++ b/tests/rowgroup-tests.cpp
@@ -16,8 +16,11 @@
    MA 02110-1301, USA. */
 
 #include <gtest/gtest.h>  // googletest header file
+#include <cstring>
 #include <iostream>
+#include <numeric>
 
+#include "countingallocator.h"
 #include "rowgroup.h"
 #include "columnwidth.h"
 #include "joblisttypes.h"
@@ -28,13 +31,44 @@
 
 using CSCDataType = execplan::CalpontSystemCatalog::ColDataType;
 using datatypes::TSInt128;
+using RGFieldsType = std::vector<uint32_t>;
+
+rowgroup::RowGroup setupRG(const std::vector<execplan::CalpontSystemCatalog::ColDataType>& cts,
+                           const RGFieldsType& widths, const RGFieldsType& charsets)
+{
+  std::vector<execplan::CalpontSystemCatalog::ColDataType> types = cts;
+  RGFieldsType offsets{2};
+  for (auto w : widths)
+  {
+    offsets.push_back(offsets.back() + w);
+  }
+  RGFieldsType roids(widths.size());
+  std::iota(roids.begin(), roids.end(), 3000);
+  RGFieldsType tkeys(widths.size());
+  std::fill(tkeys.begin(), tkeys.end(), 1);
+  RGFieldsType cscale(widths.size());
+  std::fill(cscale.begin(), cscale.end(), 0);
+  RGFieldsType precision(widths.size());
+  std::fill(precision.begin(), precision.end(), 20);
+  return rowgroup::RowGroup(roids.size(),  // column count
+                            offsets,       // oldOffset
+                            roids,         // column oids
+                            tkeys,         // keys
+                            types,         // types
+                            charsets,      // charset numbers
+                            cscale,        // scale
+                            precision,     // precision
+                            20,            // sTableThreshold
+                            true          // useStringTable
+  );
+}
 
 class RowDecimalTest : public ::testing::Test
 {
  protected:
   void SetUp() override
   {
-    uint32_t precision = WIDE_DEC_PRECISION;
+     uint32_t precision = WIDE_DEC_PRECISION;
     uint32_t oid = 3001;
 
     std::vector<CSCDataType> types;
@@ -81,7 +115,6 @@ class RowDecimalTest : public ::testing::Test
                             20,             // sTableThreshold
                             false           // useStringTable
     );
-
     rg = rgOut = inRG;
     rgD.reinit(rg);
     rgDOut.reinit(rgOut);
@@ -316,4 +349,91 @@ TEST_F(RowDecimalTest, RowEqualsCheck)
       nonequiRow.nextRow(rowSize);
     }
   }
+}
+
+static const constexpr int64_t MemoryAllowance = 10 * 1024 * 1024;
+
+class RGDataTest : public ::testing::Test
+{
+ protected:
+  RGDataTest()
+    : allocatedMemory(MemoryAllowance), alloc(allocatedMemory, MemoryAllowance / 100) {}
+  void SetUp() override
+  {
+    rg = setupRG({execplan::CalpontSystemCatalog::VARCHAR, execplan::CalpontSystemCatalog::UDECIMAL,
+                         execplan::CalpontSystemCatalog::DECIMAL, execplan::CalpontSystemCatalog::DECIMAL,
+                         execplan::CalpontSystemCatalog::DECIMAL, execplan::CalpontSystemCatalog::DECIMAL},
+                        {65536, 16, 8, 4, 2, 1}, {8, 8, 8, 8, 8, 8});
+
+    // rgD = rowgroup::RGData(rg, &alloc);
+    // rg.setData(&rgD);
+    // rg.initRow(&r);
+    // rg.getRow(0, &r);
+
+    // for (size_t i = 0; i < sValueVector.size(); i++)
+    // {
+    //   // setStringField
+    //   r.setBinaryField_offset(&sValueVector[i], sizeof(sValueVector[0]), offsets[0]);
+    //   r.setBinaryField_offset(&anotherValueVector[i], sizeof(anotherValueVector[0]), offsets[1]);
+    //   r.setIntField(s64ValueVector[i], 2);
+    //   r.setIntField(s32ValueVector[i], 3);
+    //   r.setIntField(s16ValueVector[i], 4);
+    //   r.setIntField(s8ValueVector[i], 5);
+    //   r.nextRow(rowSize);
+    // }
+
+    // rowCount = sValueVector.size();
+  }
+
+  // void TearDown() override {}
+
+  rowgroup::Row r;
+  rowgroup::RowGroup rg;
+  rowgroup::RGData rgD;
+  std::atomic<int64_t> allocatedMemory{MemoryAllowance};
+  allocators::CountingAllocator<rowgroup::RGDataBufType> alloc;
+};
+  // bool useStringTable = true;
+TEST_F(RGDataTest, AllocData)
+{
+    std::cout << " test  allocatedMemery " << allocatedMemory.load() << " rowsize " << rg.getRowSize() << " " << rg.getMaxDataSize() << std::endl;
+    rgD = rowgroup::RGData(rg, &alloc);
+    rg.setData(&rgD);
+    rg.initRow(&r);
+    rg.getRow(0, &r);
+    std::cout << " test inStringTable(colIndex) " << r.inStringTable(0) << std::endl;
+
+    std::cout << " test  allocatedMemery " << allocatedMemory.load() << std::endl;
+    auto currentAllocation = allocatedMemory.load();
+    EXPECT_LE(currentAllocation, MemoryAllowance - rg.getMaxDataSize());
+
+    r.setStringField(utils::ConstString{"testaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, 0);
+    std::cout << " test  allocatedMemery " << allocatedMemory.load() << std::endl;
+    std::cout << " test  inStringTable " << r.getColumnWidth(0) << std::endl;
+    EXPECT_LE(allocatedMemory.load(), currentAllocation);
+
+    currentAllocation = allocatedMemory.load();
+    r.nextRow();
+    r.setStringField(utils::ConstString{"testaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, 0);
+    std::cout << " test  allocatedMemery " << allocatedMemory.load() << std::endl;
+    std::cout << " test  inStringTable " << r.getColumnWidth(0) << std::endl;
+    EXPECT_EQ(allocatedMemory.load(), currentAllocation);
+
+    currentAllocation = allocatedMemory.load();
+    r.nextRow();
+    std::string longString(64 * 1024 + 1000, 'a');
+    auto cs = utils::ConstString(longString);
+    std::cout << "test longString " << longString.size() << " cs len " << cs.length()<< std::endl;
+
+    r.setStringField(cs, 0);
+    std::cout << " test  allocatedMemery " << allocatedMemory.load() << std::endl;
+    std::cout << " test  inStringTable " << r.getColumnWidth(0) << std::endl;
+    EXPECT_LE(allocatedMemory.load(), currentAllocation);
+
+    rgD = rowgroup::RGData(rg);
+    std::cout << " test  allocatedMemery " << allocatedMemory.load() << std::endl;
+
+    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+
+    // reinit
 }

--- a/tests/rowgroup-tests.cpp
+++ b/tests/rowgroup-tests.cpp
@@ -357,7 +357,7 @@ class RGDataTest : public ::testing::Test
 {
  protected:
   RGDataTest()
-    : allocatedMemory(MemoryAllowance), alloc(&allocatedMemory, MemoryAllowance / 100) {}
+    : allocatedMemory(MemoryAllowance) {}
   void SetUp() override
   {
     rg = setupRG({execplan::CalpontSystemCatalog::VARCHAR, execplan::CalpontSystemCatalog::UDECIMAL,
@@ -372,38 +372,38 @@ class RGDataTest : public ::testing::Test
   rowgroup::RowGroup rg;
   rowgroup::RGData rgD;
   std::atomic<int64_t> allocatedMemory{MemoryAllowance};
-  allocators::CountingAllocator<rowgroup::RGDataBufType> alloc;
 };
   // bool useStringTable = true;
 TEST_F(RGDataTest, AllocData)
 {
-    rgD = rowgroup::RGData(rg, alloc);
-    rg.setData(&rgD);
-    rg.initRow(&r);
-    rg.getRow(0, &r);
+  allocators::CountingAllocator<rowgroup::RGDataBufType> alloc(&allocatedMemory, MemoryAllowance / 100, MemoryAllowance / 10000);
+  rgD = rowgroup::RGData(rg, alloc);
+  rg.setData(&rgD);
+  rg.initRow(&r);
+  rg.getRow(0, &r);
 
-    auto currentAllocation = allocatedMemory.load();
-    EXPECT_LE(currentAllocation, MemoryAllowance - rg.getMaxDataSize());
+  auto currentAllocation = allocatedMemory.load();
+  EXPECT_LE(currentAllocation, MemoryAllowance - rg.getMaxDataSize());
 
-    r.setStringField(utils::ConstString{"testaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, 0);
-    EXPECT_LE(allocatedMemory.load(), currentAllocation);
+  r.setStringField(utils::ConstString{"testaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, 0);
+  EXPECT_LE(allocatedMemory.load(), currentAllocation);
 
-    currentAllocation = allocatedMemory.load();
-    r.nextRow();
-    r.setStringField(utils::ConstString{"testaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, 0);
-    EXPECT_EQ(allocatedMemory.load(), currentAllocation);
+  currentAllocation = allocatedMemory.load();
+  r.nextRow();
+  r.setStringField(utils::ConstString{"testaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, 0);
+  EXPECT_EQ(allocatedMemory.load(), currentAllocation);
 
-    currentAllocation = allocatedMemory.load();
-    r.nextRow();
-    std::string longString(64 * 1024 + 1000, 'a');
-    auto cs = utils::ConstString(longString);
+  currentAllocation = allocatedMemory.load();
+  r.nextRow();
+  std::string longString(64 * 1024 + 1000, 'a');
+  auto cs = utils::ConstString(longString);
 
-    r.setStringField(cs, 0);
-    EXPECT_LE(allocatedMemory.load(), currentAllocation);
+  r.setStringField(cs, 0);
+  EXPECT_LE(allocatedMemory.load(), currentAllocation);
 
-    rgD = rowgroup::RGData(rg);
+  rgD = rowgroup::RGData(rg);
 
-    EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
+  EXPECT_EQ(allocatedMemory.load(), MemoryAllowance);
 
     // reinit
 }

--- a/tests/rowgroup-tests.cpp
+++ b/tests/rowgroup-tests.cpp
@@ -364,25 +364,6 @@ class RGDataTest : public ::testing::Test
                          execplan::CalpontSystemCatalog::DECIMAL, execplan::CalpontSystemCatalog::DECIMAL,
                          execplan::CalpontSystemCatalog::DECIMAL, execplan::CalpontSystemCatalog::DECIMAL},
                         {65536, 16, 8, 4, 2, 1}, {8, 8, 8, 8, 8, 8});
-
-    // rgD = rowgroup::RGData(rg, &alloc);
-    // rg.setData(&rgD);
-    // rg.initRow(&r);
-    // rg.getRow(0, &r);
-
-    // for (size_t i = 0; i < sValueVector.size(); i++)
-    // {
-    //   // setStringField
-    //   r.setBinaryField_offset(&sValueVector[i], sizeof(sValueVector[0]), offsets[0]);
-    //   r.setBinaryField_offset(&anotherValueVector[i], sizeof(anotherValueVector[0]), offsets[1]);
-    //   r.setIntField(s64ValueVector[i], 2);
-    //   r.setIntField(s32ValueVector[i], 3);
-    //   r.setIntField(s16ValueVector[i], 4);
-    //   r.setIntField(s8ValueVector[i], 5);
-    //   r.nextRow(rowSize);
-    // }
-
-    // rowCount = sValueVector.size();
   }
 
   // void TearDown() override {}
@@ -397,7 +378,7 @@ class RGDataTest : public ::testing::Test
 TEST_F(RGDataTest, AllocData)
 {
     std::cout << " test  allocatedMemery " << allocatedMemory.load() << " rowsize " << rg.getRowSize() << " " << rg.getMaxDataSize() << std::endl;
-    rgD = rowgroup::RGData(rg, &alloc);
+    rgD = rowgroup::RGData(rg, alloc);
     rg.setData(&rgD);
     rg.initRow(&r);
     rg.getRow(0, &r);

--- a/utils/common/atomicops.h
+++ b/utils/common/atomicops.h
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <sched.h>
+#include <atomic>
 
 /*
 This is an attempt to wrap the differneces between Windows and Linux around atomic ops.
@@ -30,6 +31,16 @@ Boost has something in interprocess::ipcdetail, but it doesn't have 64-bit API's
 
 namespace atomicops
 {
+// Atomic operations for atomic<int64_t> references
+inline int64_t atomicAddRef(std::atomic<int64_t>& ref, int64_t val)
+{
+  return ref.fetch_add(val, std::memory_order_relaxed);
+}
+
+inline int64_t atomicSubRef(std::atomic<int64_t>& ref, int64_t val)
+{
+  return ref.fetch_sub(val, std::memory_order_relaxed);
+}
 // Returns the resulting, incremented value
 template <typename T>
 inline T atomicInc(volatile T* mem)

--- a/utils/common/countingallocator.h
+++ b/utils/common/countingallocator.h
@@ -44,8 +44,7 @@ public:
     // Copy constructor (template to allow conversion between different types)
     template <typename U>
     CountingAllocator(const CountingAllocator<U>& other) noexcept
-        : memoryLimit_(other.memoryLimit_) {}
-
+        : memoryLimit_(other.memoryLimit_),  memoryLimitLowerBound(other.memoryLimitLowerBound) {}
 
     // Allocate memory for n objects of type T
     template <typename U = T>

--- a/utils/common/countingallocator.h
+++ b/utils/common/countingallocator.h
@@ -61,6 +61,7 @@ public:
         T* ptr = static_cast<T*>(::operator new(n * sizeof(T)));
         // std::cout << "[Allocate] " << n * sizeof(T) << " bytes at " << static_cast<void*>(ptr)
         //           << ". current timit: " << std::dec << memoryLimitRef_.load() << std::hex << " bytes.\n";
+        // std::cout << std::dec;
         return ptr;
     }
 
@@ -87,6 +88,7 @@ public:
         memoryLimitRef_.fetch_add(n * sizeof(T), std::memory_order_relaxed);
         // std::cout << "[Deallocate] " << n * sizeof(T) << " bytes from " << static_cast<void*>(ptr)
         //           << ". current timit: " << std::dec << memoryLimitRef_.load() << std::hex << " bytes.\n";
+        // std::cout << std::dec;
     }
 
     // Equality operators (allocators are equal if they share the same counter)

--- a/utils/common/countingallocator.h
+++ b/utils/common/countingallocator.h
@@ -35,8 +35,8 @@ namespace allocators
 // When a sync op hits MemoryLimitLowerBound trying to allocate more memory, it throws.
 // SQL operators or TBPS runtime must catch the exception and act acordingly.
 
-const constexpr std::int64_t MemoryLimitLowerBound = 500 * 1024 * 1024;  // WIP
-const constexpr std::int64_t CheckPointStepSize = 100 * 1024 * 1024;     // WIP
+const constexpr int64_t MemoryLimitLowerBound = 500 * 1024 * 1024;  // WIP
+const constexpr int64_t CheckPointStepSize = 100 * 1024 * 1024;     // WIP
 
 // Custom Allocator that tracks allocated memory using an atomic counter
 template <typename T>
@@ -88,8 +88,8 @@ class CountingAllocator
 
   // Constructor accepting a reference to an atomic counter
   explicit CountingAllocator(std::atomic<int64_t>* memoryLimit,
-                             const uint64_t lowerBound = MemoryLimitLowerBound,
-                             const uint64_t checkPointStepSize = CheckPointStepSize) noexcept
+                             const int64_t checkPointStepSize = CheckPointStepSize,
+                             const int64_t lowerBound = MemoryLimitLowerBound) noexcept
    : memoryLimit_(memoryLimit), memoryLimitLowerBound_(lowerBound), checkPointStepSize_(checkPointStepSize)
   {
   }

--- a/utils/common/countingallocator.h
+++ b/utils/common/countingallocator.h
@@ -1,0 +1,91 @@
+/* Copyright (C) 2024 MariaDB Corporation
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+   MA 02110-1301, USA. */
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <atomic>
+#include <cstddef>
+#include <iostream>
+#include <utility>
+
+namespace allocators 
+{
+
+// const constexpr std::uint64_t CounterUpdateUnitSize = 4 * 1024 * 1024; 
+const constexpr std::int64_t MemoryLimitLowerBound = 100 * 1024 * 1024;  // WIP
+
+// Custom Allocator that tracks allocated memory using an atomic counter
+template <typename T>
+class CountingAllocator {
+public:
+    using value_type = T;
+
+    // Constructor accepting a reference to an atomic counter
+    explicit CountingAllocator(std::atomic<int64_t>& memoryLimit, const uint64_t lowerBound = MemoryLimitLowerBound) noexcept
+        : memoryLimitRef_(memoryLimit), memoryLimitLowerBound(lowerBound) {}
+
+    // Copy constructor (template to allow conversion between different types)
+    template <typename U>
+    CountingAllocator(const CountingAllocator<U>& other) noexcept
+        : memoryLimitRef_(other.memoryLimitRef_) {}
+
+    // Allocate memory for n objects of type T
+    T* allocate(std::size_t n) {
+        auto memCounted = memoryLimitRef_.fetch_sub(n * sizeof(T), std::memory_order_relaxed);
+        if (memCounted < memoryLimitLowerBound) {
+            memoryLimitRef_.fetch_add(n * sizeof(T), std::memory_order_relaxed);
+            throw std::bad_alloc();
+        }
+        
+        T* ptr = static_cast<T*>(::operator new(n * sizeof(T)));
+        // std::cout << "[Allocate] " << n * sizeof(T) << " bytes at " << static_cast<void*>(ptr)
+        //           << ". current timit: " << std::dec << memoryLimitRef_.load() << std::hex << " bytes.\n";
+        return ptr;
+    }
+
+    // Deallocate memory for n objects of type T
+    void deallocate(T* ptr, std::size_t n) noexcept {
+        ::operator delete(ptr);
+        memoryLimitRef_.fetch_add(n * sizeof(T), std::memory_order_relaxed);
+        // std::cout << "[Deallocate] " << n * sizeof(T) << " bytes from " << static_cast<void*>(ptr)
+        //           << ". current timit: " << std::dec << memoryLimitRef_.load() << std::hex << " bytes.\n";
+    }
+
+    // Equality operators (allocators are equal if they share the same counter)
+    template <typename U>
+    bool operator==(const CountingAllocator<U>& other) const noexcept {
+        return &memoryLimitRef_ == &other.memoryLimitRef_;
+    }
+
+    template <typename U>
+    bool operator!=(const CountingAllocator<U>& other) const noexcept {
+        return !(*this == other);
+    }
+
+private:
+    std::atomic<int64_t>& memoryLimitRef_;
+    int64_t memoryLimitLowerBound = 0;
+
+    // Grant access to other instances of CountingAllocator with different types
+    template <typename U>
+    friend class CountingAllocator;
+};
+
+}  // namespace allocators

--- a/utils/common/fixedallocator.cpp
+++ b/utils/common/fixedallocator.cpp
@@ -42,6 +42,7 @@ FixedAllocator::FixedAllocator(const FixedAllocator& f)
   currentlyStored = 0;
   useLock = f.useLock;
   lock = false;
+  alloc = f.alloc;
 }
 
 FixedAllocator& FixedAllocator::operator=(const FixedAllocator& f)
@@ -51,6 +52,7 @@ FixedAllocator& FixedAllocator::operator=(const FixedAllocator& f)
   tmpSpace = f.tmpSpace;
   useLock = f.useLock;
   lock = false;
+  alloc = f.alloc;
   deallocateAll();
   return *this;
 }

--- a/utils/common/fixedallocator.cpp
+++ b/utils/common/fixedallocator.cpp
@@ -69,8 +69,6 @@ void FixedAllocator::setAllocSize(uint allocSize)
 
 void FixedAllocator::newBlock()
 {
-  // boost::shared_ptr<FixedAllocatorBufType> next;
-
   capacityRemaining = elementCount * elementSize;
 
   if (!tmpSpace || mem.size() == 0)
@@ -83,9 +81,6 @@ void FixedAllocator::newBlock()
     {
       mem.emplace_back(boost::make_shared<FixedAllocatorBufType>(elementCount * elementSize));
     }
-    // next.reset(new uint8_t[elementCount * elementSize]);
-    // mem.push_back(next);
-    // nextAlloc = next.get();
     nextAlloc = mem.back().get();
   }
   else

--- a/utils/common/poolallocator.cpp
+++ b/utils/common/poolallocator.cpp
@@ -20,7 +20,6 @@
  *
  ******************************************************************************************/
 
-#include <iostream>
 //#define NDEBUG
 #include <cassert>
 #include <boost/smart_ptr/allocate_shared_array.hpp>
@@ -48,15 +47,12 @@ void PoolAllocator::deallocateAll()
   capacityRemaining = 0;
   nextAlloc = NULL;
   memUsage = 0;
-  // WIP double check the space is cleaned up.
   mem.clear();
   oob.clear();
 }
 
 void PoolAllocator::newBlock()
 {
-  // boost::shared_ptr<PoolAllocatorBufType[]> next;
-
   capacityRemaining = allocSize;
 
   if (!tmpSpace || mem.size() == 0)
@@ -69,7 +65,6 @@ void PoolAllocator::newBlock()
     {
       mem.emplace_back(boost::make_shared<PoolAllocatorBufType>(allocSize));
     }
-    // mem.push_back(next);
     nextAlloc = mem.back().get();
   }
   else

--- a/utils/common/poolallocator.cpp
+++ b/utils/common/poolallocator.cpp
@@ -52,13 +52,13 @@ void PoolAllocator::deallocateAll()
 
 void PoolAllocator::newBlock()
 {
-  std::shared_ptr<uint8_t[]> next;
+  std::shared_ptr<PoolAllocatorBufType[]> next;
 
   capacityRemaining = allocSize;
 
   if (!tmpSpace || mem.size() == 0)
   {
-    next.reset(new uint8_t[allocSize]);
+    next.reset(new PoolAllocatorBufType[allocSize]);
     mem.push_back(next);
     nextAlloc = next.get();
   }
@@ -71,7 +71,7 @@ void* PoolAllocator::allocOOB(uint64_t size)
   OOBMemInfo memInfo;
 
   memUsage += size;
-  memInfo.mem.reset(new uint8_t[size]);
+  memInfo.mem.reset(new PoolAllocatorBufType[size]);
   memInfo.size = size;
   void* ret = (void*)memInfo.mem.get();
   oob[ret] = memInfo;

--- a/utils/common/stlpoolallocator.h
+++ b/utils/common/stlpoolallocator.h
@@ -102,7 +102,7 @@ STLPoolAllocator<T>::STLPoolAllocator(joblist::ResourceManager* rm)
   if (rm) 
   {
     auto alloc = rm->getAllocator<PoolAllocatorBufType>();
-    pa.reset(new PoolAllocator(alloc));
+    pa.reset(new PoolAllocator(alloc, DEFAULT_SIZE));
   }
   else
   {

--- a/utils/common/stlpoolallocator.h
+++ b/utils/common/stlpoolallocator.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <boost/shared_ptr.hpp>
 #include "poolallocator.h"
+#include "resourcemanager.h"
 
 #undef min
 #undef max
@@ -61,6 +62,7 @@ class STLPoolAllocator
   };
 
   STLPoolAllocator() throw();
+  STLPoolAllocator(joblist::ResourceManager* rm);
   STLPoolAllocator(const STLPoolAllocator&) throw();
   STLPoolAllocator(uint32_t capacity) throw();
   template <class U>
@@ -92,6 +94,20 @@ template <class T>
 STLPoolAllocator<T>::STLPoolAllocator() throw()
 {
   pa.reset(new PoolAllocator(DEFAULT_SIZE));
+}
+
+template <class T>
+STLPoolAllocator<T>::STLPoolAllocator(joblist::ResourceManager* rm)
+{
+  if (rm) 
+  {
+    auto alloc = rm->getAllocator<PoolAllocatorBufType>();
+    pa.reset(new PoolAllocator(alloc));
+  }
+  else
+  {
+    pa.reset(new PoolAllocator(DEFAULT_SIZE));
+  }
 }
 
 template <class T>

--- a/utils/common/stlpoolallocator.h
+++ b/utils/common/stlpoolallocator.h
@@ -117,12 +117,6 @@ STLPoolAllocator<T>::STLPoolAllocator(const STLPoolAllocator<T>& s) throw()
 }
 
 template <class T>
-STLPoolAllocator<T>::STLPoolAllocator(uint32_t capacity) throw()
-{
-  pa.reset(new PoolAllocator(capacity));
-}
-
-template <class T>
 template <class U>
 STLPoolAllocator<T>::STLPoolAllocator(const STLPoolAllocator<U>& s) throw()
 {
@@ -132,17 +126,6 @@ STLPoolAllocator<T>::STLPoolAllocator(const STLPoolAllocator<U>& s) throw()
 template <class T>
 STLPoolAllocator<T>::~STLPoolAllocator()
 {
-}
-
-template <class T>
-void STLPoolAllocator<T>::usePoolAllocator(boost::shared_ptr<PoolAllocator> p)
-{
-  pa = p;
-}
-template <class T>
-boost::shared_ptr<utils::PoolAllocator> STLPoolAllocator<T>::getPoolAllocator()
-{
-  return pa;
 }
 
 template <class T>

--- a/utils/joiner/joinpartition.cpp
+++ b/utils/joiner/joinpartition.cpp
@@ -436,7 +436,7 @@ int64_t JoinPartition::processSmallBuffer(RGData& rgData)
     the amount stored in RowGroups in mem + the size of the hash table.  The RowGroups
     in that case use 600MB, so 3.4GB is used by the hash table.  3.4GB/100M rows = 34 bytes/row
     */
-    htSizeEstimate += rg.getDataSize() + (34 * rg.getRowCount());
+    htSizeEstimate += rg.getMaxDataSizeWithStrings() + (34 * rg.getRowCount());
 
     if (htSizeEstimate > htTargetSize)
       ret += convertToSplitMode();

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -57,43 +57,34 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
 {
   uint i;
 
+  auto alloc = resourceManager_->getAllocator<rowgroup::Row::Pointer>();
+  rows.reset(new RowPointersVec(alloc));
+
   getBucketCount();
   m_bucketLocks.reset(new boost::mutex[bucketCount]);
 
   if (smallRG.getColTypes()[smallJoinColumn] == CalpontSystemCatalog::LONGDOUBLE)
   {
-    ld.reset(new boost::scoped_ptr<ldhash_t>[bucketCount]);
-    // _pool.reset(new boost::shared_ptr<PoolAllocator>[bucketCount]);
     for (i = 0; i < bucketCount; i++)
     {
-      // STLPoolAllocator<pair<const long double, Row::Pointer>> alloc(resourceManager_);
-      // _pool[i] = alloc.getPoolAllocator();
       auto alloc = resourceManager_->getAllocator<pair<const long double, Row::Pointer>>();
-      ld[i].reset(new ldhash_t(10, hasher(), ldhash_t::key_equal(), alloc));
+      ld.emplace_back(std::unique_ptr<ldhash_t>(new ldhash_t(10, hasher(), ldhash_t::key_equal(), alloc)));
     }
   }
   else if (smallRG.usesStringTable())
   {
-    sth.reset(new boost::scoped_ptr<sthash_t>[bucketCount]);
-    _pool.reset(new boost::shared_ptr<PoolAllocator>[bucketCount]);
     for (i = 0; i < bucketCount; i++)
     {
-      // STLPoolAllocator<pair<const int64_t, Row::Pointer>> alloc(resourceManager_);
-      // _pool[i] = alloc.getPoolAllocator();
       auto alloc = resourceManager_->getAllocator<pair<const int64_t, Row::Pointer>>();
-      sth[i].reset(new sthash_t(10, hasher(), sthash_t::key_equal(), alloc));
+      sth.emplace_back(std::unique_ptr<sthash_t>(new sthash_t(10, hasher(), sthash_t::key_equal(), alloc)));
     }
   }
   else
   {
-    h.reset(new boost::scoped_ptr<hash_t>[bucketCount]);
-    _pool.reset(new boost::shared_ptr<PoolAllocator>[bucketCount]);
     for (i = 0; i < bucketCount; i++)
     {
-      // STLPoolAllocator<pair<const int64_t, uint8_t*>> alloc(resourceManager_);
-      // _pool[i] = alloc.getPoolAllocator();
       auto alloc = resourceManager_->getAllocator<pair<const int64_t, uint8_t*>>();
-      h[i].reset(new hash_t(10, hasher(), hash_t::key_equal(), alloc));
+      h.emplace_back(std::unique_ptr<hash_t>(new hash_t(10, hasher(), hash_t::key_equal(), alloc)));
     }
   }
 
@@ -148,13 +139,6 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
   nullValueForJoinColumn = smallNullRow.getSignedNullValue(smallJoinColumn);
 }
 
-// TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::RowGroup& largeInput,
-//                          const vector<uint32_t>& smallJoinColumns, const vector<uint32_t>& largeJoinColumns,
-//                          JoinType jt, threadpool::ThreadPool* jsThreadPool)
-//  : TupleJoiner(smallInput, largeInput, smallJoinColumns, largeJoinColumns, jt, jsThreadPool, nullptr)
-// {
-// }
-
 // Typeless joiner ctor
 TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::RowGroup& largeInput,
                          const vector<uint32_t>& smallJoinColumns, const vector<uint32_t>& largeJoinColumns,
@@ -178,14 +162,11 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
 
   getBucketCount();
 
-  _pool.reset(new boost::shared_ptr<PoolAllocator>[bucketCount]);
-  ht.reset(new boost::scoped_ptr<typelesshash_t>[bucketCount]);
   for (i = 0; i < bucketCount; i++)
   {
-    // STLPoolAllocator<pair<const TypelessData, Row::Pointer>> alloc(resourceManager_);
-    // _pool[i] = alloc.getPoolAllocator();
     auto alloc = resourceManager_->getAllocator<pair<const TypelessData, Row::Pointer>>();
-    ht[i].reset(new typelesshash_t(10, hasher(), typelesshash_t::key_equal(), alloc));
+    ht.emplace_back(std::unique_ptr<typelesshash_t>(
+        new typelesshash_t(10, hasher(), typelesshash_t::key_equal(), alloc)));
   }
   m_bucketLocks.reset(new boost::mutex[bucketCount]);
 
@@ -237,11 +218,10 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
 
   // note, 'numcores' is implied by tuplehashjoin on calls to insertRGData().
   // TODO: make it explicit to avoid future confusion.
-  storedKeyAlloc.reset(new FixedAllocator[numCores]);
   for (i = 0; i < (uint)numCores; i++)
   {
     auto alloc = resourceManager_->getAllocator<utils::FixedAllocatorBufType>();
-    storedKeyAlloc[i] = FixedAllocator(alloc, keyLength);
+    storedKeyAlloc.emplace_back(FixedAllocator(alloc, keyLength));
   }
 }
 
@@ -282,7 +262,7 @@ void TupleJoiner::getBucketCount()
 }
 
 template <typename buckets_t, typename hash_table_t>
-void TupleJoiner::bucketsToTables(buckets_t* buckets, hash_table_t* tables)
+void TupleJoiner::bucketsToTables(buckets_t* buckets, hash_table_t& tables)
 {
   uint i;
 
@@ -304,7 +284,7 @@ void TupleJoiner::bucketsToTables(buckets_t* buckets, hash_table_t* tables)
         }
         tables[i]->insert(buckets[i].begin(), buckets[i].end());
       }
-      
+
       wasProductive = true;
       buckets[i].clear();
     }
@@ -329,7 +309,7 @@ void TupleJoiner::um_insertTypeless(uint threadID, uint rowCount, Row& r)
     uint bucket = bucketPicker((char*)td[i].data, td[i].len, bpSeed) & bucketMask;
     v[bucket].emplace_back(pair<TypelessData, Row::Pointer>(td[i], r.getPointer()));
   }
-  bucketsToTables(&v[0], ht.get());
+  bucketsToTables(&v[0], ht);
 }
 
 void TupleJoiner::um_insertLongDouble(uint rowCount, Row& r)
@@ -348,7 +328,7 @@ void TupleJoiner::um_insertLongDouble(uint rowCount, Row& r)
     else
       v[bucket].emplace_back(pair<long double, Row::Pointer>(smallKey, r.getPointer()));
   }
-  bucketsToTables(&v[0], ld.get());
+  bucketsToTables(&v[0], ld);
 }
 
 void TupleJoiner::um_insertInlineRows(uint rowCount, Row& r)
@@ -370,7 +350,7 @@ void TupleJoiner::um_insertInlineRows(uint rowCount, Row& r)
     else
       v[bucket].emplace_back(pair<int64_t, uint8_t*>(smallKey, r.getData()));
   }
-  bucketsToTables(&v[0], h.get());
+  bucketsToTables(&v[0], h);
 }
 
 void TupleJoiner::um_insertStringTable(uint rowCount, Row& r)
@@ -392,7 +372,7 @@ void TupleJoiner::um_insertStringTable(uint rowCount, Row& r)
     else
       v[bucket].emplace_back(pair<int64_t, Row::Pointer>(smallKey, r.getPointer()));
   }
-  bucketsToTables(&v[0], sth.get());
+  bucketsToTables(&v[0], sth);
 }
 
 void TupleJoiner::insertRGData(RowGroup& rg, uint threadID)
@@ -412,7 +392,7 @@ void TupleJoiner::insertRGData(RowGroup& rg, uint threadID)
       r.zeroRid();
     }
   }
-  
+
   rg.getRow(0, &r);
 
   if (joinAlg == UM)
@@ -430,7 +410,7 @@ void TupleJoiner::insertRGData(RowGroup& rg, uint threadID)
   {
     // while in PM-join mode, inserting is single-threaded
     for (i = 0; i < rowCount; i++, r.nextRow())
-      rows.push_back(r.getPointer());
+      rows->push_back(r.getPointer());
   }
 }
 
@@ -495,7 +475,7 @@ void TupleJoiner::insert(Row& r, bool zeroTheRid)
     }
   }
   else
-    rows.push_back(r.getPointer());
+    rows->push_back(r.getPointer());
 }
 
 void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uint32_t threadID,
@@ -511,8 +491,8 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
     uint32_t size = v.size();
 
     for (i = 0; i < size; i++)
-      if (v[i] < rows.size())
-        matches->push_back(rows[v[i]]);
+      if (v[i] < rows->size())
+        matches->push_back((*rows)[v[i]]);
 
     if (UNLIKELY((semiJoin() || antiJoin()) && matches->size() == 0))
       matches->push_back(smallNullRow.getPointer());
@@ -539,7 +519,7 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
       for (; range.first != range.second; ++range.first)
         matches->push_back(range.first->second);
     }
-    else if (largeSideRow.getColType(largeKeyColumns[0]) == CalpontSystemCatalog::LONGDOUBLE && ld)
+    else if (largeSideRow.getColType(largeKeyColumns[0]) == CalpontSystemCatalog::LONGDOUBLE && !ld.empty())
     {
       // This is a compare of two long double
       long double largeKey;
@@ -575,7 +555,7 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
         largeKey = largeSideRow.getIntField(largeKeyColumns[0]);
       }
 
-      if (ld)
+      if (!ld.empty())
       {
         // Compare against long double
         long double ldKey = largeKey;
@@ -622,7 +602,7 @@ void TupleJoiner::match(rowgroup::Row& largeSideRow, uint32_t largeRowIndex, uin
 
   if (UNLIKELY(inUM() && (joinType & MATCHNULLS) && !isNull && !typelessJoin))
   {
-    if (largeRG.getColType(largeKeyColumns[0]) == CalpontSystemCatalog::LONGDOUBLE && ld)
+    if (largeRG.getColType(largeKeyColumns[0]) == CalpontSystemCatalog::LONGDOUBLE && !ld.empty())
     {
       uint bucket = bucketPicker((char*)&(joblist::LONGDOUBLENULL), sizeof(joblist::LONGDOUBLENULL), bpSeed) &
                     bucketMask;
@@ -752,7 +732,7 @@ void TupleJoiner::doneInserting()
     for (i = 0; i < rowCount; i++)
     {
       if (joinAlg == PM)
-        smallRow.setPointer(rows[pmpos++]);
+        smallRow.setPointer((*rows)[pmpos++]);
       else if (typelessJoin)
       {
         while (thit == ht[bucket]->end())
@@ -842,14 +822,13 @@ void TupleJoiner::umJoinConvert(size_t begin, size_t end)
 
   while (begin < end)
   {
-    smallRow.setPointer(rows[begin++]);
+    smallRow.setPointer((*rows)[begin++]);
     insert(smallRow);
   }
 }
 
 void TupleJoiner::setInUM()
 {
-  vector<Row::Pointer> empty;
   Row smallRow;
   uint32_t i, size;
 
@@ -857,7 +836,7 @@ void TupleJoiner::setInUM()
     return;
 
   joinAlg = UM;
-  size = rows.size();
+  size = rows->size();
   size_t chunkSize =
       ((size / numCores) + 1 < 50000 ? 50000
                                      : (size / numCores) + 1);  // don't start a thread to process < 50k rows
@@ -875,17 +854,15 @@ void TupleJoiner::setInUM()
 #ifdef TJ_DEBUG
   cout << "done\n";
 #endif
-  rows.swap(empty);
+  auto alloc = resourceManager_->getAllocator<rowgroup::Row::Pointer>();
+  rows.reset(new RowPointersVec(alloc));
 
   if (typelessJoin)
   {
-    tmpKeyAlloc.reset(new FixedAllocator[threadCount]);
-
     for (i = 0; i < threadCount; i++)
     {
       auto alloc = resourceManager_->getAllocator<utils::FixedAllocatorBufType>();
-      tmpKeyAlloc[i] = FixedAllocator(alloc, keyLength, true);
-
+      tmpKeyAlloc.emplace_back(FixedAllocator(alloc, keyLength, true));
     }
   }
 }
@@ -912,8 +889,8 @@ void TupleJoiner::setInUM(vector<RGData>& rgs)
     return;
 
   {  // don't need rows anymore, free the mem
-    vector<Row::Pointer> empty;
-    rows.swap(empty);
+    auto alloc = resourceManager_->getAllocator<rowgroup::Row::Pointer>();
+    rows.reset(new RowPointersVec(alloc));
   }
 
   joinAlg = UM;
@@ -938,12 +915,10 @@ void TupleJoiner::setInUM(vector<RGData>& rgs)
 
   if (typelessJoin)
   {
-    tmpKeyAlloc.reset(new FixedAllocator[threadCount]);
-
     for (i = 0; i < threadCount; i++)
     {
       auto alloc = resourceManager_->getAllocator<utils::FixedAllocatorBufType>();
-      tmpKeyAlloc[i] = FixedAllocator(alloc, keyLength, true);
+      tmpKeyAlloc.emplace_back(FixedAllocator(alloc, keyLength, true));
     }
   }
 }
@@ -961,9 +936,9 @@ void TupleJoiner::markMatches(uint32_t threadID, uint32_t rowCount)
   for (i = 0; i < rowCount; i++)
     for (j = 0; j < matches[i].size(); j++)
     {
-      if (matches[i][j] < rows.size())
+      if (matches[i][j] < rows->size())
       {
-        smallRow[threadID].setPointer(rows[matches[i][j]]);
+        smallRow[threadID].setPointer((*rows)[matches[i][j]]);
         smallRow[threadID].markRow();
       }
     }
@@ -997,12 +972,10 @@ void TupleJoiner::setThreadCount(uint32_t cnt)
 
   if (typelessJoin)
   {
-    tmpKeyAlloc.reset(new FixedAllocator[threadCount]);
-
     for (uint32_t i = 0; i < threadCount; i++)
     {
       auto alloc = resourceManager_->getAllocator<utils::FixedAllocatorBufType>();
-      tmpKeyAlloc[i] = FixedAllocator(alloc, keyLength, true);
+      tmpKeyAlloc.emplace_back(FixedAllocator(alloc, keyLength, true));
     }
   }
 
@@ -1026,14 +999,14 @@ void TupleJoiner::getUnmarkedRows(vector<Row::Pointer>* out)
   {
     uint32_t i, size;
 
-    size = rows.size();
+    size = rows->size();
 
     for (i = 0; i < size; i++)
     {
-      smallR.setPointer(rows[i]);
+      smallR.setPointer((*rows)[i]);
 
       if (!smallR.isMarked())
-        out->push_back(rows[i]);
+        out->push_back((*rows)[i]);
     }
   }
   else
@@ -1091,28 +1064,6 @@ void TupleJoiner::getUnmarkedRows(vector<Row::Pointer>* out)
         }
     }
   }
-}
-
-uint64_t TupleJoiner::getMemUsage() const
-{
-  if (inUM() && typelessJoin)
-  {
-    size_t ret = 0;
-    for (uint i = 0; i < bucketCount; i++)
-      ret += _pool[i]->getMemUsage();
-    for (int i = 0; i < numCores; i++)
-      ret += storedKeyAlloc[i].getMemUsage();
-    return ret;
-  }
-  else if (inUM())
-  {
-    size_t ret = 0;
-    for (uint i = 0; i < bucketCount; i++)
-      ret += _pool[i]->getMemUsage();
-    return ret;
-  }
-  else
-    return (rows.size() * sizeof(Row::Pointer));
 }
 
 void TupleJoiner::setFcnExpFilter(boost::shared_ptr<funcexp::FuncExpWrapper> pt)
@@ -1253,7 +1204,7 @@ size_t TupleJoiner::size() const
     return ret;
   }
 
-  return rows.size();
+  return rows->size();
 }
 
 class TypelessDataStringEncoder
@@ -1824,20 +1775,9 @@ void TupleJoiner::setTableName(const string& tname)
 
 void TupleJoiner::clearData()
 {
-  _pool.reset(new boost::shared_ptr<utils::PoolAllocator>[bucketCount]);
-  if (typelessJoin)
-    ht.reset(new boost::scoped_ptr<typelesshash_t>[bucketCount]);
-  else if (smallRG.getColTypes()[smallKeyColumns[0]] == CalpontSystemCatalog::LONGDOUBLE)
-    ld.reset(new boost::scoped_ptr<ldhash_t>[bucketCount]);
-  else if (smallRG.usesStringTable())
-    sth.reset(new boost::scoped_ptr<sthash_t>[bucketCount]);
-  else
-    h.reset(new boost::scoped_ptr<hash_t>[bucketCount]);
-
+  // This loop calls dtors and deallocates mem.
   for (uint i = 0; i < bucketCount; i++)
   {
-    // STLPoolAllocator<pair<const TypelessData, Row::Pointer>> alloc(resourceManager_);
-    // _pool[i] = alloc.getPoolAllocator();
     auto alloc = resourceManager_->getAllocator<pair<const TypelessData, Row::Pointer>>();
     if (typelessJoin)
       ht[i].reset(new typelesshash_t(10, hasher(), typelesshash_t::key_equal(), alloc));
@@ -1846,11 +1786,13 @@ void TupleJoiner::clearData()
     else if (smallRG.usesStringTable())
       sth[i].reset(new sthash_t(10, hasher(), sthash_t::key_equal(), alloc));
     else
+    {
       h[i].reset(new hash_t(10, hasher(), hash_t::key_equal(), alloc));
+    }
   }
 
-  std::vector<rowgroup::Row::Pointer> empty;
-  rows.swap(empty);
+  auto alloc = resourceManager_->getAllocator<rowgroup::Row::Pointer>();
+  rows.reset(new RowPointersVec(alloc));
   finished = false;
 }
 
@@ -1913,11 +1855,10 @@ std::shared_ptr<TupleJoiner> TupleJoiner::copyForDiskJoin()
 
   if (typelessJoin)
   {
-    ret->storedKeyAlloc.reset(new FixedAllocator[numCores]);
     for (int i = 0; i < numCores; i++)
     {
       auto alloc = resourceManager_->getAllocator<utils::FixedAllocatorBufType>();
-      storedKeyAlloc[i] = FixedAllocator(alloc, keyLength);
+      storedKeyAlloc.emplace_back(FixedAllocator(alloc, keyLength));
     }
   }
 

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -66,9 +66,9 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
     // _pool.reset(new boost::shared_ptr<PoolAllocator>[bucketCount]);
     for (i = 0; i < bucketCount; i++)
     {
-      STLPoolAllocator<pair<const long double, Row::Pointer>> alloc(resourceManager_);
+      // STLPoolAllocator<pair<const long double, Row::Pointer>> alloc(resourceManager_);
       // _pool[i] = alloc.getPoolAllocator();
-      // auto alloc = resourceManager_->getAllocator<pair<const long double, Row::Pointer>>();
+      auto alloc = resourceManager_->getAllocator<pair<const long double, Row::Pointer>>();
       ld[i].reset(new ldhash_t(10, hasher(), ldhash_t::key_equal(), alloc));
     }
   }
@@ -78,9 +78,9 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
     _pool.reset(new boost::shared_ptr<PoolAllocator>[bucketCount]);
     for (i = 0; i < bucketCount; i++)
     {
-      STLPoolAllocator<pair<const int64_t, Row::Pointer>> alloc(resourceManager_);
+      // STLPoolAllocator<pair<const int64_t, Row::Pointer>> alloc(resourceManager_);
       // _pool[i] = alloc.getPoolAllocator();
-      // auto alloc = resourceManager_->getAllocator<pair<const int64_t, Row::Pointer>>();
+      auto alloc = resourceManager_->getAllocator<pair<const int64_t, Row::Pointer>>();
       sth[i].reset(new sthash_t(10, hasher(), sthash_t::key_equal(), alloc));
     }
   }
@@ -90,9 +90,9 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
     _pool.reset(new boost::shared_ptr<PoolAllocator>[bucketCount]);
     for (i = 0; i < bucketCount; i++)
     {
-      STLPoolAllocator<pair<const int64_t, uint8_t*>> alloc(resourceManager_);
+      // STLPoolAllocator<pair<const int64_t, uint8_t*>> alloc(resourceManager_);
       // _pool[i] = alloc.getPoolAllocator();
-      // auto alloc = resourceManager_->getAllocator<pair<const int64_t, uint8_t*>>();
+      auto alloc = resourceManager_->getAllocator<pair<const int64_t, uint8_t*>>();
       h[i].reset(new hash_t(10, hasher(), hash_t::key_equal(), alloc));
     }
   }
@@ -182,9 +182,9 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
   ht.reset(new boost::scoped_ptr<typelesshash_t>[bucketCount]);
   for (i = 0; i < bucketCount; i++)
   {
-    STLPoolAllocator<pair<const TypelessData, Row::Pointer>> alloc(resourceManager_);
+    // STLPoolAllocator<pair<const TypelessData, Row::Pointer>> alloc(resourceManager_);
     // _pool[i] = alloc.getPoolAllocator();
-    // auto alloc = resourceManager_->getAllocator<pair<const TypelessData, Row::Pointer>>();
+    auto alloc = resourceManager_->getAllocator<pair<const TypelessData, Row::Pointer>>();
     ht[i].reset(new typelesshash_t(10, hasher(), typelesshash_t::key_equal(), alloc));
   }
   m_bucketLocks.reset(new boost::mutex[bucketCount]);
@@ -1836,9 +1836,9 @@ void TupleJoiner::clearData()
 
   for (uint i = 0; i < bucketCount; i++)
   {
-    STLPoolAllocator<pair<const TypelessData, Row::Pointer>> alloc(resourceManager_);
+    // STLPoolAllocator<pair<const TypelessData, Row::Pointer>> alloc(resourceManager_);
     // _pool[i] = alloc.getPoolAllocator();
-    // auto alloc = resourceManager_->getAllocator<pair<const TypelessData, Row::Pointer>>();
+    auto alloc = resourceManager_->getAllocator<pair<const TypelessData, Row::Pointer>>();
     if (typelessJoin)
       ht[i].reset(new typelesshash_t(10, hasher(), typelesshash_t::key_equal(), alloc));
     else if (smallRG.getColTypes()[smallKeyColumns[0]] == CalpontSystemCatalog::LONGDOUBLE)

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -308,6 +308,7 @@ void TupleJoiner::bucketsToTables(buckets_t* buckets, hash_table_t* tables)
       wasProductive = true;
       buckets[i].clear();
     }
+    // TODO use CV here instead of busy sleep
     if (!done && !wasProductive)
       ::usleep(1000 * numCores);
   }

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -66,9 +66,9 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
     // _pool.reset(new boost::shared_ptr<PoolAllocator>[bucketCount]);
     for (i = 0; i < bucketCount; i++)
     {
-      // STLPoolAllocator<pair<const long double, Row::Pointer>> alloc(resourceManager_);
+      STLPoolAllocator<pair<const long double, Row::Pointer>> alloc(resourceManager_);
       // _pool[i] = alloc.getPoolAllocator();
-      auto alloc = resourceManager_->getAllocator<pair<const long double, Row::Pointer>>();
+      // auto alloc = resourceManager_->getAllocator<pair<const long double, Row::Pointer>>();
       ld[i].reset(new ldhash_t(10, hasher(), ldhash_t::key_equal(), alloc));
     }
   }
@@ -78,9 +78,9 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
     _pool.reset(new boost::shared_ptr<PoolAllocator>[bucketCount]);
     for (i = 0; i < bucketCount; i++)
     {
-      // STLPoolAllocator<pair<const int64_t, Row::Pointer>> alloc(resourceManager_);
+      STLPoolAllocator<pair<const int64_t, Row::Pointer>> alloc(resourceManager_);
       // _pool[i] = alloc.getPoolAllocator();
-      auto alloc = resourceManager_->getAllocator<pair<const int64_t, Row::Pointer>>();
+      // auto alloc = resourceManager_->getAllocator<pair<const int64_t, Row::Pointer>>();
       sth[i].reset(new sthash_t(10, hasher(), sthash_t::key_equal(), alloc));
     }
   }
@@ -90,9 +90,9 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
     _pool.reset(new boost::shared_ptr<PoolAllocator>[bucketCount]);
     for (i = 0; i < bucketCount; i++)
     {
-      // STLPoolAllocator<pair<const int64_t, uint8_t*>> alloc(resourceManager_);
+      STLPoolAllocator<pair<const int64_t, uint8_t*>> alloc(resourceManager_);
       // _pool[i] = alloc.getPoolAllocator();
-      auto alloc = resourceManager_->getAllocator<pair<const int64_t, uint8_t*>>();
+      // auto alloc = resourceManager_->getAllocator<pair<const int64_t, uint8_t*>>();
       h[i].reset(new hash_t(10, hasher(), hash_t::key_equal(), alloc));
     }
   }
@@ -182,9 +182,9 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
   ht.reset(new boost::scoped_ptr<typelesshash_t>[bucketCount]);
   for (i = 0; i < bucketCount; i++)
   {
-    // STLPoolAllocator<pair<const TypelessData, Row::Pointer>> alloc(resourceManager_);
+    STLPoolAllocator<pair<const TypelessData, Row::Pointer>> alloc(resourceManager_);
     // _pool[i] = alloc.getPoolAllocator();
-    auto alloc = resourceManager_->getAllocator<pair<const TypelessData, Row::Pointer>>();
+    // auto alloc = resourceManager_->getAllocator<pair<const TypelessData, Row::Pointer>>();
     ht[i].reset(new typelesshash_t(10, hasher(), typelesshash_t::key_equal(), alloc));
   }
   m_bucketLocks.reset(new boost::mutex[bucketCount]);
@@ -1836,9 +1836,9 @@ void TupleJoiner::clearData()
 
   for (uint i = 0; i < bucketCount; i++)
   {
-    // STLPoolAllocator<pair<const TypelessData, Row::Pointer>> alloc;
+    STLPoolAllocator<pair<const TypelessData, Row::Pointer>> alloc(resourceManager_);
     // _pool[i] = alloc.getPoolAllocator();
-    auto alloc = resourceManager_->getAllocator<pair<const TypelessData, Row::Pointer>>();
+    // auto alloc = resourceManager_->getAllocator<pair<const TypelessData, Row::Pointer>>();
     if (typelessJoin)
       ht[i].reset(new typelesshash_t(10, hasher(), typelesshash_t::key_equal(), alloc));
     else if (smallRG.getColTypes()[smallKeyColumns[0]] == CalpontSystemCatalog::LONGDOUBLE)

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -160,6 +160,9 @@ TupleJoiner::TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::R
 {
   uint i;
 
+  auto alloc = resourceManager_->getAllocator<rowgroup::Row::Pointer>();
+  rows.reset(new RowPointersVec(alloc));
+
   getBucketCount();
 
   for (i = 0; i < bucketCount; i++)

--- a/utils/joiner/tuplejoiner.h
+++ b/utils/joiner/tuplejoiner.h
@@ -478,37 +478,37 @@ class TupleJoiner
   }
 
  private:
-   typedef std::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
-                                  utils::STLPoolAllocator<std::pair<const int64_t, uint8_t*> > >
-      hash_t;
-  typedef std::unordered_multimap<int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
-                                  utils::STLPoolAllocator<std::pair<const int64_t, rowgroup::Row::Pointer> > >
-      sthash_t;
-  typedef std::unordered_multimap<
-      TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
-      utils::STLPoolAllocator<std::pair<const TypelessData, rowgroup::Row::Pointer> > >
-      typelesshash_t;
-  // MCOL-1822 Add support for Long Double AVG/SUM small side
-  typedef std::unordered_multimap<
-      long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
-      utils::STLPoolAllocator<std::pair<const long double, rowgroup::Row::Pointer> > >
-      ldhash_t;
+    // typedef std::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
+    //                                 utils::STLPoolAllocator<std::pair<const int64_t, uint8_t*> > >
+    //     hash_t;
+    // typedef std::unordered_multimap<int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
+    //                                 utils::STLPoolAllocator<std::pair<const int64_t, rowgroup::Row::Pointer> > >
+    //     sthash_t;
+    // typedef std::unordered_multimap<
+    //     TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
+    //     utils::STLPoolAllocator<std::pair<const TypelessData, rowgroup::Row::Pointer> > >
+    //     typelesshash_t;
+    // // MCOL-1822 Add support for Long Double AVG/SUM small side
+    // typedef std::unordered_multimap<
+    //     long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
+    //     utils::STLPoolAllocator<std::pair<const long double, rowgroup::Row::Pointer> > >
+    //     ldhash_t;
 
-  // typedef std::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
-  //                                 allocators::CountingAllocator<std::pair<const int64_t, uint8_t*> > >
-  //     hash_t;
-  // typedef std::unordered_multimap<int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
-  //                                 allocators::CountingAllocator<std::pair<const int64_t, rowgroup::Row::Pointer> > >
-  //     sthash_t;
-  // typedef std::unordered_multimap<
-  //     TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
-  //     allocators::CountingAllocator<std::pair<const TypelessData, rowgroup::Row::Pointer> > >
-  //     typelesshash_t;
-  // // MCOL-1822 Add support for Long Double AVG/SUM small side
-  // typedef std::unordered_multimap<
-  //     long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
-  //     allocators::CountingAllocator<std::pair<const long double, rowgroup::Row::Pointer> > >
-  //     ldhash_t;
+    typedef std::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
+                                    allocators::CountingAllocator<std::pair<const int64_t, uint8_t*> > >
+        hash_t;
+    typedef std::unordered_multimap<int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
+                                    allocators::CountingAllocator<std::pair<const int64_t, rowgroup::Row::Pointer> > >
+        sthash_t;
+    typedef std::unordered_multimap<
+        TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
+        allocators::CountingAllocator<std::pair<const TypelessData, rowgroup::Row::Pointer> > >
+        typelesshash_t;
+    // MCOL-1822 Add support for Long Double AVG/SUM small side
+    typedef std::unordered_multimap<
+        long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
+        allocators::CountingAllocator<std::pair<const long double, rowgroup::Row::Pointer> > >
+        ldhash_t;
 
   typedef hash_t::iterator iterator;
   typedef typelesshash_t::iterator thIterator;

--- a/utils/joiner/tuplejoiner.h
+++ b/utils/joiner/tuplejoiner.h
@@ -478,21 +478,37 @@ class TupleJoiner
   }
 
  private:
-  typedef std::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
-                                  allocators::CountingAllocator<std::pair<const int64_t, uint8_t*> > >
+   typedef std::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
+                                  utils::STLPoolAllocator<std::pair<const int64_t, uint8_t*> > >
       hash_t;
   typedef std::unordered_multimap<int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
-                                  allocators::CountingAllocator<std::pair<const int64_t, rowgroup::Row::Pointer> > >
+                                  utils::STLPoolAllocator<std::pair<const int64_t, rowgroup::Row::Pointer> > >
       sthash_t;
   typedef std::unordered_multimap<
       TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
-      allocators::CountingAllocator<std::pair<const TypelessData, rowgroup::Row::Pointer> > >
+      utils::STLPoolAllocator<std::pair<const TypelessData, rowgroup::Row::Pointer> > >
       typelesshash_t;
   // MCOL-1822 Add support for Long Double AVG/SUM small side
   typedef std::unordered_multimap<
       long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
-      allocators::CountingAllocator<std::pair<const long double, rowgroup::Row::Pointer> > >
+      utils::STLPoolAllocator<std::pair<const long double, rowgroup::Row::Pointer> > >
       ldhash_t;
+
+  // typedef std::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
+  //                                 allocators::CountingAllocator<std::pair<const int64_t, uint8_t*> > >
+  //     hash_t;
+  // typedef std::unordered_multimap<int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
+  //                                 allocators::CountingAllocator<std::pair<const int64_t, rowgroup::Row::Pointer> > >
+  //     sthash_t;
+  // typedef std::unordered_multimap<
+  //     TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
+  //     allocators::CountingAllocator<std::pair<const TypelessData, rowgroup::Row::Pointer> > >
+  //     typelesshash_t;
+  // // MCOL-1822 Add support for Long Double AVG/SUM small side
+  // typedef std::unordered_multimap<
+  //     long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
+  //     allocators::CountingAllocator<std::pair<const long double, rowgroup::Row::Pointer> > >
+  //     ldhash_t;
 
   typedef hash_t::iterator iterator;
   typedef typelesshash_t::iterator thIterator;

--- a/utils/joiner/tuplejoiner.h
+++ b/utils/joiner/tuplejoiner.h
@@ -26,6 +26,7 @@
 #include <boost/scoped_array.hpp>
 #include <unordered_map>
 
+#include "resourcemanager.h"
 #include "rowgroup.h"
 #include "joiner.h"
 #include "fixedallocator.h"
@@ -266,14 +267,22 @@ class TupleJoiner
   };
 
   /* ctor to use for numeric join */
+  // TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::RowGroup& largeInput,
+  //             uint32_t smallJoinColumn, uint32_t largeJoinColumn, joblist::JoinType jt,
+  //             threadpool::ThreadPool* jsThreadPool);
+
   TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::RowGroup& largeInput,
               uint32_t smallJoinColumn, uint32_t largeJoinColumn, joblist::JoinType jt,
-              threadpool::ThreadPool* jsThreadPool);
+              threadpool::ThreadPool* jsThreadPool, joblist::ResourceManager* rm);
 
   /* ctor to use for string & compound join */
-  TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::RowGroup& largeInput,
+  // TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::RowGroup& largeInput,
+  //             const std::vector<uint32_t>& smallJoinColumns, const std::vector<uint32_t>& largeJoinColumns,
+  //             joblist::JoinType jt, threadpool::ThreadPool* jsThreadPool);
+
+    TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::RowGroup& largeInput,
               const std::vector<uint32_t>& smallJoinColumns, const std::vector<uint32_t>& largeJoinColumns,
-              joblist::JoinType jt, threadpool::ThreadPool* jsThreadPool);
+              joblist::JoinType jt, threadpool::ThreadPool* jsThreadPool, joblist::ResourceManager* rm);
 
   ~TupleJoiner();
 
@@ -562,6 +571,8 @@ class TupleJoiner
   void bucketsToTables(buckets_t*, hash_table_t*);
 
   bool _convertToDiskJoin;
+  joblist::ResourceManager* resourceManager_ = nullptr;
+
 };
 
 }  // namespace joiner

--- a/utils/joiner/tuplejoiner.h
+++ b/utils/joiner/tuplejoiner.h
@@ -204,6 +204,9 @@ class TypelessDataStructure
   }
 };
 
+using RowPointersVec =
+    std::vector<rowgroup::Row::Pointer, allocators::CountingAllocator<rowgroup::Row::Pointer>>;
+using RowPointersVecUP = std::unique_ptr<RowPointersVec>;
 class TupleJoiner
 {
  public:
@@ -268,20 +271,12 @@ class TupleJoiner
   };
 
   /* ctor to use for numeric join */
-  // TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::RowGroup& largeInput,
-  //             uint32_t smallJoinColumn, uint32_t largeJoinColumn, joblist::JoinType jt,
-  //             threadpool::ThreadPool* jsThreadPool);
-
   TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::RowGroup& largeInput,
               uint32_t smallJoinColumn, uint32_t largeJoinColumn, joblist::JoinType jt,
               threadpool::ThreadPool* jsThreadPool, joblist::ResourceManager* rm);
 
   /* ctor to use for string & compound join */
-  // TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::RowGroup& largeInput,
-  //             const std::vector<uint32_t>& smallJoinColumns, const std::vector<uint32_t>& largeJoinColumns,
-  //             joblist::JoinType jt, threadpool::ThreadPool* jsThreadPool);
-
-    TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::RowGroup& largeInput,
+  TupleJoiner(const rowgroup::RowGroup& smallInput, const rowgroup::RowGroup& largeInput,
               const std::vector<uint32_t>& smallJoinColumns, const std::vector<uint32_t>& largeJoinColumns,
               joblist::JoinType jt, threadpool::ThreadPool* jsThreadPool, joblist::ResourceManager* rm);
 
@@ -333,9 +328,9 @@ class TupleJoiner
   void setThreadCount(uint32_t cnt);
   void setPMJoinResults(std::shared_ptr<std::vector<uint32_t>[]>, uint32_t threadID);
   std::shared_ptr<std::vector<uint32_t>[]> getPMJoinArrays(uint32_t threadID);
-  std::vector<rowgroup::Row::Pointer>* getSmallSide()
+  RowPointersVec& getSmallSide()
   {
-    return &rows;
+    return *rows;
   }
   inline bool smallOuterJoin()
   {
@@ -381,8 +376,6 @@ class TupleJoiner
   /* To allow sorting */
   bool operator<(const TupleJoiner&) const;
 
-  uint64_t getMemUsage() const;
-
   /* Typeless join interface */
   inline bool isTypelessJoin()
   {
@@ -410,7 +403,7 @@ class TupleJoiner
   {
     return discreteValues;
   }
-  inline const boost::scoped_array<std::vector<int128_t> >& getCPData()
+  inline const boost::scoped_array<std::vector<int128_t>>& getCPData()
   {
     return cpValues;
   }
@@ -478,37 +471,22 @@ class TupleJoiner
   }
 
  private:
-    // typedef std::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
-    //                                 utils::STLPoolAllocator<std::pair<const int64_t, uint8_t*> > >
-    //     hash_t;
-    // typedef std::unordered_multimap<int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
-    //                                 utils::STLPoolAllocator<std::pair<const int64_t, rowgroup::Row::Pointer> > >
-    //     sthash_t;
-    // typedef std::unordered_multimap<
-    //     TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
-    //     utils::STLPoolAllocator<std::pair<const TypelessData, rowgroup::Row::Pointer> > >
-    //     typelesshash_t;
-    // // MCOL-1822 Add support for Long Double AVG/SUM small side
-    // typedef std::unordered_multimap<
-    //     long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
-    //     utils::STLPoolAllocator<std::pair<const long double, rowgroup::Row::Pointer> > >
-    //     ldhash_t;
-
-    typedef std::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
-                                    allocators::CountingAllocator<std::pair<const int64_t, uint8_t*> > >
-        hash_t;
-    typedef std::unordered_multimap<int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
-                                    allocators::CountingAllocator<std::pair<const int64_t, rowgroup::Row::Pointer> > >
-        sthash_t;
-    typedef std::unordered_multimap<
-        TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
-        allocators::CountingAllocator<std::pair<const TypelessData, rowgroup::Row::Pointer> > >
-        typelesshash_t;
-    // MCOL-1822 Add support for Long Double AVG/SUM small side
-    typedef std::unordered_multimap<
-        long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
-        allocators::CountingAllocator<std::pair<const long double, rowgroup::Row::Pointer> > >
-        ldhash_t;
+  typedef std::unordered_multimap<int64_t, uint8_t*, hasher, std::equal_to<int64_t>,
+                                  allocators::CountingAllocator<std::pair<const int64_t, uint8_t*>>>
+      hash_t;
+  typedef std::unordered_multimap<
+      int64_t, rowgroup::Row::Pointer, hasher, std::equal_to<int64_t>,
+      allocators::CountingAllocator<std::pair<const int64_t, rowgroup::Row::Pointer>>>
+      sthash_t;
+  typedef std::unordered_multimap<
+      TypelessData, rowgroup::Row::Pointer, hasher, std::equal_to<TypelessData>,
+      allocators::CountingAllocator<std::pair<const TypelessData, rowgroup::Row::Pointer>>>
+      typelesshash_t;
+  // MCOL-1822 Add support for Long Double AVG/SUM small side
+  typedef std::unordered_multimap<
+      long double, rowgroup::Row::Pointer, hasher, LongDoubleEq,
+      allocators::CountingAllocator<std::pair<const long double, rowgroup::Row::Pointer>>>
+      ldhash_t;
 
   typedef hash_t::iterator iterator;
   typedef typelesshash_t::iterator thIterator;
@@ -521,11 +499,11 @@ class TupleJoiner
 
   rowgroup::RGData smallNullMemory;
 
-  boost::scoped_array<boost::scoped_ptr<hash_t> > h;  // used for UM joins on ints
-  boost::scoped_array<boost::scoped_ptr<sthash_t> >
+  std::vector<std::unique_ptr<hash_t>> h;  // used for UM joins on ints
+  std::vector<std::unique_ptr<sthash_t>>
       sth;  // used for UM join on ints where the backing table uses a string table
-  boost::scoped_array<boost::scoped_ptr<ldhash_t> > ld;  // used for UM join on long double
-  std::vector<rowgroup::Row::Pointer> rows;              // used for PM join
+  std::vector<std::unique_ptr<ldhash_t>> ld;  // used for UM join on long double
+  RowPointersVecUP rows;                      // used for PM join
 
   /* This struct is rough.  The BPP-JL stores the parsed results for
   the logical block being processed.  There are X threads at once, so
@@ -546,18 +524,16 @@ class TupleJoiner
   };
   JoinAlg joinAlg;
   joblist::JoinType joinType;
-  // WIP
-  std::shared_ptr<boost::shared_ptr<utils::PoolAllocator>[]> _pool;  // pools for the table and nodes
   uint32_t threadCount;
   std::string tableName;
 
   /* vars, & fcns for typeless join */
   bool typelessJoin;
   std::vector<uint32_t> smallKeyColumns, largeKeyColumns;
-  boost::scoped_array<boost::scoped_ptr<typelesshash_t> > ht;  // used for UM join on strings
+  std::vector<std::unique_ptr<typelesshash_t>> ht;  // used for UM join on strings
   uint32_t keyLength;
-  boost::scoped_array<utils::FixedAllocator> storedKeyAlloc;
-  boost::scoped_array<utils::FixedAllocator> tmpKeyAlloc;
+  std::vector<utils::FixedAllocator> storedKeyAlloc;
+  std::vector<utils::FixedAllocator> tmpKeyAlloc;
   bool bSignedUnsignedJoin;  // Set if we have a signed vs unsigned compare in a join. When not set, we can
                              // save checking for the signed bit.
 
@@ -571,7 +547,7 @@ class TupleJoiner
   /* Runtime casual partitioning support */
   void updateCPData(const rowgroup::Row& r);
   boost::scoped_array<bool> discreteValues;
-  boost::scoped_array<std::vector<int128_t> > cpValues;  // if !discreteValues, [0] has min, [1] has max
+  boost::scoped_array<std::vector<int128_t>> cpValues;  // if !discreteValues, [0] has min, [1] has max
   uint32_t uniqueLimit;
   bool finished;
 
@@ -590,7 +566,7 @@ class TupleJoiner
   void um_insertStringTable(uint rowcount, rowgroup::Row& r);
 
   template <typename buckets_t, typename hash_table_t>
-  void bucketsToTables(buckets_t*, hash_table_t*);
+  void bucketsToTables(buckets_t*, hash_table_t&);
 
   bool _convertToDiskJoin;
   joblist::ResourceManager* resourceManager_ = nullptr;

--- a/utils/loggingcpp/ErrorMessage.txt
+++ b/utils/loggingcpp/ErrorMessage.txt
@@ -108,6 +108,8 @@
 
 2060	ERR_UNION_DECIMAL_OVERFLOW	Union operation exceeds maximum DECIMAL precision of 38.
 
+2063	ERR_TNS_DISTINCT_IS_TOO_BIG	DISTINCT memory limit is exceeded whilst running TNS step.
+
 # Sub-query errors
 3001	ERR_NON_SUPPORT_SUB_QUERY_TYPE	This subquery type is not supported yet.
 3002	ERR_MORE_THAN_1_ROW	Subquery returns more than 1 row.

--- a/utils/messageqcpp/bytestream.cpp
+++ b/utils/messageqcpp/bytestream.cpp
@@ -50,8 +50,8 @@ void ByteStream::doCopy(const ByteStream& rhs)
 
   if (fMaxLen < rlen)
   {
-    delete[] fBuf;
-    fBuf = new uint8_t[rlen + ISSOverhead];
+    deallocate(fBuf);
+    fBuf = allocate(rlen + ISSOverhead);
     fMaxLen = rlen;
   }
 
@@ -83,7 +83,7 @@ ByteStream& ByteStream::operator=(const ByteStream& rhs)
       doCopy(rhs);
     else
     {
-      delete[] fBuf;
+      deallocate(fBuf);
       fBuf = fCurInPtr = fCurOutPtr = 0;
       fMaxLen = 0;
       // Clear `longStrings`.
@@ -100,12 +100,40 @@ ByteStream::ByteStream(uint32_t initSize) : fBuf(0), fCurInPtr(0), fCurOutPtr(0)
     growBuf(initSize);
 }
 
+// WIP remove this one, replacing the allocator arg with a default nullptr.
+ByteStream::ByteStream(allocators::CountingAllocator<uint8_t>* allocator, uint32_t initSize)
+ : fBuf(0), fCurInPtr(0), fCurOutPtr(0), fMaxLen(0), allocator(allocator)
+{
+  if (initSize > 0)
+    growBuf(initSize);
+}
+
 void ByteStream::add(const uint8_t b)
 {
   if (fBuf == 0 || (static_cast<uint32_t>(fCurInPtr - fBuf) == fMaxLen + ISSOverhead))
     growBuf();
 
   *fCurInPtr++ = b;
+}
+
+BSBufType* ByteStream::allocate(const size_t size)
+{
+  if (allocator)
+  {
+    auto* mem = allocator->allocate(size);
+    return new (mem) BSBufType[size];
+  }
+  return new BSBufType[size];
+}
+
+void ByteStream::deallocate(BSBufType* ptr)
+{
+  if (allocator)
+  {
+    size_t count = (fMaxLen) ? fMaxLen + ISSOverhead : 0;
+    return allocator->deallocate(ptr, count);
+  }
+  return delete[] fBuf;
 }
 
 void ByteStream::growBuf(uint32_t toSize)
@@ -117,7 +145,7 @@ void ByteStream::growBuf(uint32_t toSize)
     else
       toSize = ((toSize + BlockSize - 1) / BlockSize) * BlockSize;
 
-    fBuf = new uint8_t[toSize + ISSOverhead];
+    fBuf = allocate(toSize + ISSOverhead);
 #ifdef ZERO_ON_NEW
     memset(fBuf, 0, (toSize + ISSOverhead));
 #endif
@@ -137,14 +165,14 @@ void ByteStream::growBuf(uint32_t toSize)
     // Make sure we at least double the allocation
     toSize = std::max(toSize, fMaxLen * 2);
 
-    uint8_t* t = new uint8_t[toSize + ISSOverhead];
+    BSBufType* t = allocate(toSize + ISSOverhead);
     uint32_t curOutOff = fCurOutPtr - fBuf;
     uint32_t curInOff = fCurInPtr - fBuf;
     memcpy(t, fBuf, fCurInPtr - fBuf);
 #ifdef ZERO_ON_NEW
     memset(t + (fCurInPtr - fBuf), 0, (toSize + ISSOverhead) - (fCurInPtr - fBuf));
 #endif
-    delete[] fBuf;
+    deallocate(fBuf);
     fBuf = t;
     fMaxLen = toSize;
     fCurInPtr = fBuf + curInOff;
@@ -513,8 +541,8 @@ void ByteStream::load(const uint8_t* bp, uint32_t len)
 
   if (len > fMaxLen)
   {
-    delete[] fBuf;
-    fBuf = new uint8_t[newMaxLen + ISSOverhead];
+    deallocate(fBuf);
+    fBuf = allocate(newMaxLen + ISSOverhead);
     fMaxLen = newMaxLen;
   }
 
@@ -547,8 +575,10 @@ void ByteStream::swap(ByteStream& rhs)
   std::swap(fCurOutPtr, rhs.fCurOutPtr);
   std::swap(fMaxLen, rhs.fMaxLen);
   std::swap(longStrings, rhs.longStrings);
+  std::swap(allocator, rhs.allocator);
 }
 
+// WIP use allocator
 ifstream& operator>>(ifstream& ifs, ByteStream& bs)
 {
   int ifs_len;
@@ -624,7 +654,6 @@ void ByteStream::needAtLeast(size_t amount)
   if (currentSpace < amount)
     growBuf(fMaxLen + amount);
 }
-
 
 ByteStream& ByteStream::operator<<(const ByteStream& bs)
 {

--- a/utils/messageqcpp/bytestream.cpp
+++ b/utils/messageqcpp/bytestream.cpp
@@ -180,17 +180,17 @@ void ByteStream::growBuf(uint32_t toSize)
   }
 }
 
-std::vector<std::shared_ptr<uint8_t[]>>& ByteStream::getLongStrings()
+std::vector<rowgroup::StringStoreBufSPType>& ByteStream::getLongStrings()
 {
   return longStrings;
 }
 
-const std::vector<std::shared_ptr<uint8_t[]>>& ByteStream::getLongStrings() const
+const std::vector<rowgroup::StringStoreBufSPType>& ByteStream::getLongStrings() const
 {
   return longStrings;
 }
 
-void ByteStream::setLongStrings(const std::vector<std::shared_ptr<uint8_t[]>>& other)
+void ByteStream::setLongStrings(const std::vector<rowgroup::StringStoreBufSPType>& other)
 {
   longStrings = other;
 }

--- a/utils/messageqcpp/bytestream.cpp
+++ b/utils/messageqcpp/bytestream.cpp
@@ -101,7 +101,7 @@ ByteStream::ByteStream(uint32_t initSize) : fBuf(0), fCurInPtr(0), fCurOutPtr(0)
 }
 
 // WIP remove this one, replacing the allocator arg with a default nullptr.
-ByteStream::ByteStream(allocators::CountingAllocator<uint8_t>* allocator, uint32_t initSize)
+ByteStream::ByteStream(allocators::CountingAllocator<uint8_t>& allocator, uint32_t initSize)
  : fBuf(0), fCurInPtr(0), fCurOutPtr(0), fMaxLen(0), allocator(allocator)
 {
   if (initSize > 0)

--- a/utils/messageqcpp/bytestream.h
+++ b/utils/messageqcpp/bytestream.h
@@ -37,6 +37,7 @@
 #include "serializeable.h"
 #include "any.hpp"
 #include "countingallocator.h"
+#include "buffertypes.h"
 
 class ByteStreamTestSuite;
 
@@ -437,9 +438,9 @@ class ByteStream : public Serializeable
       3 * sizeof(uint32_t);  // space for the BS magic & length & number of long strings.
 
   // Methods to get and set `long strings`.
-  EXPORT std::vector<std::shared_ptr<uint8_t[]>>& getLongStrings();
-  EXPORT const std::vector<std::shared_ptr<uint8_t[]>>& getLongStrings() const;
-  EXPORT void setLongStrings(const std::vector<std::shared_ptr<uint8_t[]>>& other);
+  EXPORT std::vector<rowgroup::StringStoreBufSPType>& getLongStrings();
+  EXPORT const std::vector<rowgroup::StringStoreBufSPType>& getLongStrings() const;
+  EXPORT void setLongStrings(const std::vector<rowgroup::StringStoreBufSPType>& other);
 
   friend class ::ByteStreamTestSuite;
 
@@ -474,7 +475,7 @@ class ByteStream : public Serializeable
   BSBufType* fCurOutPtr;  // the point in fBuf where data is extracted from next
   uint32_t fMaxLen;     // how big fBuf is currently
   // Stores `long strings`.
-  std::vector<std::shared_ptr<uint8_t[]>> longStrings;
+  std::vector<rowgroup::StringStoreBufSPType> longStrings;
   allocators::CountingAllocator<BSBufType>* allocator = nullptr;
 };
 

--- a/utils/messageqcpp/bytestream.h
+++ b/utils/messageqcpp/bytestream.h
@@ -19,6 +19,7 @@
 */
 
 #pragma once
+#include <optional>
 #include <string>
 #include <iostream>
 #include <sys/types.h>
@@ -78,7 +79,7 @@ class ByteStream : public Serializeable
    *	default ctor
    */
   EXPORT explicit ByteStream(uint32_t initSize = 8192);  // multiples of pagesize are best
-  explicit ByteStream(allocators::CountingAllocator<BSBufType>* alloc, uint32_t initSize = 8192);
+  explicit ByteStream(allocators::CountingAllocator<BSBufType>& alloc, uint32_t initSize = 8192);
   /**
    *	ctor with a uint8_t array and len initializer
    */
@@ -476,7 +477,7 @@ class ByteStream : public Serializeable
   uint32_t fMaxLen;     // how big fBuf is currently
   // Stores `long strings`.
   std::vector<rowgroup::StringStoreBufSPType> longStrings;
-  allocators::CountingAllocator<BSBufType>* allocator = nullptr;
+  std::optional<allocators::CountingAllocator<BSBufType>> allocator = {};
 };
 
 template <int W, typename T = void>

--- a/utils/messageqcpp/compressed_iss.cpp
+++ b/utils/messageqcpp/compressed_iss.cpp
@@ -102,7 +102,7 @@ const SBS CompressedInetStreamSocket::read(const struct timespec* timeout, bool*
   uint32_t storedLen = *(uint32_t*)readBS->buf();
 
   if (!storedLen)
-    return SBS(new ByteStream(0));
+    return SBS(new ByteStream(0U));
 
   uncompressedSize = storedLen;
   ret.reset(new ByteStream(uncompressedSize));

--- a/utils/messageqcpp/inetstreamsocket.cpp
+++ b/utils/messageqcpp/inetstreamsocket.cpp
@@ -527,7 +527,8 @@ const SBS InetStreamSocket::read(const struct ::timespec* timeout, bool* isTimeO
         return SBS(new ByteStream(0U));
 
       // Allocate new memory for the `long string`.
-      // WIP must account this allocation also.
+      // TODO account this allocation also despite the fact BS allocations are insignificant
+      // compared with structs used by SQL operators. 
       rowgroup::StringStoreBufSPType longString(
           new uint8_t[sizeof(rowgroup::StringStore::MemChunk) + memChunk.currentSize]);
 

--- a/utils/messageqcpp/inetstreamsocket.cpp
+++ b/utils/messageqcpp/inetstreamsocket.cpp
@@ -515,7 +515,7 @@ const SBS InetStreamSocket::read(const struct ::timespec* timeout, bool* isTimeO
     return SBS(new ByteStream(0U));
   res->advanceInputPtr(msglen);
 
-  std::vector<std::shared_ptr<uint8_t[]>> longStrings;
+  std::vector<rowgroup::StringStoreBufSPType> longStrings;
   try
   {
     for (uint32_t i = 0; i < longStringSize; ++i)
@@ -527,7 +527,8 @@ const SBS InetStreamSocket::read(const struct ::timespec* timeout, bool* isTimeO
         return SBS(new ByteStream(0U));
 
       // Allocate new memory for the `long string`.
-      std::shared_ptr<uint8_t[]> longString(
+      // WIP must account this allocation also.
+      rowgroup::StringStoreBufSPType longString(
           new uint8_t[sizeof(rowgroup::StringStore::MemChunk) + memChunk.currentSize]);
 
       uint8_t* longStringData = longString.get();

--- a/utils/messageqcpp/inetstreamsocket.cpp
+++ b/utils/messageqcpp/inetstreamsocket.cpp
@@ -494,25 +494,25 @@ const SBS InetStreamSocket::read(const struct ::timespec* timeout, bool* isTimeO
     //		{
     //			logIoError("InetStreamSocket::read: timeout during readToMagic", 0);
     //		}
-    return SBS(new ByteStream(0));
+    return SBS(new ByteStream(0U));
   }
 
   // we need to read the 4-byte message length first.
   uint32_t msglen;
   if (!readFixedSizeData(pfd, reinterpret_cast<uint8_t*>(&msglen), sizeof(msglen), timeout, isTimeOut, stats,
                          msecs))
-    return SBS(new ByteStream(0));
+    return SBS(new ByteStream(0U));
 
   // Read the number of the `long strings`.
   uint32_t longStringSize;
   if (!readFixedSizeData(pfd, reinterpret_cast<uint8_t*>(&longStringSize), sizeof(longStringSize), timeout,
                          isTimeOut, stats, msecs))
-    return SBS(new ByteStream(0));
+    return SBS(new ByteStream(0U));
 
   // Read the actual data of the `ByteStream`.
   SBS res(new ByteStream(msglen));
   if (!readFixedSizeData(pfd, res->getInputPtr(), msglen, timeout, isTimeOut, stats, msecs))
-    return SBS(new ByteStream(0));
+    return SBS(new ByteStream(0U));
   res->advanceInputPtr(msglen);
 
   std::vector<std::shared_ptr<uint8_t[]>> longStrings;
@@ -524,7 +524,7 @@ const SBS InetStreamSocket::read(const struct ::timespec* timeout, bool* isTimeO
       rowgroup::StringStore::MemChunk memChunk;
       if (!readFixedSizeData(pfd, reinterpret_cast<uint8_t*>(&memChunk),
                              sizeof(rowgroup::StringStore::MemChunk), timeout, isTimeOut, stats, msecs))
-        return SBS(new ByteStream(0));
+        return SBS(new ByteStream(0U));
 
       // Allocate new memory for the `long string`.
       std::shared_ptr<uint8_t[]> longString(
@@ -539,7 +539,7 @@ const SBS InetStreamSocket::read(const struct ::timespec* timeout, bool* isTimeO
       // Read the `long string`.
       if (!readFixedSizeData(pfd, memChunkPointer->data, memChunkPointer->currentSize, timeout, isTimeOut,
                              stats, msecs))
-        return SBS(new ByteStream(0));
+        return SBS(new ByteStream(0U));
 
       longStrings.push_back(longString);
     }
@@ -547,7 +547,7 @@ const SBS InetStreamSocket::read(const struct ::timespec* timeout, bool* isTimeO
   catch (std::bad_alloc& exception)
   {
     logIoError("InetStreamSocket::read: error during read for 'long strings' - 'bad_alloc'", 0);
-    return SBS(new ByteStream(0));
+    return SBS(new ByteStream(0U));
   }
   catch (std::exception& exception)
   {

--- a/utils/rowgroup/buffertypes.h
+++ b/utils/rowgroup/buffertypes.h
@@ -1,6 +1,5 @@
-
 /*
-   Copyright (c) 2024 MariaDB Corporation
+   Copyright (c) 2025 MariaDB Corporation
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License

--- a/utils/rowgroup/buffertypes.h
+++ b/utils/rowgroup/buffertypes.h
@@ -1,0 +1,30 @@
+
+/*
+   Copyright (c) 2024 MariaDB Corporation
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+#pragma once
+
+#include <boost/smart_ptr/shared_ptr.hpp>
+#include <cstdint>
+
+namespace rowgroup
+{
+  using RGDataBufType = uint8_t[];
+  using StringStoreBufType = uint8_t[];
+  using StringStoreBufSPType = boost::shared_ptr<uint8_t[]>;
+}  // namespace rowgroup

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -31,7 +31,6 @@
 #include <iterator>
 using namespace std;
 
-
 #include <numeric>
 
 #include "bytestream.h"
@@ -49,7 +48,10 @@ namespace rowgroup
 {
 using cscType = execplan::CalpontSystemCatalog::ColDataType;
 
-
+StringStore::StringStore(allocators::CountingAllocator<StringStoreBufType>* alloc) : StringStore()
+{
+  this->alloc = alloc;
+}
 
 StringStore::~StringStore()
 {
@@ -94,11 +96,22 @@ uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
   if (mem.size() > 0)
     lastMC = (MemChunk*)mem.back().get();
 
+  std::cout << "StringStore::storeString len " << len << std::endl;
   if ((len + 4) >= CHUNK_SIZE)
   {
-    std::shared_ptr<uint8_t[]> newOne(new uint8_t[len + sizeof(MemChunk) + 4]);
-    longStrings.push_back(newOne);
-    lastMC = (MemChunk*)longStrings.back().get();
+    auto allocSize = len + sizeof(MemChunk) + 4;
+    if (alloc)
+    {
+      cout << "StringStore::storeString longStrings with alloc " << std::endl;
+      longStrings.emplace_back(std::allocate_shared<StringStoreBufType>(*alloc, allocSize));
+    }
+    else
+    {
+      cout << "StringStore::storeString longStrings no alloc " << std::endl;
+      longStrings.emplace_back(std::make_shared<uint8_t[]>(allocSize));
+    }
+    // std::shared_ptr<uint8_t[]> newOne(new uint8_t[len + sizeof(MemChunk) + 4]);
+    lastMC = reinterpret_cast<MemChunk*>(longStrings.back().get());
     lastMC->capacity = lastMC->currentSize = len + 4;
     memcpy(lastMC->data, &len, 4);
     memcpy(lastMC->data + 4, data, len);
@@ -112,10 +125,21 @@ uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
     {
       // mem usage debugging
       // if (lastMC)
-      // cout << "Memchunk efficiency = " << lastMC->currentSize << "/" << lastMC->capacity << endl;
-      std::shared_ptr<uint8_t[]> newOne(new uint8_t[CHUNK_SIZE + sizeof(MemChunk)]);
-      mem.push_back(newOne);
-      lastMC = (MemChunk*)mem.back().get();
+      if (alloc)
+      {
+        cout << "StringStore::storeString with alloc " << std::endl;
+        mem.emplace_back(std::allocate_shared<StringStoreBufType>(*alloc, CHUNK_SIZE + sizeof(MemChunk)));
+        // std::allocate_shared) newOne(new uint8_t[CHUNK_SIZE + sizeof(MemChunk)]);
+      }
+      else
+      {
+        cout << "StringStore::storeString no alloc " << std::endl;
+        mem.emplace_back(std::make_shared<uint8_t[]>(CHUNK_SIZE + sizeof(MemChunk)));
+        // mem.emplace_back(std::allocate_shared<StringStoreBufType>(*alloc, CHUNK_SIZE + sizeof(MemChunk)));
+        // std::shared_ptr<uint8_t[]> newOne(new uint8_t[CHUNK_SIZE + sizeof(MemChunk)]);
+      }
+      // mem.push_back(newOne);
+      lastMC = reinterpret_cast<MemChunk*>(mem.back().get());
       lastMC->currentSize = 0;
       lastMC->capacity = CHUNK_SIZE;
       memset(lastMC->data, 0, CHUNK_SIZE);
@@ -172,7 +196,7 @@ void StringStore::deserialize(ByteStream& bs)
 
   // mem.clear();
   bs >> count;
-  mem.resize(count);
+  // mem.resize(count);
   bs >> tmp8;
   empty = (bool)tmp8;
 
@@ -181,7 +205,18 @@ void StringStore::deserialize(ByteStream& bs)
     bs >> size;
     // cout << "deserializing " << size << " bytes\n";
     buf = bs.buf();
-    mem[i].reset(new uint8_t[size + sizeof(MemChunk)]);
+
+    if (alloc)
+    {
+      cout << "StringStore::deserialize with alloc " << std::endl;
+      mem.emplace_back(std::allocate_shared<StringStoreBufType>(*alloc, size + sizeof(MemChunk)));
+    }
+    else
+    {
+      cout << "StringStore::deserialize no alloc " << std::endl;
+      mem.emplace_back(std::make_shared<uint8_t[]>(size + sizeof(MemChunk)));
+    }
+    // mem[i].reset(new uint8_t[size + sizeof(MemChunk)]);
     mc = (MemChunk*)mem[i].get();
     mc->currentSize = size;
     mc->capacity = size;
@@ -302,7 +337,6 @@ void UserDataStore::deserialize(ByteStream& bs)
   return;
 }
 
-
 RGData::RGData(const RowGroup& rg, uint32_t rowCount)
 {
   // cout << "rgdata++ = " << __sync_add_and_fetch(&rgDataCount, 1) << endl;
@@ -312,7 +346,6 @@ RGData::RGData(const RowGroup& rg, uint32_t rowCount)
     strings.reset(new StringStore());
 
   userDataStore.reset();
-
 
 #ifdef VALGRIND
   /* In a PM-join, we can serialize entire tables; not every value has been
@@ -343,13 +376,44 @@ RGData::RGData(const RowGroup& rg)
 #endif
 }
 
+RGData::RGData(const RowGroup& rg, allocators::CountingAllocator<RGDataBufType>* alloc) : alloc(alloc)
+{
+  // rowData = shared_ptr<uint8_t[]>(buf, [alloc, allocSize](uint8_t* p) { alloc->deallocate(p, allocSize);
+  // });
+  rowData = std::allocate_shared<RGDataBufType>(*alloc, rg.getMaxDataSize());
+  // rowData = std::make_shared(uint8_t[rg.getMaxDataSize()]);
+
+  if (rg.usesStringTable())
+    strings.reset(new StringStore(alloc));
+
+  userDataStore.reset();
+
+#ifdef VALGRIND
+  /* In a PM-join, we can serialize entire tables; not every value has been
+   * filled in yet.  Need to look into that.  Valgrind complains that
+   * those bytes are uninitialized, this suppresses that error.
+   */
+  memset(rowData.get(), 0, rg.getMaxDataSize());
+#endif
+}
+
 void RGData::reinit(const RowGroup& rg, uint32_t rowCount)
 {
-  rowData.reset(new uint8_t[rg.getDataSize(rowCount)]);
+  if (alloc)
+  {
+    cout << "RGData::reinit with alloc " << std::endl;
+    rowData = std::allocate_shared<RGDataBufType>(*alloc, rg.getDataSize(rowCount));
+  }
+  else
+  {
+    cout << "RGData::reinit no alloc " << std::endl;
+    rowData.reset(new uint8_t[rg.getDataSize(rowCount)]);
+  }
+
   userDataStore.reset();
 
   if (rg.usesStringTable())
-    strings.reset(new StringStore());
+    strings.reset(new StringStore(alloc));
   else
     strings.reset();
 
@@ -1314,9 +1378,8 @@ string RowGroup::toString(const std::vector<uint64_t>& used) const
     os << "rowcount = " << getRowCount() << endl;
     if (!used.empty())
     {
-      uint64_t cnt =
-          std::accumulate(used.begin(), used.end(), 0ULL,
-                          [](uint64_t a, uint64_t bits) { return a + __builtin_popcountll(bits); });
+      uint64_t cnt = std::accumulate(used.begin(), used.end(), 0ULL, [](uint64_t a, uint64_t bits)
+                                     { return a + __builtin_popcountll(bits); });
       os << "sparse row count = " << cnt << endl;
     }
     os << "base rid = " << getBaseRid() << endl;

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -100,12 +100,12 @@ uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
   if ((len + 4) >= CHUNK_SIZE)
   {
     auto allocSize = len + sizeof(MemChunk) + 4;
-    if (alloc)
-    {
-      cout << "StringStore::storeString longStrings with alloc " << std::endl;
-      longStrings.emplace_back(std::allocate_shared<StringStoreBufType>(*alloc, allocSize));
-    }
-    else
+    // if (alloc)
+    // {
+    //   cout << "StringStore::storeString longStrings with alloc " << std::endl;
+    //   longStrings.emplace_back(std::allocate_shared<StringStoreBufType>(*alloc, allocSize));
+    // }
+    // else
     {
       cout << "StringStore::storeString longStrings no alloc " << std::endl;
       longStrings.emplace_back(std::make_shared<uint8_t[]>(allocSize));
@@ -128,14 +128,14 @@ uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
       if (alloc)
       {
         cout << "StringStore::storeString with alloc " << std::endl;
-        mem.emplace_back(std::allocate_shared<StringStoreBufType>(*alloc, CHUNK_SIZE + sizeof(MemChunk)));
-        // std::allocate_shared) newOne(new uint8_t[CHUNK_SIZE + sizeof(MemChunk)]);
+        mem.emplace_back(boost::allocate_shared<StringStoreBufType>(*alloc, CHUNK_SIZE + sizeof(MemChunk)));
+        // boost::allocate_shared) newOne(new uint8_t[CHUNK_SIZE + sizeof(MemChunk)]);
       }
       else
       {
         cout << "StringStore::storeString no alloc " << std::endl;
-        mem.emplace_back(std::make_shared<uint8_t[]>(CHUNK_SIZE + sizeof(MemChunk)));
-        // mem.emplace_back(std::allocate_shared<StringStoreBufType>(*alloc, CHUNK_SIZE + sizeof(MemChunk)));
+        mem.emplace_back(boost::make_shared<uint8_t[]>(CHUNK_SIZE + sizeof(MemChunk)));
+        // mem.emplace_back(boost::allocate_shared<StringStoreBufType>(*alloc, CHUNK_SIZE + sizeof(MemChunk)));
         // std::shared_ptr<uint8_t[]> newOne(new uint8_t[CHUNK_SIZE + sizeof(MemChunk)]);
       }
       // mem.push_back(newOne);
@@ -209,12 +209,12 @@ void StringStore::deserialize(ByteStream& bs)
     if (alloc)
     {
       cout << "StringStore::deserialize with alloc " << std::endl;
-      mem.emplace_back(std::allocate_shared<StringStoreBufType>(*alloc, size + sizeof(MemChunk)));
+      mem.emplace_back(boost::allocate_shared<StringStoreBufType>(*alloc, size + sizeof(MemChunk)));
     }
     else
     {
       cout << "StringStore::deserialize no alloc " << std::endl;
-      mem.emplace_back(std::make_shared<uint8_t[]>(size + sizeof(MemChunk)));
+      mem.emplace_back(boost::make_shared<uint8_t[]>(size + sizeof(MemChunk)));
     }
     // mem[i].reset(new uint8_t[size + sizeof(MemChunk)]);
     mc = (MemChunk*)mem[i].get();
@@ -230,7 +230,7 @@ void StringStore::deserialize(ByteStream& bs)
 
 void StringStore::clear()
 {
-  vector<std::shared_ptr<uint8_t[]> > emptyv;
+  vector<boost::shared_ptr<uint8_t[]> > emptyv;
   vector<std::shared_ptr<uint8_t[]> > emptyv2;
   mem.swap(emptyv);
   longStrings.swap(emptyv2);
@@ -380,7 +380,7 @@ RGData::RGData(const RowGroup& rg, allocators::CountingAllocator<RGDataBufType>*
 {
   // rowData = shared_ptr<uint8_t[]>(buf, [alloc, allocSize](uint8_t* p) { alloc->deallocate(p, allocSize);
   // });
-  rowData = std::allocate_shared<RGDataBufType>(*alloc, rg.getMaxDataSize());
+  rowData = boost::allocate_shared<RGDataBufType>(*alloc, rg.getMaxDataSize());
   // rowData = std::make_shared(uint8_t[rg.getMaxDataSize()]);
 
   if (rg.usesStringTable())
@@ -402,7 +402,7 @@ void RGData::reinit(const RowGroup& rg, uint32_t rowCount)
   if (alloc)
   {
     cout << "RGData::reinit with alloc " << std::endl;
-    rowData = std::allocate_shared<RGDataBufType>(*alloc, rg.getDataSize(rowCount));
+    rowData = boost::allocate_shared<RGDataBufType>(*alloc, rg.getDataSize(rowCount));
   }
   else
   {

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -302,6 +302,12 @@ void UserDataStore::deserialize(ByteStream& bs)
   return;
 }
 
+
+RGData::RGData(allocators::CountingAllocator<RGDataBufType>& _alloc) : RGData()
+{
+  alloc = _alloc;
+}
+
 RGData::RGData(const RowGroup& rg, uint32_t rowCount)
 {
   // cout << "rgdata++ = " << __sync_add_and_fetch(&rgDataCount, 1) << endl;

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -96,19 +96,19 @@ uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
   if (mem.size() > 0)
     lastMC = (MemChunk*)mem.back().get();
 
-  std::cout << "StringStore::storeString len " << len << std::endl;
+  // std::cout << "StringStore::storeString len " << len << std::endl;
   if ((len + 4) >= CHUNK_SIZE)
   {
     auto allocSize = len + sizeof(MemChunk) + 4;
-    // if (alloc)
-    // {
-    //   cout << "StringStore::storeString longStrings with alloc " << std::endl;
-    //   longStrings.emplace_back(std::allocate_shared<StringStoreBufType>(*alloc, allocSize));
-    // }
-    // else
+    if (alloc)
     {
-      cout << "StringStore::storeString longStrings no alloc " << std::endl;
-      longStrings.emplace_back(std::make_shared<uint8_t[]>(allocSize));
+      // cout << "StringStore::storeString longStrings with alloc " << std::endl;
+      longStrings.emplace_back(boost::allocate_shared<StringStoreBufType>(*alloc, allocSize));
+    }
+    else
+    {
+      // cout << "StringStore::storeString longStrings no alloc " << std::endl;
+      longStrings.emplace_back(boost::make_shared<uint8_t[]>(allocSize));
     }
     // std::shared_ptr<uint8_t[]> newOne(new uint8_t[len + sizeof(MemChunk) + 4]);
     lastMC = reinterpret_cast<MemChunk*>(longStrings.back().get());
@@ -127,13 +127,13 @@ uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
       // if (lastMC)
       if (alloc)
       {
-        cout << "StringStore::storeString with alloc " << std::endl;
+        // cout << "StringStore::storeString with alloc " << std::endl;
         mem.emplace_back(boost::allocate_shared<StringStoreBufType>(*alloc, CHUNK_SIZE + sizeof(MemChunk)));
         // boost::allocate_shared) newOne(new uint8_t[CHUNK_SIZE + sizeof(MemChunk)]);
       }
       else
       {
-        cout << "StringStore::storeString no alloc " << std::endl;
+        // cout << "StringStore::storeString no alloc " << std::endl;
         mem.emplace_back(boost::make_shared<uint8_t[]>(CHUNK_SIZE + sizeof(MemChunk)));
         // mem.emplace_back(boost::allocate_shared<StringStoreBufType>(*alloc, CHUNK_SIZE + sizeof(MemChunk)));
         // std::shared_ptr<uint8_t[]> newOne(new uint8_t[CHUNK_SIZE + sizeof(MemChunk)]);
@@ -196,7 +196,7 @@ void StringStore::deserialize(ByteStream& bs)
 
   // mem.clear();
   bs >> count;
-  // mem.resize(count);
+  mem.reserve(count);
   bs >> tmp8;
   empty = (bool)tmp8;
 
@@ -208,12 +208,12 @@ void StringStore::deserialize(ByteStream& bs)
 
     if (alloc)
     {
-      cout << "StringStore::deserialize with alloc " << std::endl;
+      // cout << "StringStore::deserialize with alloc " << std::endl;
       mem.emplace_back(boost::allocate_shared<StringStoreBufType>(*alloc, size + sizeof(MemChunk)));
     }
     else
     {
-      cout << "StringStore::deserialize no alloc " << std::endl;
+      // cout << "StringStore::deserialize no alloc " << std::endl;
       mem.emplace_back(boost::make_shared<uint8_t[]>(size + sizeof(MemChunk)));
     }
     // mem[i].reset(new uint8_t[size + sizeof(MemChunk)]);
@@ -231,7 +231,7 @@ void StringStore::deserialize(ByteStream& bs)
 void StringStore::clear()
 {
   vector<boost::shared_ptr<uint8_t[]> > emptyv;
-  vector<std::shared_ptr<uint8_t[]> > emptyv2;
+  vector<StringStoreBufSPType> emptyv2;
   mem.swap(emptyv);
   longStrings.swap(emptyv2);
   empty = true;
@@ -401,12 +401,12 @@ void RGData::reinit(const RowGroup& rg, uint32_t rowCount)
 {
   if (alloc)
   {
-    cout << "RGData::reinit with alloc " << std::endl;
+    // cout << "RGData::reinit with alloc " << std::endl;
     rowData = boost::allocate_shared<RGDataBufType>(*alloc, rg.getDataSize(rowCount));
   }
   else
   {
-    cout << "RGData::reinit no alloc " << std::endl;
+    // cout << "RGData::reinit no alloc " << std::endl;
     rowData.reset(new uint8_t[rg.getDataSize(rowCount)]);
   }
 

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -64,10 +64,6 @@ uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
 
   empty = false;  // At least a nullptr is being stored.
 
-  // Sometimes the caller actually wants "" to be returned.......   argggghhhh......
-  // if (len == 0)
-  //	return numeric_limits<uint32_t>::max();
-
   if ((len == 8 || len == 9) && *((uint64_t*)data) == *((uint64_t*)joblist::CPNULLSTRMARK.c_str()))
     return numeric_limits<uint64_t>::max();
 
@@ -80,18 +76,15 @@ uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
   if (mem.size() > 0)
     lastMC = (MemChunk*)mem.back().get();
 
-  // std::cout << "StringStore::storeString len " << len << std::endl;
   if ((len + 4) >= CHUNK_SIZE)
   {
     auto allocSize = len + sizeof(MemChunk) + 4;
     if (alloc)
     {
-      // cout << "StringStore::storeString longStrings with alloc " << std::endl;
       longStrings.emplace_back(boost::allocate_shared<StringStoreBufType>(*alloc, allocSize));
     }
     else
     {
-      // cout << "StringStore::storeString longStrings no alloc " << std::endl;
       longStrings.emplace_back(boost::make_shared<uint8_t[]>(allocSize));
     }
     // std::shared_ptr<uint8_t[]> newOne(new uint8_t[len + sizeof(MemChunk) + 4]);
@@ -107,22 +100,14 @@ uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
   {
     if ((lastMC == nullptr) || (lastMC->capacity - lastMC->currentSize < (len + 4)))
     {
-      // mem usage debugging
-      // if (lastMC)
       if (alloc)
       {
-        // cout << "StringStore::storeString with alloc " << std::endl;
         mem.emplace_back(boost::allocate_shared<StringStoreBufType>(*alloc, CHUNK_SIZE + sizeof(MemChunk)));
-        // boost::allocate_shared) newOne(new uint8_t[CHUNK_SIZE + sizeof(MemChunk)]);
       }
       else
       {
-        // cout << "StringStore::storeString no alloc " << std::endl;
         mem.emplace_back(boost::make_shared<uint8_t[]>(CHUNK_SIZE + sizeof(MemChunk)));
-        // mem.emplace_back(boost::allocate_shared<StringStoreBufType>(*alloc, CHUNK_SIZE + sizeof(MemChunk)));
-        // std::shared_ptr<uint8_t[]> newOne(new uint8_t[CHUNK_SIZE + sizeof(MemChunk)]);
       }
-      // mem.push_back(newOne);
       lastMC = reinterpret_cast<MemChunk*>(mem.back().get());
       lastMC->currentSize = 0;
       lastMC->capacity = CHUNK_SIZE;
@@ -187,20 +172,16 @@ void StringStore::deserialize(ByteStream& bs)
   for (i = 0; i < count; i++)
   {
     bs >> size;
-    // cout << "deserializing " << size << " bytes\n";
     buf = bs.buf();
 
     if (alloc)
     {
-      // cout << "StringStore::deserialize with alloc " << std::endl;
       mem.emplace_back(boost::allocate_shared<StringStoreBufType>(*alloc, size + sizeof(MemChunk)));
     }
     else
     {
-      // cout << "StringStore::deserialize no alloc " << std::endl;
       mem.emplace_back(boost::make_shared<uint8_t[]>(size + sizeof(MemChunk)));
     }
-    // mem[i].reset(new uint8_t[size + sizeof(MemChunk)]);
     mc = (MemChunk*)mem[i].get();
     mc->currentSize = size;
     mc->capacity = size;
@@ -386,12 +367,10 @@ void RGData::reinit(const RowGroup& rg, uint32_t rowCount)
 {
   if (alloc)
   {
-    // cout << "RGData::reinit with alloc " << std::endl;
     rowData = boost::allocate_shared<RGDataBufType>(*alloc, rg.getDataSize(rowCount));
   }
   else
   {
-    // cout << "RGData::reinit no alloc " << std::endl;
     rowData.reset(new uint8_t[rg.getDataSize(rowCount)]);
   }
 

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -48,29 +48,13 @@ namespace rowgroup
 {
 using cscType = execplan::CalpontSystemCatalog::ColDataType;
 
-StringStore::StringStore(allocators::CountingAllocator<StringStoreBufType>* alloc) : StringStore()
+StringStore::StringStore(allocators::CountingAllocator<StringStoreBufType> alloc) : StringStore()
 {
   this->alloc = alloc;
 }
 
 StringStore::~StringStore()
 {
-#if 0
-    // for mem usage debugging
-    uint32_t i;
-    uint64_t inUse = 0, allocated = 0;
-
-    for (i = 0; i < mem.size(); i++)
-    {
-        MemChunk* tmp = (MemChunk*) mem.back().get();
-        inUse += tmp->currentSize;
-        allocated += tmp->capacity;
-    }
-
-    if (allocated > 0)
-        cout << "~SS: " << inUse << "/" << allocated << " = " << (float) inUse / (float) allocated << endl;
-
-#endif
 }
 
 uint64_t StringStore::storeString(const uint8_t* data, uint32_t len)
@@ -376,15 +360,16 @@ RGData::RGData(const RowGroup& rg)
 #endif
 }
 
-RGData::RGData(const RowGroup& rg, allocators::CountingAllocator<RGDataBufType>* alloc) : alloc(alloc)
+RGData::RGData(const RowGroup& rg, allocators::CountingAllocator<RGDataBufType>& _alloc) : alloc(_alloc)
 {
-  // rowData = shared_ptr<uint8_t[]>(buf, [alloc, allocSize](uint8_t* p) { alloc->deallocate(p, allocSize);
-  // });
-  rowData = boost::allocate_shared<RGDataBufType>(*alloc, rg.getMaxDataSize());
+  rowData = boost::allocate_shared<RGDataBufType>(alloc.value(), rg.getMaxDataSize());
   // rowData = std::make_shared(uint8_t[rg.getMaxDataSize()]);
 
   if (rg.usesStringTable())
-    strings.reset(new StringStore(alloc));
+  {
+    allocators::CountingAllocator<StringStoreBufType> ssAlloc = _alloc;
+    strings.reset(new StringStore(ssAlloc)); 
+  }
 
   userDataStore.reset();
 
@@ -413,7 +398,18 @@ void RGData::reinit(const RowGroup& rg, uint32_t rowCount)
   userDataStore.reset();
 
   if (rg.usesStringTable())
-    strings.reset(new StringStore(alloc));
+  {
+    if (alloc)
+    {
+      allocators::CountingAllocator<StringStoreBufType> ssAlloc = alloc.value();
+      strings.reset(new StringStore(ssAlloc)); 
+    }
+    else
+    {
+      strings.reset(new StringStore()); 
+    }
+
+  }
   else
     strings.reset();
 

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -258,6 +258,7 @@ class RGData
 {
  public:
   RGData() = default;  // useless unless followed by an = or a deserialize operation
+  RGData(allocators::CountingAllocator<RGDataBufType>&);
   RGData(const RowGroup& rg, uint32_t rowCount);  // allocates memory for rowData
   explicit RGData(const RowGroup& rg);
   explicit RGData(const RowGroup& rg, allocators::CountingAllocator<RGDataBufType>& alloc);

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -183,7 +183,7 @@ class StringStore
   std::string empty_str;
   static constexpr const uint32_t CHUNK_SIZE = 64 * 1024;  // allocators like powers of 2
 
-  std::vector<std::shared_ptr<uint8_t[]>> mem;
+  std::vector<boost::shared_ptr<uint8_t[]>> mem;
 
   // To store strings > 64KB (BLOB/TEXT)
   std::vector<std::shared_ptr<uint8_t[]>> longStrings;
@@ -284,7 +284,7 @@ class RGData
   void clear();
   void reinit(const RowGroup& rg);
   void reinit(const RowGroup& rg, uint32_t rowCount);
-  inline void setStringStore(std::shared_ptr<StringStore>& ss)
+  inline void setStringStore(boost::shared_ptr<StringStore>& ss)
   {
     strings = ss;
   }
@@ -323,8 +323,8 @@ class RGData
   }
 
  private:
-  std::shared_ptr<RGDataBufType> rowData;
-  std::shared_ptr<StringStore> strings;
+  boost::shared_ptr<RGDataBufType> rowData;
+  boost::shared_ptr<StringStore> strings;
   std::shared_ptr<UserDataStore> userDataStore;
   allocators::CountingAllocator<RGDataBufType>* alloc = nullptr;
 
@@ -1536,7 +1536,7 @@ class RowGroup : public messageqcpp::Serializeable
                          const uint16_t& blockNum);
   inline void getLocation(uint32_t* partNum, uint16_t* segNum, uint8_t* extentNum, uint16_t* blockNum);
 
-  inline void setStringStore(std::shared_ptr<StringStore>);
+  inline void setStringStore(boost::shared_ptr<StringStore>);
 
   const CHARSET_INFO* getCharset(uint32_t col);
 
@@ -1848,7 +1848,8 @@ inline uint32_t RowGroup::getStringTableThreshold() const
   return sTableThreshold;
 }
 
-inline void RowGroup::setStringStore(std::shared_ptr<StringStore> ss)
+// WIP mb unused
+inline void RowGroup::setStringStore(boost::shared_ptr<StringStore> ss)
 {
   if (useStringTable)
   {

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -136,7 +136,7 @@ class StringStore
 {
  public:
   StringStore() = default;
-  StringStore(allocators::CountingAllocator<StringStoreBufType>* alloc);
+  StringStore(allocators::CountingAllocator<StringStoreBufType> alloc);
   StringStore(const StringStore&) = delete;
   StringStore(StringStore&&) = delete;
   StringStore& operator=(const StringStore&) = delete;
@@ -187,11 +187,11 @@ class StringStore
   std::vector<boost::shared_ptr<uint8_t[]>> mem;
 
   // To store strings > 64KB (BLOB/TEXT)
-  std::vector<StringStoreBufSPType> longStrings;
+  std::vector<boost::shared_ptr<uint8_t[]>> longStrings;
   bool empty = true;
   bool fUseStoreStringMutex = false;  //@bug6065, make StringStore::storeString() thread safe
   boost::mutex fMutex;
-  allocators::CountingAllocator<StringStoreBufType>* alloc = nullptr;
+  std::optional<allocators::CountingAllocator<StringStoreBufType>> alloc {};
 };
 
 // Where we store user data for UDA(n)F
@@ -264,8 +264,8 @@ class RGData
   RGData() = default;  // useless unless followed by an = or a deserialize operation
   RGData(const RowGroup& rg, uint32_t rowCount);  // allocates memory for rowData
   explicit RGData(const RowGroup& rg);
-  explicit RGData(const RowGroup& rg, allocators::CountingAllocator<RGDataBufType>* alloc);
-  RGData& operator=(const RGData&) = default;
+  explicit RGData(const RowGroup& rg, allocators::CountingAllocator<RGDataBufType>& alloc);
+  RGData& operator=(const RGData& rhs) = default;
   RGData& operator=(RGData&&) = default;
   RGData(const RGData&) = default;
   RGData(RGData&&) = default;
@@ -327,7 +327,7 @@ class RGData
   boost::shared_ptr<RGDataBufType> rowData;
   boost::shared_ptr<StringStore> strings;
   std::shared_ptr<UserDataStore> userDataStore;
-  allocators::CountingAllocator<RGDataBufType>* alloc = nullptr;
+  std::optional<allocators::CountingAllocator<RGDataBufType>> alloc = {};
 
   // Need sig to support backward compat.  RGData can deserialize both forms.
   static const uint32_t RGDATA_SIG = 0xffffffff;  // won't happen for 'old' Rowgroup data
@@ -998,7 +998,7 @@ inline void Row::setStringField(const utils::ConstString& str, uint32_t colIndex
 
   if (inStringTable(colIndex))
   {
-    std::cout << "setStringField storeString len " << length << std::endl; 
+    // std::cout << "setStringField storeString len " << length << std::endl; 
     offset = strings->storeString((const uint8_t*)str.str(), length);
     *((uint64_t*)&data[offsets[colIndex]]) = offset;
     //		cout << " -- stored offset " << *((uint32_t *) &data[offsets[colIndex]])
@@ -1007,7 +1007,7 @@ inline void Row::setStringField(const utils::ConstString& str, uint32_t colIndex
   }
   else
   {
-    std::cout << "setStringField memcpy " << std::endl; 
+    // std::cout << "setStringField memcpy " << std::endl; 
     memcpy(&data[offsets[colIndex]], str.str(), length);
     memset(&data[offsets[colIndex] + length], 0, offsets[colIndex + 1] - (offsets[colIndex] + length));
   }

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -1,6 +1,6 @@
 /*
    Copyright (C) 2014 InfiniDB, Inc.
-   Copyright (c) 2019 MariaDB Corporation
+   Copyright (c) 2016-2024 MariaDB Corporation
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License
@@ -127,10 +127,6 @@ inline T derefFromTwoVectorPtrs(const std::vector<T>* outer, const std::vector<T
   auto outerIdx = inner->operator[](innerIdx);
   return outer->operator[](outerIdx);
 }
-
-// using RGDataBufType = uint8_t[];
-// using StringStoreBufType = uint8_t[];
-// using StringStoreBufSPType = boost::shared_ptr<uint8_t[]>;
 
 class StringStore
 {
@@ -998,7 +994,6 @@ inline void Row::setStringField(const utils::ConstString& str, uint32_t colIndex
 
   if (inStringTable(colIndex))
   {
-    // std::cout << "setStringField storeString len " << length << std::endl; 
     offset = strings->storeString((const uint8_t*)str.str(), length);
     *((uint64_t*)&data[offsets[colIndex]]) = offset;
     //		cout << " -- stored offset " << *((uint32_t *) &data[offsets[colIndex]])
@@ -1007,7 +1002,6 @@ inline void Row::setStringField(const utils::ConstString& str, uint32_t colIndex
   }
   else
   {
-    // std::cout << "setStringField memcpy " << std::endl; 
     memcpy(&data[offsets[colIndex]], str.str(), length);
     memset(&data[offsets[colIndex] + length], 0, offsets[colIndex + 1] - (offsets[colIndex] + length));
   }
@@ -1849,7 +1843,7 @@ inline uint32_t RowGroup::getStringTableThreshold() const
   return sTableThreshold;
 }
 
-// WIP mb unused
+// TODO This is unused, so rm this in the dev branch.
 inline void RowGroup::setStringStore(boost::shared_ptr<StringStore> ss)
 {
   if (useStringTable)

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -54,6 +54,7 @@
 
 #include "collation.h"
 #include "common/hashfamily.h"
+#include "buffertypes.h"
 
 // Workaround for my_global.h #define of isnan(X) causing a std::std namespace
 
@@ -127,9 +128,9 @@ inline T derefFromTwoVectorPtrs(const std::vector<T>* outer, const std::vector<T
   return outer->operator[](outerIdx);
 }
 
-using RGDataBufType = uint8_t[];
-// using RGDataBufType = std::vector<uint8_t>;
-using StringStoreBufType = uint8_t[];
+// using RGDataBufType = uint8_t[];
+// using StringStoreBufType = uint8_t[];
+// using StringStoreBufSPType = boost::shared_ptr<uint8_t[]>;
 
 class StringStore
 {
@@ -186,7 +187,7 @@ class StringStore
   std::vector<boost::shared_ptr<uint8_t[]>> mem;
 
   // To store strings > 64KB (BLOB/TEXT)
-  std::vector<std::shared_ptr<uint8_t[]>> longStrings;
+  std::vector<StringStoreBufSPType> longStrings;
   bool empty = true;
   bool fUseStoreStringMutex = false;  //@bug6065, make StringStore::storeString() thread safe
   boost::mutex fMutex;

--- a/utils/rowgroup/rowstorage.cpp
+++ b/utils/rowgroup/rowstorage.cpp
@@ -1226,7 +1226,7 @@ class RowGroupStorage
   {
     messageqcpp::ByteStream bs;
     fRowGroupOut->setData(rgdata);
-    rgdata->serialize(bs, fRowGroupOut->getDataSize());
+    rgdata->serialize(bs, fRowGroupOut->getSizeWithStrings());
 
     int errNo;
     if ((errNo = fDumper->write(makeRGFilename(rgid), (char*)bs.buf(), bs.length())) != 0)

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -772,6 +772,12 @@ void IdbOrderBy::initialize(const RowGroup& rg)
   fRowGroup.initRow(&row1);
   fRowGroup.initRow(&row2);
 
+  // These two blocks contain structs with memory accounting.
+  {
+    auto alloc = fRm->getAllocator<OrderByRow>();
+    fOrderByQueue.reset(new SortingPQ(rowgroup::rgCommonSize, alloc));
+  }
+
   if (fDistinct)
   {
     auto alloc = fRm->getAllocator<rowgroup::Row::Pointer>();

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -737,7 +737,8 @@ IdbOrderBy::IdbOrderBy()
 
 IdbOrderBy::~IdbOrderBy()
 {
-  if (fRm)
+  // returnRGDataMemory2RM() returns all memory before the dtor is called.
+  if (fRm && fMemSize > 0)
     fRm->returnMemory(fMemSize, fSessionMemLimit);
 
   // delete compare objects

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -28,7 +28,6 @@ using namespace std;
 #include "calpontselectexecutionplan.h"
 #include "rowgroup.h"
 
-
 using namespace boost;
 
 #include "errorids.h"
@@ -748,13 +747,14 @@ IdbOrderBy::~IdbOrderBy()
     delete *i++;
 }
 
+// INV fRm is not NULL here
 void IdbOrderBy::initialize(const RowGroup& rg)
 {
   // initialize rows
   IdbCompare::initialize(rg);
 
   uint64_t newSize = rg.getSizeWithStrings(fRowsPerRG);
-  if (fRm && !fRm->getMemory(newSize, fSessionMemLimit))
+  if (!fRm->getMemory(newSize, fSessionMemLimit))
   {
     cerr << IDBErrorInfo::instance()->errorMsg(fErrorCode) << " @" << __FILE__ << ":" << __LINE__;
     throw IDBExcept(fErrorCode);
@@ -774,7 +774,8 @@ void IdbOrderBy::initialize(const RowGroup& rg)
 
   if (fDistinct)
   {
-    fDistinctMap.reset(new DistinctMap_t(10, Hasher(this, getKeyLength()), Eq(this, getKeyLength())));
+    auto alloc = fRm->getAllocator<rowgroup::Row::Pointer>();
+    fDistinctMap.reset(new DistinctMap_t(10, Hasher(this, getKeyLength()), Eq(this, getKeyLength()), alloc));
   }
 }
 

--- a/utils/windowfunction/idborderby.h
+++ b/utils/windowfunction/idborderby.h
@@ -29,8 +29,9 @@
 
 #include <boost/scoped_ptr.hpp>
 
-#include <tr1/unordered_set>
+#include <unordered_set>
 
+#include "countingallocator.h"
 #include "rowgroup.h"
 #include "hasher.h"
 #include "stlpoolallocator.h"
@@ -457,9 +458,8 @@ class IdbOrderBy : public IdbCompare
     bool operator()(const rowgroup::Row::Pointer&, const rowgroup::Row::Pointer&) const;
   };
 
-  typedef std::tr1::unordered_set<rowgroup::Row::Pointer, Hasher, Eq,
-                                  utils::STLPoolAllocator<rowgroup::Row::Pointer> >
-      DistinctMap_t;
+  using DistinctMap_t = std::unordered_set<rowgroup::Row::Pointer, Hasher, Eq,
+                                  allocators::CountingAllocator<rowgroup::Row::Pointer>>;
   boost::scoped_ptr<DistinctMap_t> fDistinctMap;
   rowgroup::Row row1, row2;  // scratch space for Hasher & Eq
 

--- a/utils/windowfunction/idborderby.h
+++ b/utils/windowfunction/idborderby.h
@@ -33,6 +33,7 @@
 #include <unordered_set>
 
 #include "countingallocator.h"
+#include "resourcemanager.h"
 #include "rowgroup.h"
 #include "hasher.h"
 // #include "stlpoolallocator.h"
@@ -434,6 +435,20 @@ class IdbOrderBy : public IdbCompare
   SortingPQ& getQueue()
   {
     return *fOrderByQueue;
+  }
+  void returnAllRGDataMemory2RM()
+  {
+    while (!fOrderByQueue->empty())
+    {
+      fOrderByQueue->pop();
+    }
+    fRm->returnMemory(fMemSize, fSessionMemLimit);
+    fMemSize = 0;
+  }
+   void returnRGDataMemory2RM(const size_t rgDataSize)
+  {
+    fRm->returnMemory(rgDataSize, fSessionMemLimit);
+    fMemSize -= rgDataSize;
   }
   CompareRule& getRule()
   {

--- a/utils/windowfunction/idborderby.h
+++ b/utils/windowfunction/idborderby.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <memory>
 #include <queue>
 #include <utility>
 #include <vector>
@@ -34,7 +35,7 @@
 #include "countingallocator.h"
 #include "rowgroup.h"
 #include "hasher.h"
-#include "stlpoolallocator.h"
+// #include "stlpoolallocator.h"
 
 // forward reference
 namespace joblist
@@ -44,16 +45,26 @@ class ResourceManager;
 
 namespace ordering
 {
-template <typename _Tp, typename _Sequence = std::vector<_Tp>,
+template <typename _Tp, typename _Sequence = std::vector<_Tp, allocators::CountingAllocator<_Tp>>,
           typename _Compare = std::less<typename _Sequence::value_type> >
-class reservablePQ : private std::priority_queue<_Tp, _Sequence, _Compare>
+class ReservablePQ : private std::priority_queue<_Tp, _Sequence, _Compare>
 {
  public:
   typedef typename std::priority_queue<_Tp, _Sequence, _Compare>::size_type size_type;
-  reservablePQ(size_type capacity = 0)
+  explicit ReservablePQ(size_type capacity, std::atomic<int64_t>* memoryLimit,
+                    const int64_t checkPointStepSize = allocators::CheckPointStepSize,
+                    const int64_t lowerBound = allocators::MemoryLimitLowerBound)
+    : std::priority_queue<_Tp, _Sequence, _Compare>(_Compare(),
+        _Sequence(allocators::CountingAllocator<_Tp>(memoryLimit, checkPointStepSize, lowerBound)))
   {
     reserve(capacity);
-  };
+  }
+  explicit ReservablePQ(size_type capacity, allocators::CountingAllocator<_Tp> alloc)
+    : std::priority_queue<_Tp, _Sequence, _Compare>(_Compare(),
+        _Sequence(alloc))
+  {
+    reserve(capacity);
+  }
   void reserve(size_type capacity)
   {
     this->c.reserve(capacity);
@@ -73,7 +84,7 @@ class reservablePQ : private std::priority_queue<_Tp, _Sequence, _Compare>
 class IdbCompare;
 class OrderByRow;
 
-typedef reservablePQ<OrderByRow> SortingPQ;
+using SortingPQ = ReservablePQ<OrderByRow>;
 
 // order by specification
 struct IdbSortSpec
@@ -419,16 +430,17 @@ class IdbOrderBy : public IdbCompare
   {
     return fDistinct;
   }
+  // INV fOrderByQueue is always a valid pointer that is instantiated in constructor
   SortingPQ& getQueue()
   {
-    return fOrderByQueue;
+    return *fOrderByQueue;
   }
   CompareRule& getRule()
   {
     return fRule;
   }
 
-  SortingPQ fOrderByQueue;
+  std::unique_ptr<SortingPQ> fOrderByQueue = nullptr;
 
  protected:
   std::vector<IdbSortSpec> fOrderByCond;

--- a/writeengine/client/we_clients.cpp
+++ b/writeengine/client/we_clients.cpp
@@ -358,7 +358,7 @@ Error:
   boost::mutex::scoped_lock lk(fMlock);
 
   MessageQueueMap::iterator map_tok;
-  sbs.reset(new ByteStream(0));
+  sbs.reset(new ByteStream(0U));
 
   for (map_tok = fSessionMessages.begin(); map_tok != fSessionMessages.end(); ++map_tok)
   {


### PR DESCRIPTION
The patch delivers CountingAllocator that is propagated into TNS and THJS to account for stdlib structs memory consumption, e.g. hashmaps and priority_queues. The allocator has been also propagated into some of the existing Allocators: STD, Fixed etc. ByteStream also got CountingAllocator support and now PP uses ByteStream with memory accounting processing PrimitiveJob.