### PR TITLE
chore(compilation): proper use of plugin_ref

### DIFF
--- a/dbcon/mysql/ha_mcs.cpp
+++ b/dbcon/mysql/ha_mcs.cpp
@@ -1830,11 +1830,8 @@ static int columnstore_init_func(void* p)
 
   LEX_CSTRING name = {STRING_WITH_LEN("INNODB")};
   auto* plugin_innodb = ha_resolve_by_name(0, &name, 0);
-#if !defined(DBUG_OFF) || MYSQL_VERSION_ID >= 100900
-  if (!plugin_innodb || (*plugin_innodb)->state != PLUGIN_IS_READY)
-#else
-  if (!plugin_innodb || plugin_innodb->state != PLUGIN_IS_READY)
-#endif
+  if (!plugin_innodb || plugin_state(plugin_innodb) != PLUGIN_IS_READY)
+
   {
     DBUG_RETURN(HA_ERR_RETRY_INIT);
   }


### PR DESCRIPTION
There is macro defined for proper use


```
#ifdef DBUG_OFF
typedef struct st_plugin_int *plugin_ref;
...
#define plugin_state(pi) ((pi)->state)
#else
typedef struct st_plugin_int **plugin_ref;
...
#define plugin_state(pi) ((pi)[0]->state)
#endif