### PR TITLE
MCOL-6101: joblist library not linked against openssl libraries

### DIFF
--- a/dbcon/joblist/CMakeLists.txt
+++ b/dbcon/joblist/CMakeLists.txt
@@ -64,6 +64,7 @@ set(joblist_LIB_SRCS
 add_library(joblist SHARED ${joblist_LIB_SRCS})
 target_include_directories(joblist BEFORE PUBLIC ${OPENSSL_INCLUDE_DIR})
 add_dependencies(joblist loggingcpp)
+target_link_libraries(joblist PRIVATE ssl)
 
 install(TARGETS joblist DESTINATION ${ENGINE_LIBDIR} COMPONENT columnstore-engine)
 


### PR DESCRIPTION
Joblist uses the decrypt_password function which requires the openssl libraries.

This should be linked explictly.