### PR TITLE
DNM: Coordinator nodes (an addition to read-only nodes)

### DIFF
--- a/cmapi/cmapi_server/constants.py
+++ b/cmapi/cmapi_server/constants.py
@@ -4,6 +4,7 @@ TODO: move main constant paths here and replace in files in next releases.
 """
 import os
 from typing import NamedTuple
+from enum import Enum
 
 
 # default MARIADB ColumnStore config path
@@ -60,6 +61,16 @@ CMAPI_SINGLE_NODE_XML = os.path.join(
     CMAPI_INSTALL_PATH, 'cmapi_server/SingleNode.xml'
 )
 
+class MCSProgs(Enum):
+    STORAGE_MANAGER = 'StorageManager'
+    WORKER_NODE = 'workernode'
+    CONTROLLER_NODE = 'controllernode'
+    PRIM_PROC = 'PrimProc'
+    EXE_MGR = 'ExeMgr'
+    WRITE_ENGINE_SERVER = 'WriteEngineServer'
+    DML_PROC = 'DMLProc'
+    DDL_PROC = 'DDLProc'
+
 # constants for dispatchers
 class ProgInfo(NamedTuple):
     """NamedTuple for some additional info about handling mcs processes."""
@@ -73,17 +84,17 @@ class ProgInfo(NamedTuple):
 # on top level of process handling
 # mcs-storagemanager starts conditionally inside mcs-loadbrm, but should be
 # stopped using cmapi
-ALL_MCS_PROGS = {
+ALL_MCS_PROGS: dict[MCSProgs, ProgInfo] = {
     # workernode starts on primary and non primary node with 1 or 2 added
     # to subcommand (DBRM_Worker1 - on primary, DBRM_Worker2 - non primary)
-    'StorageManager': ProgInfo(15, 'mcs-storagemanager', '', False, 1),
-    'workernode': ProgInfo(13, 'mcs-workernode', 'DBRM_Worker{}', False, 1),
-    'controllernode': ProgInfo(11, 'mcs-controllernode', 'fg', True),
-    'PrimProc': ProgInfo(5, 'mcs-primproc', '', False, 1),
-    'ExeMgr': ProgInfo(9, 'mcs-exemgr', '', False, 1),
-    'WriteEngineServer': ProgInfo(7, 'mcs-writeengineserver', '', False, 3),
-    'DMLProc': ProgInfo(3, 'mcs-dmlproc', '', False),
-    'DDLProc': ProgInfo(1, 'mcs-ddlproc', '', False),
+    MCSProgs.STORAGE_MANAGER: ProgInfo(15, 'mcs-storagemanager', '', False, 1),
+    MCSProgs.WORKER_NODE: ProgInfo(13, 'mcs-workernode', 'DBRM_Worker{}', False, 1),
+    MCSProgs.CONTROLLER_NODE: ProgInfo(11, 'mcs-controllernode', 'fg', True),
+    MCSProgs.PRIM_PROC: ProgInfo(5, 'mcs-primproc', '', False, 1),
+    MCSProgs.EXE_MGR: ProgInfo(9, 'mcs-exemgr', '', False, 1),
+    MCSProgs.WRITE_ENGINE_SERVER: ProgInfo(7, 'mcs-writeengineserver', '', False, 3),
+    MCSProgs.DML_PROC: ProgInfo(3, 'mcs-dmlproc', '', False),
+    MCSProgs.DDL_PROC: ProgInfo(1, 'mcs-ddlproc', '', False),
 }
 
 # constants for docker container dispatcher

--- a/cmapi/cmapi_server/constants.py
+++ b/cmapi/cmapi_server/constants.py
@@ -66,7 +66,6 @@ class MCSProgs(Enum):
     WORKER_NODE = 'workernode'
     CONTROLLER_NODE = 'controllernode'
     PRIM_PROC = 'PrimProc'
-    EXE_MGR = 'ExeMgr'
     WRITE_ENGINE_SERVER = 'WriteEngineServer'
     DML_PROC = 'DMLProc'
     DDL_PROC = 'DDLProc'
@@ -91,7 +90,6 @@ ALL_MCS_PROGS: dict[MCSProgs, ProgInfo] = {
     MCSProgs.WORKER_NODE: ProgInfo(13, 'mcs-workernode', 'DBRM_Worker{}', False, 1),
     MCSProgs.CONTROLLER_NODE: ProgInfo(11, 'mcs-controllernode', 'fg', True),
     MCSProgs.PRIM_PROC: ProgInfo(5, 'mcs-primproc', '', False, 1),
-    MCSProgs.EXE_MGR: ProgInfo(9, 'mcs-exemgr', '', False, 1),
     MCSProgs.WRITE_ENGINE_SERVER: ProgInfo(7, 'mcs-writeengineserver', '', False, 3),
     MCSProgs.DML_PROC: ProgInfo(3, 'mcs-dmlproc', '', False),
     MCSProgs.DDL_PROC: ProgInfo(1, 'mcs-ddlproc', '', False),

--- a/cmapi/cmapi_server/controllers/api_clients.py
+++ b/cmapi/cmapi_server/controllers/api_clients.py
@@ -68,6 +68,7 @@ class ClusterControllerClient:
         :param node_info: Information about the node to add.
         :return: The response from the API.
         """
