### PR TITLE
MCOL-6098: Add vanilla rockylinux with gcc-8.5 to CI

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -16,33 +16,43 @@ local platforms_arm = {
 };
 
 local builddir = "verylongdirnameforverystrangecpackbehavior";
+
+local get_build_command(command) = "bash /mdb/" + builddir + "/storage/columnstore/columnstore/build/" + command + " ";
+
+local clang(version) = [get_build_command("install_clang_deb.sh " + version),
+                        get_build_command("update-clang-version.sh " + version + " 100"),
+                        get_build_command("install_libc++.sh " + version),
+                        "export CC=/usr/bin/clang",
+                        "export CXX=/usr/bin/clang++"
+                        ];
+
 local customEnvCommandsMap = {
-  // 'clang-18': ["bash /mdb/" + builddir + "/storage/columnstore/columnstore/build/install_clang_deb.sh 18"],
-  "clang-20": ["bash /mdb/" + builddir + "/storage/columnstore/columnstore/build/install_clang_deb.sh 20"],
+  "clang-20": clang("20"),
 };
 
 local customEnvCommands(envkey, builddir) =
-  local updateAlternatives = {
-    "clang-20": ["bash /mdb/" + builddir +
-                 "/storage/columnstore/columnstore/build/update-clang-version.sh 20 100"],
-  };
   (if (std.objectHas(customEnvCommandsMap, envkey))
-   then customEnvCommandsMap[envkey] + updateAlternatives[envkey] else []);
+   then customEnvCommandsMap[envkey] else []);
 
 
 local customBootstrapParamsForExisitingPipelines(envkey) =
   local customBootstrapMap = {
-    "ubuntu:24.04": "--custom-cmake-flags '-DCOLUMNSTORE_ASAN_FOR_UNITTESTS=YES'",
+//    "ubuntu:24.04": "--custom-cmake-flags '-DCOLUMNSTORE_ASAN_FOR_UNITTESTS=YES'",
   };
   (if (std.objectHas(customBootstrapMap, envkey))
    then customBootstrapMap[envkey] else "");
 
 local customBootstrapParamsForAdditionalPipelinesMap = {
-  ASAN: "--asan",
+  ASan: "--asan",
   TSAN: "--tsan",
-  UBSAN: "--ubsan",
+  UBSan: "--ubsan",
+  MSan: "--msan",
+  "libcpp": "--libcpp",
 };
 
+local customBuildFlags(buildKey) =
+  (if (std.objectHas(customBootstrapParamsForAdditionalPipelinesMap, buildKey))
+   then customBootstrapParamsForAdditionalPipelinesMap[buildKey] else "");
 
 local any_branch = "**";
 
@@ -83,7 +93,7 @@ local make_clickable_link(link) = "echo -e '\\e]8;;" +  link + "\\e\\\\" +  link
 local echo_running_on = ["echo running on ${DRONE_STAGE_MACHINE}",
       make_clickable_link("https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Instances:search=:${DRONE_STAGE_MACHINE};v=3;$case=tags:true%5C,client:false;$regex=tags:false%5C,client:false;sort=desc:launchTime")];
 
-local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", customBootstrapParams="", customBuildEnvCommandsMapKey="") = {
+local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", customBootstrapParamsKey="", customBuildEnvCommandsMapKey="") = {
   local pkg_format = if (std.split(platform, ":")[0] == "rockylinux") then "rpm" else "deb",
   local img = if (platform == "rockylinux:8") then platform else "detravi/" + std.strReplace(platform, "/", "-"),
   local branch_ref = if (branch == any_branch) then current_branch else branch,
@@ -91,7 +101,9 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
   local branchp = if (branch == "**") then "" else branch + "/",
   local brancht = if (branch == "**") then "" else branch + "-",
   local platformKey = std.strReplace(std.strReplace(platform, ":", ""), "/", "-"),
-  local result = platformKey + if customBuildEnvCommandsMapKey != "" then "_" + customBuildEnvCommandsMapKey else "",
+  local result = platformKey +
+     (if customBuildEnvCommandsMapKey != "" then "_" + customBuildEnvCommandsMapKey else "") +
+     (if customBootstrapParamsKey != "" then "_" + customBootstrapParamsKey else ""),
 
   local packages_url = "https://cspkg.s3.amazonaws.com/" + branchp + event + "/${DRONE_BUILD_NUMBER}/" + server,
   local publish_pkg_url = "https://cspkg.s3.amazonaws.com/index.html?prefix=" + branchp + event + "/${DRONE_BUILD_NUMBER}/" + server + "/" + arch + "/" + result + "/",
@@ -187,15 +199,17 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
   local getContainerName(stepname) = stepname + "$${DRONE_BUILD_NUMBER}",
 
   local prepareTestContainer(containerName, result, do_setup) =
