### PR TITLE
chore(build): Ubuntu 20 fix build

### DIFF
--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -428,7 +428,7 @@ RGData::RGData(const RowGroup& rg, allocators::CountingAllocator<RGDataBufType>&
   if (rg.usesStringTable())
   {
     allocators::CountingAllocator<StringStoreBufType> ssAlloc = _alloc;
-    strings.reset(new StringStore(ssAlloc)); 
+    strings.reset(new StringStore(ssAlloc));
     strings->useOnlyLongStrings(rg.usesOnlyLongString());
   }
 
@@ -455,12 +455,12 @@ void RGData::reinit(const RowGroup& rg, uint32_t rowCount)
     if (alloc)
     {
       allocators::CountingAllocator<StringStoreBufType> ssAlloc = alloc.value();
-      strings.reset(new StringStore(ssAlloc)); 
+      strings.reset(new StringStore(ssAlloc));
       strings->useOnlyLongStrings(rg.usesOnlyLongString());
     }
     else
     {
-      strings.reset(new StringStore()); 
+      strings.reset(new StringStore());
     }
   }
   else
@@ -1368,7 +1368,7 @@ void RowGroup::deserialize(ByteStream& bs)
   charsets.insert(charsets.begin(), charsetNumbers.size(), nullptr);
 }
 
-void RowGroup::setUseAggregateDataStore(bool b, std::span<boost::shared_ptr<GroupConcat>> group_concats)
+void RowGroup::setUseAggregateDataStore(bool b, boost::span<boost::shared_ptr<GroupConcat>> group_concats)
 {
   idbassert(!b || !group_concats.empty());
   if (useAggregateDataStore && !b)

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -27,12 +27,13 @@
 
 #pragma once
 
-#include <span>
 #include <vector>
 #include <string>
 #include <stdexcept>
 // #define NDEBUG
 #include <cassert>
+
+#include <boost/core/span.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <boost/thread/mutex.hpp>
@@ -1103,7 +1104,7 @@ inline void Row::setStringField(const utils::ConstString& str, uint32_t colIndex
   }
   else
   {
-    // std::cout << "setStringField memcpy " << std::endl; 
+    // std::cout << "setStringField memcpy " << std::endl;
     uint8_t* buf = &data[offsets[colIndex]];
     memset(buf + length, 0,
            offsets[colIndex + 1] - (offsets[colIndex] + length));  // needed for memcmp in equals().
@@ -1640,7 +1641,7 @@ class RowGroup : public messageqcpp::Serializeable
   {
     return useOnlyLongStrings;
   }
-  void setUseAggregateDataStore(bool b, std::span<boost::shared_ptr<GroupConcat>> group_concats = {});
+  void setUseAggregateDataStore(bool b, boost::span<boost::shared_ptr<GroupConcat>> group_concats = {});
   bool usesAggregateDataStore() const
   {
     return useAggregateDataStore;
@@ -2314,7 +2315,7 @@ inline void RGData::getRow(uint32_t num, Row* row)
 {
   uint32_t incomingRowSize = row->getSize();
   idbassert(columnCount == row->getColumnCount() && rowSize == incomingRowSize);
-  
+
   row->setData(
       Row::Pointer(&rowData[RowGroup::getHeaderSize() + (num * incomingRowSize)], strings.get(),
                       userDataStore.get(), aggregateDataStore.get()));


### PR DESCRIPTION
Build is broken since clang was turned off for Ubuntu 20.04, that has GCC 9 as vanilla compiler

groupconcat uses c++20 features that are missing for GCC 9.0

- std::ranges usage was replaced by closest boost alternative for GCC 9.0 in Ubuntu 20.04 that lacks this in stdlib
- std::span usage was replaced by boost::span for GCC 9.0 in Ubuntu 20.04 that lacks this in stdlib