### PR TITLE
chore(build): update boost version from 1.84 to 1.88 

### DIFF
--- a/cmake/boost.1.88.named_proxy.hpp.patch
+++ b/cmake/boost.1.88.named_proxy.hpp.patch
@@ -1,0 +1,10 @@
++++ a/boost/interprocess/detail/named_proxy.hpp	2025-04-14 16:24:12.018395298 +0000
++++ b/boost/interprocess/detail/named_proxy.hpp	2025-04-14 16:24:12.018395298 +0000
+@@ -89,6 +89,7 @@
+       } BOOST_INTERPROCESS_CATCH_END
+    }
+
++   virtual ~CtorArgN() {}
+    private:
+    template<std::size_t ...IdxPack>
+    void construct(void *mem, true_, const index_tuple<IdxPack...>&)

--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -43,6 +43,8 @@ ExternalProject_Add(
     URL_HASH SHA256=3621533e820dcab1e8012afd583c0c73cf0f77694952b81352bf38c1488f9cb4
     CONFIGURE_COMMAND ./bootstrap.sh
     UPDATE_COMMAND ""
+    PATCH_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> patch -p1 -i
+                  ${CMAKE_SOURCE_DIR}/storage/columnstore/columnstore/cmake/boost.1.88.named_proxy.hpp.patch
     BUILD_COMMAND ./b2 -q ${_b2args}
     BUILD_IN_SOURCE TRUE
     INSTALL_COMMAND ./b2 -q install ${_b2args}

--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -1,4 +1,4 @@
-find_package(Boost 1.84.0 COMPONENTS chrono filesystem program_options regex system thread)
+find_package(Boost 1.88.0 COMPONENTS chrono filesystem program_options regex system thread)
 
 if(Boost_FOUND)
     add_custom_target(external_boost)
@@ -9,9 +9,6 @@ include(ExternalProject)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     set(_toolset "gcc")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
-        set(_extra "pch=off")
-    endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     set(_toolset "clang")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
@@ -42,8 +39,8 @@ endforeach()
 ExternalProject_Add(
     external_boost
     PREFIX .boost
-    URL https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.gz
-    URL_HASH SHA256=a5800f405508f5df8114558ca9855d2640a2de8f0445f051fa1c7c3383045724
+    URL https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz
+    URL_HASH SHA256=3621533e820dcab1e8012afd583c0c73cf0f77694952b81352bf38c1488f9cb4
     CONFIGURE_COMMAND ./bootstrap.sh
     UPDATE_COMMAND ""
     BUILD_COMMAND ./b2 -q ${_b2args}

--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -72,10 +72,11 @@ set(CLANG_FLAGS
     -Wno-format-truncation
     -Wno-register
     -Wno-typedef-redefinition
+    -Wno-missing-template-arg-list-after-template-kw
 )
 
 set(GNU_FLAGS # suppressed warnings
-    -Wno-deprecated-copy -Wno-deprecated-declarations -Wno-format-truncation -Wno-register -Wno-unused-variable
+    -Wno-deprecated-copy -Wno-deprecated-declarations -Wno-format-truncation -Wno-register
 )
 # } end compiler specific flags
 

--- a/ddlproc/ddlproc.cpp
+++ b/ddlproc/ddlproc.cpp
@@ -40,8 +40,6 @@ using namespace oam;
 #include "distributedenginecomm.h"
 using namespace joblist;
 
-// #include "boost/filesystem/operations.hpp"
-// #include "boost/filesystem/path.hpp"
 #include <boost/scoped_ptr.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/thread.hpp>

--- a/dmlproc/dmlproc.cpp
+++ b/dmlproc/dmlproc.cpp
@@ -25,8 +25,6 @@
 #include <string>
 #include <set>
 #include <clocale>
-// #include "boost/filesystem/operations.hpp"
-// #include "boost/filesystem/path.hpp"
 using namespace std;
 
 #include "liboamcpp.h"

--- a/oamapps/columnstoreSupport/columnstoreSupport.cpp
+++ b/oamapps/columnstoreSupport/columnstoreSupport.cpp
@@ -255,11 +255,11 @@ void* reportThread(string* reporttype)
       boost::filesystem::path configFile =
           std::string(MCSSYSCONFDIR) + std::string("/columnstore/Columnstore.xml");
       boost::filesystem::copy_file(configFile, "./Columnstore.xml",
-                                   boost::filesystem::copy_option::overwrite_if_exists);
+                                   boost::filesystem::copy_options::overwrite_existing);
       boost::filesystem::path SMconfigFile =
           std::string(MCSSYSCONFDIR) + std::string("/columnstore/storagemanager.cnf");
       boost::filesystem::copy_file(SMconfigFile, "./storagemanager.cnf",
-                                   boost::filesystem::copy_option::overwrite_if_exists);
+                                   boost::filesystem::copy_options::overwrite_existing);
       system("sed -i 's/.*aws_access_key_id.*/aws_access_key_id={PRIVATE}/' ./storagemanager.cnf");
       system("sed -i 's/.*aws_secret_access_key.*/aws_secret_access_key={PRIVATE}/' ./storagemanager.cnf");
       fclose(pOutputFile);
