### PR TITLE
fix(ub): logger was null ptr in configListener

### DIFF
--- a/storage-manager/src/Downloader.cpp
+++ b/storage-manager/src/Downloader.cpp
@@ -30,11 +30,11 @@ namespace storagemanager
 {
 Downloader::Downloader() : maxDownloads(0)
 {
+  logger = SMLogging::get();
   storage = CloudStorage::get();
   configListener();
   Config::get()->addConfigListener(this);
   workers.setName("Downloader");
-  logger = SMLogging::get();
   tmpPath = "downloading";
   bytesDownloaded = 0;
 }

--- a/storage-manager/src/SMLogging.cpp
+++ b/storage-manager/src/SMLogging.cpp
@@ -21,12 +21,6 @@
 
 using namespace std;
 
-namespace
-{
-storagemanager::SMLogging* smLog = NULL;
-boost::mutex m;
-};  // namespace
-
 namespace storagemanager
 {
 SMLogging::SMLogging()

--- a/storage-manager/src/SMLogging.cpp
+++ b/storage-manager/src/SMLogging.cpp
@@ -44,13 +44,8 @@ SMLogging::~SMLogging()
 
 SMLogging* SMLogging::get()
 {
-  if (smLog)
-    return smLog;
-  boost::mutex::scoped_lock s(m);
-  if (smLog)
-    return smLog;
-  smLog = new SMLogging();
-  return smLog;
+  static SMLogging smLog;
+  return &smLog;
 }
 
 void SMLogging::log(int priority, const char* format, ...)


### PR DESCRIPTION
fix of nullptr member function

```
/mdb/verylongdirnameforverystrangecpackbehavior/storage/columnstore/columnstore/storage-manager/src/Downloader.cpp:229:16: runtime error: member call on null pointer of type 'struct SMLogging'
    #0 0x7c1454f15baa in storagemanager::Downloader::configListener() (/lib/x86_64-linux-gnu/libstoragemanager.so+0x53dbaa) (BuildId: 746cba0c09d97391702c5703e5f52a60112dfb3e)
    #1 0x7c1454f1a665 in storagemanager::Downloader::Downloader() (/lib/x86_64-linux-gnu/libstoragemanager.so+0x542665) (BuildId: 746cba0c09d97391702c5703e5f52a60112dfb3e)
    #2 0x7c1454f0f8ba in storagemanager::Cache::Cache() (/lib/x86_64-linux-gnu/libstoragemanager.so+0x5378ba) (BuildId: 746cba0c09d97391702c5703e5f52a60112dfb3e)
    #3 0x7c1454f1021c in storagemanager::Cache::get() (/lib/x86_64-linux-gnu/libstoragemanager.so+0x53821c) (BuildId: 746cba0c09d97391702c5703e5f52a60112dfb3e)
    #4 0x7c1454e2d20b in storagemanager::IOCoordinator::IOCoordinator() (/lib/x86_64-linux-gnu/libstoragemanager.so+0x45520b) (BuildId: 746cba0c09d97391702c5703e5f52a60112dfb3e)
    #5 0x7c1454e2debc in storagemanager::IOCoordinator::get() (/lib/x86_64-linux-gnu/libstoragemanager.so+0x455ebc) (BuildId: 746cba0c09d97391702c5703e5f52a60112dfb3e)
    #6 0x55f76e147d04  (/usr/bin/StorageManager+0x18d04) (BuildId: e356f8ce5fa8ed7e1a0f970e4bcbd588c8a71969)
    #7 0x55f76e146298  (/usr/bin/StorageManager+0x17298) (BuildId: e356f8ce5fa8ed7e1a0f970e4bcbd588c8a71969)
    #8 0x7c1453d861c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #9 0x7c1453d8628a in __libc_start_main_impl ../csu/libc-start.c:360
    #10 0x55f76e1468b4  (/usr/bin/StorageManager+0x178b4) (BuildId: e356f8ce5fa8ed7e1a0f970e4bcbd588c8a71969)

/mdb/verylongdirnameforverystrangecpackbehavior/storage/columnstore/columnstore/storage-manager/src/Downloader.cpp:242:18: runtime error: member call on null pointer of type 'struct SMLogging'
    #0 0x7c1454f15c31 in storagemanager::Downloader::configListener() (/lib/x86_64-linux-gnu/libstoragemanager.so+0x53dc31) (BuildId: 746cba0c09d97391702c5703e5f52a60112dfb3e)
    #1 0x7c1454f1a665 in storagemanager::Downloader::Downloader() (/lib/x86_64-linux-gnu/libstoragemanager.so+0x542665) (BuildId: 746cba0c09d97391702c5703e5f52a60112dfb3e)
    #2 0x7c1454f0f8ba in storagemanager::Cache::Cache() (/lib/x86_64-linux-gnu/libstoragemanager.so+0x5378ba) (BuildId: 746cba0c09d97391702c5703e5f52a60112dfb3e)
    #3 0x7c1454f1021c in storagemanager::Cache::get() (/lib/x86_64-linux-gnu/libstoragemanager.so+0x53821c) (BuildId: 746cba0c09d97391702c5703e5f52a60112dfb3e)
    #4 0x7c1454e2d20b in storagemanager::IOCoordinator::IOCoordinator() (/lib/x86_64-linux-gnu/libstoragemanager.so+0x45520b) (BuildId: 746cba0c09d97391702c5703e5f52a60112dfb3e)
    #5 0x7c1454e2debc in storagemanager::IOCoordinator::get() (/lib/x86_64-linux-gnu/libstoragemanager.so+0x455ebc) (BuildId: 746cba0c09d97391702c5703e5f52a60112dfb3e)
    #6 0x55f76e147d04  (/usr/bin/StorageManager+0x18d04) (BuildId: e356f8ce5fa8ed7e1a0f970e4bcbd588c8a71969)
    #7 0x55f76e146298  (/usr/bin/StorageManager+0x17298) (BuildId: e356f8ce5fa8ed7e1a0f970e4bcbd588c8a71969)
    #8 0x7c1453d861c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #9 0x7c1453d8628a in __libc_start_main_impl ../csu/libc-start.c:360
    #10 0x55f76e1468b4  (/usr/bin/StorageManager+0x178b4) (BuildId: e356f8ce5fa8ed7e1a0f970e4bcbd588c8a71969)
```