-    'sh -c "apk add bash && bash /mdb/' + builddir + "/storage/columnstore/columnstore/build/prepare_test_container.sh" +
+    'sh -c "apk add bash && ' + get_build_command("prepare_test_container.sh") +
     " --container-name " + containerName +
     " --docker-image " + img +
     " --result-path " + result +
     " --packages-url " + packages_url +
-    " --do-setup " + std.toString(do_setup) + '"',
+    " --do-setup " + std.toString(do_setup) +
+    if result=="ubuntu24.04_clang-20_libcpp" then "" else " --install-libcpp " +     //FIX THIS HACK
+    '"',
 
   local reportTestStage(containerName, result, stage) =
-    'sh -c "apk add bash && bash /mdb/' + builddir + '/storage/columnstore/columnstore/build/report_test_stage.sh' +
+    'sh -c "apk add bash && ' + get_build_command("report_test_stage.sh") +
     ' --container-name ' + containerName +
     ' --result-path ' + result +
     ' --stage ' + stage + '"',
@@ -218,7 +232,7 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
     volumes: [pipeline._volumes.mdb, pipeline._volumes.docker],
     commands: [
       prepareTestContainer(getContainerName("smoke"), result, true),
-      "bash /mdb/" + builddir + "/storage/columnstore/columnstore/build/run_smoke.sh" +
+      get_build_command("run_smoke.sh") +
       ' --container-name ' + getContainerName("smoke"),
     ],
   },
@@ -290,7 +304,8 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
       prepareTestContainer(getContainerName("mtr"), result, true),
       'MTR_SUITE_LIST=$([ "$MTR_FULL_SUITE" == true ] && echo "' + mtr_full_set + '" || echo "$MTR_SUITE_LIST")',
 
-      'apk add bash && bash /mdb/' + builddir + '/storage/columnstore/columnstore/build/run_mtr.sh' +
+      'apk add bash &&' +
+      get_build_command("run_mtr.sh") +
       ' --container-name ' + getContainerName("mtr") +
       ' --distro ' + platform +
       ' --suite-list $${MTR_SUITE_LIST}' +
@@ -334,7 +349,8 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
       "export REGRESSION_REF=$${REGRESSION_REF:-$$REGRESSION_REF_AUX}",
       'echo "$$REGRESSION_REF"',
 
-      "apk add bash && bash /mdb/" + builddir + "/storage/columnstore/columnstore/build/run_regression.sh" +
+      "apk add bash && " +
+      get_build_command("run_regression.sh") +
       " --container-name " + getContainerName("regression") +
       " --test-name " + name +
       " --distro " + platform +
@@ -415,8 +431,8 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
     },
     commands: [
       prepareTestContainer(getContainerName("cmapi"), result, true),
-
-      "apk add bash && bash /mdb/" + builddir + "/storage/columnstore/columnstore/build/run_cmapi_test.sh" +
+      "apk add bash && " +
+      get_build_command("run_cmapi_test.sh") +
       " --container-name " + getContainerName("cmapi") +
       " --pkg-format " + pkg_format,
     ],
@@ -449,16 +465,16 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
     },
     commands: [
       "echo $$DOCKER_PASSWORD | docker login --username $$DOCKER_LOGIN --password-stdin",
-
-      "apk add bash && bash /mdb/" + builddir + "/storage/columnstore/columnstore/build/run_multi_node_mtr.sh " +
-      "--columnstore-image-name $${MCS_IMAGE_NAME} " +
-      "--distro " + platform,
+      "apk add bash && " +
+      get_build_command("run_multi_node_mtr.sh") +
+      " --columnstore-image-name $${MCS_IMAGE_NAME} " +
+      " --distro " + platform,
     ],
   },
 
   kind: "pipeline",
   type: "docker",