@@ -857,7 +857,7 @@ int main(int argc, char* argv[])
 
     boost::filesystem::path configFile = std::string(MCSMYCNFDIR) + "/columnstore.cnf";
     boost::filesystem::copy_file(configFile, "./columnstore.cnf",
-                                 boost::filesystem::copy_option::overwrite_if_exists);
+                                 boost::filesystem::copy_options::overwrite_existing);
   }
 
   int wait = 0;

--- a/primitives/primproc/primitiveserver.cpp
+++ b/primitives/primproc/primitiveserver.cpp
@@ -1555,14 +1555,9 @@ struct BPPHandler
     bs >> stepID;
     bs >> uniqueID;
 
-    boost::unique_lock<boost::shared_mutex> lk(getDJLock(uniqueID));
-    boost::mutex::scoped_lock scoped(bppLock);
-
-    bppKeysIt = std::find(bppKeys.begin(), bppKeys.end(), uniqueID);
-
-    if (bppKeysIt != bppKeys.end())
+    boost::shared_ptr<BPPV> bppv = nullptr;
     {
-      boost::unique_lock<shared_mutex> lk(getDJLock(uniqueID));
+      boost::unique_lock<boost::shared_mutex> lk(getDJLock(uniqueID));
       boost::mutex::scoped_lock scoped(bppLock);
 
       bppKeysIt = std::find(bppKeys.begin(), bppKeys.end(), uniqueID);

--- a/storage-manager/src/LocalStorage.cpp
+++ b/storage-manager/src/LocalStorage.cpp
@@ -94,7 +94,7 @@ inline void LocalStorage::addLatency()
 int LocalStorage::copy(const bf::path& source, const bf::path& dest)
 {
   boost::system::error_code err;
-  bf::copy_file(source, dest, bf::copy_option::fail_if_exists, err);
+  bf::copy_file(source, dest, bf::copy_options::none, err);
   if (err)
   {
     errno = err.value();

--- a/storage-manager/src/Ownership.cpp
+++ b/storage-manager/src/Ownership.cpp
@@ -77,7 +77,7 @@ bf::path Ownership::get(const bf::path& p, bool getOwnership)
   bf::path::const_iterator pit;
   int i, levels;
 
-  normalizedPath.normalize();
+  normalizedPath.lexically_normal();
   // cerr << "Ownership::get() param = " << normalizedPath.string() << endl;
   if (prefixDepth > 0)
   {

--- a/tools/ddlcleanup/ddlcleanup.cpp
+++ b/tools/ddlcleanup/ddlcleanup.cpp
@@ -26,8 +26,8 @@
 #include <stdexcept>
 #include <sstream>
 #include <unistd.h>
-#include "boost/filesystem/operations.hpp"
-#include "boost/filesystem/path.hpp"
+#include "boost/filesystem.hpp"
+
 using namespace std;
 
 #include "rwlock.h"

--- a/utils/configcpp/configcpp.cpp
+++ b/utils/configcpp/configcpp.cpp
@@ -370,7 +370,7 @@ void Config::writeConfig(const string& configFile) const
       {
       }
 
-      fs::copy_file(dcf, scft, fs::copy_option::overwrite_if_exists);
+      fs::copy_file(dcf, scft, fs::copy_options::overwrite_existing);
 
       try
       {

--- a/utils/idbdatafile/IDBPolicy.cpp
+++ b/utils/idbdatafile/IDBPolicy.cpp
@@ -19,8 +19,8 @@
 #include <iostream>
 #include <sstream>
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
 #include <boost/thread/thread.hpp>
+#include <boost/filesystem/operations.hpp>
 
 #include "configcpp.h"  // for Config
 #include "oamcache.h"

--- a/utils/idbdatafile/PosixFileSystem.cpp
+++ b/utils/idbdatafile/PosixFileSystem.cpp
@@ -24,8 +24,7 @@
 #include <stdio.h>
 #include <iostream>
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem.hpp>
 
 using namespace std;
 

--- a/versioning/BRM/extentmap.h
+++ b/versioning/BRM/extentmap.h
@@ -40,7 +40,10 @@
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <boost/interprocess/containers/vector.hpp>
 #include <boost/interprocess/containers/map.hpp>
+
+
 #include <boost/interprocess/managed_shared_memory.hpp>
+
 #include <boost/interprocess/mapped_region.hpp>
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/unordered_map.hpp>

--- a/writeengine/bulk/we_bulkload.cpp
+++ b/writeengine/bulk/we_bulkload.cpp
@@ -34,10 +34,11 @@
 #include <string.h>
 #include <vector>
 #include <sstream>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
+
+#include <boost/filesystem.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
+
 #include <pwd.h>
 
 #include "we_bulkstatus.h"

--- a/writeengine/redistribute/we_redistributecontrol.cpp
+++ b/writeengine/redistribute/we_redistributecontrol.cpp
@@ -36,8 +36,7 @@ using namespace std;
 #include "boost/scoped_array.hpp"
 #include "boost/thread.hpp"
 #include "boost/thread/mutex.hpp"
-#include "boost/filesystem/path.hpp"
-#include "boost/filesystem/operations.hpp"
+#include "boost/filesystem.hpp"
 using namespace boost;
 
 #include "installdir.h"

--- a/writeengine/redistribute/we_redistributecontrolthread.cpp
+++ b/writeengine/redistribute/we_redistributecontrolthread.cpp
@@ -33,8 +33,7 @@ using namespace std;
 #include "boost/scoped_ptr.hpp"
 #include "boost/scoped_array.hpp"
 #include "boost/thread/mutex.hpp"
-#include "boost/filesystem/path.hpp"
-#include "boost/filesystem/operations.hpp"
+#include "boost/filesystem.hpp"
 using namespace boost;
 
 #include "mcsconfig.h"

--- a/writeengine/redistribute/we_redistributeworkerthread.cpp
+++ b/writeengine/redistribute/we_redistributeworkerthread.cpp
@@ -32,8 +32,7 @@ using namespace std;
 #include "boost/scoped_ptr.hpp"
 #include "boost/scoped_array.hpp"
 #include "boost/thread/mutex.hpp"
-#include "boost/filesystem/path.hpp"
-#include "boost/filesystem/operations.hpp"
+#include "boost/filesystem.hpp"
 using namespace boost;
 
 #include "installdir.h"

--- a/writeengine/server/we_ddlcommandproc.cpp
+++ b/writeengine/server/we_ddlcommandproc.cpp
@@ -19,8 +19,7 @@
 // $Id: we_ddlcommandproc.cpp 3082 2011-09-26 22:00:38Z chao $
 
 #include <unistd.h>
-#include "boost/filesystem/operations.hpp"
-#include "boost/filesystem/path.hpp"
+#include "boost/filesystem.hpp"
 #include "boost/scoped_ptr.hpp"
 using namespace std;
 

--- a/writeengine/shared/we_bulkrollbackfilecompressed.cpp
+++ b/writeengine/shared/we_bulkrollbackfilecompressed.cpp
@@ -24,7 +24,6 @@
 #include <sstream>
 #include <boost/scoped_array.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
 
 #include "we_define.h"
 #include "we_fileop.h"

--- a/writeengine/shared/we_bulkrollbackfilecompressedhdfs.cpp
+++ b/writeengine/shared/we_bulkrollbackfilecompressedhdfs.cpp
@@ -20,7 +20,6 @@
 #include <sstream>
 #include <boost/scoped_array.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
 
 #include "we_define.h"
 #include "we_fileop.h"

--- a/writeengine/shared/we_bulkrollbackmgr.cpp
+++ b/writeengine/shared/we_bulkrollbackmgr.cpp
@@ -30,7 +30,6 @@
 #include <boost/scoped_array.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
 
 #include "we_bulkrollbackmgr.h"
 

--- a/writeengine/shared/we_rbmetawriter.cpp
+++ b/writeengine/shared/we_rbmetawriter.cpp
@@ -26,7 +26,6 @@
 #include <sstream>
 #include <unistd.h>
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
 
 #include "we_config.h"
 #include "we_convertor.h"

--- a/writeengine/xml/we_xmljob.cpp
+++ b/writeengine/xml/we_xmljob.cpp
@@ -37,9 +37,7 @@
 #include "we_convertor.h"
 #include "dataconvert.h"
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
-
+#include <boost/filesystem.hpp>
 #include <sys/time.h>
 
 using namespace std;


### PR DESCRIPTION
- updated boost from **1.84** (December 13th, 2023) to **1.88** (April 10th, 2025)
- updated usage of `boost::filesystem` due API breaking change
- `boost::interprocess` patched ad-hoc (**sic!**), as `CtorArgN `from `boost/interprocess/detail/named_proxy.hpp` used for forwarding was inherited from base class with virtual d-tor before boost 1.85, and now it's standalone class, and we got  warning for class with virtual functions without virtual d-tor, that is hard to suppress locally, we just include the header
