### PR TITLE
MCOL-4869: More detailed error report about BufferedFile open failure.

### DIFF
--- a/tests/BufferedFile.cpp
+++ b/tests/BufferedFile.cpp
@@ -1,0 +1,77 @@
+/* Copyright (C) 2024 MariaDB Corporation.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+   MA 02110-1301, USA. */
+
+#include <cstdio>
+#include <fstream>
+#include <sys/stat.h>
+#include <gtest/gtest.h>
+#include "BufferedFile.h"
+
+std::string message(const std::string& fname, int err)
+{
+  return std::string("unable to open file: ") + fname + ", exception: " + strerror(err);
+}
+
+TEST(BufferedFileTest, NoError)
+{
+  const char fname[] = "/tmp/foo.bar";
+  std::ofstream out(fname);
+
+  EXPECT_NO_THROW(idbdatafile::BufferedFile bf(fname, "r", 0));
+  remove(fname);
+}
+
+TEST(BufferedFileTest, NoEnt)
+{
+  const char fname[] = "/home/BufferedFile_test";
+
+  EXPECT_THROW(
+      {
+        try
+        {
+          idbdatafile::BufferedFile bf(fname, "r", 0);
+        }
+        catch (const std::runtime_error& e)
+        {
+          EXPECT_EQ(message(fname, ENOENT), e.what());
+          throw;
+        }
+      },
+      std::runtime_error);
+}
+
+TEST(BufferedFileTest, NotDir)
+{
+  std::string fake_dir_name = "/tmp/foo";
+  std::ofstream out(fake_dir_name);
+  std::string fname = fake_dir_name + "/bar";
+
+  EXPECT_THROW(
+      {
+        try
+        {
+          idbdatafile::BufferedFile bf(fname.c_str(), "r", 0);
+        }
+        catch (const std::runtime_error& e)
+        {
+          EXPECT_EQ(message(fname, ENOTDIR), e.what());
+          throw;
+        }
+      },
+      std::runtime_error);
+  remove(fake_dir_name.c_str());
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,6 +101,10 @@ if(WITH_UNITTESTS)
     columnstore_link(bytestream ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} ${CPPUNIT_LIBRARIES} cppunit)
     add_test(NAME columnstore:bytestream COMMAND bytestream)
 
+    add_executable(idbdatafile_test BufferedFile.cpp)
+    columnstore_link(idbdatafile_test ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} gtest gtest_main)
+    add_test(NAME columnstore:idbdatafile_test COMMAND idbdatafile_test)
+
     # standalone EM routines test
     add_executable(brm_em_standalone brm-em-standalone.cpp)
     columnstore_link(brm_em_standalone ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} ${CPPUNIT_LIBRARIES} cppunit)

--- a/utils/idbdatafile/BufferedFile.cpp
+++ b/utils/idbdatafile/BufferedFile.cpp
@@ -31,10 +31,13 @@ BufferedFile::BufferedFile(const char* fname, const char* mode, unsigned opts)
  : IDBDataFile(fname), m_fp(0), m_buffer(0)
 {
   m_fp = fopen(fname, mode);
+  int err = errno;
 
   if (m_fp == NULL)
   {
-    throw std::runtime_error("unable to open Buffered file ");
+    static string message = "unable to open file: ";
+
+    throw std::runtime_error(message + fname + ", exception: " + strerror(err));
   }
 
   applyOptions(opts);


### PR DESCRIPTION
The BufferedFile constructor is improved about more descriptive error report about file open failure by using errno.