-  name: std.join(" ", [branch, platform, event, arch, server, customBootstrapParams, customBuildEnvCommandsMapKey]),
+  name: std.join(" ", [branch, platform, event, arch, server, customBootstrapParamsKey, customBuildEnvCommandsMapKey]),
   platform: { arch: arch },
   clone: { depth: 10 },
   steps: [
@@ -519,15 +535,16 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
                        ]
                        + customEnvCommands(customBuildEnvCommandsMapKey, builddir) +
                        [
-                        'bash -c "set -o pipefail && bash /mdb/' + builddir + "/storage/columnstore/columnstore/build/bootstrap_mcs.sh " +
+                        'bash -c "set -o pipefail && ' +
+                         get_build_command("bootstrap_mcs.sh") +
                          "--build-type RelWithDebInfo " +
                          "--distro " + platform + " " +
+                         "--build-packages --install-deps --sccache " +
                          "--build-path " + "/mdb/" + builddir + "/builddir " +
-                         "--build-packages --install-deps --sccache" +
-                         " " + customBootstrapParams +
-                         " " + customBootstrapParamsForExisitingPipelines(platform) + " | " +
-                         "/mdb/" + builddir + "/storage/columnstore/columnstore/build/ansi2txt.sh " +
-                         "/mdb/" + builddir + "/" + result + '/build.log "',
+                          " " + customBootstrapParamsForExisitingPipelines(platform) +
+                          " " + customBuildFlags(customBootstrapParamsKey) +
+                          " | " + get_build_command("ansi2txt.sh") +
+                          "/mdb/" + builddir + "/" + result + '/build.log "',
                        ],
            },
            {
@@ -539,7 +556,7 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
                DEBIAN_FRONTEND: "noninteractive",
              },
              commands: [
-               "bash /mdb/" + builddir + "/storage/columnstore/columnstore/build/build_cmapi.sh --distro " + platform,
+               get_build_command("build_cmapi.sh") + " --distro " + platform,
              ],
            },
            {
@@ -551,7 +568,7 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
              },
              volumes: [pipeline._volumes.mdb],
              commands: [
-               "bash /mdb/" + builddir + "/storage/columnstore/columnstore/build/createrepo.sh --result " + result,
+               get_build_command("createrepo.sh") + " --result " + result,
              ],
            },
            {
@@ -669,6 +686,18 @@ local FinalPipeline(branch, event) = {
   for b in std.objectFields(platforms)
   for platform in ["ubuntu:24.04"]
   for buildenv in std.objectFields(customEnvCommandsMap)
+  for triggeringEvent in events
+  for server in servers[current_branch]
+]
++
+[
+  Pipeline(b, platform, triggeringEvent, a, server, flag, envcommand)
+  for a in ["amd64"]
+  for b in std.objectFields(platforms)
+  for platform in ["ubuntu:24.04"]
+  for flag in ["libcpp"]
+  for envcommand in ["clang-20"]
+//  for flag in std.objectFields(customBootstrapParamsForAdditionalPipelinesMap)
   for triggeringEvent in events
   for server in servers[current_branch]
 ]

--- a/build/install_libc++.sh
+++ b/build/install_libc++.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eo pipefail
+
+SCRIPT_LOCATION=$(dirname "$0")
+source "$SCRIPT_LOCATION"/utils.sh
+
+VERSION="$1"
+
+if [[ $# -ne 1 ]]; then
+  echo "Please pass clang-version as a first parameter"
+  exit 1
+fi
+
+change_ubuntu_mirror us
+
+message "Installing libc++-${VERSION}"
+
+retry_eval 5 apt-get clean && apt-get update && apt-get install -y libc++-${VERSION}-dev libc++abi-${VERSION}-dev

--- a/storage-manager/CMakeLists.txt
+++ b/storage-manager/CMakeLists.txt
@@ -82,7 +82,6 @@ target_include_directories(storagemanager PRIVATE ${Boost_INCLUDE_DIRS})
 
 columnstore_executable(StorageManager src/main.cpp)
 columnstore_link(StorageManager storagemanager)
-set_property(TARGET StorageManager PROPERTY CXX_STANDARD 20)
 
 set(TMPDIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/storage-manager/src/S3Storage.h
+++ b/storage-manager/src/S3Storage.h
@@ -19,12 +19,12 @@
 
 #include <deque>
 #include <string>
-#include <map>
 #include <memory>
 #include <optional>
+#include <unordered_map>
+
 #include "CloudStorage.h"
 #include "libmarias3/marias3.h"
-#include "Config.h"
 #include <curl/curl.h>
 
 namespace storagemanager

--- a/utils/regr/modamysql.cpp
+++ b/utils/regr/modamysql.cpp
@@ -1,14 +1,7 @@
 #include <my_config.h>
 #include <cmath>
-#include <iostream>
-#include <sstream>
 #include <string.h>
 #include <unordered_map>
-#include <algorithm>
-#include <sstream>
-#include <iostream>
-#include <charconv>
-#include "boost/lexical_cast.hpp"
 #include "idb_mysql.h"
 
 namespace

--- a/writeengine/bulk/we_cmdargs.cpp
+++ b/writeengine/bulk/we_cmdargs.cpp
@@ -303,7 +303,7 @@ void WECmdArgs::parseCmdLineArgs(int argc, char** argv)
       fAllowMissingColumn = true;
     }
   }
-  if (vm.contains("max-errors"))
+  if (vm.count("max-errors"))
   {
     auto optarg= vm["max-errors"].as<string>();
     if (optarg == "all")

--- a/writeengine/splitter/we_cmdargs.cpp
+++ b/writeengine/splitter/we_cmdargs.cpp
@@ -736,7 +736,7 @@ void WECmdArgs::parseCmdLineArgs(int argc, char** argv)
       fBatchQty = 10000;
     }
   }
-  if (vm.contains("max-errors"))
+  if (vm.count("max-errors"))
   {
     auto optarg = vm["max-errors"].as<string>();
     if (optarg == "all")


### PR DESCRIPTION
regular rockylinux 8 build will use plain vanilla gcc8.5, and run singlenode mtr
gcc-toolset will use gcc-toolset-11 and run multinode_mtr  