+        #TODO: fix interface as in remove_node used or think about universal
         return self._request('PUT', 'node', {**node_info, **extra})
 
     def remove_node(

--- a/cmapi/cmapi_server/controllers/endpoints.py
+++ b/cmapi/cmapi_server/controllers/endpoints.py
@@ -434,7 +434,7 @@ class ConfigController:
                 MCSProcessManager.stop_node(
                     is_primary=node_config.is_primary_node(),
                     use_sudo=use_sudo,
-                    timeout=request_timeout
+                    timeout=request_timeout,
                 )
             except CMAPIBasicError as err:
                 raise_422_error(
@@ -463,6 +463,7 @@ class ConfigController:
                     MCSProcessManager.start_node(
                         is_primary=node_config.is_primary_node(),
                         use_sudo=use_sudo,
+                        is_read_only=node_config.is_read_only(),
                     )
                 except CMAPIBasicError as err:
                     raise_422_error(
@@ -666,7 +667,8 @@ class StartController:
         try:
             MCSProcessManager.start_node(
                 is_primary=node_config.is_primary_node(),
-                use_sudo=use_sudo
+                use_sudo=use_sudo,
+                is_read_only=node_config.is_read_only(),
             )
         except CMAPIBasicError as err:
             raise_422_error(
@@ -701,7 +703,7 @@ class ShutdownController:
             MCSProcessManager.stop_node(
                 is_primary=node_config.is_primary_node(),
                 use_sudo=use_sudo,
-                timeout=timeout
+                timeout=timeout,
             )
         except CMAPIBasicError as err:
             raise_422_error(
@@ -910,6 +912,7 @@ class ClusterController:
         node = request_body.get('node', None)
         config = request_body.get('config', DEFAULT_MCS_CONF_PATH)
         in_transaction = request_body.get('in_transaction', False)
+        read_only = request_body.get('read_only', False)
 
         if node is None:
             raise_422_error(module_logger, func_name, 'missing node argument')
@@ -917,9 +920,9 @@ class ClusterController:
         try:
             if not in_transaction:
                 with TransactionManager(extra_nodes=[node]):
-                    response = ClusterHandler.add_node(node, config)
+                    response = ClusterHandler.add_node(node, config, read_only)
             else:
-                response = ClusterHandler.add_node(node, config)
+                response = ClusterHandler.add_node(node, config, read_only)
         except CMAPIBasicError as err:
             raise_422_error(module_logger, func_name, err.message)
 

--- a/cmapi/cmapi_server/controllers/endpoints.py
+++ b/cmapi/cmapi_server/controllers/endpoints.py
@@ -913,16 +913,20 @@ class ClusterController:
         config = request_body.get('config', DEFAULT_MCS_CONF_PATH)
         in_transaction = request_body.get('in_transaction', False)
         read_only = request_body.get('read_only', False)
+        add_other_nodes_dbroots = request_body.get('add_other_nodes_dbroots', True)
 
         if node is None:
             raise_422_error(module_logger, func_name, 'missing node argument')
 
+        if not read_only and ('add_other_nodes_dbroots' in request_body):
+            raise_422_error(module_logger, func_name, 'add_other_nodes_dbroots is only valid when read_only is true')
+
         try:
             if not in_transaction:
                 with TransactionManager(extra_nodes=[node]):
-                    response = ClusterHandler.add_node(node, config, read_only)
+                    response = ClusterHandler.add_node(node, config, read_only, add_other_nodes_dbroots)
             else:
-                response = ClusterHandler.add_node(node, config, read_only)
+                response = ClusterHandler.add_node(node, config, read_only, add_other_nodes_dbroots)
         except CMAPIBasicError as err:
             raise_422_error(module_logger, func_name, err.message)
 

--- a/cmapi/cmapi_server/handlers/cluster.py
+++ b/cmapi/cmapi_server/handlers/cluster.py
@@ -15,7 +15,7 @@ from cmapi_server.helpers import (
     get_current_key, get_version, update_revision_and_manager,
 )
 from cmapi_server.node_manipulation import (
-    add_node, add_dbroot, remove_node, switch_node_maintenance,
+    add_node, add_dbroot, remove_node, switch_node_maintenance, update_dbroots_of_readonly_nodes,
 )
 from mcs_node_control.models.misc import get_dbrm_master
 from mcs_node_control.models.node_config import NodeConfig
@@ -140,7 +140,10 @@ class ClusterHandler():
         return {'timestamp': operation_start_time}
 
     @staticmethod
-    def add_node(node: str, config: str = DEFAULT_MCS_CONF_PATH) -> dict:
+    def add_node(
+        node: str, config: str = DEFAULT_MCS_CONF_PATH,
+        read_only: bool = False,
+    ) -> dict:
         """Method to add node to MCS CLuster.
 
         :param node: node IP or name or FQDN
@@ -148,6 +151,8 @@ class ClusterHandler():
         :param config: columnstore xml config file path,
                        defaults to DEFAULT_MCS_CONF_PATH
         :type config: str, optional
+        :param read_only: add node in read-only mode, defaults to False
+        :type read_only: bool, optional
         :raises CMAPIBasicError: on exception while starting transaction
         :raises CMAPIBasicError: if transaction start isn't successful
         :raises CMAPIBasicError: on exception while adding node
@@ -158,20 +163,25 @@ class ClusterHandler():
         :rtype: dict
         """
         logger: logging.Logger = logging.getLogger('cmapi_server')
-        logger.debug(f'Cluster add node command called. Adding node {node}.')
+        logger.debug(
+            f'Cluster add node command called. Adding node {node} in '
+            f'{"read-only" if read_only else "read-write"} mode.'
+        )
 
         response = {'timestamp': str(datetime.now())}
 
         try:
             add_node(
                 node, input_config_filename=config,
-                output_config_filename=config
+                output_config_filename=config,
+                read_only=read_only,
             )
             if not get_dbroots(node, config):
-                add_dbroot(
-                    host=node, input_config_filename=config,
-                    output_config_filename=config
-                )
+                if not read_only:  # Read-only nodes don't own dbroots
+                    add_dbroot(
+                        host=node, input_config_filename=config,
+                        output_config_filename=config
+                    )
         except Exception as err:
             raise CMAPIBasicError('Error while adding node.') from err
 
@@ -214,6 +224,8 @@ class ClusterHandler():
                 node, input_config_filename=config,
                 output_config_filename=config
             )
+            with NodeConfig().modify_config(config) as root:
+                update_dbroots_of_readonly_nodes(root)
         except Exception as err:
             raise CMAPIBasicError('Error while removing node.') from err
 

--- a/cmapi/cmapi_server/handlers/cluster.py
+++ b/cmapi/cmapi_server/handlers/cluster.py
@@ -224,14 +224,16 @@ class ClusterHandler():
                 node, input_config_filename=config,
                 output_config_filename=config
             )
-            with NodeConfig().modify_config(config) as root:
-                update_dbroots_of_readonly_nodes(root)
+
         except Exception as err:
             raise CMAPIBasicError('Error while removing node.') from err
 
         response['node_id'] = node
         active_nodes = get_active_nodes(config)
         if len(active_nodes) > 0:
+            with NodeConfig().modify_config(config) as root:
+                update_dbroots_of_readonly_nodes(root)
+
             update_revision_and_manager(
                 input_config_filename=config, output_config_filename=config
             )

--- a/cmapi/cmapi_server/handlers/cluster.py
+++ b/cmapi/cmapi_server/handlers/cluster.py
@@ -50,7 +50,7 @@ def toggle_cluster_state(
     broadcast_new_config(config, distribute_secrets=True)
 
 
-class ClusterHandler():
+class ClusterHandler:
     """Class for handling MCS Cluster operations."""
 
     @staticmethod
@@ -143,6 +143,7 @@ class ClusterHandler():
     def add_node(
         node: str, config: str = DEFAULT_MCS_CONF_PATH,
         read_only: bool = False,
+        add_other_nodes_dbroots: bool = True,
     ) -> dict:
         """Method to add node to MCS CLuster.
 
@@ -151,8 +152,10 @@ class ClusterHandler():
         :param config: columnstore xml config file path,
                        defaults to DEFAULT_MCS_CONF_PATH
         :type config: str, optional
-        :param read_only: add node in read-only mode, defaults to False
+        :param read_only: add node in read-only mode (not starting write engine), defaults to False
         :type read_only: bool, optional
+        :param add_other_nodes_dbroots: for read-only nodes, whether to add dbroots of other nodes
+        :type add_other_nodes_dbroots: bool, optional
         :raises CMAPIBasicError: on exception while starting transaction
         :raises CMAPIBasicError: if transaction start isn't successful
         :raises CMAPIBasicError: on exception while adding node
@@ -170,11 +173,15 @@ class ClusterHandler():
 
         response = {'timestamp': str(datetime.now())}
 
+        if not read_only and add_other_nodes_dbroots is not True:
+            raise CMAPIBasicError('add_other_nodes_dbroots is only valid when read_only is true')
+
         try:
             add_node(
                 node, input_config_filename=config,
                 output_config_filename=config,
                 read_only=read_only,
+                add_other_nodes_dbroots=add_other_nodes_dbroots,
             )
             if not get_dbroots(node, config):
                 if not read_only:  # Read-only nodes don't own dbroots

--- a/cmapi/cmapi_server/helpers.py
+++ b/cmapi/cmapi_server/helpers.py
@@ -11,7 +11,6 @@ import os
 import socket
 import time
 from collections import namedtuple
-from functools import partial
 from random import random
 from shutil import copyfile
 from typing import Tuple, Optional
@@ -379,7 +378,7 @@ def broadcast_new_config(
                 ) as response:
                     resp_json =  await response.json(encoding='utf-8')
                     response.raise_for_status()
-                logging.info(f'Node {node} config put successfull.')
+                logging.info(f'Node {node} config put successful.')
             except aiohttp.ClientResponseError as err:
                 # TODO: may be better to check if resp status is 422 cause
                 #       it's like a signal that cmapi server raised it in
@@ -577,6 +576,7 @@ def get_dbroots(node, config=DEFAULT_MCS_CONF_PATH):
     dbroots = []
     smc_node = root.find('./SystemModuleConfig')
     mod_count = int(smc_node.find('./ModuleCount3').text)
+
     for i in range(1, mod_count+1):
         ip_addr = smc_node.find(f'./ModuleIPAddr{i}-1-3').text
         hostname = smc_node.find(f'./ModuleHostName{i}-1-3').text
@@ -596,6 +596,7 @@ def get_dbroots(node, config=DEFAULT_MCS_CONF_PATH):
                 dbroots.append(
                     smc_node.find(f"./ModuleDBRootID{i}-{j}-3").text
                 )
+
     return dbroots
 
 

--- a/cmapi/cmapi_server/helpers.py
+++ b/cmapi/cmapi_server/helpers.py
@@ -135,6 +135,10 @@ def start_transaction(
         # this copy will be updated if an optional node can't be reached
         real_active_nodes = set(active_nodes)
         logging.trace(f'Active nodes on start transaction {active_nodes}')
+
+        if not len(active_nodes):
+            logging.warning('No active nodes found, transaction start will not have any effect')
+
         for node in active_nodes:
             url = f'https://{node}:8640/cmapi/{version}/node/begin'
             node_success = False

--- a/cmapi/cmapi_server/logging_management.py
+++ b/cmapi/cmapi_server/logging_management.py
@@ -104,7 +104,8 @@ def enable_console_logging(logger: logging.Logger) -> None:
 def config_cmapi_server_logging():
     # add custom level TRACE only for develop purposes
     # could be activated using API endpoints or cli tool without relaunching
-    add_logging_level('TRACE', 5)
+    if not hasattr(logging, 'TRACE'):
+        add_logging_level('TRACE', 5)
     cherrypy._cplogging.LogManager.error = custom_cherrypy_error
     # reconfigure cherrypy.access log message format
     # Default access_log_format '{h} {l} {u} {t} "{r}" {s} {b} "{f}" "{a}"'

--- a/cmapi/cmapi_server/managers/process.py
+++ b/cmapi/cmapi_server/managers/process.py
@@ -7,7 +7,8 @@ from time import sleep
 import psutil
 
 from cmapi_server.exceptions import CMAPIBasicError
-from cmapi_server.constants import MCS_INSTALL_BIN, ALL_MCS_PROGS
+from cmapi_server.constants import MCS_INSTALL_BIN, ALL_MCS_PROGS, MCSProgs, ProgInfo
+from cmapi_server.process_dispatchers.base import BaseDispatcher
 from cmapi_server.process_dispatchers.systemd import SystemdDispatcher
 from cmapi_server.process_dispatchers.container import (
     ContainerDispatcher
@@ -18,7 +19,7 @@ from mcs_node_control.models.misc import get_workernodes
 from mcs_node_control.models.process import Process
 
 
-PROCESS_DISPATCHERS = {
+PROCESS_DISPATCHERS: dict[str, type[BaseDispatcher]] = {
     'systemd': SystemdDispatcher,
     # could be used in docker containers and OSes w/o systemd
     'container': ContainerDispatcher,
@@ -32,10 +33,10 @@ class MCSProcessManager:
     e.g. re/-start or stop systemd services, run executable.
     """
     CONTROLLER_MAX_RETRY = 30
-    mcs_progs = {}
+    mcs_progs: dict[str, ProgInfo] = {}
     mcs_version_info = None
     dispatcher_name = None
-    process_dispatcher = None
+    process_dispatcher: BaseDispatcher = None
 
     @classmethod
     def _get_prog_name(cls, name: str) -> str:
@@ -47,12 +48,13 @@ class MCSProcessManager:
         :rtype: str
         """
         if cls.dispatcher_name == 'systemd':
-            return ALL_MCS_PROGS[name].service_name
+            prog = MCSProgs(name)
+            return ALL_MCS_PROGS[prog].service_name
         return name
 
     @classmethod
     def _get_sorted_progs(
-        cls, is_primary: bool, reverse: bool = False
+        cls, is_primary: bool, reverse: bool = False, is_read_only: bool = False
     ) -> dict:
         """Get sorted services dict.
 
@@ -72,6 +74,13 @@ class MCSProcessManager:
                 for prog_name, prog_info in cls.mcs_progs.items()
                 if prog_name not in PRIMARY_PROGS
             }
+
+        if is_read_only:
+            logging.debug('Node is in read-only mode, skipping WriteEngine')
+            unsorted_progs.pop(
+                MCSProgs.WRITE_ENGINE_SERVER.value, None
+            )
+
         if reverse:
             # stop sequence builds using stop_priority property
             return dict(
@@ -89,7 +98,8 @@ class MCSProcessManager:
         if cls.mcs_progs:
             logging.warning('Mcs ProcessHandler already detected processes.')
 
-        for prog_name, prog_info in ALL_MCS_PROGS.items():
+        for prog, prog_info in ALL_MCS_PROGS.items():
+            prog_name = prog.value
             if os.path.exists(os.path.join(MCS_INSTALL_BIN, prog_name)):
                 cls.mcs_progs[prog_name] = prog_info
 
@@ -404,19 +414,26 @@ class MCSProcessManager:
         return set(node_progs) == set(p['name'] for p in running_procs)
 
     @classmethod
-    def start_node(cls, is_primary: bool, use_sudo: bool = True):
+    def start_node(
+        cls,
+        is_primary: bool,
+        use_sudo: bool = True,
+        is_read_only: bool = False,
+    ) -> None:
         """Start mcs node processes.
 
         :param is_primary: is node primary or not, defaults to True
         :type is_primary: bool
         :param use_sudo: use sudo or not, defaults to True
         :type use_sudo: bool, optional
+        :param is_read_only: if true, doesn't start WriteEngine
+        :type is_read_only: bool, optional
         :raises CMAPIBasicError: immediately if one mcs process not started
         """
-        for prog_name in cls._get_sorted_progs(is_primary):
+        for prog_name in cls._get_sorted_progs(is_primary=is_primary, is_read_only=is_read_only):
             if (
                     cls.dispatcher_name == 'systemd'
-                    and prog_name == 'StorageManager'
+                    and prog_name == MCSProgs.STORAGE_MANAGER.value
             ):
                 # TODO: MCOL-5458
                 logging.info(
@@ -424,9 +441,9 @@ class MCSProcessManager:
                 )
                 continue
             # TODO: additional error handling
-            if prog_name == 'controllernode':
+            if prog_name == MCSProgs.CONTROLLER_NODE.value:
                 cls._wait_for_workernodes()
-            if prog_name in ('DMLProc', 'DDLProc'):
+            if prog_name in (MCSProgs.DML_PROC.value, MCSProgs.DDL_PROC.value):
                 cls._wait_for_controllernode()
             if not cls.start(prog_name, is_primary, use_sudo):
                 logging.error(f'Process "{prog_name}" not started properly.')
@@ -434,7 +451,10 @@ class MCSProcessManager:
 
     @classmethod
     def stop_node(
-        cls, is_primary: bool, use_sudo: bool = True, timeout: int = 10
+        cls,
+        is_primary: bool,
+        use_sudo: bool = True,
+        timeout: int = 10,
     ):
         """Stop mcs node processes.
 
@@ -450,14 +470,14 @@ class MCSProcessManager:
         # so use full available list of processes. Otherwise, it could cause
         # undefined behaviour when primary gone and then recovers (failover
         # triggered 2 times).
-        for prog_name in cls._get_sorted_progs(True, reverse=True):
+        for prog_name in cls._get_sorted_progs(is_primary=True, reverse=True):
             if not cls.stop(prog_name, is_primary, use_sudo):
                 logging.error(f'Process "{prog_name}" not stopped properly.')
                 raise CMAPIBasicError(f'Error while stopping "{prog_name}"')
 
     @classmethod
-    def restart_node(cls, is_primary: bool, use_sudo: bool):
+    def restart_node(cls, is_primary: bool, use_sudo: bool, is_read_only: bool = False):
         """TODO: For next releases."""
         if cls.get_running_mcs_procs():
             cls.stop_node(is_primary, use_sudo)
-        cls.start_node(is_primary, use_sudo)
+        cls.start_node(is_primary, use_sudo, is_read_only)

--- a/cmapi/cmapi_server/managers/transaction.py
+++ b/cmapi/cmapi_server/managers/transaction.py
@@ -106,10 +106,10 @@ class TransactionManager(ContextDecorator):
         try:
             rollback_transaction(self.txn_id, nodes=nodes)
             self.active_transaction = False
-            logging.debug(f'Success rollback of transaction "{self.txn_id}".')
+            logging.debug(f'Successful rollback of transaction "{self.txn_id}".')
         except Exception:
             logging.error(
-                f'Error while rollback transaction "{self.txn_id}"',
+                f'Error while rolling back transaction "{self.txn_id}"',
                 exc_info=True
             )
 

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -64,6 +64,7 @@ def add_node(
     output_config_filename: Optional[str] = None,
     use_rebalance_dbroots: bool = True,
     read_only: bool = False,
+    add_other_nodes_dbroots: bool = True,
 ):
     """Add node to a cluster.
 
@@ -102,7 +103,7 @@ def add_node(
                 _add_WES(c_root, pm_num, node)
             else:
                 logging.info('Node is read-only, skipping WES addition.')
-                _add_read_only_node(c_root, node)
+                _add_read_only_node(c_root, node, add_other_nodes_dbroots)
 
             _add_DBRM_Worker(c_root, node)
             _add_Module_entries(c_root, node)
@@ -113,7 +114,8 @@ def add_node(
                     _rebalance_dbroots(c_root)
                     _move_primary_node(c_root)
 
-            update_dbroots_of_readonly_nodes(c_root)
+            if read_only and add_other_nodes_dbroots:
+                update_dbroots_of_readonly_nodes(c_root)
     except Exception:
         logging.error(
             'Caught exception while adding node, config file is unchanged',
@@ -1020,8 +1022,8 @@ def _add_WES(root, pm_num, node):
     etree.SubElement(wes_node, "Port").text = "8630"
 
 
-def _add_read_only_node(root: etree.Element, node: str) -> None:
-    '''Add node name to ReadOnlyNodes if it is not already there'''
+def _add_read_only_node(root: etree.Element, node: str, add_other_nodes_dbroots: bool = True) -> None:
+    '''Add node name to ReadOnlyNodes if it is not already there, with attribute'''
     read_only_nodes = root.find('./ReadOnlyNodes')
     if read_only_nodes is None:
         read_only_nodes = etree.SubElement(root, 'ReadOnlyNodes')
@@ -1031,9 +1033,11 @@ def _add_read_only_node(root: etree.Element, node: str) -> None:
                 logging.warning(
                     f"_add_read_only_node(): node {node} already exists in ReadOnlyNodes"
                 )
+                n.set("add_other_nodes_dbroots", str(add_other_nodes_dbroots).lower())
                 return
-
-    etree.SubElement(read_only_nodes, "Node").text = node
+    node_elem = etree.SubElement(read_only_nodes, "Node")
+    node_elem.text = node
+    node_elem.set("add_other_nodes_dbroots", str(add_other_nodes_dbroots).lower())
 
 
 def _add_DBRM_Worker(root, node):
@@ -1202,17 +1206,28 @@ def get_pm_module_num_to_addr_map(root: etree.Element) -> dict[int, str]:
 def update_dbroots_of_readonly_nodes(root: etree.Element) -> None:
     """Read-only nodes do not have their own dbroots, but they must have all the dbroots of the other nodes
     So this function sets list of dbroots of each read-only node to the list of all the dbroots in the cluster
+
+    There is a special sub-mode of read-only nodes: coordinator nodes, they don't add dbroots of other nodes.
+    They are identified by the add_other_nodes_dbroots="false" attribute.
     """
-    nc = NodeConfig()
+
     pm_num_to_addr = get_pm_module_num_to_addr_map(root)
-    for ro_node in nc.get_read_only_nodes(root):
+    read_only_nodes = root.find('./ReadOnlyNodes')
+    if read_only_nodes is None:
+        return
+    for n in read_only_nodes.findall("./Node"):
+        add_dbroots = n.get("add_other_nodes_dbroots", "true").lower() == "true"
+        if not add_dbroots:
+            logging.info(f"Not adding dbroots of other nodes to {n.text} because it is a coordinator node")
+            continue
+
+        ro_node = n.text
         # Get PM num by IP address
         this_ip_pm_num = None
         for pm_num, pm_addr in pm_num_to_addr.items():
             if pm_addr == ro_node:
                 this_ip_pm_num = pm_num
                 break
-
         if this_ip_pm_num is not None:
             # Add dbroots of other nodes to this read-only node
             add_dbroots_of_other_nodes(root, this_ip_pm_num)

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -62,7 +62,8 @@ def switch_node_maintenance(
 def add_node(
     node: str, input_config_filename: str = DEFAULT_MCS_CONF_PATH,
     output_config_filename: Optional[str] = None,
-    use_rebalance_dbroots: bool = True
+    use_rebalance_dbroots: bool = True,
+    read_only: bool = False,
 ):
     """Add node to a cluster.
 
@@ -96,14 +97,23 @@ def add_node(
     try:
         if not _replace_localhost(c_root, node):
             pm_num = _add_node_to_PMS(c_root, node)
-            _add_WES(c_root, pm_num, node)
+
+            if not read_only:
+                _add_WES(c_root, pm_num, node)
+            else:
+                logging.info('Node is read-only, skipping WES addition.')
+                _add_read_only_node(c_root, node)
+
             _add_DBRM_Worker(c_root, node)
             _add_Module_entries(c_root, node)
             _add_active_node(c_root, node)
             _add_node_to_ExeMgrs(c_root, node)
             if use_rebalance_dbroots:
-                _rebalance_dbroots(c_root)
-                _move_primary_node(c_root)
+                if not read_only:
+                    _rebalance_dbroots(c_root)
+                    _move_primary_node(c_root)
+
+            update_dbroots_of_readonly_nodes(c_root)
     except Exception:
         logging.error(
             'Caught exception while adding node, config file is unchanged',
@@ -157,7 +167,11 @@ def remove_node(
 
         if len(active_nodes) > 1:
             pm_num = _remove_node_from_PMS(c_root, node)
-            _remove_WES(c_root, pm_num)
+
+            is_read_only = node in node_config.get_read_only_nodes(c_root)
+            if not is_read_only:
+                _remove_WES(c_root, pm_num)
+
             _remove_DBRM_Worker(c_root, node)
             _remove_Module_entries(c_root, node)
             _remove_from_ExeMgrs(c_root, node)
@@ -168,9 +182,11 @@ def remove_node(
                 # TODO: unspecific name, need to think of a better one
                 _remove_node(c_root, node)
 
-            if use_rebalance_dbroots:
+            if use_rebalance_dbroots and not is_read_only:
                 _rebalance_dbroots(c_root)
                 _move_primary_node(c_root)
+
+            update_dbroots_of_readonly_nodes(c_root)
         else:
             # TODO:
             #   - IMO undefined behaviour here. Removing one single node
@@ -244,7 +260,7 @@ def rebalance_dbroots(
 #
 # returns the id of the new dbroot on success
 # raises an exception on error
-def add_dbroot(input_config_filename = None, output_config_filename = None, host = None):
+def add_dbroot(input_config_filename = None, output_config_filename = None, host = None) -> int:
     node_config = NodeConfig()
     if input_config_filename is None:
         c_root = node_config.get_current_config_root()
@@ -376,11 +392,15 @@ def __remove_helper(parent_node, node):
 
 def _remove_node(root, node):
     '''
-    remove node from DesiredNodes, InactiveNodes, and ActiveNodes
+    remove node from DesiredNodes, InactiveNodes, ActiveNodes and (if present) ReadOnlyNodes
     '''
 
     for n in (root.find("./DesiredNodes"), root.find("./InactiveNodes"), root.find("./ActiveNodes")):
         __remove_helper(n, node)
+
+    read_only_nodes = root.find('./ReadOnlyNodes')
+    if read_only_nodes is not None:
+        __remove_helper(read_only_nodes, node)
 
 
 # This moves a node from ActiveNodes to InactiveNodes
@@ -529,6 +549,19 @@ def unassign_dbroot1(root):
         i += 1
 
 
+def _get_existing_db_roots(root: etree.Element) -> list[int]:
+    '''Get all the existing dbroot IDs from the config file'''
+    # There can be holes in the dbroot numbering, so can't just scan from [1-dbroot_count]
+    # Going to scan from 1-99 instead
+    sysconf_node = root.find("./SystemConfig")
+    existing_dbroots = []
+    for num in range(1, 100):
+        node = sysconf_node.find(f"./DBRoot{num}")
+        if node is not None:
+            existing_dbroots.append(num)
+    return existing_dbroots
+
+
 def _rebalance_dbroots(root, test_mode=False):
     # TODO: add code to detect whether we are using shared storage or not.  If not, exit
     # without doing anything.
@@ -572,14 +605,7 @@ def _rebalance_dbroots(root, test_mode=False):
 
     current_mapping = get_current_dbroot_mapping(root)
     sysconf_node = root.find("./SystemConfig")
-
-    # There can be holes in the dbroot numbering, so can't just scan from [1-dbroot_count]
-    # Going to scan from 1-99 instead.
-    existing_dbroots = []
-    for num in range(1, 100):
-        node = sysconf_node.find(f"./DBRoot{num}")
-        if node is not None:
-            existing_dbroots.append(num)
+    existing_dbroots = _get_existing_db_roots(root)
 
     # assign the unassigned dbroots
     unassigned_dbroots = set(existing_dbroots) - set(current_mapping[0])
@@ -631,7 +657,7 @@ def _rebalance_dbroots(root, test_mode=False):
                         # timed out
                         # possible node is not ready, leave retry as-is
                         pass
-                    except Exception as e:
+                    except Exception:
                         retry = False
 
                 if not found_master:
@@ -994,6 +1020,22 @@ def _add_WES(root, pm_num, node):
     etree.SubElement(wes_node, "Port").text = "8630"
 
 
+def _add_read_only_node(root: etree.Element, node: str) -> None:
+    '''Add node name to ReadOnlyNodes if it is not already there'''
+    read_only_nodes = root.find('./ReadOnlyNodes')
+    if read_only_nodes is None:
+        read_only_nodes = etree.SubElement(root, 'ReadOnlyNodes')
+    else:
+        for n in read_only_nodes.findall("./Node"):
+            if n.text == node:
+                logging.warning(
+                    f"_add_read_only_node(): node {node} already exists in ReadOnlyNodes"
+                )
+                return
+
+    etree.SubElement(read_only_nodes, "Node").text = node
+
+
 def _add_DBRM_Worker(root, node):
     '''
     find the highest numbered DBRM_Worker entry, or one that isn't used atm
@@ -1096,7 +1138,7 @@ def _add_node_to_PMS(root, node):
 
     return new_pm_num
 
-def _replace_localhost(root, node):
+def _replace_localhost(root: etree.Element, node: str) -> bool:
     # if DBRM_Controller/IPAddr is 127.0.0.1 or localhost,
     # then replace all instances, else do nothing.
     controller_host = root.find('./DBRM_Controller/IPAddr')
@@ -1144,3 +1186,75 @@ def _replace_localhost(root, node):
 # New Exception types
 class NodeNotFoundException(Exception):
     pass
+
+
+def get_pm_module_num_to_addr_map(root: etree.Element) -> dict[int, str]:
+    """Get a mapping of PM module numbers to their IP addresses"""
+    module_num_to_addr = {}
+    smc_node = root.find("./SystemModuleConfig")
+    mod_count = int(smc_node.find("./ModuleCount3").text)
+    for i in range(1, mod_count + 1):
+        ip_addr = smc_node.find(f"./ModuleIPAddr{i}-1-3").text
+        module_num_to_addr[i] = ip_addr
+    return module_num_to_addr
+
+
+def update_dbroots_of_readonly_nodes(root: etree.Element) -> None:
+    """Read-only nodes do not have their own dbroots, but they must have all the dbroots of the other nodes
+    So this function sets list of dbroots of each read-only node to the list of all the dbroots in the cluster
+    """
+    nc = NodeConfig()
+    pm_num_to_addr = get_pm_module_num_to_addr_map(root)
+    for ro_node in nc.get_read_only_nodes(root):
+        # Get PM num by IP address
+        this_ip_pm_num = None
+        for pm_num, pm_addr in pm_num_to_addr.items():
+            if pm_addr == ro_node:
+                this_ip_pm_num = pm_num
+                break
+
+        if this_ip_pm_num is not None:
+            # Add dbroots of other nodes to this read-only node
+            add_dbroots_of_other_nodes(root, this_ip_pm_num)
+        else:  # This should not happen
+            err_msg = f"Could not find PM number for read-only node {ro_node}"
+            logging.error(err_msg)
+            raise NodeNotFoundException(err_msg)
+
+
+def add_dbroots_of_other_nodes(root: etree.Element, module_num: int) -> None:
+    """Adds all the dbroots listed in the config to this (read-only) node"""
+    existing_dbroots = _get_existing_db_roots(root)
+    sysconf_node = root.find("./SystemModuleConfig")
+
+    # Remove existing dbroots from this module
+    remove_dbroots_of_node(root, module_num)
+
+    # Write node's dbroot count
+    dbroot_count_node = etree.SubElement(
+        sysconf_node, f"ModuleDBRootCount{module_num}-3"
+    )
+    dbroot_count_node.text = str(len(existing_dbroots))
+
+    # Write new dbroot IDs to the module mapping
+    for i, dbroot_id in enumerate(existing_dbroots, start=1):
+        dbroot_id_node = etree.SubElement(
+            sysconf_node, f"ModuleDBRootID{module_num}-{i}-3"
+        )
+        dbroot_id_node.text = str(dbroot_id)
+
+    logging.info("Added %d dbroots to read-only node %d: %s", len(existing_dbroots), module_num, sorted(existing_dbroots))
+
+
+def remove_dbroots_of_node(root: etree.Element, module_num: int) -> None:
+    """Removes all the dbroots listed in the config from this (read-only) node"""
+    sysconf_node = root.find("./SystemModuleConfig")
+    dbroot_count_node = sysconf_node.find(f"./ModuleDBRootCount{module_num}-3")
+    if dbroot_count_node is not None:
+        sysconf_node.remove(dbroot_count_node)
+
+    # Remove existing dbroot IDs
+    for i in range(1, 100):
+        dbroot_id_node = sysconf_node.find(f"./ModuleDBRootID{module_num}-{i}-3")
+        if dbroot_id_node is not None:
+            sysconf_node.remove(dbroot_id_node)

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -178,8 +178,14 @@ def remove_node(
             _remove_Module_entries(c_root, node)
             _remove_from_ExeMgrs(c_root, node)
 
+            # FIXME MCOL-6105: for some reason deactivate_only is always True, so the nodes are never removed from InactiveNodes
             if deactivate_only:
                 _deactivate_node(c_root, node)
+
+                # Remove node from ReadOnlyNodes if it is present there
+                read_only_nodes = c_root.find('./ReadOnlyNodes')
+                if read_only_nodes is not None:
+                    __remove_helper(read_only_nodes, node)
             else:
                 # TODO: unspecific name, need to think of a better one
                 _remove_node(c_root, node)

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -1023,7 +1023,7 @@ def _add_WES(root, pm_num, node):
 
 
 def _add_read_only_node(root: etree.Element, node: str, add_other_nodes_dbroots: bool = True) -> None:
-    '''Add node name to ReadOnlyNodes if it is not already there, with attribute'''
+    '''Add node name to ReadOnlyNodes if it is not already there, also set attribute add_other_nodes_dbroots in the tag'''
     read_only_nodes = root.find('./ReadOnlyNodes')
     if read_only_nodes is None:
         read_only_nodes = etree.SubElement(root, 'ReadOnlyNodes')

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -1216,11 +1216,6 @@ def update_dbroots_of_readonly_nodes(root: etree.Element) -> None:
     if read_only_nodes is None:
         return
     for n in read_only_nodes.findall("./Node"):
-        add_dbroots = n.get("add_other_nodes_dbroots", "true").lower() == "true"
-        if not add_dbroots:
-            logging.info(f"Not adding dbroots of other nodes to {n.text} because it is a coordinator node")
-            continue
-
         ro_node = n.text
         # Get PM num by IP address
         this_ip_pm_num = None
@@ -1229,8 +1224,13 @@ def update_dbroots_of_readonly_nodes(root: etree.Element) -> None:
                 this_ip_pm_num = pm_num
                 break
         if this_ip_pm_num is not None:
-            # Add dbroots of other nodes to this read-only node
-            add_dbroots_of_other_nodes(root, this_ip_pm_num)
+            add_dbroots = n.get("add_other_nodes_dbroots", "true").lower() == "true"
+            if add_dbroots:
+                # Add dbroots of other nodes to this read-only node
+                add_dbroots_of_other_nodes(root, this_ip_pm_num)
+            else:
+                logging.info(f"Not adding dbroots of other nodes to {n.text} because it is a coordinator node")
+                remove_dbroots_of_node(root, this_ip_pm_num)
         else:  # This should not happen
             err_msg = f"Could not find PM number for read-only node {ro_node}"
             logging.error(err_msg)

--- a/cmapi/cmapi_server/process_dispatchers/container.py
+++ b/cmapi/cmapi_server/process_dispatchers/container.py
@@ -11,7 +11,7 @@ from time import sleep
 import psutil
 
 from cmapi_server.constants import (
-    IFLAG, LIBJEMALLOC_DEFAULT_PATH, MCS_INSTALL_BIN, ALL_MCS_PROGS
+    IFLAG, LIBJEMALLOC_DEFAULT_PATH, MCS_INSTALL_BIN, ALL_MCS_PROGS, MCSProgs
 )
 from cmapi_server.exceptions import CMAPIBasicError
 from cmapi_server.process_dispatchers.base import BaseDispatcher
@@ -126,7 +126,8 @@ class ContainerDispatcher(BaseDispatcher):
         :return: command with arguments if needed
         :rtype: str
         """
-        service_info = ALL_MCS_PROGS[service]
+        prog = MCSProgs(service)
+        service_info = ALL_MCS_PROGS[prog]
         command = os.path.join(MCS_INSTALL_BIN, service)
 
         if service_info.subcommand:
@@ -188,7 +189,8 @@ class ContainerDispatcher(BaseDispatcher):
             env=env_vars
         )
         # TODO: any other way to detect service finished its initialisation?
-        sleep(ALL_MCS_PROGS[service].delay)
+        prog = MCSProgs(service)
+        sleep(ALL_MCS_PROGS[prog].delay)
         logger.debug(f'Started "{service}".')
 
         if is_primary and service == 'DDLProc':

--- a/cmapi/cmapi_server/test/test_cluster.py
+++ b/cmapi/cmapi_server/test/test_cluster.py
@@ -6,6 +6,7 @@ from shutil import copyfile
 
 import requests
 
+from cmapi_server.constants import MCSProgs
 from cmapi_server.controllers.dispatcher import _version
 from cmapi_server.managers.process import MCSProcessManager
 from cmapi_server.test.unittest_global import (
@@ -199,7 +200,7 @@ class ClusterAddNodeTestCase(BaseClusterTestCase):
 
         # Check Columntore started
         controllernode = subprocess.check_output(
-            ['pgrep', 'controllernode'])
+            ['pgrep', MCSProgs.CONTROLLER_NODE.value])
         self.assertIsNotNone(controllernode)
 
 

--- a/cmapi/cmapi_server/test/test_mcs_process_operations.py
+++ b/cmapi/cmapi_server/test/test_mcs_process_operations.py
@@ -65,7 +65,7 @@ class MCSProcessManagerTest(BaseProcessDispatcherCase):
 
     def test_mcs_process_manager(self):
         MCSProcessManager.detect('systemd', '')
-        for prog in MCSProcessManager._get_sorted_progs(True, True).values():
+        for prog in MCSProcessManager._get_sorted_progs(is_primary=True, reverse=True).values():
             serv_name = self.get_systemd_serv_name(prog.service_name)
             os.system(f'{SYSTEMCTL} stop {serv_name}')
         self.assertIsNone(MCSProcessManager.start_node(is_primary=True, use_sudo=False))
@@ -95,7 +95,7 @@ class MCSProcessManagerTest(BaseProcessDispatcherCase):
             )
         )
 
-        for prog in MCSProcessManager._get_sorted_progs(True).values():
+        for prog in MCSProcessManager._get_sorted_progs(is_primary=True).values():
             serv_name = self.get_systemd_serv_name(prog.service_name)
             os.system(f'{SYSTEMCTL} start {serv_name}')
 

--- a/cmapi/cmapi_server/test/test_node_manip.py
+++ b/cmapi/cmapi_server/test/test_node_manip.py
@@ -107,15 +107,19 @@ class NodeManipTester(BaseNodeManipTestCase):
             mock_update_dbroots_of_readonly_nodes.reset_mock()
 
             # Test read-only node removal
+            # Note: deactivate_only is always True in production, so node is only deactivated, not fully removed from config sections.
             node_manipulation.remove_node(
-                self.NEW_NODE_NAME, self.tmp_files[1], self.tmp_files[2],
-                deactivate_only=False,
+                self.NEW_NODE_NAME, self.tmp_files[1], self.tmp_files[2]
             )
 
             nc = NodeConfig()
             root = nc.get_current_config_root(self.tmp_files[2])
             read_only_nodes = nc.get_read_only_nodes(root)
+            # Node should be removed from ReadOnlyNodes (current code does this), but not from InactiveNodes/DesiredNodes
             self.assertEqual(len(read_only_nodes), 0)
+
+            inactive_nodes = root.find('./InactiveNodes')
+            self.assertTrue(any(n.text == self.NEW_NODE_NAME for n in inactive_nodes.findall('./Node')))
 
             mock_rebalance_dbroots.assert_not_called()
             mock_move_primary_node.assert_not_called()

--- a/cmapi/cmapi_server/test/test_node_manip.py
+++ b/cmapi/cmapi_server/test/test_node_manip.py
@@ -26,14 +26,16 @@ class NodeManipTester(BaseNodeManipTestCase):
 
         with patch('cmapi_server.node_manipulation.update_dbroots_of_readonly_nodes') as mock_update_dbroots_of_readonly_nodes:
             node_manipulation.add_node(
-                self.NEW_NODE_NAME, tmp_mcs_config_filename, self.tmp_files[0]
+                self.NEW_NODE_NAME, tmp_mcs_config_filename, self.tmp_files[0],
+                read_only=False,
             )
             mock_update_dbroots_of_readonly_nodes.assert_not_called()
 
             node_manipulation.add_node(
-                hostaddr, self.tmp_files[0], self.tmp_files[1]
+                hostaddr, self.tmp_files[0], self.tmp_files[1],
+                read_only=False,
             )
-            mock_update_dbroots_of_readonly_nodes.assert_called_once()
+            mock_update_dbroots_of_readonly_nodes.assert_not_called()
 
         # get a NodeConfig, read test.xml
         # look for some of the expected changes.
@@ -281,6 +283,8 @@ class NodeManipTester(BaseNodeManipTestCase):
 
 class TestDBRootsManipulation(unittest.TestCase):
     our_module_idx = 3
+    rw_node1_ip = '192.168.1.1'
+    rw_node2_ip = '192.168.1.2'
     ro_node1_ip = '192.168.1.3'
     ro_node2_ip = '192.168.1.4'
 
@@ -292,9 +296,9 @@ class TestDBRootsManipulation(unittest.TestCase):
         module_count = etree.SubElement(smc, 'ModuleCount3')
         module_count.text = '2'
         module1_ip = etree.SubElement(smc, 'ModuleIPAddr1-1-3')
-        module1_ip.text = '192.168.1.1'
+        module1_ip.text = self.rw_node1_ip
         module2_ip = etree.SubElement(smc, 'ModuleIPAddr2-1-3')
-        module2_ip.text = '192.168.1.2'
+        module2_ip.text = self.rw_node2_ip
 
         system_config = etree.SubElement(self.root, 'SystemConfig')
         dbroot_count = etree.SubElement(system_config, 'DBRootCount')
@@ -308,8 +312,8 @@ class TestDBRootsManipulation(unittest.TestCase):
         result = node_manipulation.get_pm_module_num_to_addr_map(self.root)
 
         expected = {
-            1: '192.168.1.1',
-            2: '192.168.1.2',
+            1: self.rw_node1_ip,
+            2: self.rw_node2_ip,
         }
         self.assertEqual(result, expected)
 
@@ -383,3 +387,33 @@ class TestDBRootsManipulation(unittest.TestCase):
             self.assertIsNotNone(dbroot2)
             self.assertEqual(dbroot1.text, '1')
             self.assertEqual(dbroot2.text, '2')
+
+    def test_update_dbroots_of_readonly_nodes_ignores_coordinator_nodes(self):
+        """Test that update_dbroots_of_readonly_nodes doesn't add dbroots to coordinator nodes
+        (read-only nodes that have add_other_nodes_dbroots="false")
+        """
+        # Add two read-only nodes, one is a coordinator node
+        smc = self.root.find('./SystemModuleConfig')
+        module_count = smc.find('./ModuleCount3')
+        module_count.text = '4'
+        module3_ip = etree.SubElement(smc, 'ModuleIPAddr3-1-3')
+        module3_ip.text = self.ro_node1_ip
+        module4_ip = etree.SubElement(smc, 'ModuleIPAddr4-1-3')
+        module4_ip.text = self.ro_node2_ip
+
+        read_only_nodes = etree.SubElement(self.root, 'ReadOnlyNodes')
+        for ip, is_coordinator in zip([self.ro_node1_ip, self.ro_node2_ip], [True, False]):
+            node = etree.SubElement(read_only_nodes, 'Node')
+            node.text = ip
+            node.set('add_other_nodes_dbroots', str(not is_coordinator).lower())
+
+        update_dbroots_of_readonly_nodes(self.root)
+
+        # Check that RO node 1 (coordinator) has no dbroots
+        module_count = self.root.find('./SystemModuleConfig/ModuleDBRootCount3-3')
+        self.assertIsNone(module_count)
+
+        # Check that RO node 2 has dbroots
+        module_count = self.root.find('./SystemModuleConfig/ModuleDBRootCount4-3')
+        self.assertIsNotNone(module_count)
+        self.assertEqual(module_count.text, '2')

--- a/cmapi/cmapi_server/test/test_node_manip.py
+++ b/cmapi/cmapi_server/test/test_node_manip.py
@@ -16,6 +16,7 @@ logging.basicConfig(level='DEBUG')
 SINGLE_NODE_XML = "./cmapi_server/SingleNode.xml"
 
 
+@unittest.skip('Temp skip for testing reason')
 class NodeManipTester(BaseNodeManipTestCase):
 
     def test_add_remove_node(self):
@@ -384,5 +385,3 @@ class TestDBRootsManipulation(unittest.TestCase):
             self.assertIsNotNone(dbroot2)
             self.assertEqual(dbroot1.text, '1')
             self.assertEqual(dbroot2.text, '2')
-
-

--- a/cmapi/cmapi_server/test/test_node_manip.py
+++ b/cmapi/cmapi_server/test/test_node_manip.py
@@ -1,17 +1,19 @@
 import logging
 import socket
+import unittest
+from unittest.mock import patch
 
 from lxml import etree
 
 from cmapi_server import node_manipulation
 from cmapi_server.constants import MCS_DATA_PATH
-from cmapi_server.test.unittest_global import (
-    tmp_mcs_config_filename, BaseNodeManipTestCase
-)
+from cmapi_server.node_manipulation import add_dbroots_of_other_nodes, remove_dbroots_of_node, update_dbroots_of_readonly_nodes
+from cmapi_server.test.unittest_global import BaseNodeManipTestCase, tmp_mcs_config_filename
 from mcs_node_control.models.node_config import NodeConfig
 
-
 logging.basicConfig(level='DEBUG')
+
+SINGLE_NODE_XML = "./cmapi_server/SingleNode.xml"
 
 
 class NodeManipTester(BaseNodeManipTestCase):
@@ -21,12 +23,18 @@ class NodeManipTester(BaseNodeManipTestCase):
             './test-output0.xml','./test-output1.xml','./test-output2.xml'
         )
         hostaddr = socket.gethostbyname(socket.gethostname())
-        node_manipulation.add_node(
-            self.NEW_NODE_NAME, tmp_mcs_config_filename, self.tmp_files[0]
-        )
-        node_manipulation.add_node(
-            hostaddr, self.tmp_files[0], self.tmp_files[1]
-        )
+
+        with patch('cmapi_server.node_manipulation.update_dbroots_of_readonly_nodes') as mock_update_dbroots_of_readonly_nodes:
+            node_manipulation.add_node(
+                self.NEW_NODE_NAME, tmp_mcs_config_filename, self.tmp_files[0]
+            )
+            mock_update_dbroots_of_readonly_nodes.assert_called_once()
+            mock_update_dbroots_of_readonly_nodes.reset_mock()
+
+            node_manipulation.add_node(
+                hostaddr, self.tmp_files[0], self.tmp_files[1]
+            )
+            mock_update_dbroots_of_readonly_nodes.assert_called_once()
 
         # get a NodeConfig, read test.xml
         # look for some of the expected changes.
@@ -40,10 +48,13 @@ class NodeManipTester(BaseNodeManipTestCase):
         node = root.find("./ExeMgr2/IPAddr")
         self.assertEqual(node.text, hostaddr)
 
-        node_manipulation.remove_node(
-            self.NEW_NODE_NAME, self.tmp_files[1], self.tmp_files[2],
-            test_mode=True
-        )
+        with patch('cmapi_server.node_manipulation.update_dbroots_of_readonly_nodes') as mock_update_dbroots_of_readonly_nodes:
+            node_manipulation.remove_node(
+                self.NEW_NODE_NAME, self.tmp_files[1], self.tmp_files[2],
+                test_mode=True
+            )
+            mock_update_dbroots_of_readonly_nodes.assert_called_once()
+
         nc = NodeConfig()
         root = nc.get_current_config_root(self.tmp_files[2])
         node = root.find('./PMS1/IPAddr')
@@ -51,6 +62,64 @@ class NodeManipTester(BaseNodeManipTestCase):
         # TODO: Fix node_manipulation add_node logic and _replace_localhost
         # node = root.find('./PMS2/IPAddr')
         # self.assertEqual(node, None)
+
+    def test_add_remove_read_only_node(self):
+        """add_node(read_only=True) should add a read-only node into the config, it does not add a WriteEngineServer (WES) and does not own dbroots"""
+        self.tmp_files = ('./config_output_rw.xml', './config_output_ro.xml', './config_output_ro_removed.xml')
+
+        # Add this host as a read-write node
+        local_host_addr = socket.gethostbyname(socket.gethostname())
+        node_manipulation.add_node(
+            local_host_addr, SINGLE_NODE_XML, self.tmp_files[0]
+        )
+
+        # Mock _rebalance_dbroots and _move_primary_node (only after the first node is added)
+        with patch('cmapi_server.node_manipulation._rebalance_dbroots') as mock_rebalance_dbroots, \
+             patch('cmapi_server.node_manipulation._move_primary_node') as mock_move_primary_node, \
+             patch('cmapi_server.node_manipulation.update_dbroots_of_readonly_nodes') as mock_update_dbroots_of_readonly_nodes:
+
+            # Add a read-only node
+            node_manipulation.add_node(
+                self.NEW_NODE_NAME, self.tmp_files[0], self.tmp_files[1],
+                read_only=True,
+            )
+
+            nc = NodeConfig()
+            root = nc.get_current_config_root(self.tmp_files[1])
+
+            # Check if read-only nodes section exists and is filled
+            read_only_nodes = nc.get_read_only_nodes(root)
+            self.assertEqual(len(read_only_nodes), 1)
+            self.assertEqual(read_only_nodes[0], self.NEW_NODE_NAME)
+
+            # Check if PMS was added
+            pms_node_ipaddr = root.find('./PMS2/IPAddr')
+            self.assertEqual(pms_node_ipaddr.text, self.NEW_NODE_NAME)
+
+            # Check that WriteEngineServer was not added
+            wes_node = root.find('./pm2_WriteEngineServer')
+            self.assertIsNone(wes_node)
+
+            mock_rebalance_dbroots.assert_not_called()
+            mock_move_primary_node.assert_not_called()
+            mock_update_dbroots_of_readonly_nodes.assert_called_once()
+            mock_update_dbroots_of_readonly_nodes.reset_mock()
+
+            # Test read-only node removal
+            node_manipulation.remove_node(
+                self.NEW_NODE_NAME, self.tmp_files[1], self.tmp_files[2],
+                deactivate_only=False,
+            )
+
+            nc = NodeConfig()
+            root = nc.get_current_config_root(self.tmp_files[2])
+            read_only_nodes = nc.get_read_only_nodes(root)
+            self.assertEqual(len(read_only_nodes), 0)
+
+            mock_rebalance_dbroots.assert_not_called()
+            mock_move_primary_node.assert_not_called()
+            mock_update_dbroots_of_readonly_nodes.assert_called_once()
+
 
     def test_add_dbroots_nodes_rebalance(self):
         self.tmp_files = (
@@ -209,3 +278,111 @@ class NodeManipTester(BaseNodeManipTestCase):
             caught_it = True
 
         self.assertTrue(caught_it)
+
+
+class TestDBRootsManipulation(unittest.TestCase):
+    our_module_idx = 3
+    ro_node1_ip = '192.168.1.3'
+    ro_node2_ip = '192.168.1.4'
+
+    def setUp(self):
+        # Mock initial XML structure (add two nodes and two dbroots)
+        self.root = etree.Element('Columnstore')
+        # Add two PM modules with IP addresses
+        smc = etree.SubElement(self.root, 'SystemModuleConfig')
+        module_count = etree.SubElement(smc, 'ModuleCount3')
+        module_count.text = '2'
+        module1_ip = etree.SubElement(smc, 'ModuleIPAddr1-1-3')
+        module1_ip.text = '192.168.1.1'
+        module2_ip = etree.SubElement(smc, 'ModuleIPAddr2-1-3')
+        module2_ip.text = '192.168.1.2'
+
+        system_config = etree.SubElement(self.root, 'SystemConfig')
+        dbroot_count = etree.SubElement(system_config, 'DBRootCount')
+        dbroot_count.text = '2'
+        dbroot1 = etree.SubElement(system_config, 'DBRoot1')
+        dbroot1.text = '/data/dbroot1'
+        dbroot2 = etree.SubElement(system_config, 'DBRoot2')
+        dbroot2.text = '/data/dbroot2'
+
+    def test_get_pm_module_num_to_addr_map(self):
+        result = node_manipulation.get_pm_module_num_to_addr_map(self.root)
+
+        expected = {
+            1: '192.168.1.1',
+            2: '192.168.1.2',
+        }
+        self.assertEqual(result, expected)
+
+    def test_add_dbroots_of_other_nodes(self):
+        '''add_dbroots_of_other_nodes must add dbroots of other nodes into mapping of the node.'''
+        add_dbroots_of_other_nodes(self.root, self.our_module_idx)
+
+        # Check that ModuleDBRootCount of the module was updated
+        module_count = self.root.find(f'./SystemModuleConfig/ModuleDBRootCount{self.our_module_idx}-3')
+        self.assertIsNotNone(module_count)
+        self.assertEqual(module_count.text, '2')
+
+        # Check that dbroots were added to ModuleDBRootID{module_num}-{i}-3
+        dbroot1 = self.root.find(f'./SystemModuleConfig/ModuleDBRootID{self.our_module_idx}-1-3')
+        dbroot2 = self.root.find(f'./SystemModuleConfig/ModuleDBRootID{self.our_module_idx}-2-3')
+        self.assertIsNotNone(dbroot1)
+        self.assertIsNotNone(dbroot2)
+        self.assertEqual(dbroot1.text, '1')
+        self.assertEqual(dbroot2.text, '2')
+
+    def test_remove_dbroots_of_node(self):
+        '''Test that remove_dbroots_of_node correctly removes dbroots from the node's mapping'''
+        # Add dbroot association to the node
+        smc = self.root.find('./SystemModuleConfig')
+        dbroot1 = etree.SubElement(smc, f'ModuleDBRootID{self.our_module_idx}-1-3')
+        dbroot1.text = '1'
+        dbroot2 = etree.SubElement(smc, f'ModuleDBRootID{self.our_module_idx}-2-3')
+        dbroot2.text = '2'
+        # Add ModuleDBRootCount to the node
+        module_count = etree.SubElement(smc, f'ModuleDBRootCount{self.our_module_idx}-3')
+        module_count.text = '2'
+
+        remove_dbroots_of_node(self.root, self.our_module_idx)
+
+        # Check that ModuleDBRootCount was removed
+        module_count = self.root.find(f'./SystemModuleConfig/ModuleDBRootCount{self.our_module_idx}-3')
+        self.assertIsNone(module_count)
+        # Check that dbroot mappings of the module were removed
+        dbroot1 = self.root.find(f'./SystemModuleConfig/ModuleDBRootID{self.our_module_idx}-1-3')
+        dbroot2 = self.root.find(f'./SystemModuleConfig/ModuleDBRootID{self.our_module_idx}-2-3')
+        self.assertIsNone(dbroot1)
+        self.assertIsNone(dbroot2)
+
+    def test_update_dbroots_of_readonly_nodes(self):
+        """Test that update_dbroots_of_readonly_nodes adds all existing dbroots to all existing read-only nodes"""
+        # Add two new new modules to the XML structure (two already exist)
+        smc = self.root.find('./SystemModuleConfig')
+        module_count = smc.find('./ModuleCount3')
+        module_count.text = '4'
+        module3_ip = etree.SubElement(smc, 'ModuleIPAddr3-1-3')
+        module3_ip.text = self.ro_node1_ip
+        module4_ip = etree.SubElement(smc, 'ModuleIPAddr4-1-3')
+        module4_ip.text = self.ro_node2_ip
+        # Add them to ReadOnlyNodes
+        read_only_nodes = etree.SubElement(self.root, 'ReadOnlyNodes')
+        for ip in [self.ro_node1_ip, self.ro_node2_ip]:
+            node = etree.SubElement(read_only_nodes, 'Node')
+            node.text = ip
+
+        update_dbroots_of_readonly_nodes(self.root)
+
+        # Check that read only nodes have all the dbroots
+        for ro_module_idx in range(3, 5):
+            module_count = self.root.find(f'./SystemModuleConfig/ModuleDBRootCount{ro_module_idx}-3')
+            self.assertIsNotNone(module_count)
+            self.assertEqual(module_count.text, '2')
+
+            dbroot1 = self.root.find(f'./SystemModuleConfig/ModuleDBRootID{ro_module_idx}-1-3')
+            dbroot2 = self.root.find(f'./SystemModuleConfig/ModuleDBRootID{ro_module_idx}-2-3')
+            self.assertIsNotNone(dbroot1)
+            self.assertIsNotNone(dbroot2)
+            self.assertEqual(dbroot1.text, '1')
+            self.assertEqual(dbroot2.text, '2')
+
+

--- a/cmapi/cmapi_server/test/test_node_manip.py
+++ b/cmapi/cmapi_server/test/test_node_manip.py
@@ -28,8 +28,7 @@ class NodeManipTester(BaseNodeManipTestCase):
             node_manipulation.add_node(
                 self.NEW_NODE_NAME, tmp_mcs_config_filename, self.tmp_files[0]
             )
-            mock_update_dbroots_of_readonly_nodes.assert_called_once()
-            mock_update_dbroots_of_readonly_nodes.reset_mock()
+            mock_update_dbroots_of_readonly_nodes.assert_not_called()
 
             node_manipulation.add_node(
                 hostaddr, self.tmp_files[0], self.tmp_files[1]

--- a/cmapi/cmapi_server/test/test_node_manip.py
+++ b/cmapi/cmapi_server/test/test_node_manip.py
@@ -16,7 +16,6 @@ logging.basicConfig(level='DEBUG')
 SINGLE_NODE_XML = "./cmapi_server/SingleNode.xml"
 
 
-@unittest.skip('Temp skip for testing reason')
 class NodeManipTester(BaseNodeManipTestCase):
 
     def test_add_remove_node(self):

--- a/cmapi/cmapi_server/test/unittest_global.py
+++ b/cmapi/cmapi_server/test/unittest_global.py
@@ -2,21 +2,14 @@ import logging
 import os
 import unittest
 from contextlib import contextmanager
-from datetime import datetime, timedelta
 from shutil import copyfile
 from tempfile import TemporaryDirectory
 
 import cherrypy
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography import x509
-from cryptography.x509.oid import NameOID
-from cryptography.hazmat.primitives import hashes
-
 from cmapi_server import helpers
 from cmapi_server.constants import CMAPI_CONF_PATH
 from cmapi_server.controllers.dispatcher import dispatcher, jsonify_error
+from cmapi_server.logging_management import config_cmapi_server_logging
 from cmapi_server.managers.process import MCSProcessManager
 from cmapi_server.managers.certificate import CertificateManager
 
@@ -80,6 +73,7 @@ class BaseServerTestCase(unittest.TestCase):
             )
             copyfile(cmapi_config_filename, self.cmapi_config_filename)
             copyfile(TEST_MCS_CONFIG_FILEPATH, self.mcs_config_filename)
+            config_cmapi_server_logging()
             self.app = cherrypy.tree.mount(
                 root=None, config=self.cmapi_config_filename
             )

--- a/cmapi/mcs_cluster_tool/__main__.py
+++ b/cmapi/mcs_cluster_tool/__main__.py
@@ -76,7 +76,10 @@ def setup_logging(verbose: bool = False) -> None:
     add_logging_level('TRACE', 5)
     dict_config(MCS_CLI_LOG_CONF_PATH)
     if verbose:
-        enable_console_logging(logging.getLogger())
+        for logger_name in ("", "mcs_cli"):
+            logger = logging.getLogger(logger_name)
+            logger.setLevel(logging.DEBUG)
+            enable_console_logging(logger)
 
 
 if __name__ == '__main__':

--- a/cmapi/mcs_cluster_tool/cluster_app.py
+++ b/cmapi/mcs_cluster_tool/cluster_app.py
@@ -198,6 +198,14 @@ def add(
             'node IP, name or FQDN. '
             'Can be used multiple times to add several nodes at a time.'
         )
+    ),
+    read_only: bool = typer.Option(
+        False,
+        '--read-only',
+        help=(
+            'Add node (or nodes, if more than one is passed) in read-only '
+            'mode.'
+        )
     )
 ):
     """Add nodes to the Columnstore cluster."""
@@ -207,7 +215,9 @@ def add(
         extra_nodes=nodes
     ):
         for node in nodes:
-            result.append(client.add_node({'node': node}))
+            result.append(
+                client.add_node({'node': node, 'read_only': read_only})
+            )
     return result
 
 

--- a/cmapi/mcs_cluster_tool/cluster_app.py
+++ b/cmapi/mcs_cluster_tool/cluster_app.py
@@ -206,6 +206,14 @@ def add(
             'Add node (or nodes, if more than one is passed) in read-only '
             'mode.'
         )
+    ),
+    coordinator_only: bool = typer.Option(
+        False,
+        '--coordinator-only',
+        help=(
+            'Add node(s) as coordinator-only (read-only, but does not add other nodes\' dbroots).'
+        ),
+        hidden=True,
     )
 ):
     """Add nodes to the Columnstore cluster."""
@@ -214,9 +222,10 @@ def add(
         timeout=timedelta(days=1).total_seconds(), handle_signals=True,
         extra_nodes=nodes
     ):
+        add_other_nodes_dbroots = not coordinator_only
         for node in nodes:
             result.append(
-                client.add_node({'node': node, 'read_only': read_only})
+                client.add_node({'node': node, 'read_only': read_only, 'add_other_nodes_dbroots': add_other_nodes_dbroots})
             )
     return result
 

--- a/cmapi/mcs_node_control/models/node_config.py
+++ b/cmapi/mcs_node_control/models/node_config.py
@@ -1,26 +1,27 @@
 import configparser
+from contextlib import contextmanager
 import grp
 import logging
 import pwd
 import re
 import socket
-from os import mkdir, replace, chown
+from os import chown, mkdir, replace
 from pathlib import Path
 from shutil import copyfile
-from xml.dom import minidom   # to pick up pretty printing functionality
+from typing import Optional
+from xml.dom import minidom  # to pick up pretty printing functionality
 
 from lxml import etree
 
 from cmapi_server.constants import (
-    DEFAULT_MCS_CONF_PATH, DEFAULT_SM_CONF_PATH,
+    DEFAULT_MCS_CONF_PATH,
+    DEFAULT_SM_CONF_PATH,
     MCS_MODULE_FILE_PATH,
 )
-# from cmapi_server.managers.process import MCSProcessManager
-from mcs_node_control.models.misc import (
-    read_module_id, get_dbroots_list
-)
-from mcs_node_control.models.network_ifaces import get_network_interfaces
 
+# from cmapi_server.managers.process import MCSProcessManager
+from mcs_node_control.models.misc import get_dbroots_list, read_module_id
+from mcs_node_control.models.network_ifaces import get_network_interfaces
 
 module_logger = logging.getLogger()
 
@@ -36,7 +37,7 @@ class NodeConfig:
     """
     def get_current_config_root(
         self, config_filename: str = DEFAULT_MCS_CONF_PATH, upgrade=True
-    ):
+    ) -> etree.Element:
         """Retrieves current configuration.
 
         Read the config and returns Element.
@@ -49,7 +50,7 @@ class NodeConfig:
         self.upgrade_config(tree=tree, upgrade=upgrade)
         return tree.getroot()
 
-    def get_root_from_string(self, config_string: str):
+    def get_root_from_string(self, config_string: str) -> etree.Element:
         root = etree.fromstring(config_string)
         self.upgrade_config(root=root)
         return root
@@ -136,6 +137,26 @@ class NodeConfig:
         with open(tmp_filename, "w") as f:
             f.write(self.to_string(tree))
         replace(tmp_filename, filename)    # atomic replacement
+
+    @contextmanager
+    def modify_config(
+        self,
+        input_config_filename: str = DEFAULT_MCS_CONF_PATH,
+        output_config_filename: Optional[str] = None,
+        ):
+        """Context manager to modify the config file
+        If exception is raised, the config file is not modified and exception is re-raised
+        If output_config_filename is not provided, the input config file is modified
+        """
+        try:
+            c_root = self.get_current_config_root(input_config_filename)
+            yield c_root
+        except Exception as e:
+            logging.error(f"modify_config(): Caught exception: '{str(e)}', config file not modified")
+            raise
+        else:
+            output_config_filename = output_config_filename or input_config_filename
+            self.write_config(c_root, output_config_filename)
 
     def to_string(self, tree):
         # TODO: try to use lxml to do this to avoid the add'l dependency
@@ -566,4 +587,18 @@ has dbroot {subel.text}')
         for i in range(1, mod_count+1):
             for j in range(1, int(smc_node.find(f"./ModuleDBRootCount{i}-3").text) + 1):
                 dbroots.append(smc_node.find(f"./ModuleDBRootID{i}-{j}-3").text)
+
         return dbroots
+
+    def get_read_only_nodes(self, root=None) -> list[str]:
+        """Get names of read only nodes from config"""
+        root = root or self.get_current_config_root()
+        return [node.text for node in root.findall('./ReadOnlyNodes/Node')]
+
+    def is_read_only(self, root=None) -> bool:
+        """Checks if this node is in read-only mode"""
+
+        root = root or self.get_current_config_root()
+        read_only_nodes = set(self.get_read_only_nodes(root))
+        my_names = set(self.get_network_addresses_and_names())
+        return bool(read_only_nodes.intersection(my_names))

--- a/cmapi/mcs_node_control/models/node_config.py
+++ b/cmapi/mcs_node_control/models/node_config.py
@@ -592,7 +592,7 @@ has dbroot {subel.text}')
 
     def get_read_only_nodes(self, root=None) -> list[str]:
         """Get names of read only nodes from config"""
-        root = root or self.get_current_config_root()
+        root = root if root is not None else self.get_current_config_root()
         return [node.text for node in root.findall('./ReadOnlyNodes/Node')]
 
     def is_read_only(self, root=None) -> bool:

--- a/cmapi/pyproject.toml
+++ b/cmapi/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.ruff]
+line-length = 80
+target-version = "py39"
+# Enable common rule sets
+select = [
+    "E",  # pycodestyle errors
+    "F",  # pyflakes: undefined names, unused imports, etc.
+    "I",  # isort: import sorting
+    "B",  # flake8-bugbear: common bugs and anti-patterns
+    "UP", # pyupgrade: use modern Python syntax
+    "N",  # pep8-naming: naming conventions
+]
+
+ignore = []
+
+# Exclude cache and temporary directories
+exclude = [
+    "__pycache__",
+]
+
+[tool.ruff.format]
+quote-style = "single"

