### PR TITLE
chore(build) : fix debug build with MYSQL_VERSION_ID < 10090

### DIFF
--- a/dbcon/mysql/ha_mcs.cpp
+++ b/dbcon/mysql/ha_mcs.cpp
@@ -1830,14 +1830,14 @@ static int columnstore_init_func(void* p)
 
   LEX_CSTRING name = {STRING_WITH_LEN("INNODB")};
   auto* plugin_innodb = ha_resolve_by_name(0, &name, 0);
-#ifdef MYSQL_GE_1009
-  if (!plugin_innodb || (*plugin_innodb)->state != PLUGIN_IS_READY) 
+#if !defined(DBUG_OFF) || MYSQL_VERSION_ID >= 100900
+  if (!plugin_innodb || (*plugin_innodb)->state != PLUGIN_IS_READY)
 #else
-  if (!plugin_innodb || plugin_innodb->state != PLUGIN_IS_READY) 
+  if (!plugin_innodb || plugin_innodb->state != PLUGIN_IS_READY)
 #endif
   {
     DBUG_RETURN(HA_ERR_RETRY_INIT);
-  } 
+  }
 
   strncpy(cs_version, columnstore_version.c_str(), sizeof(cs_version) - 1);
   cs_version[sizeof(cs_version) - 1] = 0;

--- a/utils/funcexp/func_json_contains_path.cpp
+++ b/utils/funcexp/func_json_contains_path.cpp
@@ -34,7 +34,7 @@ bool Func_json_contains_path::getBoolVal(Row& row, FunctionParm& fp, bool& isNul
 
   const string_view js = js_ns.unsafeStringRef();
 
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
   int arrayCounters[JSON_DEPTH_LIMIT];
   bool hasNegPath = false;
 #endif
@@ -76,7 +76,7 @@ bool Func_json_contains_path::getBoolVal(Row& row, FunctionParm& fp, bool& isNul
         isNull = true;
         return false;
       }
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
       hasNegPath |= path.p.types_used & JSON_PATH_NEGATIVE_INDEX;
 #endif
     }
