### PR TITLE
chore(MCOL-6018) Fix incorrect Field_decimal cast

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -3213,7 +3213,10 @@ CalpontSystemCatalog::ColType fieldType_MysqlToIDB(const Field* field)
 
     case DECIMAL_RESULT:
     {
-      Field_decimal* idp = (Field_decimal*)field;
+      const Field_new_decimal* idp = dynamic_cast<const Field_new_decimal*>(field);
+
+      idbassert(idp);
+
       ct.colDataType = CalpontSystemCatalog::DECIMAL;
       ct.colWidth = 8;
       ct.scale = idp->dec;


### PR DESCRIPTION
This is a fix of a problem found by UBSAN. MDB changed default type to represent a decimal result, C-style cast did not do proper type checking and this one-liner fixes that. Now we will have an assertion if type changes again.