### PR TITLE
Mcol 5973 100 krows dat not found

### DIFF
--- a/mysql-test/columnstore/1pmonly/t/mcs48_cpimport_central_loc_dist_source.test
+++ b/mysql-test/columnstore/1pmonly/t/mcs48_cpimport_central_loc_dist_source.test
@@ -15,7 +15,7 @@ CREATE TABLE t1(col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnstore;
 
 # Load fragmented data source files distributed across pm nodes, cpimport -m2
 # This test needs to be extended to cover multi-node setup
---exec yes | cp suite/columnstore/std_data/100Krows.dat /tmp
+--exec yes | cp $MTR_SUITE_DIR/../std_data/100Krows.dat /tmp
 
 --disable_result_log #cpimport logs thread/timestamps
 --exec cpimport -m2 mcs48_db t1 -f '/tmp' -l '100Krows.dat';

--- a/mysql-test/columnstore/1pmonly/t/mcs48_cpimport_central_loc_dist_source.test
+++ b/mysql-test/columnstore/1pmonly/t/mcs48_cpimport_central_loc_dist_source.test
@@ -15,7 +15,7 @@ CREATE TABLE t1(col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnstore;
 
 # Load fragmented data source files distributed across pm nodes, cpimport -m2
 # This test needs to be extended to cover multi-node setup
---exec yes | cp $MTR_SUITE_DIR/../std_data/100Krows.dat /tmp
+--exec yes 2>/dev/null | cp $MTR_SUITE_DIR/../std_data/100Krows.dat /tmp
 
 --disable_result_log #cpimport logs thread/timestamps
 --exec cpimport -m2 mcs48_db t1 -f '/tmp' -l '100Krows.dat';

--- a/mysql-test/columnstore/1pmonly/t/mcs48_cpimport_central_loc_dist_source.test
+++ b/mysql-test/columnstore/1pmonly/t/mcs48_cpimport_central_loc_dist_source.test
@@ -15,7 +15,7 @@ CREATE TABLE t1(col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnstore;
 
 # Load fragmented data source files distributed across pm nodes, cpimport -m2
 # This test needs to be extended to cover multi-node setup
---exec yes 2>/dev/null | cp $MTR_SUITE_DIR/../std_data/100Krows.dat /tmp
+--exec yes 2>/dev/null | cp -a $MTR_SUITE_DIR/../std_data/100Krows.dat /tmp
 
 --disable_result_log #cpimport logs thread/timestamps
 --exec cpimport -m2 mcs48_db t1 -f '/tmp' -l '100Krows.dat';

--- a/mysql-test/columnstore/1pmonly/t/mcs49_cpimport_parallel_dist.test
+++ b/mysql-test/columnstore/1pmonly/t/mcs49_cpimport_parallel_dist.test
@@ -22,7 +22,7 @@ CREATE TABLE t1(col1 INT, col2 INT, col3 CHAR(8)) ENGINE=Columnstore;
 # This test needs to be extended to cover multi-node setup
 
 --disable_result_log #cpimport logs thread/timestamps
---exec cpimport -m3 mcs49_db t1 -l 'suite/columnstore/std_data/100Krows.dat';
+--exec cpimport -m3 mcs49_db t1 -l '$MTR_SUITE_DIR/../std_data/100Krows.dat';
 --enable_result_log
 
 #Validate data


### PR DESCRIPTION
- use $MTR_SUITE_DIR instead of direct path to find data file
- preserve access rights and owner when copying data file (needed to make test working running as 'root', but cpimort running as 'mysql')