### PR TITLE
Revert "fix(MCOL-5386): Bitwise aggregation functions do not work with wide decimals (updated previous PR)"

### DIFF
--- a/mysql-test/columnstore/bugfixes/mcol_5386.result
+++ b/mysql-test/columnstore/bugfixes/mcol_5386.result
@@ -2,16 +2,10 @@ DROP DATABASE IF EXISTS mcol_5386;
 CREATE DATABASE mcol_5386;
 USE mcol_5386;
 DROP TABLE IF EXISTS t1;
-create table t1(c decimal(38)) engine=columnstore;
-insert into t1(c) values (11111111111111111111111111111111111111);
+create table t1(c decimal(19)) engine=columnstore;
+insert into t1(c) values (-2);
 select bit_or(c), bit_xor(c), bit_and(c) from t1;
 bit_or(c)	bit_xor(c)	bit_and(c)
-10324568879994270151	10324568879994270151	10324568879994270151
-DROP TABLE IF EXISTS t1;
-create table t1(c decimal(18)) engine=columnstore;
-insert into t1(c) values (999999999999999999);
-select bit_or(c), bit_xor(c), bit_and(c) from t1;
-bit_or(c)	bit_xor(c)	bit_and(c)
-999999999999999999	999999999999999999	999999999999999999
+18446744073709551614	18446744073709551614	18446744073709551614
 DROP TABLE IF EXISTS t1;
 DROP DATABASE mcol_5386;

--- a/mysql-test/columnstore/bugfixes/mcol_5386.test
+++ b/mysql-test/columnstore/bugfixes/mcol_5386.test
@@ -8,15 +8,8 @@ USE mcol_5386;
 --disable_warnings
 DROP TABLE IF EXISTS t1;
 --enable_warnings
-create table t1(c decimal(38)) engine=columnstore;
-insert into t1(c) values (11111111111111111111111111111111111111);
-select bit_or(c), bit_xor(c), bit_and(c) from t1;
-
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
-create table t1(c decimal(18)) engine=columnstore;
-insert into t1(c) values (999999999999999999);
+create table t1(c decimal(19)) engine=columnstore;
+insert into t1(c) values (-2);
 select bit_or(c), bit_xor(c), bit_and(c) from t1;
 
 --disable_warnings

--- a/utils/rowgroup/rowaggregation.cpp
+++ b/utils/rowgroup/rowaggregation.cpp
@@ -1538,24 +1538,21 @@ void RowAggregation::doBitOp(const Row& rowIn, int64_t colIn, int64_t colOut, in
     case execplan::CalpontSystemCatalog::MEDINT:
     case execplan::CalpontSystemCatalog::INT:
     case execplan::CalpontSystemCatalog::BIGINT:
-    {
-      valIn = rowIn.getIntField(colIn);
-      break;
-    }
-    // According to SQL specification, the result must fit in int64_t, 
-    // therefore, the upper 8 bytes for data types >= 8 bytes are ignored
     case execplan::CalpontSystemCatalog::DECIMAL:
     case execplan::CalpontSystemCatalog::UDECIMAL:
     {
-      valIn = rowIn.getIntField<8>(colIn);
+      valIn = rowIn.getIntField(colIn);
+
       if ((fRowGroupIn.getScale())[colIn] != 0)
       {
+        valIn = rowIn.getIntField(colIn);
         valIn /= IDB_pow[fRowGroupIn.getScale()[colIn] - 1];
 
         if (valIn > 0)
           valIn += 5;
         else if (valIn < 0)
           valIn -= 5;
+
         valIn /= 10;
       }
 

--- a/utils/rowgroup/rowgroup.h
+++ b/utils/rowgroup/rowgroup.h
@@ -919,6 +919,8 @@ inline int64_t Row::getIntField(uint32_t colIndex) const
 
     case 8: return *((int64_t*)&data[offsets[colIndex]]);
 
+    case 16: return *((int128_t*)&data[offsets[colIndex]]);
+
     default: idbassert(0); throw std::logic_error("Row::getIntField(): bad length.");
   }
 }


### PR DESCRIPTION
Reverts mariadb-corporation/mariadb-columnstore-engine#3522