### PR TITLE
MCOL-4833: verbose options for testS3Connection

### DIFF
--- a/storage-manager/CMakeLists.txt
+++ b/storage-manager/CMakeLists.txt
@@ -93,7 +93,7 @@ columnstore_link(unit_tests storagemanager)
 
 columnstore_executable(testS3Connection src/testS3Connection.cpp)
 target_compile_definitions(testS3Connection PUBLIC BOOST_NO_CXX11_SCOPED_ENUMS)
-columnstore_link(testS3Connection storagemanager)
+columnstore_link(testS3Connection storagemanager boost_program_options)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${TMPDIR})
 

--- a/storage-manager/src/S3Storage.cpp
+++ b/storage-manager/src/S3Storage.cpp
@@ -112,7 +112,7 @@ S3Storage::ScopedConnection::~ScopedConnection()
   s3->returnConnection(conn);
 }
 
-S3Storage::S3Storage(bool skipRetry) : skipRetryableErrors(skipRetry)
+S3Storage::S3Storage(bool skipRetry, bool verbose) : skipRetryableErrors(skipRetry), verbose_enabled(verbose)
 {
   /*  Check creds from envvars
       Get necessary vars from config
@@ -225,7 +225,7 @@ S3Storage::S3Storage(bool skipRetry) : skipRetryableErrors(skipRetry)
   }
 
   ms3_library_init();
-  if (libs3_debug == "enabled")
+  if (verbose_enabled || libs3_debug == "enabled")
   {
     ms3_debug(1);
   }

--- a/storage-manager/src/S3Storage.h
+++ b/storage-manager/src/S3Storage.h
@@ -32,7 +32,7 @@ namespace storagemanager
 class S3Storage : public CloudStorage
 {
  public:
-  explicit S3Storage(bool skipRetry = false);
+  explicit S3Storage(bool skipRetry = false, bool verbose = false);
 
   ~S3Storage() override;
 
@@ -57,6 +57,7 @@ class S3Storage : public CloudStorage
   void returnConnection(std::shared_ptr<Connection> conn);
 
   bool skipRetryableErrors;
+  bool verbose_enabled;
 
   std::string bucket;  // might store this as a char *, since it's only used that way
   std::string prefix;


### PR DESCRIPTION
Add  verbose option for testS3Connection enabling (curl_verbose_option + ms3_debug)
[MCOL-4833](https://jira.mariadb.org/browse/MCOL-4833)