### PR TITLE
feat(cmapi): MCOL-6006: Disable failover when shared storage not detected

### DIFF
--- a/cmapi/cmapi_server/constants.py
+++ b/cmapi/cmapi_server/constants.py
@@ -176,3 +176,7 @@ PKG_GET_VER_CMD = MultiDistroNamer(
     rhel="rpm -q --queryformat '%{{VERSION}}' {package_name}",
     deb="dpkg-query -f '${{Version}}' -W {package_name}"
 )
+
+class ClusterModeEnum(str, Enum):
+    READONLY = 'readonly'
+    READWRITE = 'readwrite'

--- a/cmapi/cmapi_server/controllers/api_clients.py
+++ b/cmapi/cmapi_server/controllers/api_clients.py
@@ -1,8 +1,9 @@
 import logging
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pyotp
 import requests
+
 
 from cmapi_server.constants import (
     CMAPI_CONF_PATH, CURRENT_NODE_CMAPI_URL, SECRET_KEY, _version
@@ -31,19 +32,16 @@ class BaseClient:
 
         :param base_url: The base URL for the API endpoints,
                          defaults to CURRENT_NODE_CMAPI_URL
-        :type base_url: str, optional
-        :param request_timeout: request timeout, defaults to None
-        :type request_timeout: Optional[float], optional
         """
         self.base_url = base_url
         self.request_timeout = request_timeout
-        self.cmd_url = None
+        self.cmd_class = None
 
     def _request(
         self, method: str, endpoint: str,
         data: Optional[Dict[str, Any]] = None,
         throw_real_exp: bool = False
-    ) -> Union[Dict[str, Any], Dict[str, str]]:
+    ) -> Union[Dict[str, Any], List[Any]]:
         """Make a request to the API.
 
         :param method: The HTTP method to use.
@@ -51,7 +49,8 @@ class BaseClient:
         :param data: The data to send with the request.
         :return: The response from the API.
         """
-        url = f'{self.cmd_url}/{endpoint}'
+
+        url = f'{self.base_url}/cmapi/{_version}/{self.cmd_class}/{endpoint}'
         cmapi_cfg_parser = get_config_parser(CMAPI_CONF_PATH)
         key = get_current_key(cmapi_cfg_parser)
         headers = {'x-api-key': key}
@@ -59,10 +58,10 @@ class BaseClient:
             headers['Content-Type'] = 'application/json'
             data = {'in_transaction': True, **(data or {})}
         try:
-            response = requests.request(
+            response = get_traced_session().request(
                 method, url, headers=headers,
                 params=data if method == 'GET' else None,
-                json=data if method in ('PUT', 'POST') else None,
+                json=data if method in ('PUT', 'POST', 'DELETE') else None,
                 timeout=self.request_timeout, verify=False
             )
             response.raise_for_status()
@@ -76,11 +75,12 @@ class BaseClient:
             if throw_real_exp:
                 raise exc
             raise CMAPIBasicError(message)
-        # TODO: different handler for timeout exception?
-        except requests.exceptions.HTTPError as exc:
+        except requests.HTTPError as exc:
             resp = exc.response
+            request_url = exc.request.url if exc.request else url
+            status_code = resp.status_code if resp is not None else 'N/A'
             error_msg = str(exc)
-            if resp.status_code == 422:
+            if status_code == 422:
                 # in this case we think cmapi server returned some value but
                 # had error during running endpoint handler code
                 try:
@@ -89,19 +89,26 @@ class BaseClient:
                 except requests.exceptions.JSONDecodeError:
                     error_msg = resp.text
             message = (
-                f'API client got an exception in request to {exc.request.url} '
-                f'with code {resp.status_code if resp is not None else "NA"} '
-                f'and error: {error_msg}'
+                f'API client got an HTTPError exception in request to {request_url} with code '
+                f'{status_code} and error: {error_msg}'
             )
             logging.error(message)
             if throw_real_exp:
                 raise exc
             raise CMAPIBasicError(message)
+        except requests.exceptions.Timeout:
+            message = f'Request to {url} timed out after {self.request_timeout}'
+            logging.error(message)
+            if throw_real_exp:
+                raise exc
+            raise CMAPIBasicError(message)
         except requests.exceptions.RequestException as exc:
-            status_code = exc.response.status_code if exc.response else 'NA'
+            resp = exc.response
+            request_url = exc.request.url if exc.request else url
+            status_code = resp.status_code if exc.response is not None else 'N/A'
             message = (
                 'API client got an undefined error in request to '
-                f'{exc.request.url} with code {status_code!r} and '
+                f'{request_url} with code {status_code!r} and '
                 f'error: {str(exc)}'
             )
             logging.error(message)
@@ -120,7 +127,7 @@ class ClusterControllerClient(BaseClient):
             self, base_url: str = CURRENT_NODE_CMAPI_URL,
             request_timeout: Optional[float] = None
     ):
-        """Initialize the ClusterControllerClient with the base URL.
+        """Initialize the BaseClient with the base URL.
 
         :param base_url: The base URL for the API endpoints,
                          defaults to CURRENT_NODE_CMAPI_URL
@@ -129,7 +136,7 @@ class ClusterControllerClient(BaseClient):
         :type request_timeout: Optional[float], optional
         """
         super().__init__(base_url, request_timeout)
-        self.cmd_url = f'{self.base_url}/cmapi/{_version}/cluster'
+        self.cmd_class = 'cluster'
 
     def start_cluster(
             self, extra: Dict[str, Any] = dict()
@@ -307,6 +314,15 @@ class ClusterControllerClient(BaseClient):
             'PUT', 'upgrade-cmapi', {'version': version, **extra}
         )
 
+    def check_shared_storage(
+            self, extra: Dict[str, Any] = dict()
+    ) -> Union[Dict[str, Any], Dict[str, str]]:
+        """Check if shared storage working.
+
+        :return: The response from the API.
+        """
+        return self._request('PUT', 'check-shared-storage', extra)
+
 
 class NodeControllerClient(BaseClient):
     """Client for the NodeController API.
@@ -327,7 +343,7 @@ class NodeControllerClient(BaseClient):
         :type request_timeout: Optional[float], optional
         """
         super().__init__(base_url, request_timeout)
-        self.cmd_url = f'{self.base_url}/cmapi/{_version}/node'
+        self.cmd_class = 'node'
 
     def get_versions(
             self, extra: Dict[str, Any] = dict()
@@ -461,6 +477,24 @@ class NodeControllerClient(BaseClient):
         return self._request(
             'PUT', 'kick-cmapi-upgrade', {'version': version, **extra}
         )
+
+    def check_shared_file(
+        self, file_path: str, check_sum: str
+    ) -> Union[Dict[str, Any], Dict[str, str]]:
+        """Get packages versions installed on a node.
+
+        :param file_path: file path to check
+        :type file_path: str
+        :param check_sum: expected MD5 file checksum
+        :type check_sum: str
+        :return: The response from the API.
+        """
+        data = {
+            'file_path': file_path,
+            'check_sum': check_sum,
+        }
+        return self._request('GET', 'check-shared-file', data)
+
 
 
 class AppControllerClient(BaseClient):

--- a/cmapi/cmapi_server/controllers/dispatcher.py
+++ b/cmapi/cmapi_server/controllers/dispatcher.py
@@ -453,6 +453,36 @@ dispatcher.connect(
 )
 
 
+# /_version/node/check-shared-file/ (GET)
+dispatcher.connect(
+    name = 'node_check_shared_file',
+    route = f'/cmapi/{_version}/node/check-shared-file',
+    action = 'check_shared_file',
+    controller = NodeController(),
+    conditions = {'method': ['GET']}
+)
+
+
+# /_version/cluster/check-shared-storage/ (PUT)
+dispatcher.connect(
+    name = 'cluster_check_shared_storage',
+    route = f'/cmapi/{_version}/cluster/check-shared-storage',
+    action = 'check_shared_storage',
+    controller = ClusterController(),
+    conditions = {'method': ['PUT']}
+)
+
+
+# /_version/node/stateful-config/ (PUT)
+dispatcher.connect(
+    name = 'node_put_stateful_config',
+    route = f'/cmapi/{_version}/node/stateful-config',
+    action = 'put_stateful_config',
+    controller = NodeController(),
+    conditions = {'method': ['PUT']}
+)
+
+
 def jsonify_error(status, message, traceback, version): \
     # pylint: disable=unused-argument
     """JSONify all CherryPy error responses (created by raising the

--- a/cmapi/cmapi_server/controllers/endpoints.py
+++ b/cmapi/cmapi_server/controllers/endpoints.py
@@ -1,4 +1,5 @@
 import logging
+import hashlib
 import socket
 import subprocess
 import time
@@ -12,6 +13,7 @@ import requests
 from mcs_node_control.models.dbrm import set_cluster_mode
 from mcs_node_control.models.node_config import NodeConfig
 from mcs_node_control.models.node_status import NodeStatus
+from pydantic import ValidationError
 
 from cmapi_server.constants import (
     CMAPI_PACKAGE_NAME, CMAPI_PORT, DEFAULT_MCS_CONF_PATH,
@@ -22,6 +24,9 @@ from cmapi_server.constants import (
 from cmapi_server.controllers.api_clients import NodeControllerClient
 from cmapi_server.controllers.error import APIError
 from cmapi_server.exceptions import CMAPIBasicError, cmapi_error_to_422
+from cmapi_server.controllers.request_models import (
+    ConfigPutRequestRootModel, StatefulConfigPutRequestModel,
+)
 from cmapi_server.handlers.cej import CEJError, CEJPasswordHandler
 from cmapi_server.handlers.cluster import ClusterHandler
 from cmapi_server.helpers import (
@@ -30,7 +35,9 @@ from cmapi_server.helpers import (
     save_cmapi_conf_file, system_ready,
 )
 from cmapi_server.logging_management import change_loggers_level
-from cmapi_server.managers.application import AppManager
+from cmapi_server.managers.application import (
+    AppManager, AppStatefulConfig, StatefulConfigModel
+)
 from cmapi_server.managers.upgrade.packages import PackagesManager
 from cmapi_server.managers.upgrade.repo import MariaDBESRepoManager
 from cmapi_server.managers.backup_restore import PreUpgradeBackupRestoreManager
@@ -341,41 +348,68 @@ class ConfigController:
                 'PUT /config called outside of an operation.'
             )
 
+        try:
+            wrapper = ConfigPutRequestRootModel.model_validate(cherrypy.request.json)
+            # the actual StatefulConfigPutRequestModel or FullConfigPutRequestModel or
+            # PutConfigSetModeRequestModel
+            req_model = wrapper.root
+        except ValidationError as exp:
+            raise_422_error(
+                module_logger, func_name, f'Mandatory attribute is missing: {exp.errors()}'
+            )
+
         req = cherrypy.request
         use_sudo = get_use_sudo(req.app.config)
-        request_body = cherrypy.request.json
-        request_revision = request_body.get('revision', None)
-        request_manager = request_body.get('manager', None)
-        request_timeout = request_body.get('timeout', None)
 
         #TODO: remove is_test
         # is_test = True means this should not save
         # the config file or apply the changes
-        is_test = request_body.get('test', False)
+        is_test = req_model.test
+        if req_model.type == 'set_mode':
+            # TODO: move it to separate endpoint
+            request_timeout = req_model.timeout
+            request_cluster_mode = req_model.cluster_mode
+            current_mode = set_cluster_mode(request_cluster_mode)
+            if current_mode == request_cluster_mode:
+                # Normal exit
+                request_response = {'timestamp': str(datetime.now())}
+                module_logger.debug(
+                    f'{func_name} returns {str(request_response)}'
+                )
+                return request_response
+            else:
+                raise_422_error(
+                    module_logger, func_name,
+                    (
+                        f'Error occured setting cluster to "{request_cluster_mode}" '
+                        f'mode, got "{current_mode}"'
+                    )
+                )
 
-        mandatory = (request_revision, request_manager, request_timeout)
-        if None in mandatory:
-            raise_422_error(
-                module_logger, func_name, 'Mandatory attribute is missing.')
+        # if stateful config is provided, we just need to fast apply only stateful config
+        success = AppStatefulConfig.apply_update(req_model.stateful_config_dict)
+        if not success:
+            logging.info('Stateful config update was stale.')
+        else:
+            logging.info(
+                f'Stateful config updated with term {req_model.stateful_config_dict.version.term} '
+                f'and seq {req_model.stateful_config_dict.version.seq}.'
+            )
 
-        request_mode = request_body.get('cluster_mode', None)
-        xml_config = request_body.get('config', None)
-        sm_config = request_body.get('sm_config', None)
-        mcs_config_filename = request_body.get(
-            'mcs_config_filename', DEFAULT_MCS_CONF_PATH
-        )
-        sm_config_filename = request_body.get(
-            'sm_config_filename', DEFAULT_SM_CONF_PATH
-        )
-        secrets = request_body.get('secrets', None)
+        if isinstance(req_model, StatefulConfigPutRequestModel):
+            return {'timestamp': str(datetime.now()), 'success': success}
 
+        request_mode = req_model.cluster_mode
+        xml_config = req_model.config
+        sm_config = req_model.sm_config
+        mcs_config_filename = req_model.mcs_config_filename
+        sm_config_filename = req_model.sm_config_filename
+        secrets = req_model.secrets
+        request_timeout = req_model.timeout
         operation_params = (request_mode, xml_config, secrets)
         # if no operation to apply, return 422
         if not any(operation_params):
-            raise_422_error(
-                module_logger, func_name,
-                'Mandatory attribute is missing.'
-            )
+            raise_422_error(module_logger, func_name, 'Mandatory operation attribute is missing.')
 
         request_headers = cherrypy.request.headers
         request_manager_address = request_headers.get('Remote-Addr', None)
@@ -406,25 +440,7 @@ class ConfigController:
         node_config = NodeConfig()
         if is_test:
             return request_response
-        if request_mode is not None:
-            current_mode = set_cluster_mode(
-                request_mode, config_filename=mcs_config_filename
-            )
-            if current_mode == request_mode:
-                # Normal exit
-                module_logger.debug(
-                    f'{func_name} returns {str(request_response)}'
-                )
-                return request_response
-            else:
-                raise_422_error(
-                    module_logger, func_name,
-                    (
-                        f'Error occured setting cluster to "{request_mode}" '
-                        f'mode, got "{current_mode}"'
-                    )
-                )
-        elif xml_config is not None:
+        if xml_config is not None:
             node_config.apply_config(
                 config_filename=mcs_config_filename,
                 xml_string=xml_config,
@@ -1429,6 +1445,30 @@ class ClusterController:
         module_logger.debug(f'{func_name} returns {str(response)}')
         return response
 
+    @cherrypy.tools.timeit()
+    @cherrypy.tools.json_in()
+    @cherrypy.tools.json_out()
+    @cherrypy.tools.validate_api_key()  # pylint: disable=no-member
+    def check_shared_storage(self):
+        """Handler for /cluster/check-shared-storage/ (PUT) endpoint."""
+        func_name = 'check_shared_storage'
+        log_begin(module_logger, func_name)
+        # Optional skip list provided by caller (e.g., failover monitor)
+        request = cherrypy.request
+        request_body = request.json or {}
+        skip_nodes = request_body.get('skip_nodes', [])
+        try:
+            response = ClusterHandler.check_shared_storage(skip_nodes)
+        except CMAPIBasicError as err:
+            raise_422_error(module_logger, func_name, err.message)
+        except Exception:
+            raise_422_error(
+                module_logger, func_name,
+                'Undefined error happened while checking shared storage.'
+            )
+        module_logger.debug(f'{func_name} returns {str(response)}')
+        return response
+
 
 class ApiKeyController:
     @cherrypy.tools.timeit()
@@ -1676,7 +1716,6 @@ class NodeController:
         module_logger.debug(f'{func_name} returns {str(response)}')
         return response
 
-
     @cherrypy.tools.timeit()
     @cherrypy.tools.json_in()
     @cherrypy.tools.json_out()
@@ -1701,7 +1740,6 @@ class NodeController:
         response = {'timestamp': str(datetime.now())}
         module_logger.debug(f'{func_name} returns {str(response)}')
         return response
-
 
     @cherrypy.tools.timeit()
     @cherrypy.tools.json_in()
@@ -1888,3 +1926,73 @@ class NodeController:
         response = {'timestamp': str(datetime.now())}
         module_logger.debug(f'{func_name} returns {str(response)}')
         return response
+
+    @cherrypy.tools.timeit()
+    @cherrypy.tools.json_out()
+    @cherrypy.tools.validate_api_key()  # pylint: disable=no-member
+    def check_shared_file(self, file_path, check_sum):
+        func_name = 'check_shared_file'
+        log_begin(module_logger, func_name)
+        ACCEPTED_PATHS = (
+            '/var/lib/columnstore/data1/',
+            '/var/lib/columnstore/storagemanager/metadata/data1/'
+        )
+        if not file_path.startswith(ACCEPTED_PATHS):
+            raise_422_error(module_logger, func_name, 'Not acceptable file_path.')
+
+        success = True
+        file_path_obj = Path(file_path)
+        logging.debug(f'Checking shared file at {file_path} with md5 {check_sum}.')
+        if not file_path_obj.exists():
+            success = False
+            logging.debug(f'Shared file {file_path} does not exist.')
+        else:
+            with file_path_obj.open(mode='rb') as file_to_check:
+                data = file_to_check.read()
+                calculated_md5 = hashlib.md5(data).hexdigest()
+            if calculated_md5 != check_sum:
+                logging.debug(
+                    f'Shared file at {file_path} md5 {calculated_md5} does not match given md5 {check_sum}.'
+                )
+                success = False
+        if success:
+            logging.debug(f'Shared file {file_path} md5 matches {check_sum}.')
+
+        response = {
+            'timestamp': str(datetime.now()),
+            'success': success
+        }
+        logging.debug(f'{func_name} returns {str(response)}')
+        return response
+
+    @cherrypy.tools.timeit()
+    @cherrypy.tools.json_in()
+    @cherrypy.tools.json_out()
+    @cherrypy.tools.validate_api_key()  # pylint: disable=no-member
+    def put_stateful_config(self):
+        """Handler for /node/stateful-config (PUT) endpoint.
+
+        #TODO: for next releases.
+        """
+
+        func_name = 'put_stateful_config'
+        log_begin(module_logger, func_name)
+
+        request_body = cherrypy.request.json
+        try:
+            request_stateful_config = StatefulConfigModel.model_validate(
+                request_body.get('stateful_config_dict')
+            )
+        except ValidationError as exp:
+            raise_422_error(module_logger, func_name,f'Invalid request body: {exp.errors()}')
+
+        success = AppStatefulConfig.apply_update(request_stateful_config)
+        if not success:
+            logging.info('Stateful config update was stale.')
+        else:
+            logging.info(
+                f'Stateful config updated with term  {request_stateful_config.version.term} '
+                f'and seq {request_stateful_config.version.seq}.'
+            )
+
+        return {'timestamp': str(datetime.now()), 'success': success}

--- a/cmapi/cmapi_server/controllers/request_models.py
+++ b/cmapi/cmapi_server/controllers/request_models.py
@@ -1,0 +1,65 @@
+from typing import Annotated, Optional, Union, Literal
+
+from pydantic import BaseModel, Discriminator, RootModel, Tag
+
+from cmapi_server.constants import (
+    DEFAULT_MCS_CONF_PATH, DEFAULT_SM_CONF_PATH, ClusterModeEnum,
+)
+from cmapi_server.managers.application import StatefulConfigModel
+
+
+class BaseConfigPutRequestModel(BaseModel):
+    timeout: int
+    test: Optional[bool] = False
+
+
+class BaseFullStatefulConfigPutRequestModel(BaseConfigPutRequestModel):
+    only_stateful_config: Optional[bool] = False
+    stateful_config_dict: StatefulConfigModel
+
+
+class StatefulConfigPutRequestModel(BaseFullStatefulConfigPutRequestModel):
+    type: Literal['stateful'] = 'stateful'
+
+
+class PutConfigSetModeRequestModel(BaseConfigPutRequestModel):
+    type: Literal['set_mode'] = 'set_mode'
+    revision: str
+    manager: str
+    cluster_mode: ClusterModeEnum
+
+
+class FullConfigPutRequestModel(BaseFullStatefulConfigPutRequestModel):
+    type: Literal['full'] = 'full'
+    revision: str
+    manager: str
+    cluster_mode: Optional[str] = None
+    config: Optional[str] = None
+    sm_config: Optional[str] = None
+    mcs_config_filename: Optional[str] = DEFAULT_MCS_CONF_PATH
+    sm_config_filename: Optional[str] = DEFAULT_SM_CONF_PATH
+    secrets: Optional[dict] = None
+
+
+def get_discriminator_value(data: dict) -> str:
+    """Custom discriminator function for ConfigRequest union."""
+    if data.get('cluster_mode') is not None:
+        return 'set_mode'
+    if data.get('only_stateful_config', False):
+        return 'stateful'
+    return 'full'
+
+
+class ConfigPutRequestRootModel(
+    RootModel[
+        Annotated[
+            Union[
+                Annotated[StatefulConfigPutRequestModel, Tag('stateful')],
+                Annotated[PutConfigSetModeRequestModel, Tag('set_mode')],
+                Annotated[FullConfigPutRequestModel, Tag('full')]
+            ],
+            Discriminator(get_discriminator_value),
+        ]
+    ]
+):
+    pass

--- a/cmapi/cmapi_server/failover_agent.py
+++ b/cmapi/cmapi_server/failover_agent.py
@@ -53,7 +53,7 @@ class FailoverAgent(AgentBase):
                 logger.info(f'FA.deactivateNodes(): deactivating node {node}')
                 node_manipulation.remove_node(
                     node, input_config_filename, output_config_filename,
-                    deactivate_only=True, test_mode=test_mode
+                    deactivate_only=False, test_mode=test_mode
                 )
                 removed_node_count += 1
             except Exception as err:

--- a/cmapi/cmapi_server/handlers/cluster.py
+++ b/cmapi/cmapi_server/handlers/cluster.py
@@ -1,18 +1,25 @@
 """Module contains Cluster business logic functions."""
+import configparser
+import hashlib
 import logging
+import os
+import tempfile
+import time
 from datetime import datetime
 from enum import Enum
 from typing import Optional
+
+import requests
 
 from mcs_node_control.models.misc import get_dbrm_master
 from mcs_node_control.models.node_config import NodeConfig
 from tracing.traced_session import get_traced_session
 
 from cmapi_server.constants import (
-    CMAPI_CONF_PATH,
-    DEFAULT_MCS_CONF_PATH,
+    CMAPI_CONF_PATH, CMAPI_PORT, DEFAULT_MCS_CONF_PATH, REQUEST_TIMEOUT,
 )
 from cmapi_server.exceptions import CMAPIBasicError, exc_to_cmapi_error
+from cmapi_server.controllers.api_clients import NodeControllerClient
 from cmapi_server.helpers import (
     broadcast_new_config,
     get_active_nodes,
@@ -88,20 +95,48 @@ class ClusterHandler:
         for node in active_nodes:
             url = f'https://{node}:8640/cmapi/{get_version()}/node/status'
             try:
-                r = get_traced_session().request('GET', url, verify=False, headers=headers)
+                r = get_traced_session().request(
+                    'GET', url, verify=False, headers=headers, timeout=REQUEST_TIMEOUT
+                )
                 r.raise_for_status()
                 r_json = r.json()
                 if len(r_json.get('services', 0)) == 0:
                     r_json['dbrm_mode'] = 'offline'
                     r_json['cluster_mode'] = 'offline'
-
+                # add node state field ('online' if services not empty and mode not offline)
+                services = r_json.get('services', [])
+                node_state = (
+                    'offline'
+                    if not services or r_json.get('cluster_mode') == 'offline'
+                    else 'online'
+                )
+                r_json['state'] = node_state
                 response[f'{str(node)}'] = r_json
                 num_nodes += 1
-            except Exception as err:
-                raise CMAPIBasicError(
-                    f'Got an error retrieving status from node {node}'
-                ) from err
+            except (requests.exceptions.RequestException, ValueError) as err:
+                # Do not fail the whole request: record node as unreachable
+                logger.error('Error retrieving status from node %s: %s', node, str(err))
+                try:
+                    node_dbroots = sorted(get_dbroots(node, config))
+                except Exception as e:
+                    logger.warning(
+                        'ClusterHandler.status: failed to obtain dbroots for node %s: %s. Using empty list.',
+                        node, e
+                    )
+                    node_dbroots = []
+                response[str(node)] = {
+                    'timestamp': str(datetime.now()),
+                    'uptime': None,
+                    'dbrm_mode': 'offline',
+                    'cluster_mode': 'offline',
+                    'dbroots': node_dbroots,
+                    'module_id': 0,
+                    'services': [],
+                    'state': 'offline',
+                    'error': f'Unreachable: {err.__class__.__name__}'
+                }
 
+        # num_nodes stays as number of reachable nodes
         response['num_nodes'] = num_nodes
         logger.debug('Successfully finished getting cluster status.')
         return response
@@ -198,6 +233,7 @@ class ClusterHandler:
             input_config_filename=config, output_config_filename=config
         )
         broadcast_new_config(config, distribute_secrets=True)
+        ClusterHandler.check_shared_storage()
         logger.debug(f'Successfully finished adding node {node}.')
         return response
 
@@ -243,6 +279,7 @@ class ClusterHandler:
                 input_config_filename=config, output_config_filename=config
             )
             broadcast_new_config(config, nodes=active_nodes)
+        ClusterHandler.check_shared_storage()
         logger.debug(f'Successfully finished removing node {node}.')
         return response
 
@@ -285,7 +322,8 @@ class ClusterHandler:
             raise CMAPIBasicError('No master found in the cluster.')
         else:
             master = master['IPAddr']
-            payload = {'cluster_mode': mode}
+            payload: dict = {}
+            payload['cluster_mode'] = mode
             url = f'https://{master}:8640/cmapi/{get_version()}/node/config'
 
         nc = NodeConfig()
@@ -296,7 +334,9 @@ class ClusterHandler:
         payload['cluster_mode'] = mode
 
         try:
-            r = get_traced_session().request('PUT', url, headers=headers, json=payload, verify=False)
+            r = get_traced_session().request(
+                'PUT', url, headers=headers, json=payload, verify=False
+            )
             r.raise_for_status()
             response['cluster-mode'] = mode
         except Exception as err:
@@ -416,5 +456,99 @@ class ClusterHandler:
         response['timestamp'] = str(datetime.now())
         logger.debug(
             'Successfully finished setting new log level to all nodes.'
+        )
+        return response
+
+    @staticmethod
+    def check_shared_storage(skip_nodes: Optional[list[str]] = None) -> dict:
+        """Check shared storage.
+
+        :return: status result
+        """
+        tmp_file_path: str
+        active_nodes = get_active_nodes()
+        if skip_nodes:
+            # Remove any nodes the caller asked us to skip (e.g., unstable HB)
+            active_nodes = [n for n in active_nodes if n not in set(skip_nodes)]
+        all_responses: dict = dict()
+        nodes_errors: dict = dict()
+        sm_parser = configparser.ConfigParser()
+        sm_config_str = NodeConfig().get_current_sm_config()
+        sm_parser.read_string(sm_config_str)
+        storage_type = sm_parser.get(
+            'ObjectStorage', 'service', fallback='LocalStorage'
+        )
+        file_dir = '/var/lib/columnstore/data1'
+        if storage_type.lower() == 's3':
+            file_dir = '/var/lib/columnstore/storagemanager/metadata/data1'
+
+        with tempfile.NamedTemporaryFile(
+            mode='wb+', delete=True, dir=file_dir, prefix='mcs_test_shared'
+        ) as temp_file:
+            file_data = rb'File to check shared storage working.'
+            temp_file.write(file_data)
+            # Make sure data is on disk/visible to other nodes before checks
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+            tmp_file_path = temp_file.name
+            logging.debug(f'Temporary file to check shared storage created at: {tmp_file_path}')
+            tmp_file_md5 = hashlib.md5(file_data).hexdigest()
+            logging.debug(f'Temporary file md5: {tmp_file_md5}')
+            for node in active_nodes:
+                logging.debug(f'Checking shared file on {node!r}.')
+                client = NodeControllerClient(
+                    request_timeout=REQUEST_TIMEOUT,
+                    base_url=f'https://{node}:{CMAPI_PORT}'
+                )
+                last_err_msg = None
+                for attempt in range(2):
+                    try:
+                        node_response = client.check_shared_file(
+                            file_path=tmp_file_path, check_sum=tmp_file_md5
+                        )
+                        logging.debug(f'Finished checking file on {node!r}')
+                        all_responses[node] = node_response
+                        break
+                    except CMAPIBasicError as err:  # per-node failure must not abort the whole check
+                        last_err_msg = err.message
+                        if attempt == 0:
+                            time.sleep(1)
+                        continue
+                else:
+                    # Retries exhausted
+                    logging.warning(
+                        f'Error checking shared file on {node!r}: {last_err_msg}',
+                        exc_info=True
+                    )
+                    nodes_errors[node] = last_err_msg or 'unknown error'
+
+        nodes_success_responses = [
+            v.get('success', False) for v in all_responses.values()
+        ]
+        if nodes_success_responses:
+            shared_storage = all(nodes_success_responses)
+        else:
+            # no nodes in cluster case
+            shared_storage = False
+        # Consider partial failures either when not all successful among reachable
+        # or when some nodes were unreachable (nodes_errors present).
+        partially_failed = False
+        if len(active_nodes) > 2:
+            if nodes_errors:
+                partially_failed = True
+            elif nodes_success_responses and not all(nodes_success_responses):
+                partially_failed = True
+
+        response = {
+            'timestamp': str(datetime.now()),
+            'shared_storage': shared_storage,
+            'partially_failed': partially_failed,
+            'active_nodes_count': len(active_nodes),
+            'nodes_responses': {**all_responses},
+            'nodes_errors': {**nodes_errors}
+        }
+
+        logging.debug(
+            'Successfully finished checking shared storage on all nodes.'
         )
         return response

--- a/cmapi/cmapi_server/helpers.py
+++ b/cmapi/cmapi_server/helpers.py
@@ -13,7 +13,7 @@ import time
 from collections import namedtuple
 from random import random
 from shutil import copyfile
-from typing import Tuple, Optional
+from typing import Any, Tuple, Optional
 from urllib.parse import urlencode, urlunparse
 
 import aiohttp
@@ -32,6 +32,7 @@ from cmapi_server.constants import (
 )
 from cmapi_server.handlers.cej import CEJPasswordHandler
 from cmapi_server.managers.process import MCSProcessManager
+from cmapi_server.managers.application import AppStatefulConfig
 from mcs_node_control.models.node_config import NodeConfig
 
 
@@ -301,28 +302,23 @@ def broadcast_new_config(
     test_mode: bool = False,
     nodes: Optional[list] = None,
     timeout: Optional[int] = None,
-    distribute_secrets: bool = False
+    distribute_secrets: bool = False,
+    stateful_config_dict: Optional[dict[str, Any]] = None
 ) -> None:
     """Send new config to nodes. Now in async way.
 
     :param cs_config_filename: Columnstore.xml path,
                                defaults to DEFAULT_MCS_CONF_PATH
-    :type cs_config_filename: str, optional
     :param cmapi_config_filename: cmapi config path,
                                   defaults to CMAPI_CONF_PATH
-    :type cmapi_config_filename: str, optional
     :param sm_config_filename: storage manager config path,
                                defaults to DEFAULT_SM_CONF_PATH
-    :type sm_config_filename: str, optional
     :param test_mode: for test purposes, defaults to False TODO: remove
-    :type test_mode: bool, optional
     :param nodes: nodes list for config put, defaults to None
-    :type nodes: Optional[list], optional
     :param timeout: timeout passing to gracefully stop DMLProc TODO: for next
                     releases. Could affect all logic of broadcacting new config
-    :type timeout: Optional[int], optional
     :param distribute_secrets: flag to distribute secrets to nodes
-    :type distribute_secrets: bool
+    :param stateful_config_dict: stateful config update dict to distribute to nodes
     :raises CMAPIBasicError: If Broadcasting config to nodes failed with errors
     """
 
@@ -333,24 +329,32 @@ def broadcast_new_config(
     if nodes is None:
         nodes = get_active_nodes(cs_config_filename)
 
-    nc = NodeConfig()
-    root = nc.get_current_config_root(config_filename=cs_config_filename)
-    with open(cs_config_filename) as f:
-        config_text = f.read()
-
-    with open(sm_config_filename) as f:
-        sm_config_text = f.read()
-
     headers = {'x-api-key': key}
-    body = {
-        'manager': root.find('./ClusterManager').text,
-        'revision': root.find('./ConfigRevision').text,
-        'timeout': 300,
-        'config': config_text,
-        'cs_config_filename': cs_config_filename,
-        'sm_config_filename': sm_config_filename,
-        'sm_config': sm_config_text
-    }
+    if stateful_config_dict:
+        body = {
+            'timeout': 300,
+            'stateful_config_dict': stateful_config_dict,
+            'only_stateful_config': True,
+        }
+    else:
+        nc = NodeConfig()
+        root = nc.get_current_config_root(config_filename=cs_config_filename)
+        with open(cs_config_filename, mode='r', encoding='utf-8') as f:
+            config_text = f.read()
+
+        with open(sm_config_filename, mode='r', encoding='utf-8') as f:
+            sm_config_text = f.read()
+
+        body = {
+            'manager': root.find('./ClusterManager').text,
+            'revision': root.find('./ConfigRevision').text,
+            'timeout': 300,
+            'config': config_text,
+            'mcs_config_filename': cs_config_filename,
+            'sm_config_filename': sm_config_filename,
+            'sm_config': sm_config_text,
+            'stateful_config_dict': AppStatefulConfig.to_dict(),
+        }
 
     if distribute_secrets:
         # TODO: do not restart cluster when put xml config only with
@@ -369,11 +373,8 @@ def broadcast_new_config(
         """Update remote node config asyncronously.
 
         :param node: node ip address or hostname
-        :type node: str
         :param headers: headers for request
-        :type headers: dict
         :param body: request body
-        :type body: dict
         :raises CMAPIBasicError: If request failed by status code
         :raises CMAPIBasicError: If request failed by some undefined error
         :raises CMAPIBasicError: If request failed by timeout
@@ -441,6 +442,27 @@ def broadcast_new_config(
             f'Broadcasting config to nodes failed with errors: {errors_str}'
         )
         raise CMAPIBasicError(final_message)
+
+
+def broadcast_stateful_config(stateful_config_dict: dict[str, Any]) -> None:
+    """Broadcast new stateful config to nodes.
+
+    :param stateful_config_dict: stateful config update dict to distribute to nodes
+    """
+
+    try:
+        broadcast_new_config(stateful_config_dict=stateful_config_dict)
+    except CMAPIBasicError as err:
+        message = (
+            f'Failed to broadcast new stateful config dict: {stateful_config_dict}, '
+            f'got error: {err.message}'
+        )
+        logging.error(message)
+        return
+    else:
+        logging.debug(
+            f'Successfully broadcasted new stateful config dict: {stateful_config_dict}'
+        )
 
 
 # Might be more appropriate to put these in node_manipulation?
@@ -590,13 +612,32 @@ def get_dbroots(node, config=DEFAULT_MCS_CONF_PATH):
     for i in range(1, mod_count+1):
         ip_addr = smc_node.find(f'./ModuleIPAddr{i}-1-3').text
         hostname = smc_node.find(f'./ModuleHostName{i}-1-3').text
-        node_fqdn = socket.gethostbyaddr(hostname)[0]
+        try:
+            node_fqdn = socket.gethostbyaddr(hostname)[0]
+        except (socket.herror, socket.gaierror, OSError) as e:
+            # Fallback if reverse lookup fails
+            logging.warning(
+                'get_dbroots(): reverse lookup failed for %r: %s. Using original hostname.',
+                hostname, e
+            )
+            node_fqdn = hostname
 
         if node in LOCALHOSTS and hostname != 'localhost':
-            node = socket.gethostbyaddr(socket.gethostname())[0]
+            try:
+                node = socket.gethostbyaddr(socket.gethostname())[0]
+            except (socket.herror, socket.gaierror, OSError) as e:
+                logging.warning(
+                    'get_dbroots(): reverse lookup failed for local hostname: %s. Using socket.gethostname().',
+                    e
+                )
+                node = socket.gethostname()
         elif node not in LOCALHOSTS and hostname == 'localhost':
             # hostname will only be loclahost if we are in one node cluster
-            hostname = socket.gethostbyaddr(socket.gethostname())[0]
+            try:
+                hostname = socket.gethostbyaddr(socket.gethostname())[0]
+            except (socket.herror, socket.gaierror, OSError) as e:
+                logging.warning('get_dbroots(): reverse lookup failed for "localhost": %s.', e)
+                hostname = socket.gethostname()
 
 
         if node == ip_addr or node == hostname or node == node_fqdn:

--- a/cmapi/cmapi_server/managers/application.py
+++ b/cmapi/cmapi_server/managers/application.py
@@ -1,8 +1,11 @@
 import logging
 import platform
-from typing import Optional, Tuple, Dict
+import threading
+from functools import total_ordering
+from typing import Any, Dict, Optional, Tuple
 
 import distro
+from pydantic import BaseModel, ConfigDict, Field
 
 from cmapi_server.constants import (
     MDB_CS_PACKAGE_NAME, MDB_SERVER_PACKAGE_NAME, PKG_GET_VER_CMD,
@@ -195,3 +198,121 @@ class AppManager:
         :rtype: str
         """
         return cls.get_installed_pkg_ver(MDB_CS_PACKAGE_NAME)
+
+@total_ordering
+class StatefulVersionModel(BaseModel):
+    """
+    Version info inspired by Raft consensus algorithm.
+
+    Provides two layers of ordering for distributed state updates:
+
+    1. term = "leader epoch" or "fencing token"
+       - Incremented each time a new leader is elected.
+       - Ensures updates from old leaders are ignored.
+       - Represents the leadership period the update belongs to.
+    2. seq = "sequence number" within a term
+       - Monotonically increases for every change made by the leader.
+       - Ensures updates from the same leader are applied in order.
+       - Represents the change number during the leader's term.
+    """
+
+    term: int = Field(ge=0)
+    seq: int = Field(ge=0)
+
+    model_config = ConfigDict(frozen=True)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, StatefulVersionModel):
+            return NotImplemented
+        return (self.term, self.seq) == (other.term, other.seq)
+
+    def __lt__(self, other: "StatefulVersionModel") -> bool:
+        if not isinstance(other, StatefulVersionModel):
+            return NotImplemented
+        return (self.term, self.seq) < (other.term, other.seq)
+
+    def next_seq(self) -> "StatefulVersionModel":
+        """Return new version with incremented seq."""
+        return StatefulVersionModel(term=self.term, seq=self.seq + 1)
+
+    def next_term(self) -> "StatefulVersionModel":
+        """Return new version with incremented term and reset seq."""
+        return StatefulVersionModel(term=self.term + 1, seq=0)
+
+
+class StatefulFlagsModel(BaseModel):
+    """Flags for stateful config."""
+
+    shared_storage_on: bool = False
+
+    model_config = ConfigDict(frozen=True)
+
+
+class StatefulConfigModel(BaseModel):
+    """Stateful config model with version and flags."""
+
+    version: StatefulVersionModel
+    flags: StatefulFlagsModel
+
+
+class AppStatefulConfig:
+    """
+    Stateful config shared by cluster nodes in memory.
+
+    Uses a versioned config with thread-safe updates to avoid stale writes.
+    Flags are stored as key-value pairs in a dictionary.
+    # TODO: Change version.term after primary changes.
+    """
+
+    _lock = threading.RLock()
+    _config: StatefulConfigModel = StatefulConfigModel(
+        version=StatefulVersionModel(term=0, seq=0),
+        flags=StatefulFlagsModel(shared_storage_on=False)
+    )
+
+    @classmethod
+    def get_config_copy(cls) -> StatefulConfigModel:
+        """Get the current config atomically.
+
+        :return: Current config with flags and version.
+        """
+        with cls._lock:
+            return cls._config.model_copy(deep=True)
+
+    @classmethod
+    def to_dict(cls) -> dict[str, Any]:
+        """
+        Get the current config flags and version atomically.
+
+        :return: Dictionary with all flags and 'version' key included.
+        """
+        with cls._lock:
+            return cls._config.model_dump(mode='json')
+
+    @classmethod
+    def apply_update(cls, new_config: StatefulConfigModel) -> bool:
+        """
+        Apply updates to config flags if the version is newer.
+
+        Only updates flags present in new_flags. The entire update is applied
+        atomically and only if the version is newer than the current version.
+
+        :param new_config: New config with updated flags and version.
+        :return: True if update was applied; False if update was stale or version missing.
+        """
+
+        with cls._lock:
+            if new_config.version <= cls._config.version:
+                return False  # stale update
+            cls._config = new_config
+            return True
+
+
+    @classmethod
+    def is_shared_storage(cls) -> bool:
+        """Check if shared storage is enabled.
+
+        :return: True if shared storage is enabled, False otherwise.
+        """
+        with cls._lock:
+            return cls._config.flags.shared_storage_on

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -26,7 +26,9 @@ from cmapi_server.constants import (
     LOCALHOSTS,
     MCS_DATA_PATH,
 )
+from cmapi_server.managers.application import AppStatefulConfig
 from cmapi_server.managers.network import NetworkManager
+
 
 PMS_NODE_PORT = '8620'
 EXEMGR_NODE_PORT = '8601'
@@ -61,6 +63,7 @@ def switch_node_maintenance(
     maintenance_element.text = str(maintenance_state).lower()
     node_config.write_config(config_root, filename=output_config_filename)
     # TODO: probably move publishing to cherrypy.engine failover channel here?
+
 
 def add_node(
     node: str, input_config_filename: str = DEFAULT_MCS_CONF_PATH,
@@ -239,10 +242,10 @@ def rebalance_dbroots(
     """Rebalance dbroots between nodes.
 
     :param input_config_filename: input mcs config path, defaults to None
-    :type input_config_filename: Optional[str], optional
     :param output_config_filename: oputput mcs config path, defaults to None
-    :type output_config_filename: Optional[str], optional
-    :rases: Exception if error happens while rebalancing.
+    :raises: Exception if error happens while rebalancing.
+
+    TODO: never used? May be better to replace direct usage of _rebalance_dbroots by this
     """
     node_config = NodeConfig()
     if input_config_filename is None:
@@ -321,30 +324,30 @@ def move_primary_node(
 
 
 def find_dbroot1(root):
-    smc_node = root.find("./SystemModuleConfig")
-    pm_count = int(smc_node.find("./ModuleCount3").text)
+    smc_node = root.find('./SystemModuleConfig')
+    pm_count = int(smc_node.find('./ModuleCount3').text)
     for pm_num in range(1, pm_count + 1):
-        dbroot_count = int(smc_node.find(f"./ModuleDBRootCount{pm_num}-3").text)
+        dbroot_count = int(smc_node.find(f'./ModuleDBRootCount{pm_num}-3').text)
         for dbroot_num in range(1, dbroot_count + 1):
-            dbroot = smc_node.find(f"./ModuleDBRootID{pm_num}-{dbroot_num}-3").text
-            if dbroot == "1":
-                name = smc_node.find(f"ModuleHostName{pm_num}-1-3").text
-                addr = smc_node.find(f"ModuleIPAddr{pm_num}-1-3").text
+            dbroot = smc_node.find(f'./ModuleDBRootID{pm_num}-{dbroot_num}-3').text
+            if dbroot == '1':
+                name = smc_node.find(f'ModuleHostName{pm_num}-1-3').text
+                addr = smc_node.find(f'ModuleIPAddr{pm_num}-1-3').text
                 return (name, addr)
-    raise NodeNotFoundException("Could not find dbroot 1 in the list of dbroot assignments!")
+    raise NodeNotFoundException('Could not find dbroot 1 in the list of dbroot assignments!')
 
 
 def _move_primary_node(root):
-    '''
-    Verify new_primary is in the list of active nodes
+    """Move primary node to the node that has dbroot 1.
 
-    Change ExeMgr1
-    Change CEJ
-    Change DMLProc
-    Change DDLProc
-    Change Contollernode
-    Change PrimaryNode
-    '''
+    Verify new_primary is in the list of active nodes
+        - Change ExeMgr1
+        - Change CEJ
+        - Change DMLProc
+        - Change DDLProc
+        - Change ControllerNode
+        - Change PrimaryNode
+    """
 
     hostname, ip4 = new_primary = find_dbroot1(root)
     logging.info(f"_move_primary_node(): dbroot 1 is assigned to {new_primary}")
@@ -405,7 +408,7 @@ def _add_active_node(root, node):
 
 
 def __remove_helper(parent_node, node):
-    nodes = list(parent_node.findall("./Node"))
+    nodes = list(parent_node.findall('./Node'))
     for n in nodes:
         if n.text == node:
             parent_node.remove(n)
@@ -558,16 +561,16 @@ def is_master():
 
 
 def unassign_dbroot1(root):
-    smc_node = root.find("./SystemModuleConfig")
-    pm_count = int(smc_node.find("./ModuleCount3").text)
+    smc_node = root.find('./SystemModuleConfig')
+    pm_count = int(smc_node.find('./ModuleCount3').text)
     owner_id = 0
     for i in range(1, pm_count + 1):
-        dbroot_count_node = smc_node.find(f"./ModuleDBRootCount{i}-3")
+        dbroot_count_node = smc_node.find(f'./ModuleDBRootCount{i}-3')
         dbroot_count = int(dbroot_count_node.text)
         dbroot_list = []
         for j in range(1, dbroot_count + 1):
-            dbroot = smc_node.find(f"./ModuleDBRootID{i}-{j}-3").text
-            if dbroot == "1":
+            dbroot = smc_node.find(f'./ModuleDBRootID{i}-{j}-3').text
+            if dbroot == '1':
                 owner_id = i                  # this node has dbroot 1
             else:
                 dbroot_list.append(dbroot)    # the dbroot assignments to keep
@@ -578,13 +581,13 @@ def unassign_dbroot1(root):
 
     # remove the dbroot entries for node owner_id
     for i in range(1, dbroot_count + 1):
-        doomed_node = smc_node.find(f"./ModuleDBRootID{owner_id}-{i}-3")
+        doomed_node = smc_node.find(f'./ModuleDBRootID{owner_id}-{i}-3')
         smc_node.remove(doomed_node)
     # create the new dbroot entries
     dbroot_count_node.text = str(len(dbroot_list))
     i = 1
     for dbroot in dbroot_list:
-        etree.SubElement(smc_node, f"ModuleDBRootID{owner_id}-{i}-3").text = dbroot
+        etree.SubElement(smc_node, f'ModuleDBRootID{owner_id}-{i}-3').text = dbroot
         i += 1
 
 
@@ -601,25 +604,28 @@ def _get_existing_db_roots(root: etree.Element) -> list[int]:
     return existing_dbroots
 
 
-def _rebalance_dbroots(root, test_mode=False):
-    # TODO: add code to detect whether we are using shared storage or not.  If not, exit
-    # without doing anything.
+def get_dbroots_paths(root: etree.Element) -> list[str]:
+    """Get all the existing dbroot IDs from the config file"""
+    # There can be holes in the dbroot numbering, so can't just scan from [1-dbroot_count]
+    # Going to scan from 1-99 instead
+    sysconf_node = root.find('./SystemConfig')
+    dbroots_paths = []
+    for num in range(1, 100):
+        dbroot_node = sysconf_node.find(f'./DBRoot{num}')
+        if dbroot_node is not None:
+            dbroots_paths.append(dbroot_node.text)
+    return dbroots_paths
 
-    '''
-    this will be a pita
-    identify unassigned dbroots
-    assign those to the node with the fewest dbroots
 
-    then,
-    id the nodes with the most dbroots and the least dbroots
-    when most - least <= 1, we're done
-    else, move a dbroot from the node with the most to the one with the least
+def _rebalance_dbroots(root):
+    """Rebalance DBRoots across nodes in the xml config.
 
-    Not going to try to be clever about the alg.  We're dealing with small lists.
-    Aiming for simplicity and comprehensibility.
-    '''
+    Notes:
+    - This is safe only when the cluster uses shared storage. On local storage,
+      reassigning DBRoots in the config without moving data is unsafe.
+    - When shared storage is OFF (state comes from AppStatefulConfig), this
+      function becomes a no-op unless explicitly overridden via ``test_mode``.
 
-    '''
     Borderline hack here.  We are going to remove dbroot1 from its current host so that
     it will always look for the current replication master and always resolve the discrepancy
     between what maxscale and what cmapi choose for the primary/master node.
@@ -639,7 +645,28 @@ def _rebalance_dbroots(root, test_mode=False):
         5) make it the primary node
 
     Once we are done with the constraint discovery process, we should refactor this.
-    '''
+    """
+
+    # Overview of the simple balancing approach:
+    # - Identify unassigned DBRoots and assign to the node with fewest DBRoots.
+    # - Then, identify the nodes with the most DBRoots and the least DBRoots.
+    #   When most - least <= 1, we're done
+    #   Else, move a DBRoot from the node with the most to the one with the least
+    # Not going to try to be clever about the alg.  We're dealing with small lists.
+    # Aiming for simplicity and comprehensibility.
+
+    # Ensure DBRoot 1 is unassigned initially. This forces placement logic to
+    # consider the (new) replication master, aligning primary node selection
+    # with MaxScale to avoid schema sync issues.
+
+
+    # If the cluster is not using shared storage, rebalancing dbroots would
+    # be invalid and potentially dangerous. Respect the stateful flag that is
+    # maintained by the shared-storage monitors and bail out early.
+    if not AppStatefulConfig.is_shared_storage():
+        logging.info('Shared storage is OFF; skipping DBRoots rebalance.')
+        return
+
     unassign_dbroot1(root)
 
     current_mapping = get_current_dbroot_mapping(root)
@@ -649,30 +676,28 @@ def _rebalance_dbroots(root, test_mode=False):
     # assign the unassigned dbroots
     unassigned_dbroots = set(existing_dbroots) - set(current_mapping[0])
 
-    '''
-    If dbroot 1 is in the unassigned list, then we need to put it on the node that will be the next
-    primary node.  Need to choose the same node as maxscale here.  For now, we will wait until
-    maxscale does the replication reconfig, then choose the new master.  Later,
-    we will choose the node using the same method that maxscale does to avoid
-    the need to go through the mariadb client.
 
-    If this process goes on longer than 1 min, then we will assume there is no maxscale,
-    so this should choose where dbroot 1 should go itself.
-    '''
+    # If dbroot 1 is in the unassigned list, then we need to put it on the node that will be
+    # the next primary node.  Need to choose the same node as maxscale here.  For now,
+    # we will wait until maxscale does the replication reconfig, then choose the new master.
+    # Later, we will choose the node using the same method that maxscale does to avoid
+    # the need to go through the mariadb client.
+    # If this process goes on longer than 1 min, then we will assume there is no maxscale,
+    # so this should choose where dbroot 1 should go itself.
     if 1 in unassigned_dbroots:
-        logging.info("Waiting for Maxscale to choose the new repl master...")
-        smc_node = root.find("./SystemModuleConfig")
+        logging.info('Waiting for Maxscale to choose the new repl master...')
+        smc_node = root.find('./SystemModuleConfig')
         # Maybe iterate over the list of ModuleHostName tags instead
-        pm_count = int(smc_node.find("./ModuleCount3").text)
+        pm_count = int(smc_node.find('./ModuleCount3').text)
         found_master = False
-        final_time = datetime.datetime.now() + datetime.timedelta(seconds = 30)
+        final_time = datetime.datetime.now() + datetime.timedelta(seconds=30)
 
         # skip this if in test mode.
         retry = True
-        while not found_master and datetime.datetime.now() < final_time and not test_mode:
+        while not found_master and datetime.datetime.now() < final_time:
             for node_num in range(1, pm_count + 1):
-                node_ip = smc_node.find(f"./ModuleIPAddr{node_num}-1-3").text
-                node_name = smc_node.find(f"./ModuleHostName{node_num}-1-3").text
+                node_ip = smc_node.find(f'./ModuleIPAddr{node_num}-1-3').text
+                node_name = smc_node.find(f'./ModuleHostName{node_num}-1-3').text
                 if pm_count == 1:
                     found_master = True
                 else:
@@ -680,7 +705,7 @@ def _rebalance_dbroots(root, test_mode=False):
                     key = helpers.get_current_key(cfg_parser)
                     version = helpers.get_version()
                     headers = {'x-api-key': key}
-                    url = f"https://{node_ip}:8640/cmapi/{version}/node/new_primary"
+                    url = f'https://{node_ip}:8640/cmapi/{version}/node/new_primary'
                     try:
                         r = get_traced_session().request(
                             'GET', url, verify=False, headers=headers, timeout=10
@@ -703,7 +728,7 @@ def _rebalance_dbroots(root, test_mode=False):
 
                 if not found_master:
                     if not retry:
-                        logging.info("There was an error retrieving replication master")
+                        logging.info('There was an error retrieving replication master')
                         break
                     else:
                         continue
@@ -711,20 +736,21 @@ def _rebalance_dbroots(root, test_mode=False):
                 # assign dbroot 1 to this node, put at the front of the list
                 current_mapping[node_num].insert(0, 1)
                 unassigned_dbroots.remove(1)
-                logging.info(f"The new replication master is {node_name}")
+                logging.info(f'The new replication master is {node_name}')
                 break
             if not found_master:
-                logging.info("New repl master has not been chosen yet")
+                logging.info('New repl master has not been chosen yet')
                 time.sleep(1)
         if not found_master:
-            logging.info("Maxscale has not reconfigured repl master, continuing...")
+            logging.info('Maxscale has not reconfigured repl master, continuing...')
 
     for dbroot in unassigned_dbroots:
         (_min, min_index) = _find_min_max_length(current_mapping)[0]
         if dbroot != 1:
             current_mapping[min_index].append(dbroot)
         else:
-            # make dbroot 1 move only if the new node goes down by putting it at the front of the list
+            # make dbroot 1 move only if the new node goes down by putting it at the front of the
+            # list
             current_mapping[min_index].insert(0, dbroot)
 
     # balance the distribution
@@ -734,18 +760,20 @@ def _rebalance_dbroots(root, test_mode=False):
         ((_min, min_index), (_max, max_index)) = _find_min_max_length(current_mapping)
 
     # write the new mapping
-    sysconf_node = root.find("./SystemModuleConfig")
+    sysconf_node = root.find('./SystemModuleConfig')
     for i in range(1, len(current_mapping)):
-        dbroot_count_node = sysconf_node.find(f"./ModuleDBRootCount{i}-3")
+        dbroot_count_node = sysconf_node.find(f'./ModuleDBRootCount{i}-3')
         # delete the original assignments for node i
         for dbroot_num in range(1, int(dbroot_count_node.text) + 1):
-            old_node = sysconf_node.find(f"./ModuleDBRootID{i}-{dbroot_num}-3")
+            old_node = sysconf_node.find(f'./ModuleDBRootID{i}-{dbroot_num}-3')
             sysconf_node.remove(old_node)
 
         # write the new assignments for node i
         dbroot_count_node.text = str(len(current_mapping[i]))
         for dbroot_num in range(len(current_mapping[i])):
-            etree.SubElement(sysconf_node, f"ModuleDBRootID{i}-{dbroot_num+1}-3").text = str(current_mapping[i][dbroot_num])
+            etree.SubElement(sysconf_node, f'ModuleDBRootID{i}-{dbroot_num+1}-3').text = str(
+                current_mapping[i][dbroot_num]
+            )
 
 
 # returns ((min, index-of-min), (max, index-of-max))

--- a/cmapi/cmapi_server/test/config_apply_example.py
+++ b/cmapi/cmapi_server/test/config_apply_example.py
@@ -38,7 +38,7 @@ config_file = Path(config_path)
 config = config_file.read_text()
 
 body = {
-    'revision': 42,
+    'revision': '42',
     'manager': '1.1.1.1',
     'timeout': 0,
     'config': config,

--- a/cmapi/cmapi_server/test/test_failover_agent.py
+++ b/cmapi/cmapi_server/test/test_failover_agent.py
@@ -3,9 +3,11 @@ import logging
 from mcs_node_control.models.node_config import NodeConfig
 
 from cmapi_server.failover_agent import FailoverAgent
+from cmapi_server.managers.network import NetworkManager
 from cmapi_server.node_manipulation import add_node, remove_node
 from cmapi_server.test.mock_resolution import simple_resolution_mock, make_local_resolution_builder
 from cmapi_server.test.unittest_global import BaseNodeManipTestCase, tmp_mcs_config_filename
+
 
 logging.basicConfig(level='DEBUG')
 
@@ -16,43 +18,83 @@ class TestFailoverAgent(BaseNodeManipTestCase):
     LOCAL_IP = '104.17.191.14'
     REMOTE_IP = '203.0.113.5'
 
-    def test_activateNodes(self):
-        self.tmp_files = ('./activate0.xml', './activate1.xml')
-        fa = FailoverAgent()
-        with (
-            make_local_resolution_builder()
-            .add_mapping(self.LOCAL_NODE, self.LOCAL_IP, bidirectional=True)
-            .add_mapping(self.REMOTE_NODE, self.REMOTE_IP, bidirectional=True)
-            .build()
-        ):
-            # First node is added with _replace_localhost
-            fa.activateNodes(
-                [self.LOCAL_NODE], tmp_mcs_config_filename, self.tmp_files[0],
-                test_mode=True
-            )
-            # Second node doesn't exist in the config skeleton
-            add_node(self.REMOTE_IP, self.tmp_files[0], self.tmp_files[1])
+    def _activate_add_remove_scenario(self, shared_storage_on: bool, use_rebalance_dbroots: bool):
+        """Common flow used by activate-nodes tests with minimal duplication.
 
-        nc = NodeConfig()
-        root = nc.get_current_config_root(self.tmp_files[1])
-        pm_count = int(root.find('./PrimitiveServers/Count').text)
-        self.assertEqual(pm_count, 2)
-        node = root.find('./PMS1/IPAddr')
-        # After _replace_localhost, PMS1 should use the resolved IP
-        self.assertEqual(node.text, self.LOCAL_IP)
-        node = root.find('./pm1_WriteEngineServer/IPAddr')
-        # After _replace_localhost, WES1 should use the resolved IP
-        self.assertEqual(node.text, self.LOCAL_IP)
-        node = root.find('./PMS2/IPAddr')
-        self.assertEqual(node.text, self.REMOTE_IP)
-        node = root.find('./pm2_WriteEngineServer/IPAddr')
-        self.assertEqual(node.text, self.REMOTE_IP)
-        remove_node(self.REMOTE_IP, self.tmp_files[1], self.tmp_files[1])
+        Steps:
+        - Optionally toggle shared_storage_on
+        - activateNodes(new node)
+        - add_node(host)
+        - verify expected layout (2 nodes, new node as PMS1)
+        - remove_node(new node) with configurable use_rebalance_dbroots
+        """
+        self.tmp_files = ('./activate0.xml', './activate1.xml')
+        # Toggle shared storage as requested and remember to restore it back.
+        original_shared_storage = self._set_shared_storage(shared_storage_on)
+        try:
+            fa = FailoverAgent()
+            with (
+                make_local_resolution_builder()
+                .add_mapping(self.LOCAL_NODE, self.LOCAL_IP, bidirectional=True)
+                .add_mapping(self.REMOTE_NODE, self.REMOTE_IP, bidirectional=True)
+                .build()
+            ):
+                # First node is added with _replace_localhost
+                fa.activateNodes(
+                    [self.LOCAL_NODE], tmp_mcs_config_filename, self.tmp_files[0],
+                    test_mode=True
+                )
+                # Second node doesn't exist in the config skeleton
+                add_node(self.REMOTE_IP, self.tmp_files[0], self.tmp_files[1])
+
+            nc = NodeConfig()
+            root = nc.get_current_config_root(self.tmp_files[1])
+            pm_count = int(root.find('./PrimitiveServers/Count').text)
+            self.assertEqual(pm_count, 2)
+            node = root.find('./PMS1/IPAddr')
+            # After _replace_localhost, PMS1 should use the resolved IP
+            self.assertEqual(node.text, self.LOCAL_IP)
+            node = root.find('./pm1_WriteEngineServer/IPAddr')
+            # After _replace_localhost, WES1 should use the resolved IP
+            self.assertEqual(node.text, self.LOCAL_IP)
+            node = root.find('./PMS2/IPAddr')
+            self.assertEqual(node.text, self.REMOTE_IP)
+            node = root.find('./pm2_WriteEngineServer/IPAddr')
+            self.assertEqual(node.text, self.REMOTE_IP)
+
+            # Note: when shared storage is off by default in a single node setup,
+            # disabling use_rebalance_dbroots avoids requiring dbroot 1 presence during
+            # _move_primary. In the shared storage ON scenario, we enable rebalancing to validate
+            # that path as well.
+            remove_node(
+                self.REMOTE_IP,
+                self.tmp_files[1],
+                self.tmp_files[1],
+                use_rebalance_dbroots=use_rebalance_dbroots,
+            )
+        finally:
+            # Restore original shared storage flag to avoid cross-test side effects
+            _ = self._set_shared_storage(original_shared_storage)
+
+    def test_activate_nodes_shared_storage_off(self):
+        """Shared storage OFF (default in single-node), no rebalance."""
+        self._activate_add_remove_scenario(
+            shared_storage_on=False,
+            use_rebalance_dbroots=False,
+        )
+
+    def test_activate_nodes_shared_storage_on(self):
+        """Shared storage ON, enforce rebalance during removal."""
+        self._activate_add_remove_scenario(
+            shared_storage_on=True,
+            use_rebalance_dbroots=True,
+        )
 
     def test_deactivateNodes(self):
         self.tmp_files = (
             './deactivate0.xml','./deactivate1.xml', './deactivate2.xml'
         )
+        original_shared_storage = self._set_shared_storage(True)
         with (
             make_local_resolution_builder()
             .add_mapping(self.LOCAL_NODE, self.LOCAL_IP, bidirectional=True)
@@ -95,6 +137,8 @@ class TestFailoverAgent(BaseNodeManipTestCase):
             self.assertFalse(node.text == self.LOCAL_NODE)
             if node.tag in ['IPAddr', 'Node']:
                 self.assertEqual(node.text, self.REMOTE_IP)
+
+        _ = self._set_shared_storage(original_shared_storage)
 
     def test_designatePrimaryNode(self):
         self.tmp_files = (

--- a/cmapi/cmapi_server/test/test_node_manip.py
+++ b/cmapi/cmapi_server/test/test_node_manip.py
@@ -7,6 +7,9 @@ from lxml import etree
 from mcs_node_control.models.node_config import NodeConfig
 
 from cmapi_server import node_manipulation
+from cmapi_server.managers.application import (
+    AppStatefulConfig, StatefulConfigModel, StatefulFlagsModel
+)
 from cmapi_server.constants import MCS_DATA_PATH
 from cmapi_server.exceptions import CMAPIBasicError
 from cmapi_server.node_manipulation import (
@@ -29,6 +32,8 @@ class NodeManipTester(BaseNodeManipTestCase):
     REMOTE_IP = '203.0.113.5'
 
     def test_add_remove_node(self):
+        # Toggle shared storage as requested and remember to restore it back.
+        original_shared_storage = self._set_shared_storage(True)
         self.tmp_files = (
             './test-output0.xml', './test-output1.xml', './test-output2.xml'
         )
@@ -85,6 +90,7 @@ class NodeManipTester(BaseNodeManipTestCase):
         # TODO: Fix node_manipulation add_node logic and _replace_localhost
         # node = root.find('./PMS2/IPAddr')
         # self.assertEqual(node, None)
+        _ = self._set_shared_storage(original_shared_storage)
 
     def test_add_remove_read_replica_node(self):
         """add_node(read_replica=True) should add a read replica node into the config,
@@ -166,6 +172,8 @@ class NodeManipTester(BaseNodeManipTestCase):
             mock_update_dbroots_of_read_replicas.assert_not_called()
 
     def test_add_dbroots_nodes_rebalance(self):
+        # Toggle shared storage as requested and remember to restore it back.
+        original_shared_storage = self._set_shared_storage(True)
         self.tmp_files = (
             './extra-dbroots-0.xml', './extra-dbroots-1.xml', './extra-dbroots-2.xml'
         )
@@ -203,6 +211,8 @@ class NodeManipTester(BaseNodeManipTestCase):
             .build()
         ):
             node_manipulation.remove_node(hostname, self.tmp_files[1], self.tmp_files[2], test_mode=True)
+
+        _ = self._set_shared_storage(original_shared_storage)
 
     def test_add_dbroot(self):
         self.tmp_files = (
@@ -323,6 +333,25 @@ class NodeManipTester(BaseNodeManipTestCase):
         with MockResolutionBuilder().add_mapping(bad_hostname, '10.0.0.5', bidirectional=False).build():
             with self.assertRaises(CMAPIBasicError):
                 node_manipulation.add_node(bad_hostname, tmp_mcs_config_filename, self.tmp_files[0])
+
+    def test_rebalance_noop_when_shared_storage_off(self):
+        # Ensure shared storage flag is False
+        current_cfg = AppStatefulConfig.get_config_copy()
+        if current_cfg.flags.shared_storage_on:
+            new_cfg = StatefulConfigModel(
+                version=current_cfg.version.next_seq(),
+                flags=StatefulFlagsModel(shared_storage_on=False)
+            )
+            AppStatefulConfig.apply_update(new_cfg)
+
+        nc = NodeConfig()
+        root = nc.get_current_config_root(tmp_mcs_config_filename)
+        smc_before = etree.tostring(root.find('./SystemModuleConfig'))
+
+        node_manipulation._rebalance_dbroots(root)
+
+        smc_after = etree.tostring(root.find('./SystemModuleConfig'))
+        self.assertEqual(smc_before, smc_after)
 
 
 class TestDBRootsManipulation(unittest.TestCase):

--- a/cmapi/cmapi_server/test/test_server.py
+++ b/cmapi/cmapi_server/test/test_server.py
@@ -220,13 +220,21 @@ class ConfigPutTestCase(BaseServerTestCase):
     def test_no_active_operation(self):
         """Test no active operation. skip_setUp"""
         body = {
-            'revision': 42,
+            'revision': '42',
             'manager': '1.1.1.1',
             'timeout': 42,
             'config': "<Columnstore>...</Columnstore>",
-            'mcs_config_filename': self.mcs_config_filename
+            'mcs_config_filename': self.mcs_config_filename,
+            'stateful_config_dict': {
+                'flags': {
+                    'shared_storage_on': True
+                },
+                'version': {
+                    'seq': 1,
+                    'term': 1
+                }
+            }
         }
-
         r = requests.put(
             self.URL, verify=False, headers=self.HEADERS, json=body
         )
@@ -242,54 +250,93 @@ class ConfigPutTestCase(BaseServerTestCase):
             BeginTestCase.URL, verify=False, headers=self.HEADERS, json=body
         )
         self.assertEqual(r.status_code, 200)
+        # no manager in body
         body = {
-            'revision': 42,
+            'revision': '42',
             'timeout': 42,
             'config': "<Columnstore>...</Columnstore>",
-            'mcs_config_filename': self.mcs_config_filename
+            'mcs_config_filename': self.mcs_config_filename,
+            'stateful_config_dict': {
+                'flags': {
+                    'shared_storage_on': True
+                },
+                'version': {
+                    'seq': 1,
+                    'term': 1
+                }
+            }
         }
         r = requests.put(
             self.URL, verify=False, headers=self.HEADERS, json=body
         )
         self.assertEqual(r.status_code, 422)
-        self.assertEqual(
-            r.json(), {'error': 'Mandatory attribute is missing.'}
+        self.assertTrue(
+            'Mandatory attribute is missing:' in r.json().get('error', ''),
+            'Error string should contain "Mandatory attribute is missing:"'
         )
+        # no timeout in body
         body = {
+            'revision': '42',
             'manager': '1.1.1.1',
-            'revision': 42,
             'config': "<Columnstore>...</Columnstore>",
-            'mcs_config_filename': self.mcs_config_filename
+            'mcs_config_filename': self.mcs_config_filename,
+            'stateful_config_dict': {
+                'flags': {
+                    'shared_storage_on': True
+                },
+                'version': {
+                    'seq': 1,
+                    'term': 1
+                }
+            }
         }
         r = requests.put(
             self.URL, verify=False, headers=self.HEADERS, json=body
         )
         self.assertEqual(r.status_code, 422)
-        self.assertEqual(
-            r.json(), {'error': 'Mandatory attribute is missing.'}
+        self.assertTrue(
+            'Mandatory attribute is missing:' in r.json().get('error', ''),
+            'Error string should contain "Mandatory attribute is missing:"'
         )
+        # no config in body
         body = {
+            'revision': '42',
             'manager': '1.1.1.1',
-            'revision': 42,
             'timeout': 42,
-            'mcs_config_filename': self.mcs_config_filename
+            'mcs_config_filename': self.mcs_config_filename,
+            'stateful_config_dict': {
+                'flags': {
+                    'shared_storage_on': True
+                },
+                'version': {
+                    'seq': 1,
+                    'term': 1
+                }
+            }
         }
         r = requests.put(
             self.URL, verify=False, headers=self.HEADERS, json=body
         )
         self.assertEqual(r.status_code, 422)
-        self.assertEqual(
-            r.json(), {'error': 'Mandatory attribute is missing.'}
-        )
+        self.assertEqual(r.json(), {'error': 'Mandatory operation attribute is missing.'})
 
     def test_no_auth(self):
         """Test no auth."""
         body = {
-            'revision': 42,
+            'revision': '42',
             'manager': '1.1.1.1',
             'timeout': 42,
             'config': "<Columnstore>...</Columnstore>",
-            'mcs_config_filename': self.mcs_config_filename
+            'mcs_config_filename': self.mcs_config_filename,
+            'stateful_config_dict': {
+                'flags': {
+                    'shared_storage_on': True
+                },
+                'version': {
+                    'seq': 1,
+                    'term': 1
+                }
+            }
         }
         r = requests.put(
             self.URL, verify=False, headers=self.NO_AUTH_HEADERS, json=body
@@ -307,29 +354,28 @@ class ConfigPutTestCase(BaseServerTestCase):
     def test_wrong_cluster_mode(self):
         """Test wrong cluster mode."""
         body = {
-            'revision': 42,
+            'revision': '42',
             'manager': '1.1.1.1',
             'timeout': 42,
             'cluster_mode': 'somemode',
-            'mcs_config_filename': self.mcs_config_filename
         }
         r = requests.put(
             self.URL, verify=False, headers=self.HEADERS, json=body
         )
         self.assertEqual(r.status_code, 422)
         self.assertTrue(
-            "Error occured setting cluster" in r.content.decode('ASCII')
+            "Input should be 'readonly' or 'readwrite'" in r.json().get('error', ''),
+            "Error string should contain 'Input should be 'readonly' or 'readwrite''"
         )
 
     def test_set_mode(self):
         """Test set mode."""
         mode = 'readwrite'
         body = {
-            'revision': 42,
+            'revision': '42',
             'manager': '1.1.1.1',
             'timeout': 42,
-            'cluster_mode': mode,
-            'mcs_config_filename': self.mcs_config_filename
+            'cluster_mode': mode
         }
         r = requests.put(
             self.URL, verify=False, headers=self.HEADERS, json=body
@@ -356,13 +402,22 @@ class ConfigPutTestCase(BaseServerTestCase):
             verify=False, headers=self.HEADERS, json=body
         )
         config_file = Path(self.mcs_config_filename)
-        config = config_file.read_text()
+        config = config_file.read_text(encoding='utf-8')
         body = {
-            'revision': 42,
+            'revision': '42',
             'manager': '1.1.1.1',
             'timeout': 15,
             'config': config,
-            'mcs_config_filename': self.mcs_config_filename
+            'mcs_config_filename': self.mcs_config_filename,
+            'stateful_config_dict': {
+                'flags': {
+                    'shared_storage_on': True
+                },
+                'version': {
+                    'seq': 1,
+                    'term': 1
+                }
+            }
         }
         r = requests.put(
             self.URL, verify=False, headers=self.HEADERS, json=body

--- a/cmapi/cmapi_server/test/unittest_global.py
+++ b/cmapi/cmapi_server/test/unittest_global.py
@@ -10,6 +10,9 @@ from cmapi_server import helpers
 from cmapi_server.constants import CMAPI_CONF_PATH
 from cmapi_server.controllers.dispatcher import dispatcher, jsonify_error
 from cmapi_server.logging_management import config_cmapi_server_logging
+from cmapi_server.managers.application import (
+    AppStatefulConfig, StatefulConfigModel, StatefulFlagsModel
+)
 from cmapi_server.managers.process import MCSProcessManager
 from cmapi_server.managers.certificate import CertificateManager
 
@@ -109,6 +112,21 @@ class BaseNodeManipTestCase(unittest.TestCase):
                 os.remove(tmp_file)
         if os.path.exists(tmp_mcs_config_filename):
             os.remove(tmp_mcs_config_filename)
+
+    def _set_shared_storage(self, target_value: bool) -> bool:
+        """Set shared_storage_on flag to target_value, return original value.
+
+        If the current value already equals target_value, no update is applied.
+        """
+        current_cfg = AppStatefulConfig.get_config_copy()
+        original_value = current_cfg.flags.shared_storage_on
+        if original_value != target_value:
+            new_cfg = StatefulConfigModel(
+                version=current_cfg.version.next_seq(),
+                flags=StatefulFlagsModel(shared_storage_on=target_value),
+            )
+            AppStatefulConfig.apply_update(new_cfg)
+        return original_value
 
 
 class BaseProcessDispatcherCase(unittest.TestCase):

--- a/cmapi/failover/agent_comm.py
+++ b/cmapi/failover/agent_comm.py
@@ -211,9 +211,10 @@ class AgentComm:
                 # determine whether we need a transaction at all.
                 # List the fcns that require a txn here.
                 if not needs_transaction and event.name in (
-                  self._agent.activateNodes,
-                  self._agent.deactivateNodes,
-                  self._agent.movePrimaryNode):
+                    self._agent.activateNodes,
+                    self._agent.deactivateNodes,
+                    self._agent.movePrimaryNode
+                ):
                     needs_transaction = True
 
                 if event.name == self._agent.activateNodes:

--- a/cmapi/failover/config.py
+++ b/cmapi/failover/config.py
@@ -3,6 +3,8 @@ import logging
 import threading
 from os.path import getmtime
 
+import lxml
+
 from cmapi_server.constants import DEFAULT_MCS_CONF_PATH, DEFAULT_SM_CONF_PATH
 from mcs_node_control.models.node_config import NodeConfig
 
@@ -66,25 +68,6 @@ class Config:
         ret = self._primary_node
         self.config_lock.release()
         return ret
-
-    def is_shared_storage(self, sm_config_file=DEFAULT_SM_CONF_PATH):
-        """Check if SM is S3 or not.
-
-        :param sm_config_file: path to SM config,
-            defaults to DEFAULT_SM_CONF_PATH
-        :type sm_config_file: str, optional
-        :return: True if SM is S3 otherwise False
-        :rtype: bool
-
-        TODO: remove in next releases, useless?
-        """
-        sm_config = configparser.ConfigParser()
-        sm_config.read(sm_config_file)
-        # only LocalStorage or S3 can be returned for now
-        storage = sm_config.get(
-            'ObjectStorage', 'service', fallback='LocalStorage'
-        )
-        return storage.lower() == 's3'
 
     def check_reload(self):
         """Check config reload.

--- a/cmapi/failover/node_monitor.py
+++ b/cmapi/failover/node_monitor.py
@@ -6,6 +6,9 @@ from .heartbeater import HeartBeater
 from .config import Config
 from .heartbeat_history import HBHistory
 from .agent_comm import AgentComm
+from .shared_storage_monitor import SharedStorageMonitor
+
+from cmapi_server.managers.application import AppStatefulConfig
 
 
 class NodeMonitor:
@@ -30,6 +33,9 @@ class NodeMonitor:
         # not used yet, KI-V-SS for V1 [old comment from Patrick]
         self.flakyNodeThreshold = flakyNodeThreshold
         self.myName = self._config.who_am_I()
+        # Pass heartbeat history to shared storage monitor so it can skip
+        # nodes that just dropped from Good to NoResponse.
+        self.shared_storage_monitor = SharedStorageMonitor(hb_history=self._hbHistory)
         #self._logger.info("Using {} as my name".format(self.myName))
 
     def __del__(self):
@@ -38,6 +44,7 @@ class NodeMonitor:
     def start(self):
         self._agentComm.start()
         self._hb.start()
+        self.shared_storage_monitor.start()
         self._die = False
         self._runner = threading.Thread(
             target=self.monitor, name='NodeMonitor'
@@ -50,6 +57,7 @@ class NodeMonitor:
         if not self._testMode:
             self._hb.stop()
         self._runner.join()
+        self.shared_storage_monitor.stop()
 
     def _removeRemovedNodes(self, desiredNodes):
         self._hbHistory.keepOnlyTheseNodes(desiredNodes)
@@ -111,8 +119,11 @@ class NodeMonitor:
             # remove nodes from history that have been removed from the cluster
             self._removeRemovedNodes(desiredNodes)
 
-            # if there are less than 3 nodes in the cluster, do nothing
-            if len(desiredNodes) < 3:
+            # if there are less than 3 nodes in the cluster or shared storage is OFF,
+            # failover must not perform any actions. Keep the thread alive but idle,
+            # so that when conditions change (e.g., shared storage becomes available),
+            # the monitor can resume work without restart.
+            if len(desiredNodes) < 3 or not AppStatefulConfig.is_shared_storage():
                 if not logged_idleness_msg:
                     self._logger.info(
                         'Failover support is inactive; '
@@ -120,6 +131,9 @@ class NodeMonitor:
                     )
                     logged_idleness_msg = True
                     logged_active_msg = False
+                # skip the rest of the loop to avoid sending heartbeats or performing any failover
+                # actions while inactive.
+                continue
             elif not logged_active_msg:
                 self._logger.info(
                     'Failover support is active, '

--- a/cmapi/failover/shared_storage_monitor.py
+++ b/cmapi/failover/shared_storage_monitor.py
@@ -1,0 +1,202 @@
+import logging
+import time
+import threading
+from pathlib import Path
+from typing import Optional, List
+
+from cmapi_server.exceptions import CMAPIBasicError
+from cmapi_server.constants import REQUEST_TIMEOUT
+from cmapi_server.controllers.api_clients import ClusterControllerClient
+from cmapi_server.helpers import broadcast_stateful_config, get_active_nodes
+from cmapi_server.managers.application import (
+    AppStatefulConfig, StatefulConfigModel, StatefulFlagsModel,
+)
+from cmapi_server.node_manipulation import get_dbroots_paths
+from mcs_node_control.models.node_config import NodeConfig
+from .heartbeat_history import HBHistory
+
+
+class SharedStorageMonitor:
+
+    def __init__(self, check_interval: int = 5, hb_history: Optional[HBHistory] = None):
+        self._die = False
+        self._logger = logging.getLogger('shared_storage_monitor')
+        self._runner = None
+        self._node_config = NodeConfig()
+        self._cluster_api_client = ClusterControllerClient(request_timeout=REQUEST_TIMEOUT)
+        self.check_interval = check_interval
+        self.last_check_time = 0
+        # Track nodes that were unreachable during the last check to avoid
+        # flipping the shared storage flag based on partial visibility.
+        self._last_unreachable_nodes: set[str] = set()
+        self._hb_history = hb_history
+
+    def __del__(self):
+        try:
+            if getattr(self, '_runner', None):
+                self.stop()
+        except Exception:   # pylint: disable=broad-except
+            pass
+
+    def start(self):
+        self._die = False
+        if self._runner and self._runner.is_alive():
+            self._logger.debug('Shared storage monitor already running.')
+            return
+        self._runner = threading.Thread(target=self.monitor, name='SharedStorageMonitor', daemon=True)
+        self._runner.start()
+
+    def stop(self):
+        self._die = True
+        if self._runner and threading.current_thread() is not self._runner:
+            self._runner.join(timeout=self.check_interval + 2)
+            if self._runner.is_alive():
+                self._logger.warning('Shared storage monitor thread did not exit promptly.')
+
+    def monitor(self):
+        self._logger.info('Starting shared storage monitor.')
+        while not self._die:
+            try:
+                self._logger.info('Shared storage monitor running check.')
+                self._monitor()
+            except Exception:  # pylint: disable=broad-except
+                self._logger.error('Shared storage monitor caught an exception.', exc_info=True)
+            if not self._die:
+                self._logger.info(
+                    'Shared storage monitor finished check, sleeping '
+                    f'{self.check_interval} seconds.'
+                )
+                time.sleep(self.check_interval)
+        self._logger.info('Shared storage monitor exited normally')
+
+    def _retrieve_unstable_nodes(self) -> List[str]:
+        """Skip nodes whose latest stable heartbeat sample is NoResponse.
+
+        We only consider the most recent finalized sample (currentTick - lateWindow),
+        avoiding partial/in-flight samples. If that value is NoResponse, we
+        temporarily exclude the node from the shared-storage check for this cycle.
+        """
+        if not self._hb_history:
+            return []
+        try:
+            active_nodes = get_active_nodes()
+        except Exception:  # pylint: disable=broad-except
+            # If we cannot load active nodes, be safe and skip none.
+            return []
+
+        unstable_nodes: list[str] = []
+        # We only need one stable sample; ask for 1 recent finalized value.
+        lookback = 1
+        for node in active_nodes:
+            # Use GoodResponse as default to avoid over-skipping brand new nodes.
+            hist = self._hb_history.getNodeHistory(node, lookback, HBHistory.GoodResponse)
+            if not hist:
+                continue
+            if hist[-1] == HBHistory.NoResponse:
+                unstable_nodes.append(node)
+        return unstable_nodes
+
+    def _check_shared_storage(self) -> Optional[bool]:
+        extra_payload = {}
+        # Compute skip list based on recent heartbeat instability (if available)
+        skip_nodes = self._retrieve_unstable_nodes()
+        if skip_nodes:
+            self._logger.debug(
+                f'Shared storage check will skip unstable nodes (HB drop): {sorted(skip_nodes)}'
+            )
+            extra_payload['skip_nodes'] = skip_nodes
+        try:
+            response = self._cluster_api_client.check_shared_storage(extra=extra_payload)
+        except CMAPIBasicError as err:
+            self._logger.error(f'Error while calling cluster shared storage check: {err.message}')
+            return None
+        except Exception:  # pylint: disable=broad-except
+            self._logger.error(
+                'Unexpected error while calling cluster shared storage check.',
+                exc_info=True
+            )
+            return None
+        shared_storage_on = response.get('shared_storage', None)
+        if shared_storage_on is None:
+            self._logger.error(
+                'Shared storage check response does not contain "shared_storage" key.'
+            )
+            shared_storage_on = False
+        active_nodes_count = int(response.get('active_nodes_count', 0))
+        if active_nodes_count < 2:
+            # we can't reliably detect shared storage state with less than 2 nodes
+            # in cluster, so we do not change the flag in this case
+            logging.debug(
+                'Less than 2 nodes in cluster, no need to change flag of shared storage.'
+            )
+            return None
+
+        # If some nodes were unreachable during the check, treat the result as
+        # inconclusive and do not update the stateful flag. This avoids flipping
+        # shared_storage_off when a node is simply down/unreachable.
+        nodes_errors = response.get('nodes_errors') or {}
+        if nodes_errors:
+            self._last_unreachable_nodes = set(nodes_errors.keys())
+            self._logger.warning(
+                'Shared storage check has unreachable nodes; deferring decision. '
+                f'Nodes: {sorted(self._last_unreachable_nodes)}'
+            )
+            return None
+
+        # No unreachable nodes; clear any previously tracked ones.
+        if self._last_unreachable_nodes:
+            self._logger.info(
+                'Previously unreachable nodes are now reachable; clearing state.'
+            )
+            self._last_unreachable_nodes.clear()
+
+        return shared_storage_on
+
+    def _check_listed_dbroots_exist(self):
+        c_root = self._node_config.get_current_config_root()
+        dbroots = get_dbroots_paths(c_root)
+        if not dbroots:
+            self._logger.error('No DBRoots found, cannot check shared storage.')
+            return False
+        for dbroot in dbroots:
+            if not Path(dbroot).exists():
+                self._logger.error(f'DBRoot {dbroot} listed in xml config does not exist.')
+                return False
+        return True
+
+    def _monitor(self):
+        dbroots_available: bool = False
+        shared_storage_on_result = None
+        if not self._node_config.is_primary_node():
+            self._logger.debug('This node is not primary, skipping shared storage check.')
+            return
+        dbroots_available = self._check_listed_dbroots_exist()
+        if not dbroots_available:
+            self._logger.info('DBRoots are not available, no need to api check shared storage.')
+            shared_storage_on_result = False
+        else:
+            shared_storage_on_result = self._check_shared_storage()
+
+        current_stateful_config: StatefulConfigModel = AppStatefulConfig.get_config_copy()
+        current_shared_storage_on: bool = current_stateful_config.flags.shared_storage_on
+        # If result is None, the check was inconclusive (e.g., some nodes unreachable);
+        # keep the current flag unchanged and exit.
+        if shared_storage_on_result is None:
+            self._logger.debug(
+                f'Shared storage check inconclusive; Keeping current state: {current_shared_storage_on}'
+            )
+            return
+
+        if not current_shared_storage_on != bool(shared_storage_on_result):
+            self._logger.debug(f'Shared storage state is unchanged: {current_shared_storage_on}')
+        else:
+            self._logger.info(
+                f'Shared storage state changed from {current_shared_storage_on} '
+                f'to {bool(shared_storage_on_result)}. Updating stateful config.'
+            )
+            new_stateful_config = StatefulConfigModel(
+                version=current_stateful_config.version.next_seq(),
+                flags=StatefulFlagsModel(shared_storage_on=bool(shared_storage_on_result))
+            )
+            new_stateful_config_dict = new_stateful_config.model_dump(mode='json')
+            broadcast_stateful_config(stateful_config_dict=new_stateful_config_dict)

--- a/cmapi/failover/test/test_agent_comm.py
+++ b/cmapi/failover/test/test_agent_comm.py
@@ -1,7 +1,6 @@
 import datetime
 import socket
 import time
-import unittest
 from contextlib import contextmanager
 
 import cherrypy
@@ -11,6 +10,7 @@ from cmapi_server.controllers.dispatcher import dispatcher, jsonify_error
 from cmapi_server.failover_agent import FailoverAgent
 from cmapi_server.managers.certificate import CertificateManager
 from cmapi_server.test.mock_resolution import MockResolutionBuilder
+from cmapi_server.test.unittest_global import BaseNodeManipTestCase
 
 from ..agent_comm import AgentComm
 
@@ -19,6 +19,7 @@ config_filename = './cmapi_server/cmapi_server.conf'
 
 @contextmanager
 def start_server():
+    # TODO: review and replace with run_server() from unittest_global.py
     CertificateManager.create_self_signed_certificate_if_not_exist()
 
     app = cherrypy.tree.mount(root = None, config = config_filename)
@@ -40,7 +41,7 @@ def start_server():
     cherrypy.engine.block()
 
 
-class TestAgentComm(unittest.TestCase):
+class TestAgentComm(BaseNodeManipTestCase):
 
     def test_with_agent_base(self):
         agent = AgentComm()
@@ -78,15 +79,17 @@ class TestAgentComm(unittest.TestCase):
 
     # This is the beginnings of an integration test, will need perms to modify the real config file
     def test_with_failover_agent(self):
+        # Toggle shared storage as requested and remember to restore it back.
+        original_shared_storage = self._set_shared_storage(True)
 
-        print("\n\n")   # make a little whitespace between tests
+        print('\n\n')   # make a little whitespace between tests
 
         # check for existence of and permissions to write to the real config file
         try:
-            f = open("/etc/columnstore/Columnstore.xml", "a")
+            f = open('/etc/columnstore/Columnstore.xml', 'a')
             f.close()
         except PermissionError:
-            print(f"Skipping {__name__}, got a permissions error opening /etc/columnstore/Columnstore.xml for writing")
+            print(f'Skipping {__name__}, got a permissions error opening /etc/columnstore/Columnstore.xml for writing')
             return
 
         success = False
@@ -115,8 +118,8 @@ class TestAgentComm(unittest.TestCase):
                     agentcomm.designatePrimaryNode(socket.gethostname())
 
                 health = agent.getNodeHealth()
-                agent.raiseAlarm("Hello world!")
-                print("Waiting up to 30s for queued events to be processed and removed")
+                agent.raiseAlarm('Hello world!')
+                print('Waiting up to 30s for queued events to be processed and removed')
                 stop_time = datetime.datetime.now() + datetime.timedelta(seconds = 30)
 
                 while datetime.datetime.now() < stop_time and not success:
@@ -124,10 +127,10 @@ class TestAgentComm(unittest.TestCase):
                     if sizes != (0, 0):
                         time.sleep(1)
                     else:
-                        print("Event queue & deduper are now empty")
+                        print('Event queue & deduper are now empty')
                         success = True
                 if not success:
-                    raise Exception("The event queue or de-duper did not empty within 30s")
+                    raise Exception('The event queue or de-duper did not empty within 30s')
                 agentcomm.die()
             except Exception as e:
                 agentcomm.die()
@@ -137,7 +140,8 @@ class TestAgentComm(unittest.TestCase):
 
             # clean up the config file, remove mysql.com
             txnid = helpers.start_transaction()
-            node_manipulation.remove_node("mysql.com")
+            node_manipulation.remove_node('mysql.com')
             helpers.update_revision_and_manager()
             helpers.broadcast_new_config()
             helpers.commit_transaction(txnid)
+            _ = self._set_shared_storage(original_shared_storage)

--- a/cmapi/failover/test/test_shared_storage_monitor.py
+++ b/cmapi/failover/test/test_shared_storage_monitor.py
@@ -1,0 +1,90 @@
+import unittest
+from unittest.mock import MagicMock
+
+# pylint: disable=protected-access
+
+from failover.shared_storage_monitor import SharedStorageMonitor
+from failover.heartbeat_history import HBHistory
+
+
+class SharedStorageMonitorTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.hb = HBHistory(tickWindow=10)
+        self.monitor = SharedStorageMonitor(check_interval=0, hb_history=self.hb)
+        self.monitor._cluster_api_client = MagicMock()
+
+    def test_check_shared_storage_returns_none_when_nodes_unreachable(self):
+        self.monitor._cluster_api_client.check_shared_storage.return_value = {
+            'shared_storage': False,
+            'active_nodes_count': 3,
+            'nodes_responses': {
+                'node-1': {'success': False, 'error': 'timeout'},
+            },
+            'nodes_errors': {'node-1': 'timeout'},
+        }
+
+        result = self.monitor._check_shared_storage()
+
+        self.assertIsNone(result)
+        self.assertEqual({'node-1'}, self.monitor._last_unreachable_nodes)
+
+    def test_check_shared_storage_recovers_after_unreachable_nodes(self):
+        # First call reports unreachable nodes
+        self.monitor._cluster_api_client.check_shared_storage.return_value = {
+            'shared_storage': False,
+            'active_nodes_count': 3,
+            'nodes_responses': {
+                'node-1': {'success': False, 'error': 'timeout'},
+            },
+            'nodes_errors': {'node-1': 'timeout'},
+        }
+        first_result = self.monitor._check_shared_storage()
+        self.assertIsNone(first_result)
+        self.assertEqual({'node-1'}, self.monitor._last_unreachable_nodes)
+
+        # Second call indicates all nodes reachable and shared storage ok
+        self.monitor._cluster_api_client.check_shared_storage.return_value = {
+            'shared_storage': True,
+            'active_nodes_count': 3,
+            'nodes_responses': {
+                'node-1': {'success': True},
+            },
+            'nodes_errors': {},
+        }
+        second_result = self.monitor._check_shared_storage()
+
+        self.assertTrue(second_result)
+        self.assertFalse(self.monitor._last_unreachable_nodes)
+
+    def test_skips_nodes_with_recent_good_to_no_transition(self):
+        # Instead of relying on environment get_active_nodes, patch the helper
+        # to return a deterministic skip list derived from HB signal.
+        self.monitor._retrieve_unstable_nodes = MagicMock(return_value=['node-2'])
+
+        # Mock API client to verify payload contains skip_nodes
+        self.monitor._cluster_api_client.check_shared_storage.return_value = {
+            'shared_storage': True,
+            'active_nodes_count': 2,
+            'nodes_responses': {
+                'node-1': {'success': True},
+            },
+            'nodes_errors': {},
+        }
+
+        _ = self.monitor._check_shared_storage()
+
+        # We expect check_shared_storage to be called with extra payload
+        calls = self.monitor._cluster_api_client.check_shared_storage.mock_calls
+        # Find latest call with kwargs
+        self.assertTrue(calls, 'check_shared_storage was not called')
+        last_call = calls[-1]
+        # last_call is call(extra={...})
+        kwargs = last_call.kwargs
+        self.assertIn('extra', kwargs)
+        self.assertIn('skip_nodes', kwargs['extra'])
+        self.assertEqual(['node-2'], kwargs['extra']['skip_nodes'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cmapi/mcs_node_control/models/node_config.py
+++ b/cmapi/mcs_node_control/models/node_config.py
@@ -398,7 +398,7 @@ class NodeConfig:
                 addrs = ni.addresses.get(fam)
                 if addrs is not None:
                     for addr in addrs:
-                        yield(addr)
+                        yield addr
 
     def get_network_addresses_and_names(self):
         """Retrievs the list of the network addresses, hostnames, and aliases
@@ -412,7 +412,7 @@ class NodeConfig:
                 addrs = ni.addresses.get(fam)
                 if addrs is not None:
                     for addr in addrs:
-                        yield(addr)
+                        yield addr
                         try:
                             (host, aliases, _) = socket.gethostbyaddr(addr)
                         except:

--- a/cmapi/requirements.in
+++ b/cmapi/requirements.in
@@ -16,5 +16,5 @@ requests==2.32.3
 # but CherryPy itself has no such a dependency
 Routes==2.5.1
 typer==0.15.2
+pydantic==2.11.7
 sentry-sdk==2.34.1
-

--- a/cmapi/requirements.txt
+++ b/cmapi/requirements.txt
@@ -27,8 +27,10 @@ aiohttp==3.11.16
     # via
     #   -r requirements.in
     #   google-auth
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via aiohttp
+annotated-types==0.7.0
+    # via pydantic
 argcomplete==3.6.2
     # via gsutil
 async-timeout==5.0.1
@@ -49,13 +51,13 @@ botocore==1.37.28
     #   s3transfer
 cachetools==5.5.2
     # via google-auth
-certifi==2025.1.31
+certifi==2025.8.3
     # via
     #   requests
     #   sentry-sdk
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.3
     # via requests
 cheroot==10.0.1
     # via cherrypy
@@ -75,11 +77,11 @@ distro==1.9.0
     # via -r requirements.in
 docutils==0.16
     # via awscli
-fasteners==0.19
+fasteners==0.20
     # via
     #   google-apitools
     #   gsutil
-frozenlist==1.5.0
+frozenlist==1.7.0
     # via
     #   aiohttp
     #   aiosignal
@@ -115,11 +117,11 @@ idna==3.10
     # via
     #   requests
     #   yarl
-jaraco-collections==5.1.0
+jaraco-collections==5.2.1
     # via cherrypy
 jaraco-context==6.0.1
     # via jaraco-text
-jaraco-functools==4.1.0
+jaraco-functools==4.3.0
     # via
     #   cheroot
     #   jaraco-text
@@ -136,13 +138,13 @@ mdurl==0.1.2
     # via markdown-it-py
 monotonic==1.6
     # via gsutil
-more-itertools==10.6.0
+more-itertools==10.7.0
     # via
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-multidict==6.3.2
+multidict==6.6.4
     # via
     #   aiohttp
     #   yarl
@@ -152,9 +154,9 @@ oauth2client==4.1.3
     #   google-apitools
 orderedmultidict==1.0.1
     # via furl
-portend==3.2.0
+portend==3.2.1
     # via cherrypy
-propcache==0.3.1
+propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
@@ -171,7 +173,11 @@ pyasn1-modules==0.4.2
     #   oauth2client
 pycparser==2.22
     # via cffi
-pygments==2.19.1
+pydantic==2.11.7
+    # via -r requirements.in
+pydantic-core==2.33.2
+    # via pydantic
+pygments==2.19.2
     # via rich
 pyopenssl==24.2.1
     # via
@@ -199,7 +205,7 @@ retry-decorator==1.1.1
     # via
     #   gcs-oauth2-boto-plugin
     #   gsutil
-rich==14.0.0
+rich==14.1.0
     # via typer
 routes==2.5.1
     # via -r requirements.in
@@ -209,7 +215,7 @@ rsa==4.7.2
     #   gcs-oauth2-boto-plugin
     #   google-auth
     #   oauth2client
-s3transfer==0.11.4
+s3transfer==0.11.5
     # via awscli
 sentry-sdk==2.34.1
     # via -r requirements.in
@@ -227,21 +233,26 @@ six==1.17.0
     #   python-dateutil
     #   pyu2f
     #   routes
-tempora==5.8.0
+tempora==5.8.1
     # via portend
 typer==0.15.2
     # via -r requirements.in
-typing-extensions==4.13.1
+typing-extensions==4.14.1
     # via
+    #   aiosignal
     #   multidict
-    #   rich
+    #   pydantic
+    #   pydantic-core
     #   typer
+    #   typing-inspection
+typing-inspection==0.4.1
+    # via pydantic
 urllib3==1.26.20
     # via
     #   botocore
     #   requests
     #   sentry-sdk
-yarl==1.19.0
+yarl==1.20.1
     # via aiohttp
 zc-lockfile==3.0.post1
     # via cherrypy


### PR DESCRIPTION
feat(cmapi,failover): MCOL-6006 Disable failover when shared storage not detected

- Add SharedStorageMonitor thread to periodically verify shared storage:
  * Writes a temp file to the shared location and validates MD5 from all nodes.
  * Skips nodes with unstable recent heartbeats; retries once; defers decision if any node is unreachable.
  * Updates a cluster-wide stateful flag (shared_storage_on) only on conclusive checks.
- New CMAPI endpoints:
  * PUT /cmapi/{ver}/cluster/check-shared-storage — orchestrates cross-node checks.
  * GET /cmapi/{ver}/node/check-shared-file — validates a given file’s MD5 on a node.
  * PUT /cmapi/{ver}/node/stateful-config — fast path to distribute stateful config updates.
- Introduce in-memory stateful config (AppStatefulConfig) with versioned flags (term/seq) and shared_storage_on flag:
  * Broadcast via helpers.broadcast_stateful_config and enhanced broadcast_new_config.
  * Config PUT is now validated with Pydantic models; supports stateful-only updates and set_mode requests.
- Failover behavior:
  * NodeMonitor keeps failover inactive when shared_storage_on is false or cluster size < 3.
  * Rebalancing DBRoots becomes a no-op when shared storage is OFF (safety guard).
- mcl status improvements: per-node 'state' (online/offline), better timeouts and error reporting.
- Routing/wiring: add dispatcher routes for new endpoints; add ClusterModeEnum.
- Tests: cover shared-storage monitor (unreachable nodes, HB-based skipping), node manipulation with shared storage ON/OFF, and server/config flows.
- Dependencies: add pydantic; minor cleanups and logging.