### PR TITLE
Remove SHOW VARIABLES LIKE 'character_set%' from the mcs228 test

### DIFF
--- a/mysql-test/columnstore/basic/r/mcs228_regexp_operator.result
+++ b/mysql-test/columnstore/basic/r/mcs228_regexp_operator.result
@@ -640,16 +640,6 @@ hello	regexp_replace(hello, 'ა.ა', 'Достоевский')
 привет	привет
 Γεια	Γεια
 სალამი	სДостоевскийმი
-SHOW VARIABLES LIKE 'character_set%';
-Variable_name	Value
-character_set_client	utf8mb3
-character_set_connection	utf8mb3
-character_set_database	utf8mb3
-character_set_filesystem	binary
-character_set_results	utf8mb3
-character_set_server	utf8mb3
-character_set_system	utf8mb3
-character_sets_dir	/usr/share/mysql/charsets/
 CREATE TABLE tw(hello text) DEFAULT CHARSET=cp1251 ENGINE COLUMNSTORE;
 INSERT INTO tw values(convert('привет' USING cp1251));
 SELECT hello, regexp_instr(hello, convert('и.е' USING cp1251)) FROM tw;

--- a/mysql-test/columnstore/basic/t/mcs228_regexp_operator.test
+++ b/mysql-test/columnstore/basic/t/mcs228_regexp_operator.test
@@ -179,7 +179,6 @@ SELECT hello, regexp_replace(hello, 'и.е', 'Достоевский') FROM t2;
 SELECT hello, regexp_replace(hello, 'ε.α', 'Достоевский') FROM t2;
 SELECT hello, regexp_replace(hello, 'ა.ა', 'Достоевский') FROM t2;
 
-SHOW VARIABLES LIKE 'character_set%';
 CREATE TABLE tw(hello text) DEFAULT CHARSET=cp1251 ENGINE COLUMNSTORE;
 INSERT INTO tw values(convert('привет' USING cp1251));
 SELECT hello, regexp_instr(hello, convert('и.е' USING cp1251)) FROM tw;


### PR DESCRIPTION
SHOW VARIABLES LIKE 'character_set%'; does not have anything connected to Columnstore and Columnstore MTR does not need to test it