@@ -98,7 +98,7 @@ bool Func_json_contains_path::getBoolVal(Row& row, FunctionParm& fp, bool& isNul
 
   while (json_get_path_next(&jsEg, &p) == 0)
   {
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
     if (hasNegPath && jsEg.value_type == JSON_VALUE_ARRAY &&
         json_skip_array_and_count(&jsEg, arrayCounters + (p.last_step - p.steps)))
     {
@@ -110,7 +110,7 @@ bool Func_json_contains_path::getBoolVal(Row& row, FunctionParm& fp, bool& isNul
     for (int restSize = argSize, curr = 0; restSize > 0; restSize--, curr++)
     {
       JSONPath& path = paths[curr];
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
       int cmp = cmpJSPath(&path.p, &p, jsEg.value_type, arrayCounters);
 #else
       int cmp = cmpJSPath(&path.p, &p, jsEg.value_type);

--- a/utils/funcexp/func_json_extract.cpp
+++ b/utils/funcexp/func_json_extract.cpp
@@ -29,7 +29,7 @@ int Func_json_extract::doExtract(Row& row, FunctionParm& fp, json_value_types* t
   bool mayMulVal;
   int wildcards;
   bool isMatch;
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
   int arrayCounter[JSON_DEPTH_LIMIT];
   bool hasNegPath = false;
 #endif
@@ -45,12 +45,12 @@ int Func_json_extract::doExtract(Row& row, FunctionParm& fp, json_value_types* t
     if (!path.parsed && parseJSPath(path, row, fp[i]))
       return 1;
 
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
     hasNegPath |= path.p.types_used & JSON_PATH_NEGATIVE_INDEX;
 #endif
   }
 
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
   wildcards = (JSON_PATH_WILD | JSON_PATH_DOUBLE_WILD | JSON_PATH_ARRAY_RANGE);
 #else
   wildcards = (JSON_PATH_WILD | JSON_PATH_DOUBLE_WILD);
@@ -70,13 +70,13 @@ int Func_json_extract::doExtract(Row& row, FunctionParm& fp, json_value_types* t
 
   while (json_get_path_next(&jsEg, &p) == 0)
   {
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
     if (hasNegPath && jsEg.value_type == JSON_VALUE_ARRAY &&
         json_skip_array_and_count(&jsEg, arrayCounter + (p.last_step - p.steps)))
       return 1;
 #endif
 
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
     isMatch = matchJSPath(paths, &p, jsEg.value_type, arrayCounter, false);
 #else
     isMatch = matchJSPath(paths, &p, jsEg.value_type, nullptr, false);

--- a/utils/funcexp/func_json_search.cpp
+++ b/utils/funcexp/func_json_search.cpp
@@ -136,7 +136,7 @@ string Func_json_search::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& i
   json_path_t p, savPath;
   const CHARSET_INFO* cs = getCharset(fp[0]);
 
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
   int arrayCounter[JSON_DEPTH_LIMIT];
   bool hasNegPath = 0;
 #endif
@@ -151,7 +151,7 @@ string Func_json_search::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& i
     {
       if (parseJSPath(path, row, fp[i]))
         goto error;
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
       hasNegPath |= path.p.types_used & JSON_PATH_NEGATIVE_INDEX;
 #endif
     }
@@ -161,7 +161,7 @@ string Func_json_search::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& i
 
   while (json_get_path_next(&jsEg, &p) == 0)
   {
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
     if (hasNegPath && jsEg.value_type == JSON_VALUE_ARRAY &&
         json_skip_array_and_count(&jsEg, arrayCounter + (p.last_step - p.steps)))
       goto error;
@@ -169,7 +169,7 @@ string Func_json_search::getStrVal(rowgroup::Row& row, FunctionParm& fp, bool& i
 
     if (json_value_scalar(&jsEg))
     {
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
       bool isMatch = matchJSPath(paths, &p, jsEg.value_type, arrayCounter);
 #else
       bool isMatch = matchJSPath(paths, &p, jsEg.value_type);

--- a/utils/funcexp/funcexp.cpp
+++ b/utils/funcexp/funcexp.cpp
@@ -163,7 +163,7 @@ FuncExp::FuncExp()
   fFuncMap["json_merge_preserve"] = new Func_json_merge();
   fFuncMap["json_normalize"] = new Func_json_normalize();
   fFuncMap["json_object"] = new Func_json_object();
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
   fFuncMap["json_overlaps"] = new Func_json_overlaps();
 #endif
   fFuncMap["json_query"] = new Func_json_query();
@@ -218,7 +218,7 @@ FuncExp::FuncExp()
   fFuncMap["regexp"] = new Func_regexp();
   fFuncMap["regexp_instr"] = new Func_regexp_instr();
   fFuncMap["regexp_replace"] = new Func_regexp_replace();
-  fFuncMap["regexp_substr"] = new Func_regexp_substr();                  // dlh
+  fFuncMap["regexp_substr"] = new Func_regexp_substr();    // dlh
   fFuncMap["repeat"] = new Func_repeat();                  // dlh
   fFuncMap["replace"] = new Func_replace();                // dlh
   fFuncMap["replace_oracle"] = new Func_replace_oracle();  // dlh

--- a/utils/funcexp/functor_json.h
+++ b/utils/funcexp/functor_json.h
@@ -12,13 +12,6 @@
 #include "functor_int.h"
 #include "functor_str.h"
 
-// Check if mariadb version >= 10.9
-#if MYSQL_VERSION_ID >= 100900
-#ifndef MYSQL_GE_1009
-#define MYSQL_GE_1009
-#endif
-#endif
-
 namespace funcexp
 {
 // The json_path_t wrapper include some flags

--- a/utils/funcexp/jsonhelpers.cpp
+++ b/utils/funcexp/jsonhelpers.cpp
@@ -13,7 +13,7 @@ int setupJSPath(json_path_t* path, CHARSET_INFO* cs, const utils::NullString& st
 
   if (!err)
   {
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
     bool support = (path->types_used & (JSON_PATH_WILD | JSON_PATH_DOUBLE_WILD | JSON_PATH_ARRAY_RANGE)) == 0;
 #else
     bool support = (path->types_used & (JSON_PATH_WILD | JSON_PATH_DOUBLE_WILD)) == 0;
@@ -252,7 +252,7 @@ int cmpPartJSPath(const json_path_step_t* a, const json_path_step_t* aEnd, const
     {
       if (b->type & JSON_PATH_ARRAY)
       {
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
         int ret = 0, corrected_n_item_a = 0;
         if (arraySize)
           corrected_n_item_a = a->n_item < 0 ? arraySize[b - tmpB] + a->n_item : a->n_item;
@@ -360,7 +360,7 @@ bool matchJSPath(const vector<funcexp::JSONPath>& paths, const json_path_t* p, j
 {
   for (size_t curr = 0; curr < paths.size(); curr++)
   {
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
     int cmp = cmpJSPath(&paths[curr].p, p, valType, arrayCounter);
 #else
     int cmp = cmpJSPath(&paths[curr].p, p, valType);

--- a/utils/funcexp/jsonhelpers.h
+++ b/utils/funcexp/jsonhelpers.h
@@ -49,7 +49,7 @@ static const int TRIVIAL_PATH_NOT_ALLOWED = 3;
 
 bool findKeyInObject(json_engine_t* jsEg, json_string_t* key);
 
-#ifdef MYSQL_GE_1009
+#if MYSQL_VERSION_ID >= 100900
 using IntType = int;
 #else
 using IntType = uint;


### PR DESCRIPTION
code from c 10.6
```
/*
  See intern_plugin_lock() for the explanation for the
  conditionally defined plugin_ref type
*/
#ifdef DBUG_OFF
typedef struct st_plugin_int *plugin_ref;
#define plugin_ref_to_int(A) A
#define plugin_int_to_ref(A) A
#define plugin_decl(pi) ((pi)->plugin)
#define plugin_dlib(pi) ((pi)->plugin_dl)
#define plugin_data(pi,cast) ((cast)((pi)->data))
#define plugin_name(pi) (&((pi)->name))
#define plugin_state(pi) ((pi)->state)
#define plugin_load_option(pi) ((pi)->load_option)
#define plugin_equals(p1,p2) ((p1) == (p2))
#else
typedef struct st_plugin_int **plugin_ref;
#define plugin_ref_to_int(A) (A ? A[0] : NULL)
#define plugin_int_to_ref(A) &(A)
#define plugin_decl(pi) ((pi)[0]->plugin)
#define plugin_dlib(pi) ((pi)[0]->plugin_dl)
#define plugin_data(pi,cast) ((cast)((pi)[0]->data))
#define plugin_name(pi) (&((pi)[0]->name))
#define plugin_state(pi) ((pi)[0]->state)
#define plugin_load_option(pi) ((pi)[0]->load_option)
#define plugin_equals(p1,p2) ((p1) && (p2) && (p1)[0] == (p2)[0])
#endif
```