### PR TITLE
MCOL-5966 move unittest dependencies installation bootstrap, add skip-unit-tests flag

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -71,33 +71,6 @@ local testRun(platform) =
   };
   platform_map[platform];
 
-local gcc_version = '11';
-
-local rockylinux8_deps = "dnf install -y 'dnf-command(config-manager)' " +
-                               '&& dnf config-manager --set-enabled powertools ' +
-                               '&& dnf install -y gcc-toolset-' + gcc_version + ' libarchive cmake ' +
-                               '&& . /opt/rh/gcc-toolset-' + gcc_version + '/enable ';
-
-local rockylinux9_deps = "dnf install -y 'dnf-command(config-manager)' " +
-                               '&& dnf config-manager --set-enabled crb ' +
-                               '&& dnf install -y gcc gcc-c++';
-
-local rockylinux_common_deps = ' && dnf install -y git lz4 lz4-devel cppunit-devel cmake3 boost-devel snappy-devel pcre2-devel';
-
-local deb_deps = 'apt update && apt install --yes git libboost-all-dev libcppunit-dev libsnappy-dev cmake libpcre2-dev';
-
-local testPreparation(platform) =
-  local platform_map = {
-    'rockylinux:8': rockylinux8_deps + rockylinux_common_deps,
-    'rockylinux:9': rockylinux9_deps + rockylinux_common_deps,
-    'debian:11': deb_deps,
-    'debian:12': deb_deps,
-    'ubuntu:20.04': deb_deps,
-    'ubuntu:22.04': deb_deps,
-    'ubuntu:24.04': deb_deps,
-
-  };
-  platform_map[platform];
 
 local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') = {
   local pkg_format = if (std.split(platform, ':')[0] == 'rockylinux') then 'rpm' else 'deb',
