### PR TITLE
Fix thread arg errors (app instead of sequence)

### DIFF
--- a/cmapi/cmapi_server/__main__.py
+++ b/cmapi/cmapi_server/__main__.py
@@ -36,7 +36,7 @@ def worker(app):
     repeatedly.
     """
     while True:
-        t = threading.Timer(5.0, clean_txn_by_timeout, app)
+        t = threading.Timer(5.0, clean_txn_by_timeout, args=(app,))
         t.start()
         t.join()
 
@@ -76,7 +76,7 @@ class TxnBackgroundThread(plugins.SimplePlugin):
         """Plugin entrypoint"""
 
         self.t = threading.Thread(
-            target=worker, name='TxnBackgroundThread', args=(self.app)
+            target=worker, name='TxnBackgroundThread', args=(self.app,)
         )
         self.t.daemon = True
         self.t.start()


### PR DESCRIPTION
Third argument of Thread is a sequence. Without it we get this error:
`18/Apr/2025 07:30:50 [INFO] (cherrypy.error) {MainThread} ENGINE Bus STARTED
    self.run()
  File "/usr/share/columnstore/cmapi/python/lib/python3.9/threading.py", line 917, in run
    self._target(*self._args, **self._kwargs)
TypeError: __main__.worker() argument after * must be an iterable, not Application`