--- a/dbcon/ddlpackageproc/altertableprocessor.cpp
+++ b/dbcon/ddlpackageproc/altertableprocessor.cpp
@@ -761,8 +761,7 @@ void AlterTableProcessor::addColumn(uint32_t sessionID, execplan::CalpontSystemC
 
   int pmNum = 1;
   OamCache* oamcache = OamCache::makeOamCache();
-  boost::shared_ptr<std::map<int, int> > dbRootPMMap = oamcache->getDBRootToPMMap();
-  pmNum = (*dbRootPMMap)[dbRoot];
+  pmNum = oamcache->getOwnerPM(dbRoot);
 
   boost::shared_ptr<messageqcpp::ByteStream> bsIn;
   // Will create files on each PM as needed.
@@ -925,7 +924,7 @@ void AlterTableProcessor::addColumn(uint32_t sessionID, execplan::CalpontSystemC
       if (rc != 0)
         throw std::runtime_error("Error while calling getSysCatDBRoot ");
 
-      pmNum = (*dbRootPMMap)[dbRoot];
+      pmNum = oamcache->getOwnerPM(dbRoot);
       bs.restart();
       bs << (ByteStream::byte)WE_SVR_UPDATE_SYSTABLE_AUTO;
       bs << uniqueId;
@@ -1317,8 +1316,7 @@ void AlterTableProcessor::dropColumn(uint32_t sessionID, execplan::CalpontSystem
 
   boost::shared_ptr<messageqcpp::ByteStream> bsIn;
   OamCache* oamcache = OamCache::makeOamCache();
-  boost::shared_ptr<std::map<int, int> > dbRootPMMap = oamcache->getDBRootToPMMap();
-  pmNum = (*dbRootPMMap)[dbRoot];
+  pmNum = oamcache->getOwnerPM(dbRoot);
 
   // MCOL-66 The DBRM can't handle concurrent DDL
   boost::mutex::scoped_lock lk(dbrmMutex);
@@ -1379,7 +1377,7 @@ void AlterTableProcessor::dropColumn(uint32_t sessionID, execplan::CalpontSystem
     if (rc != 0)
       throw std::runtime_error("Error while calling getSysCatDBRoot ");
 
-    pmNum = (*dbRootPMMap)[dbRoot];
+    pmNum = oamcache->getOwnerPM(dbRoot);
     bytestream.restart();
     bytestream << (ByteStream::byte)WE_SVR_UPDATE_SYSTABLE_AUTO;
     bytestream << uniqueId;
@@ -1452,7 +1450,7 @@ void AlterTableProcessor::dropColumn(uint32_t sessionID, execplan::CalpontSystem
   if (rc != 0)
     throw std::runtime_error("Error while calling getSysCatDBRoot ");
 
-  pmNum = (*dbRootPMMap)[dbRoot];
+  pmNum = oamcache->getOwnerPM(dbRoot);
 
   try
   {
@@ -1706,8 +1704,7 @@ void AlterTableProcessor::setColumnDefault(uint32_t sessionID, execplan::Calpont
 
   int pmNum = 1;
   OamCache* oamcache = OamCache::makeOamCache();
-  boost::shared_ptr<std::map<int, int> > dbRootPMMap = oamcache->getDBRootToPMMap();
-  pmNum = (*dbRootPMMap)[dbRoot];
+  pmNum = oamcache->getOwnerPM(dbRoot);
 
   boost::shared_ptr<messageqcpp::ByteStream> bsIn;
 
@@ -1795,8 +1792,7 @@ void AlterTableProcessor::dropColumnDefault(uint32_t sessionID, execplan::Calpon
 
   int pmNum = 1;
   OamCache* oamcache = OamCache::makeOamCache();
-  boost::shared_ptr<std::map<int, int> > dbRootPMMap = oamcache->getDBRootToPMMap();
-  pmNum = (*dbRootPMMap)[dbRoot];
+  pmNum = oamcache->getOwnerPM(dbRoot);
 
   boost::shared_ptr<messageqcpp::ByteStream> bsIn;
 
@@ -2001,8 +1997,7 @@ void AlterTableProcessor::renameTable(uint32_t sessionID, execplan::CalpontSyste
 
   boost::shared_ptr<messageqcpp::ByteStream> bsIn;
   OamCache* oamcache = OamCache::makeOamCache();
-  boost::shared_ptr<std::map<int, int> > dbRootPMMap = oamcache->getDBRootToPMMap();
-  pmNum = (*dbRootPMMap)[dbRoot];
+  pmNum = oamcache->getOwnerPM(dbRoot);
 
   try
   {
@@ -2067,7 +2062,7 @@ void AlterTableProcessor::renameTable(uint32_t sessionID, execplan::CalpontSyste
   if (rc != 0)
     throw std::runtime_error("Error while calling getSysCatDBRoot");
 
-  pmNum = (*dbRootPMMap)[dbRoot];
+  pmNum = oamcache->getOwnerPM(dbRoot);
 
   try
   {
@@ -2131,8 +2126,7 @@ void AlterTableProcessor::tableComment(uint32_t sessionID, execplan::CalpontSyst
   int pmNum = 1;
   rc = fDbrm->getSysCatDBRoot(sysOid, dbRoot);
   OamCache* oamcache = OamCache::makeOamCache();
-  boost::shared_ptr<std::map<int, int> > dbRootPMMap = oamcache->getDBRootToPMMap();
-  pmNum = (*dbRootPMMap)[dbRoot];
+  pmNum = oamcache->getOwnerPM(dbRoot);
 
   if (rc != 0)
     throw std::runtime_error("Error while calling getSysCatDBRoot");
@@ -2354,8 +2348,7 @@ void AlterTableProcessor::renameColumn(uint32_t sessionID, execplan::CalpontSyst
 
   int pmNum = 1;
   OamCache* oamcache = OamCache::makeOamCache();
-  boost::shared_ptr<std::map<int, int> > dbRootPMMap = oamcache->getDBRootToPMMap();
-  pmNum = (*dbRootPMMap)[dbRoot];
+  pmNum = oamcache->getOwnerPM(dbRoot);
   boost::shared_ptr<messageqcpp::ByteStream> bsIn;
 
   CalpontSystemCatalog::TableName tableName;
@@ -2539,7 +2532,7 @@ void AlterTableProcessor::renameColumn(uint32_t sessionID, execplan::CalpontSyst
     if (rc != 0)
       throw std::runtime_error("Error while calling getSysCatDBRoot");
 
-    pmNum = (*dbRootPMMap)[dbRoot];
+    pmNum = oamcache->getOwnerPM(dbRoot);
 
     // send to WES to process
     try

--- a/dbcon/ddlpackageproc/createtableprocessor.cpp
+++ b/dbcon/ddlpackageproc/createtableprocessor.cpp
@@ -326,8 +326,7 @@ CreateTableProcessor::DDLResult CreateTableProcessor::processPackageInternal(
     bytestream << (uint32_t)dbRoot;
     tableDef.serialize(bytestream);
     boost::shared_ptr<messageqcpp::ByteStream> bsIn;
-    boost::shared_ptr<std::map<int, int> > dbRootPMMap = oamcache->getDBRootToPMMap();
-    pmNum = (*dbRootPMMap)[dbRoot];
+    pmNum = oamcache->getOwnerPM(dbRoot);
     // MCOL-66 The DBRM can't handle concurrent DDL
     boost::mutex::scoped_lock lk(dbrmMutex);
 
@@ -450,7 +449,7 @@ CreateTableProcessor::DDLResult CreateTableProcessor::processPackageInternal(
 
     bytestream << (uint32_t)dbRoot;
     tableDef.serialize(bytestream);
-    pmNum = (*dbRootPMMap)[dbRoot];
+    pmNum = oamcache->getOwnerPM(dbRoot);
 
     try
     {
@@ -666,7 +665,7 @@ CreateTableProcessor::DDLResult CreateTableProcessor::processPackageInternal(
       return result;
     }
 
-    pmNum = (*dbRootPMMap)[useDBRoot];
+    pmNum = oamcache->getOwnerPM(useDBRoot);
 
     try
     {

--- a/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
+++ b/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
@@ -611,8 +611,7 @@ void DDLPackageProcessor::createFiles(CalpontSystemCatalog::TableName aTableName
   try
   {
     OamCache* oamcache = OamCache::makeOamCache();
-    boost::shared_ptr<std::map<int, int> > dbRootPMMap = oamcache->getDBRootToPMMap();
-    int pmNum = (*dbRootPMMap)[useDBRoot];
+    int pmNum = oamcache->getOwnerPM(useDBRoot);
 
     fWEClient->write(bytestream, (uint32_t)pmNum);
     bsIn.reset(new ByteStream());

--- a/dbcon/ddlpackageproc/droptableprocessor.cpp
+++ b/dbcon/ddlpackageproc/droptableprocessor.cpp
@@ -359,8 +359,7 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackageInternal(ddlpack
       return result;
     }
 
-    boost::shared_ptr<std::map<int, int> > dbRootPMMap = oamcache->getDBRootToPMMap();
-    pmNum = (*dbRootPMMap)[dbRoot];
+    pmNum = oamcache->getOwnerPM(dbRoot);
 
     try
     {
@@ -464,7 +463,7 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackageInternal(ddlpack
       return result;
     }
 
-    pmNum = (*dbRootPMMap)[dbRoot];
+    pmNum = oamcache->getOwnerPM(dbRoot);
 
     try
     {
@@ -1275,8 +1274,7 @@ TruncTableProcessor::DDLResult TruncTableProcessor::processPackageInternal(ddlpa
       bytestream << (uint32_t)colType.compressionType;
     }
 
-    boost::shared_ptr<std::map<int, int> > dbRootPMMap = oamcache->getDBRootToPMMap();
-    pmNum = (*dbRootPMMap)[useDBRoot];
+    pmNum = oamcache->getOwnerPM(useDBRoot);
 
     try
     {

--- a/dbcon/dmlpackageproc/commandpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/commandpackageprocessor.cpp
@@ -845,20 +845,15 @@ void CommandPackageProcessor::clearTableLock(uint64_t uniqueId, const dmlpackage
     establishTableLockToClear(tableLockID, lockInfo);
     lockGrabbed = true;
 
-    oam::OamCache* oamCache = oam::OamCache::makeOamCache();
-    oam::OamCache::dbRootPMMap_t dbRootPmMap = oamCache->getDBRootToPMMap();
-    std::map<int, int>::const_iterator mapIter;
     std::set<int> pmSet;
 
     // Construct relevant list of PMs based on the DBRoots associated
     // with the tableLock.
     for (unsigned int k = 0; k < lockInfo.dbrootList.size(); k++)
     {
-      mapIter = dbRootPmMap->find(lockInfo.dbrootList[k]);
-
-      if (mapIter != dbRootPmMap->end())
+      if (!oamcache()->isOffline(lockInfo.dbrootList[k]))
       {
-        int pm = mapIter->second;
+        int pm = oamcache()->getOwnerPM(lockInfo.dbrootList[k]);
         pmSet.insert(pm);
       }
       else

--- a/dbcon/dmlpackageproc/deletepackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/deletepackageprocessor.cpp
@@ -643,7 +643,7 @@ bool DeletePackageProcessor::processRowgroup(ByteStream& aRowGroup, DMLResult& r
 {
   bool rc = false;
   // cout << "Get dbroot " << dbroot << endl;
-  int pmNum = (*fDbRootPMMap)[dbroot];
+  int pmNum = oamcache()->getOwnerPM(dbroot);
   DMLTable* tablePtr = cpackage.get_Table();
   ByteStream bytestream;
   bytestream << (ByteStream::byte)WE_SVR_DELETE;

--- a/dbcon/dmlpackageproc/dmlpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/dmlpackageprocessor.cpp
@@ -350,7 +350,7 @@ int DMLPackageProcessor::rollBackTransaction(uint64_t uniqueId, BRM::TxnID txnID
 
     while (1)
     {
-      if (msgRecived == fWEClient->getPmCount())
+      if (msgRecived == fWEClient->getRWConnectionsCount())
         break;
 
       fWEClient->read(uniqueId, bsIn);

--- a/dbcon/dmlpackageproc/dmlpackageprocessor.h
+++ b/dbcon/dmlpackageproc/dmlpackageprocessor.h
@@ -165,8 +165,6 @@ class DMLPackageProcessor
       std::cout << "Cannot make connection to WES" << std::endl;
     }
 
-    oam::OamCache* oamCache = oam::OamCache::makeOamCache();
-    fDbRootPMMap = oamCache->getDBRootToPMMap();
     fDbrm = aDbrm;
     fSessionID = sid;
     fExeMgr = new execplan::ClientRotator(fSessionID, "ExeMgr");
@@ -489,6 +487,8 @@ class DMLPackageProcessor
                      uint32_t tableOid);
   int endTransaction(uint64_t uniqueId, BRM::TxnID txnID, bool success);
 
+  oam::OamCache* oamcache() { return oam::OamCache::makeOamCache(); }
+
   /** @brief the Session Manager interface
    */
   execplan::SessionManager fSessionManager;
@@ -500,8 +500,6 @@ class DMLPackageProcessor
   uint32_t fPMCount;
   WriteEngine::WEClients* fWEClient;
   BRM::DBRM* fDbrm;
-  boost::shared_ptr<std::map<int, int> > fDbRootPMMap;
-  oam::Oam fOam;
   bool fRollbackPending;  // When set, any derived object should stop what it's doing and cleanup in
                           // preparation for a Rollback
   execplan::ClientRotator* fExeMgr;

--- a/dbcon/dmlpackageproc/insertpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/insertpackageprocessor.cpp
@@ -275,8 +275,7 @@ DMLPackageProcessor::DMLResult InsertPackageProcessor::processPackageInternal(
       if (tmpSet)
       {
         dbroot = tmp.dbRoot;
-        boost::shared_ptr<std::map<int, int> > dbRootPMMap = oamcache->getDBRootToPMMap();
-        pmNum = (*dbRootPMMap)[dbroot];
+        pmNum = oamcache->getOwnerPM(dbroot);
 
         //@Bug 4760. validate pm value
         if (pmNum == 0)

--- a/dbcon/dmlpackageproc/updatepackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/updatepackageprocessor.cpp
@@ -161,8 +161,7 @@ DMLPackageProcessor::DMLResult UpdatePackageProcessor::processPackageInternal(
         int32_t sessionId = fSessionID;
         std::string processName("DMLProc");
         int i = 0;
-        OamCache* oamcache = OamCache::makeOamCache();
-        std::vector<int> pmList = oamcache->getModuleIds();
+        std::vector<int> pmList = oamcache()->getModuleIds();
         std::vector<uint32_t> pms;
 
         for (unsigned i = 0; i < pmList.size(); i++)
@@ -437,8 +436,7 @@ uint64_t UpdatePackageProcessor::fixUpRows(dmlpackage::CalpontDMLPackage& cpacka
   uint64_t rowsProcessed = 0;
   uint32_t dbroot = 1;
   bool metaData = false;
-  oam::OamCache* oamCache = oam::OamCache::makeOamCache();
-  std::vector<int> fPMs = oamCache->getModuleIds();
+  std::vector<int> fPMs = oamcache()->getModuleIds();
   std::map<unsigned, bool> pmState;
   string emsg;
   string emsgStr;
@@ -726,7 +724,7 @@ bool UpdatePackageProcessor::processRowgroup(ByteStream& aRowGroup, DMLResult& r
 {
   bool rc = false;
   // cout << "Get dbroot " << dbroot << endl;
-  uint32_t pmNum = (*fDbRootPMMap)[dbroot];
+  uint32_t pmNum = oamcache()->getOwnerPM(dbroot);
 
   ByteStream bytestream;
   bytestream << (uint8_t)WE_SVR_UPDATE;

--- a/dbcon/joblist/primitivestep.h
+++ b/dbcon/joblist/primitivestep.h
@@ -61,6 +61,7 @@
 #include "rowgroup.h"
 #include "rowaggregation.h"
 #include "funcexpwrapper.h"
+#include "oamcache.h"
 
 namespace joblist
 {
@@ -1458,7 +1459,7 @@ class TupleBPS : public BatchPrimitive, public TupleDeliveryStep
   uint32_t blocksPerJob;
 
   /* Pseudo column filter processing.  Think about refactoring into a separate class. */
-  bool processPseudoColFilters(uint32_t extentIndex, boost::shared_ptr<std::map<int, int>> dbRootPMMap) const;
+  bool processPseudoColFilters(uint32_t extentIndex, oam::OamCache* oamCache) const;
   template <typename T>
   bool processOneFilterType(int8_t colWidth, T value, uint32_t type) const;
   template <typename T>
@@ -1472,6 +1473,7 @@ class TupleBPS : public BatchPrimitive, public TupleDeliveryStep
   bool compareRange(uint8_t COP, int64_t min, int64_t max, int64_t val) const;
   bool hasPCFilter, hasPMFilter, hasRIDFilter, hasSegmentFilter, hasDBRootFilter, hasSegmentDirFilter,
       hasPartitionFilter, hasMaxFilter, hasMinFilter, hasLBIDFilter, hasExtentIDFilter;
+  int findClosestPM(const std::map<int, std::set<int>>& dbrootConnMap, int dbroot);
 };
 
 /** @brief class FilterStep

--- a/dbcon/mysql/is_columnstore_files.cpp
+++ b/dbcon/mysql/is_columnstore_files.cpp
@@ -33,6 +33,7 @@
 #include "we_brm.h"
 #include "bytestream.h"
 #include "liboamcpp.h"
+#include "oamcache.h"
 #include "messagequeue.h"
 #include "messagequeuepool.h"
 #include "we_messages.h"
@@ -119,7 +120,7 @@ static int generate_result(BRM::OID_t oid, BRM::DBRM* emp, TABLE* table, THD* th
   off_t compressedFileSize = 0;
   we_config.initConfigCache();
   messageqcpp::MessageQueueClient* msgQueueClient;
-  oam::Oam oam_instance;
+  oam::OamCache* oamcache = oam::OamCache::makeOamCache();
   int pmId = 0;
   int rc;
 
@@ -141,7 +142,7 @@ static int generate_result(BRM::OID_t oid, BRM::DBRM* emp, TABLE* table, THD* th
 
     try
     {
-      oam_instance.getDbrootPmConfig(iter->dbRoot, pmId);
+      pmId = oamcache->getOwnerPM(iter->dbRoot);
     }
     catch (std::runtime_error&)
     {

--- a/dmlproc/batchinsertprocessor.cpp
+++ b/dmlproc/batchinsertprocessor.cpp
@@ -230,6 +230,15 @@ void BatchInsertProc::buildLastPkg(messageqcpp::ByteStream& bs)
   bs << rt;
 }
 
+uint32_t BatchInsertProc::selectNextPM()
+{
+  uint32_t pm;
+  do
+  {
+    pm = fBatchLoader->selectNextPM();
+  } while (pm != 0 && fWEClient->isConnectionReadonly(pm));
+  return pm;
+}
 void BatchInsertProc::sendFirstBatch()
 {
   uint32_t firstPmId = 0;
@@ -237,7 +246,7 @@ void BatchInsertProc::sendFirstBatch()
 
   try
   {
-    firstPmId = fBatchLoader->selectNextPM();
+    firstPmId = selectNextPM();
   }
   catch (std::exception& ex)
   {
@@ -268,7 +277,7 @@ void BatchInsertProc::sendNextBatch()
 
   try
   {
-    fCurrentPMid = fBatchLoader->selectNextPM();
+    fCurrentPMid = selectNextPM();
   }
   catch (std::exception& ex)
   {

--- a/dmlproc/batchinsertprocessor.h
+++ b/dmlproc/batchinsertprocessor.h
@@ -68,6 +68,7 @@ class BatchInsertProc
   void setHwm();
   void receiveAllMsg();
   void receiveOutstandingMsg();
+  uint32_t selectNextPM();
 
  private:
   SP_PKG fInsertPkgQueue;

--- a/dmlproc/dmlproc.cpp
+++ b/dmlproc/dmlproc.cpp
@@ -253,7 +253,6 @@ void rollbackAll(DBRM* dbrm)
   message5.format(args5);
   ml.logInfoMessage(message5);
   OamCache* oamcache = OamCache::makeOamCache();
-  OamCache::dbRootPMMap_t dbRootPMMap = oamcache->getDBRootToPMMap();
   int errorTxn = 0;
 
   for (i = 0; i < tableLocks.size(); i++)
@@ -393,7 +392,7 @@ void rollbackAll(DBRM* dbrm)
 
       try
       {
-        rollbackProcessor.processBulkRollback(tableLocks[i], dbrm, uniqueId, dbRootPMMap, lockReleased);
+        rollbackProcessor.processBulkRollback(tableLocks[i], dbrm, uniqueId, oamcache, lockReleased);
         ostringstream oss;
         oss << "DMLProc started bulkrollback on table OID " << tableLocks[i].tableOID << " and table lock id "
             << tableLocks[i].id << " finished and tablelock is released.";

--- a/dmlproc/dmlprocessor.cpp
+++ b/dmlproc/dmlprocessor.cpp
@@ -1155,8 +1155,6 @@ void PackageHandler::run()
     logging::Message message(1);
     args.add("dmlprocessor.cpp PackageHandler::run() package type");
     args.add((uint64_t)fPackageType);
-    args.add(" ,transaction ID: ");
-    args.add(fTxnid);
     args.add(e.what());
     message.format(args);
     ml.logErrorMessage(message);
@@ -1404,7 +1402,9 @@ void DMLProcessor::operator()()
       messageqcpp::ByteStream::byte status = 255;
       messageqcpp::ByteStream::octbyte rowCount = 0;
 
-      if (fDbrm->getSystemState(stateFlags) >
+      int rr = fDbrm->getSystemState(stateFlags);
+
+      if (rr >
           0)  // > 0 implies succesful retrieval. It doesn't imply anything about the contents
       {
         messageqcpp::ByteStream results;
@@ -1845,7 +1845,7 @@ void DMLProcessor::operator()()
 
 void RollbackTransactionProcessor::processBulkRollback(BRM::TableLockInfo lockInfo, BRM::DBRM* dbrm,
                                                        uint64_t uniqueId,
-                                                       OamCache::dbRootPMMap_t& dbRootPMMap,
+                                                       OamCache* oamcache,
                                                        bool& lockReleased)
 {
   // Take over ownership of stale lock.
@@ -1884,7 +1884,7 @@ void RollbackTransactionProcessor::processBulkRollback(BRM::TableLockInfo lockIn
 
   for (uint32_t i = 0; i < lockInfo.dbrootList.size(); i++)
   {
-    pmId = (*dbRootPMMap)[lockInfo.dbrootList[i]];
+    pmId = oamcache->getOwnerPM(lockInfo.dbrootList[i]);
     pmSet.insert(pmId);
   }
 

--- a/dmlproc/dmlprocessor.h
+++ b/dmlproc/dmlprocessor.h
@@ -321,7 +321,7 @@ class RollbackTransactionProcessor : public dmlpackageprocessor::DMLPackageProce
   }
 
   void processBulkRollback(BRM::TableLockInfo lockInfo, BRM::DBRM* dbrm, uint64_t uniqueId,
-                           oam::OamCache::dbRootPMMap_t& dbRootPMMap, bool& lockReleased);
+                           oam::OamCache* oamcache, bool& lockReleased);
 
  protected:
  private:

--- a/oam/oamcpp/liboamcpp.cpp
+++ b/oam/oamcpp/liboamcpp.cpp
@@ -684,11 +684,13 @@ void Oam::getPmDbrootConfig(const int pmid, DBRootConfigList& dbrootconfiglist)
  * Get DBRoot - PM Config data
  *
  ********************************************************************/
-void Oam::getDbrootPmConfig(const int dbrootid, int& pmid)
+void Oam::getDbrootPmConfig(const int dbrootid, set<int>& pmids)
 {
   SystemModuleTypeConfig systemmoduletypeconfig;
   ModuleTypeConfig moduletypeconfig;
   ModuleConfig moduleconfig;
+
+  pmids.clear();
 
   try
   {
@@ -716,12 +718,15 @@ void Oam::getDbrootPmConfig(const int dbrootid, int& pmid)
           {
             if (*pt1 == dbrootid)
             {
-              pmid = (*pt).DeviceID;
-              return;
+              pmids.insert((*pt).DeviceID);
             }
           }
         }
       }
+    }
+    if (!pmids.empty())
+    {
+      return;
     }
 
     // dbrootid not found, return with error

--- a/oam/oamcpp/liboamcpp.h
+++ b/oam/oamcpp/liboamcpp.h
@@ -384,7 +384,7 @@ class Oam
   /**
    *@brief Get DBRoot - PM Config data
    */
-  EXPORT void getDbrootPmConfig(const int dbrootid, int& pmid);
+  EXPORT void getDbrootPmConfig(const int dbrootid, set<int>& pmid);
 
   /**
    *@brief Get System DBRoot Config data

--- a/oam/oamcpp/oamcache.cpp
+++ b/oam/oamcpp/oamcache.cpp
@@ -39,7 +39,6 @@ using namespace boost;
 namespace oam
 {
 
-
 struct CacheReloaded
 {
   CacheReloaded()
@@ -56,11 +55,20 @@ OamCache* OamCache::makeOamCache()
   return &cache.oamcache;
 }
 
+static bool isWESConfigured(config::Config* config, int moduleID)
+{
+  char buff[200];
+  snprintf(buff, sizeof(buff), "pm%u_WriteEngineServer", moduleID);
+  string fServer(buff);
+  // Check if WES IP address record exists in the config (if not, this is a read-only node)
+  std::string otherEndDnOrIPStr = config->getConfig(fServer, "IPAddr");
+  return !(otherEndDnOrIPStr.empty() || otherEndDnOrIPStr == "unassigned");
+}
 void OamCache::checkReload()
 {
   Oam oam;
   config::Config* config = config::Config::makeConfig();
-  int temp;
+  set<int> temp;
 
   if (config->getCurrentMTime() == mtime)
     return;
@@ -73,7 +81,7 @@ void OamCache::checkReload()
   idbassert(txt != "");
   numDBRoots = config->fromText(txt);
 
-  dbRootPMMap.reset(new map<int, int>());
+  dbRootPMMap.reset(new map<int, set<int>>());
 
   // cerr << "reloading oamcache\n";
   for (uint32_t i = 0; i < dbroots.size(); i++)
@@ -88,37 +96,30 @@ void OamCache::checkReload()
   oam.getSystemConfig("pm", moduletypeconfig);
   int moduleID = 0;
 
+  rwPMs.clear();
   for (unsigned i = 0; i < moduletypeconfig.ModuleCount; i++)
   {
     moduleID = atoi((moduletypeconfig.ModuleNetworkList[i])
                         .DeviceName.substr(MAX_MODULE_TYPE_SIZE, MAX_MODULE_ID_SIZE)
                         .c_str());
     uniquePids.insert(moduleID);
+    if (isWESConfigured(config, moduleID))
+    {
+      rwPMs.insert(moduleID);
+    }
   }
 
   std::set<int>::const_iterator it = uniquePids.begin();
   moduleIds.clear();
   uint32_t i = 0;
-  map<int, int> pmToConnectionMap;
+  pmConnectionMap.clear();
 
   // Restore for Windows when we support multiple PMs
   while (it != uniquePids.end())
   {
-    pmToConnectionMap[*it] = i++;
+    pmConnectionMap[*it] = i++;
     moduleIds.push_back(*it);
     it++;
-  }
-
-  dbRootConnectionMap.reset(new map<int, int>());
-
-  for (i = 0; i < dbroots.size(); i++)
-  {
-    map<int, int>::iterator pmIter = pmToConnectionMap.find((*dbRootPMMap)[dbroots[i]]);
-
-    if (pmIter != pmToConnectionMap.end())
-    {
-      (*dbRootConnectionMap)[dbroots[i]] = (*pmIter).second;
-    }
   }
 
   pmDbrootsMap.reset(new OamCache::PMDbrootsMap_t::element_type());
@@ -142,21 +143,18 @@ void OamCache::checkReload()
   tm = oam.getModuleInfo();
   OAMParentModuleName = boost::get<3>(tm);
   systemName = config->getConfig("SystemConfig", "SystemName");
-}
+  dbRootConnectionMap.clear();
 
-OamCache::dbRootPMMap_t OamCache::getDBRootToPMMap()
-{
-  return dbRootPMMap;
-}
+  for (i = 0; i < dbroots.size(); i++)
+  {
+    auto pmIter = pmConnectionMap.find(getOwnerPM(dbroots[i]));
 
-OamCache::dbRootPMMap_t OamCache::getDBRootToConnectionMap()
-{
-  return dbRootConnectionMap;
-}
+    if (pmIter != pmConnectionMap.end())
+    {
+      dbRootConnectionMap[dbroots[i]] = (*pmIter).second;
+    }
+  }
 
-OamCache::PMDbrootsMap_t OamCache::getPMToDbrootsMap()
-{
-  return pmDbrootsMap;
 }
 
 uint32_t OamCache::getDBRootCount()
@@ -235,6 +233,79 @@ string OamCache::getModuleName()
   moduleFile.close();
 
   return moduleName;
+}
+
+bool OamCache::isAccessibleBy(int dbRoot, int pmId)
+{
+  return (*dbRootPMMap)[dbRoot].contains(pmId);
+}
+
+bool OamCache::isOffline(int dbRoot)
+{
+  return dbRootConnectionMap.find(dbRoot) == dbRootConnectionMap.end();
+}
+
+int OamCache::getClosestPM(int dbroot) // who can access dbroot's records for read requests - either owner or us.
+{
+  if ((*dbRootPMMap)[dbroot].contains(mLocalPMId))
+  {
+    return mLocalPMId;
+  }
+  for(auto j : (*dbRootPMMap)[dbroot])
+  {
+    int pm = j;
+    if (rwPMs.contains(pm))
+    {
+      return pm;
+    }
+  }
+  idbassert_s(0, "dbroot " << dbroot << " has empty set of PM's");
+}
+
+int OamCache::getClosestConnection(int dbroot) // connection index to owner's PM or ours PM - who can access dbRoot.
+{
+  return pmConnectionMap[getClosestPM(dbroot)];
+}
+
+int OamCache::getOwnerConnection(int dbroot) // connection index to owner's PM.
+{
+  return pmConnectionMap[getOwnerPM(dbroot)];
+}
+
+int OamCache::getOwnerPM(int dbroot) // Owner's PM index.
+{
+  for(auto j : (*dbRootPMMap)[dbroot])
+  {
+    int pm = j;
+    if (rwPMs.contains(pm))
+    {
+      return pm;
+    }
+  }
+  idbassert_s(0, "cannot find owner for dbroot " << dbroot);
+}
+
+std::vector<int> OamCache::getPMDBRoots(int PM) // what DBRoots are owned by given PM.
+{
+  std::vector<int> result;
+  for (const auto& dbroot : (*dbRootPMMap))
+  {
+    if (dbroot.second.find(PM) != dbroot.second.end())
+    {
+      result.push_back(dbroot.first);
+    }
+  }
+  return result;
+}
+
+std::vector<int> OamCache::getAllDBRoots() // get all DBRoots.
+{
+  std::vector<int> result;
+  for (const auto& dbroot : (*dbRootPMMap))
+  {
+    result.push_back(dbroot.first);
+  }
+  return result;
 }
 
 } /* namespace oam */

--- a/oam/oamcpp/oamcache.h
+++ b/oam/oamcpp/oamcache.h
@@ -20,6 +20,7 @@
 
 #include <unistd.h>
 #include <map>
+#include <set>
 #include <vector>
 #include <boost/shared_ptr.hpp>
 
@@ -31,7 +32,7 @@ namespace oam
 class OamCache
 {
  public:
-  typedef boost::shared_ptr<std::map<int, int> > dbRootPMMap_t;
+  typedef boost::shared_ptr<std::map<int, std::set<int>> > dbRootPMMap_t;
   typedef std::vector<int> dbRoots;
   typedef boost::shared_ptr<std::map<int, dbRoots> > PMDbrootsMap_t;
   virtual ~OamCache() = default;
@@ -42,9 +43,14 @@ class OamCache
     mtime = 0;
   }
 
-  dbRootPMMap_t getDBRootToPMMap();
-  dbRootPMMap_t getDBRootToConnectionMap();
-  PMDbrootsMap_t getPMToDbrootsMap();
+  int getClosestPM(int dbroot); // who can access dbroot's records for read requests - either owner or us.
+  int getClosestConnection(int dbroot); // connection index to owner's PM or ours PM - who can access dbRoot.
+  int getOwnerConnection(int dbroot); // connection index to owner's PM.
+  int getOwnerPM(int dbroot); // Owner's PM index.
+  std::vector<int> getPMDBRoots(int PM); // what DBRoots are owned by given PM.
+  std::vector<int> getAllDBRoots(); // get all DBRoots.
+  bool isAccessibleBy(int dbRoot, int pmId);
+  bool isOffline(int dbRoot); // not registered in map.
   uint32_t getDBRootCount();
   DBRootConfigList& getDBRootNums();
   std::vector<int>& getModuleIds();
@@ -61,7 +67,7 @@ class OamCache
   OamCache& operator=(const OamCache&) const = delete;
 
   dbRootPMMap_t dbRootPMMap;
-  dbRootPMMap_t dbRootConnectionMap;
+  map<int, int> dbRootConnectionMap;
   PMDbrootsMap_t pmDbrootsMap;
   uint32_t numDBRoots = 1;
   time_t mtime = 0;
@@ -71,6 +77,8 @@ class OamCache
   int mLocalPMId = 0;  // The PM id running on this machine
   std::string systemName;
   std::string moduleName;
+  map<int, int> pmConnectionMap;
+  set<int> rwPMs;
 };
 
 }  // namespace oam

--- a/tools/cleartablelock/cleartablelock.cpp
+++ b/tools/cleartablelock/cleartablelock.cpp
@@ -159,19 +159,22 @@ int constructPMList(const std::vector<uint32_t>& dbRootList, std::vector<uint32_
     // Get OAM information
     oam::Oam oam;
     std::set<uint32_t> pmSet;  // used to filter out duplicates
-    int pm;
+    std::set<int> pms;
 
     for (unsigned j = 0; j < dbRootList.size(); j++)
     {
       dbRoot = dbRootList[j];
-      oam.getDbrootPmConfig(dbRootList[j], pm);
-      pmSet.insert(pm);
+      oam.getDbrootPmConfig(dbRootList[j], pms);
+      for (auto pm : pms)
+      {
+        pmSet.insert(pm);
+      }
     }
 
     // Store unique set of PM IDs into output vector
-    for (std::set<uint32_t>::const_iterator iter = pmSet.begin(); iter != pmSet.end(); ++iter)
+    for (auto pm : pmSet)
     {
-      pmList.push_back(*iter);
+      pmList.push_back(pm);
     }
   }
   catch (std::exception& ex)

--- a/utils/batchloader/batchloader.h
+++ b/utils/batchloader/batchloader.h
@@ -119,8 +119,7 @@ class BatchLoader
   uint32_t fFirstPm;
   execplan::CalpontSystemCatalog::SCN fSessionId;
   uint32_t fTableOid;
-  oam::OamCache::PMDbrootsMap_t fPmDbrootMap;
-  oam::OamCache::dbRootPMMap_t fDbrootPMmap;
+  oam::OamCache* fOamCache;
 };
 
 }  // namespace batchloader

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -4144,13 +4144,12 @@ uint64_t DBRM::getTableLock(const vector<uint32_t>& pmList, uint32_t tableOID, s
   uint32_t tmp32;
   vector<uint32_t> dbRootsList;
   OamCache* oamcache = OamCache::makeOamCache();
-  OamCache::PMDbrootsMap_t pmDbroots = oamcache->getPMToDbrootsMap();
   int moduleId = 0;
 
   for (uint32_t i = 0; i < pmList.size(); i++)
   {
     moduleId = pmList[i];
-    vector<int> dbroots = (*pmDbroots)[moduleId];
+    vector<int> dbroots = oamcache->getPMDBRoots(moduleId);
 
     for (uint32_t j = 0; j < dbroots.size(); j++)
       dbRootsList.push_back((uint32_t)dbroots[j]);

--- a/versioning/BRM/extentmap.cpp
+++ b/versioning/BRM/extentmap.cpp
@@ -1826,7 +1826,7 @@ void ExtentMap::save(const string& filename)
 
   if (!out)
   {
-    log_errno("ExtentMap::save(): can't open file " + filename);
+    log_errno("ExtentMap::save(): open");
     releaseFreeList(READ);
     releaseEMIndex(READ);
     releaseEMEntryTable(READ);
@@ -4541,7 +4541,7 @@ void ExtentMap::getDbRootHWMInfo(int OID, uint16_t pmNumber, EmDbRootHWMInfo_v& 
            "There are no DBRoots for OID "
         << OID << " and PM " << pmNumber << endl;
     log(oss.str(), logging::LOG_TYPE_CRITICAL);
-    throw invalid_argument(oss.str());
+    // previously it was logic error with invalid_argument(oss.str()) exception.
   }
 
   grabEMEntryTable(READ);
@@ -6178,10 +6178,8 @@ unsigned ExtentMap::getDbRootCount()
 void ExtentMap::getPmDbRoots(int pm, vector<int>& dbRootVec)
 {
   oam::OamCache* oamcache = oam::OamCache::makeOamCache();
-  oam::OamCache::PMDbrootsMap_t pmDbroots = oamcache->getPMToDbrootsMap();
 
-  dbRootVec.clear();
-  dbRootVec = (*pmDbroots)[pm];
+  dbRootVec = oamcache->getPMDBRoots(pm);
 }
 
 DBRootVec ExtentMap::getAllDbRoots()
@@ -6189,13 +6187,11 @@ DBRootVec ExtentMap::getAllDbRoots()
   DBRootVec dbRootResultVec;
   oam::OamCache* oamcache = oam::OamCache::makeOamCache();
   // NB The routine uses int for dbroot id that contradicts with the type used here, namely uint16_t
-  oam::OamCache::PMDbrootsMap_t pmDbroots = oamcache->getPMToDbrootsMap();
-  auto& pmDbrootsRef = *pmDbroots;
+  auto pmDbroots = oamcache->getAllDBRoots();
 
-  for (auto& pmDBRootPair : pmDbrootsRef)
+  for (auto& DBRoot : pmDbroots)
   {
-    for (auto dbRootId : pmDBRootPair.second)
-      dbRootResultVec.push_back(dbRootId);
+    dbRootResultVec.push_back(DBRoot);
   }
   return dbRootResultVec;
 }

--- a/writeengine/client/we_clients.cpp
+++ b/writeengine/client/we_clients.cpp
@@ -154,6 +154,21 @@ struct QueueShutdown
     x.shutdown();
   }
 };
+
+/**
+ * This function checks if the WriteEngineServer (WES) is configured
+ * for the specified node in the configuration.
+ * @param config Pointer to the configuration object
+ * @param fOtherEnd The name of the node to check
+ * @return true if WES is configured, false otherwise
+ */
+bool isWESConfigured(config::Config* config, const std::string& fOtherEnd)
+{
+  // Check if WES IP address record exists in the config (if not, this is a read-only node)
+  std::string otherEndDnOrIPStr = config->getConfig(fOtherEnd, "IPAddr");
+  return !(otherEndDnOrIPStr.empty() || otherEndDnOrIPStr == "unassigned");
+}
+
 }  // namespace
 
 namespace WriteEngine
@@ -224,6 +239,13 @@ void WEClients::Setup()
     snprintf(buff, sizeof(buff), "pm%u_WriteEngineServer", moduleID);
     string fServer(buff);
 
+    // Check if WES is configured for this module
+    if (!isWESConfigured(rm->getConfig(), fServer))
+    {
+      writeToLog(__FILE__, __LINE__, "Skipping WriteEngineServer client creation for " + fServer + " as the node is read-only", LOG_TYPE_INFO);
+      continue;
+    }
+
     boost::shared_ptr<MessageQueueClient> cl(new MessageQueueClient(fServer, rm->getConfig()));
     boost::shared_ptr<boost::mutex> nl(new boost::mutex());
 
@@ -285,6 +307,11 @@ void WEClients::Setup()
       writeToLog(__FILE__, __LINE__, "Could not connect to " + fServer, LOG_TYPE_ERROR);
     }
   }
+}
+
+bool WEClients::isConnectionReadonly(uint32_t connection)
+{
+  return fPmConnections[connection] == nullptr;
 }
 
 int WEClients::Close()

--- a/writeengine/client/we_clients.cpp
+++ b/writeengine/client/we_clients.cpp
@@ -505,8 +505,9 @@ void WEClients::write(const messageqcpp::ByteStream& msg, uint32_t connection)
     fPmConnections[connection]->write(msg);
   else
   {
+    // new behavior: connection client is nullptr means it is read-only.
     ostringstream os;
-    os << "Lost connection to WriteEngineServer on pm" << connection;
+    os << "Connection to readonly pm" << connection;
     throw runtime_error(os.str());
   }
 }

--- a/writeengine/client/we_clients.h
+++ b/writeengine/client/we_clients.h
@@ -114,6 +114,18 @@ class WEClients
     return pmCount;
   }
 
+  uint32_t getRWConnectionsCount()
+  {
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < fPmConnections.size(); i++)
+    {
+      count += fPmConnections[i] != nullptr;
+    }
+    return count;
+  }
+
+  bool isConnectionReadonly(uint32_t connection);
+
  private:
   WEClients(const WEClients& weClient);
   WEClients& operator=(const WEClients& weClient);

--- a/writeengine/client/we_ddlcommandclient.cpp
+++ b/writeengine/client/we_ddlcommandclient.cpp
@@ -37,6 +37,7 @@ namespace WriteEngine
 WE_DDLCommandClient::WE_DDLCommandClient()
 {
   fWEClient = new WEClients(WEClients::DDLPROC);
+  fOamCache = oam::OamCache::makeOamCache();
 }
 
 WE_DDLCommandClient::~WE_DDLCommandClient()
@@ -64,7 +65,7 @@ uint8_t WE_DDLCommandClient::UpdateSyscolumnNextval(uint32_t columnOid, uint64_t
 
   try
   {
-    fOam.getDbrootPmConfig(dbRoot, pmNum);
+    pmNum = fOamCache->getOwnerPM(dbRoot);
     fWEClient->write(command, pmNum);
 
     while (1)

--- a/writeengine/client/we_ddlcommandclient.h
+++ b/writeengine/client/we_ddlcommandclient.h
@@ -26,6 +26,7 @@
 #include "dbrm.h"
 #include "liboamcpp.h"
 #include "writeengine.h"
+#include "oamcache.h"
 
 #define EXPORT
 
@@ -50,7 +51,7 @@ class WE_DDLCommandClient
  private:
   BRM::DBRM fDbrm;
   WEClients* fWEClient;
-  oam::Oam fOam;
+  oam::OamCache* fOamCache;
 };
 
 }  // namespace WriteEngine

--- a/writeengine/redistribute/we_redistributecontrolthread.cpp
+++ b/writeengine/redistribute/we_redistributecontrolthread.cpp
@@ -758,8 +758,7 @@ int RedistributeControlThread::executeRedistributePlan()
 int RedistributeControlThread::connectToWes(int dbroot)
 {
   int ret = 0;
-  OamCache::dbRootPMMap_t dbrootToPM = fOamCache->getDBRootToPMMap();
-  int pmId = (*dbrootToPM)[dbroot];
+  int pmId = fOamCache->getOwnerPM(dbroot);
   ostringstream oss;
   oss << "pm" << pmId << "_WriteEngineServer";
 

--- a/writeengine/redistribute/we_redistributeworkerthread.cpp
+++ b/writeengine/redistribute/we_redistributeworkerthread.cpp
@@ -134,11 +134,10 @@ void RedistributeWorkerThread::handleRequest()
       {
         memcpy(&fPlanEntry, fBs.buf(), sizeof(RedistributePlanEntry));
         fBs.advance(sizeof(RedistributePlanEntry));
-        OamCache::dbRootPMMap_t dbrootToPM = fOamCache->getDBRootToPMMap();
         fMyId.first = fPlanEntry.source;
-        fMyId.second = (*dbrootToPM)[fMyId.first];
+        fMyId.second = fOamCache->getOwnerPM(fMyId.first);
         fPeerId.first = fPlanEntry.destination;
-        fPeerId.second = (*dbrootToPM)[fPeerId.first];
+        fPeerId.second = fOamCache->getOwnerPM(fPeerId.first);
 
         if (grabTableLock() == 0)
         {

--- a/writeengine/shared/we_define.cpp
+++ b/writeengine/shared/we_define.cpp
@@ -154,7 +154,7 @@ WErrorCodes::WErrorCodes() : fErrorCodes()
   fErrorCodes[ERR_BULK_SEND_MSG_ERR] = " in a bulk load send msg";
   fErrorCodes[ERR_BULK_MISSING_EXTENT_ENTRY] = " missing Extent Entry when trying to save LBID info for CP";
   fErrorCodes[ERR_BULK_MISSING_EXTENT_ROW] = " missing Extent Row when trying to save LBID info for CP";
-  fErrorCodes[ERR_BULK_ROW_FILL_BUFFER] = " Single row fills read buffer; try larger read buffer via -c flag in cpimport";
+  fErrorCodes[ERR_BULK_ROW_FILL_BUFFER] = " Single row fills read buffer; try larger read buffer.";
   fErrorCodes[ERR_BULK_DBROOT_CHANGE] = " Local PM DBRoot settings changed during bulk load.";
   fErrorCodes[ERR_BULK_ROLLBACK_MISS_ROOT] = " Mode3 automatic rollback not performed. DBRoot missing.";
   fErrorCodes[ERR_BULK_ROLLBACK_SEG_LIST] = " Error building segment file list in a directory.";
@@ -284,7 +284,8 @@ std::string WErrorCodes::errorString(int code)
     case ERR_FILE_DISK_SPACE:
     {
       logging::Message::Args args;
-      args.add("configured by WriteEngine.MaxFileSystemDiskUsagePct in Columnstore.xml");
+      std::string msgArg;  // empty str arg; no extra info in this context
+      args.add(msgArg);
       return logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_EXTENT_DISK_SPACE, args);
       break;
     }


### PR DESCRIPTION
@drrtuy requested a new mode to be implemented: coordinator-only mode is almost identical to read-only mode, but it doesn't add dbroots of other nodes to the node.
So this new mode it is a subset of functionality of read-only mode. To avoid over-complicating everything, i added a new parameter `add_other_nodes_dbroots` to `add_node`, it is true by default.
So 
read_only=false and add_other_nodes_dbroots=false --> normal mode
read_only=true and add_other_nodes_dbroots=true --> read_only mode
read_only=true and add_other_nodes_dbroots=false --> coordinator_only mode
read_only=false and add_other_nodes_dbroots=true --> invalid combination, will raise an exception