@@ -272,6 +245,14 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
     ],
   },
   _volumes:: {
+    lib: {
+          name: 'lib',
+          path: '/lib',
+    },
+    usr: {
+       name: 'usr',
+       path: '/usr',
+    },
     mdb: {
       name: 'mdb',
       path: '/mdb',
@@ -721,7 +702,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
              name: 'build',
              depends_on: ['clone-mdb'],
              image: img,
-             volumes: [pipeline._volumes.mdb],
+             volumes: [pipeline._volumes.lib, pipeline._volumes.usr, pipeline._volumes.mdb],
              environment: {
                DEBIAN_FRONTEND: 'noninteractive',
                DEB_BUILD_OPTIONS: 'parallel=4',
@@ -749,6 +730,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
                           '--build-type RelWithDebInfo ' +
                           '--distro ' + platform + ' ' +
                           '--build-packages --sccache ' +
+                          '--skip-unit-tests ' +
                           '--server-version ' + server + ' | ' +
                           '/mdb/' + builddir + '/storage/columnstore/columnstore/build/ansi2txt.sh ' +
                           '/mdb/' + builddir + '/' + result + '/build.log"' ,
@@ -766,13 +748,12 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
              name: 'unittests',
              depends_on: ['build'],
              image: img,
-             volumes: [pipeline._volumes.mdb],
+             volumes: [pipeline._volumes.lib, pipeline._volumes.usr, pipeline._volumes.mdb],
              environment: {
                DEBIAN_FRONTEND: 'noninteractive',
              },
              commands: [
                'cd /mdb/' + builddir,
-               testPreparation(platform),
                testRun(platform),
              ],
            },
@@ -838,7 +819,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
          (if (std.length(mdb_server_versions) == 0) then [] else [pipeline.upgradelog] + [pipeline.publish('upgradelog')]) +
          (if (event == 'cron') then [pipeline.publish('regressionlog latest', 'latest')] else []),
 
-  volumes: [pipeline._volumes.mdb { temp: {} }, pipeline._volumes.docker { host: { path: '/var/run/docker.sock' } }],
+  volumes: [pipeline._volumes.lib { temp: {} }, pipeline._volumes.usr { temp: {} }, pipeline._volumes.mdb { temp: {} }, pipeline._volumes.docker { host: { path: '/var/run/docker.sock' } }],
   trigger: {
     event: [event],
     branch: [branch],

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -702,7 +702,11 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
              name: 'build',
              depends_on: ['clone-mdb'],
              image: img,
-             volumes: [pipeline._volumes.lib, pipeline._volumes.usr, pipeline._volumes.mdb],
+             volumes: [
+                { name: 'lib',    path: '/lib-tmp' },
+                { name: 'usr',    path: '/usr-tmp' },
+                pipeline._volumes.mdb
+             ],
              environment: {
                DEBIAN_FRONTEND: 'noninteractive',
                DEB_BUILD_OPTIONS: 'parallel=4',
@@ -735,6 +739,9 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
                           '/mdb/' + builddir + '/storage/columnstore/columnstore/build/ansi2txt.sh ' +
                           '/mdb/' + builddir + '/' + result + '/build.log"' ,
                 'sccache --show-stats',
+
+                'cp -a /usr/. /usr-tmp/',
+                'cp -a /lib/. /lib-tmp/',
 
                 // move engine and cmapi packages to one dir and make a repo
                 if (pkg_format == 'rpm') then "mv -v -t ./" + result + "/ /mdb/" + builddir + "/*.rpm /drone/src/cmapi/" + result + "/*.rpm && createrepo ./" + result

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -245,10 +245,6 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
     ],
   },
   _volumes:: {
-    usr: {
-       name: 'usr',
-       path: '/usr',
-    },
     mdb: {
       name: 'mdb',
       path: '/mdb',
@@ -698,7 +694,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
              name: 'build',
              depends_on: ['clone-mdb'],
              image: img,
-             volumes: [pipeline._volumes.usr, pipeline._volumes.mdb],
+             volumes: [pipeline._volumes.mdb],
              environment: {
                DEBIAN_FRONTEND: 'noninteractive',
                DEB_BUILD_OPTIONS: 'parallel=4',
@@ -738,25 +734,15 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
 
                 // list storage manager binary
                 'ls -la /mdb/' + builddir + '/storage/columnstore/columnstore/storage-manager',
-             ],
-           },
-           {
-             name: 'unittests',
-             depends_on: ['build'],
-             image: img,
-             volumes: [pipeline._volumes.usr, pipeline._volumes.mdb],
-             environment: {
-               DEBIAN_FRONTEND: 'noninteractive',
-             },
-             commands: [
-               'ln -sfn /usr/lib /lib',
-               'cd /mdb/' + builddir,
-               testRun(platform),
+
+                #run unittests
+                'cd /mdb/' + builddir,
+                testRun(platform),
              ],
            },
            {
              name: 'pkg',
-             depends_on: ['unittests'],
+             depends_on: ['build'],
              image: 'alpine/git',
              when: {
                status: ['success', 'failure'],
@@ -816,7 +802,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
          (if (std.length(mdb_server_versions) == 0) then [] else [pipeline.upgradelog] + [pipeline.publish('upgradelog')]) +
          (if (event == 'cron') then [pipeline.publish('regressionlog latest', 'latest')] else []),
 
-  volumes: [pipeline._volumes.usr { temp: {} }, pipeline._volumes.mdb { temp: {} }, pipeline._volumes.docker { host: { path: '/var/run/docker.sock' } }],
+  volumes: [pipeline._volumes.mdb { temp: {} }, pipeline._volumes.docker { host: { path: '/var/run/docker.sock' } }],
   trigger: {
     event: [event],
     branch: [branch],

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -245,10 +245,6 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
     ],
   },
   _volumes:: {
-    lib: {
-          name: 'lib',
-          path: '/lib',
-    },
     usr: {
        name: 'usr',
        path: '/usr',
@@ -702,11 +698,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
              name: 'build',
              depends_on: ['clone-mdb'],
              image: img,
-             volumes: [
-                { name: 'lib',    path: '/lib-tmp' },
-                { name: 'usr',    path: '/usr-tmp' },
-                pipeline._volumes.mdb
-             ],
+             volumes: [pipeline._volumes.usr, pipeline._volumes.mdb],
              environment: {
                DEBIAN_FRONTEND: 'noninteractive',
                DEB_BUILD_OPTIONS: 'parallel=4',
@@ -740,9 +732,6 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
                           '/mdb/' + builddir + '/' + result + '/build.log"' ,
                 'sccache --show-stats',
 
-                'cp -a /usr/. /usr-tmp/',
-                'cp -a /lib/. /lib-tmp/',
-
                 // move engine and cmapi packages to one dir and make a repo
                 if (pkg_format == 'rpm') then "mv -v -t ./" + result + "/ /mdb/" + builddir + "/*.rpm /drone/src/cmapi/" + result + "/*.rpm && createrepo ./" + result
                 else "mv -v -t ./" + result + "/ /mdb/*.deb /drone/src/cmapi/" + result + "/*.deb && dpkg-scanpackages " + result + " | gzip > ./" + result + "/Packages.gz",
@@ -755,11 +744,12 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
              name: 'unittests',
              depends_on: ['build'],
              image: img,
-             volumes: [pipeline._volumes.lib, pipeline._volumes.usr, pipeline._volumes.mdb],
+             volumes: [pipeline._volumes.usr, pipeline._volumes.mdb],
              environment: {
                DEBIAN_FRONTEND: 'noninteractive',
              },
              commands: [
+               'ln -sfn /usr/lib /lib',
                'cd /mdb/' + builddir,
                testRun(platform),
              ],
@@ -826,7 +816,7 @@ local Pipeline(branch, platform, event, arch='amd64', server='10.6-enterprise') 
          (if (std.length(mdb_server_versions) == 0) then [] else [pipeline.upgradelog] + [pipeline.publish('upgradelog')]) +
          (if (event == 'cron') then [pipeline.publish('regressionlog latest', 'latest')] else []),
 
-  volumes: [pipeline._volumes.lib { temp: {} }, pipeline._volumes.usr { temp: {} }, pipeline._volumes.mdb { temp: {} }, pipeline._volumes.docker { host: { path: '/var/run/docker.sock' } }],
+  volumes: [pipeline._volumes.usr { temp: {} }, pipeline._volumes.mdb { temp: {} }, pipeline._volumes.docker { host: { path: '/var/run/docker.sock' } }],
   trigger: {
     event: [event],
     branch: [branch],

--- a/build/bootstrap_mcs.sh
+++ b/build/bootstrap_mcs.sh
@@ -402,7 +402,8 @@ build_package() {
     echo "Building a package for $OS"
     echo "Build command: $command"
     eval "$command"
-
+    message "find / -name libexpat.so.1:" #TODO: remove
+    find / -name libexpat.so.1 #TODO: remove
     check_errorcode
 
 }

--- a/build/bootstrap_mcs.sh
+++ b/build/bootstrap_mcs.sh
@@ -97,25 +97,25 @@ disable_git_restore_frozen_revision() {
 install_deps() {
     message_split
 
-    RPM_BUILD_DEPS="dnf install -y lz4 lz4-devel systemd-devel git make libaio-devel openssl-devel boost-devel bison \
+    RPM_BUILD_DEPS="dnf install -q -y lz4 lz4-devel systemd-devel git make libaio-devel openssl-devel boost-devel bison \
       snappy-devel flex libcurl-devel libxml2-devel ncurses-devel automake libtool policycoreutils-devel \
       rpm-build lsof iproute pam-devel perl-DBI cracklib-devel expect createrepo python3 checkpolicy \
-      cppunit-devel cmake3 libxcrypt-devel xz-devel zlib-devel libzstd-devel glibc-devel"
+      cppunit-devel cmake3 libxcrypt-devel xz-devel zlib-devel libzstd-devel glibc-devel pcre2-devel"
 
-    DEB_BUILD_DEPS="apt-get -y update && apt-get -y install build-essential automake libboost-all-dev \
+    DEB_BUILD_DEPS="apt-get -qq update && apt-get -qq -o Dpkg::Use-Pty=0 install build-essential automake libboost-all-dev \
       bison cmake libncurses5-dev libaio-dev libsystemd-dev libpcre2-dev libperl-dev libssl-dev libxml2-dev \
       libkrb5-dev flex libpam-dev git libsnappy-dev libcurl4-openssl-dev libgtest-dev libcppunit-dev googletest \
       libjemalloc-dev liblz-dev liblzo2-dev liblzma-dev liblz4-dev libbz2-dev libbenchmark-dev libdistro-info-perl \
       graphviz devscripts ccache equivs eatmydata curl"
 
     if [[ "$OS" == *"rockylinux:8"* || "$OS" == *"rocky:8"* ]]; then
-        command="dnf install -y curl 'dnf-command(config-manager)' && dnf config-manager --set-enabled powertools && \
+        command="dnf install -q -y curl 'dnf-command(config-manager)' && dnf config-manager --set-enabled powertools && \
       dnf install -y gcc-toolset-${GCC_VERSION} libarchive cmake && . /opt/rh/gcc-toolset-${GCC_VERSION}/enable && \
       ${RPM_BUILD_DEPS}"
 
     elif [[ "$OS" == "rockylinux:9"* || "$OS" == "rocky:9"* ]]; then
-        command="dnf install -y 'dnf-command(config-manager)' && dnf config-manager --set-enabled crb && \
-      dnf install -y pcre2-devel gcc gcc-c++ curl-minimal && ${RPM_BUILD_DEPS}"
+        command="dnf install -q -y 'dnf-command(config-manager)' && dnf config-manager --set-enabled crb && \
+      dnf install -q -y gcc gcc-c++ curl-minimal && ${RPM_BUILD_DEPS}"
 
     elif [[ "$OS" == "debian:11"* ]] || [[ "$OS" == "debian:12"* ]] || [[ "$OS" == "ubuntu:20.04"* ]] || [[ "$OS" == "ubuntu:22.04"* ]] || [[ "$OS" == "ubuntu:24.04"* ]]; then
         command="${DEB_BUILD_DEPS}"
@@ -205,7 +205,7 @@ modify_packaging() {
 
     #disable LTO for 22.04 for now
     if [[ $OS == 'ubuntu:22.04' || $OS == 'ubuntu:24.04' ]]; then
-        apt install -y lto-disabled-list &&
+        apt-get -qq -o Dpkg::Use-Pty=0 lto-disabled-list &&
             for i in mariadb-plugin-columnstore mariadb-server mariadb-server-core mariadb mariadb-10.6; do
                 echo "$i any" >>/usr/share/lto-disabled-list/lto-disabled-list
             done &&
@@ -263,7 +263,7 @@ construct_cmake_flags() {
                     -DCMAKE_BUILD_TYPE=$MCS_BUILD_TYPE \
                     -DPLUGIN_GSSAPI=NO"
 
-    if [[ $SKIP_UNIT_TESTS = true ]]; then
+    if [[ $SKIP_UNIT_TESTS = true && $BUILD_PACKAGES = false ]]; then
         warn "Unittests are not build"
 
     else
@@ -395,7 +395,7 @@ build_package() {
     if [[ $pkg_format == "rpm" ]]; then
         command="cmake ${MDB_CMAKE_FLAGS} && make -j\$(nproc) package"
     else
-        command="mk-build-deps debian/control -t 'apt-get -y -o Debug::pkgProblemResolver=yes --no-install-recommends' -r -i && \
+       command="mk-build-deps debian/control -t 'apt-get -qq -o Dpkg::Use-Pty=0 --no-install-recommends' -r -i && \
        CMAKEFLAGS='${MDB_CMAKE_FLAGS}' debian/autobake-deb.sh"
     fi
 
@@ -450,7 +450,7 @@ check_user_and_group() {
 run_unit_tests() {
     message_split
     if [[ $SKIP_UNIT_TESTS = true ]]; then
-        warn "Skipping unittests"
+        warn "Unittests will not be executed"
     else
         message "Running unittests"
         cd $MARIA_BUILD_PATH


### PR DESCRIPTION
unittest dependencies installation moved to bootstrap's build step, 
--skip-unit-tests flag added to bootstrap_mcs.sh invocation to not run unit tests during build step