### PR TITLE
disable warings in tests

### DIFF
--- a/mysql-test/columnstore/devregression/t/mcs7154_regression_bug4509.test
+++ b/mysql-test/columnstore/devregression/t/mcs7154_regression_bug4509.test
@@ -18,7 +18,9 @@ USE tpch1;
 # Create corresponding in the server
 # -------------------------------------------------------------- #
 
+--disable_warnings
 CREATE USER IF NOT EXISTS'cejuser'@'localhost' IDENTIFIED BY 'Vagrant1!0000001';
+--enable_warnings
 
 GRANT ALL PRIVILEGES ON *.* TO 'cejuser'@'localhost';
 FLUSH PRIVILEGES;

--- a/mysql-test/columnstore/devregression/t/mcs7213_regression_MCOL-2225.test
+++ b/mysql-test/columnstore/devregression/t/mcs7213_regression_MCOL-2225.test
@@ -22,7 +22,9 @@ drop table if exists mcol2225c;
 # Create corresponding in the server
 # -------------------------------------------------------------- #
 
+--disable_warnings
 CREATE USER IF NOT EXISTS'cejuser'@'localhost' IDENTIFIED BY 'Vagrant1!0000001';
+--enable_warnings
 
 GRANT ALL PRIVILEGES ON *.* TO 'cejuser'@'localhost';
 FLUSH PRIVILEGES;

--- a/mysql-test/columnstore/devregression/t/mcs7237_regression_MCOL-812.test
+++ b/mysql-test/columnstore/devregression/t/mcs7237_regression_MCOL-812.test
@@ -22,7 +22,9 @@ DROP TABLE IF EXISTS test.mcol812b;
 # Create corresponding in the server
 # -------------------------------------------------------------- #
 
+--disable_warnings
 CREATE USER IF NOT EXISTS'cejuser'@'localhost' IDENTIFIED BY 'Vagrant1!0000001';
+--enable_warnings
 
 GRANT ALL PRIVILEGES ON *.* TO 'cejuser'@'localhost';
 FLUSH PRIVILEGES;


### PR DESCRIPTION
disble "user exists" warnigs for "create user if" in the MTR tests