### PR TITLE
 MCOL-5603 Online alter can break data consistency

### DIFF
--- a/dbcon/mysql/ha_mcs.cpp
+++ b/dbcon/mysql/ha_mcs.cpp
@@ -930,7 +930,7 @@ int ha_mcs::external_lock(THD* thd, int lock_type)
   get_lock_data() in lock.cc
 */
 
-THR_LOCK_DATA** ha_mcs::store_lock(THD* /*thd*/, THR_LOCK_DATA** to, enum thr_lock_type /*lock_type*/)
+THR_LOCK_DATA** ha_mcs::store_lock(THD* thd, THR_LOCK_DATA** to, enum thr_lock_type lock_type)
 {
   // if (lock_type != TL_IGNORE && lock.type == TL_UNLOCK)
   //  lock.type=lock_type;
@@ -938,6 +938,10 @@ THR_LOCK_DATA** ha_mcs::store_lock(THD* /*thd*/, THR_LOCK_DATA** to, enum thr_lo
 #ifdef INFINIDB_DEBUG
   puts("store_lock");
 #endif
+  if (thd_sql_command(thd) == SQLCOM_ALTER_TABLE && thd_tx_isolation(thd) == ISO_REPEATABLE_READ &&
+      lock_type == TL_READ)
+    table->reginfo.lock_type = TL_READ_NO_INSERT;
+
   return to;
 }
 


### PR DESCRIPTION
copy of https://github.com/mariadb-corporation/mariadb-columnstore-engine/pull/3021

Propagate the TL lock to TL_READ_NO_INSERT, blocking any concurrent writes until the end of a copy stage.

After that, this lock will be unlocked, allowing a window to write into a table before MDL is upgraded to exclusive (see online_alter_read_from_binlog call and the "alter_table_online_before_lock" debug syncpoint). This window will be covered by the second replication iteration after the lock upgrade