### PR TITLE
Mcol 6018 asan use after free in primproc

### DIFF
--- a/primitives/blockcache/filebuffermgr.cpp
+++ b/primitives/blockcache/filebuffermgr.cpp
@@ -293,8 +293,11 @@ void FileBufferMgr::flushOIDs(const uint32_t* oids, uint32_t count)
         {
           fbList.erase(fFBPool[tmpIt->second->poolIdx].listLoc());
           fEmptyPoolSlots.push_back(tmpIt->second->poolIdx);
-          fbSet.erase(tmpIt->second);
           fCacheSize--;
+        }
+        for (byLBID_t::iterator tmpIt = itList.first; tmpIt != itList.second; tmpIt++)
+        {
+          fbSet.erase(tmpIt->second);
         }
       }
     }


### PR DESCRIPTION
This changeset adds Environment entries into systemd unit files for MCS and MDB services to work with ASAN.

Also, it fixes use-after-free in PrimProc.