### PR TITLE
feat: MCOL-4889 analyze and vacuum bloat

### DIFF
--- a/dbcon/dmlpackageproc/commandpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/commandpackageprocessor.cpp
@@ -22,10 +22,12 @@
  *
  ***********************************************************************/
 #include <ctime>
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <set>
 #include <vector>
+#include <iomanip>
 #include <boost/scoped_ptr.hpp>
 
 #include "commandpackageprocessor.h"
@@ -474,6 +476,10 @@ DMLPackageProcessor::DMLResult CommandPackageProcessor::processPackageInternal(
     else if (stmt == "ANALYZEPARTITIONBLOAT")
     {
       analyzePartitionBloat(cpackage, result);
+    }
+    else if (stmt == "ANALYZETABLEBLOAT")
+    {
+      analyzeTableBloat(cpackage, result);
     }
     else if (!cpackage.get_Logging())
     {
@@ -1195,7 +1201,7 @@ void CommandPackageProcessor::analyzePartitionBloat(const dmlpackage::CalpontDML
       return;
     }
 
-    // SELECT COUNT(aux) AS count_aux FROM schema.table WHERE idbPartition(aux) = partitionStr;
+    // SELECT COUNT(aux) AS count_aux, COUNT(CASE aux WHEN 1 THEN 1 END) AS count_aux_deleted FROM schema.table WHERE idbPartition(aux) = partitionStr;
     CalpontSelectExecutionPlan csep;
     CalpontSelectExecutionPlan::ReturnedColumnList returnedColumnList;
     CalpontSelectExecutionPlan::FilterTokenList filterTokenList;
@@ -1223,16 +1229,74 @@ void CommandPackageProcessor::analyzePartitionBloat(const dmlpackage::CalpontDML
     SRCP auxSRCP(auxCol->clone());
     countAuxCol->aggParms().push_back(auxSRCP);
 
+    // Create the CASE aux WHEN 1 THEN 1 END expression
+    FunctionColumn* caseCol = new FunctionColumn();
+    caseCol->functionName("case_simple");  // Use case_simple for expression comparison
+    caseCol->sessionID(fSessionID);
+    caseCol->expressionId(2);
+    caseCol->alias("case_aux_deleted");
+    
+    // Set the result type for the CASE expression
+    CalpontSystemCatalog::ColType caseColType;
+    caseColType.colDataType = CalpontSystemCatalog::INT;
+    caseColType.colWidth = 4;
+    caseCol->resultType(caseColType);
+    
+    // Create the WHEN value: 1
+    ConstantColumn* whenValue = new ConstantColumn("1", ConstantColumn::NUM);
+    whenValue->sessionID(fSessionID);
+    
+    // Create the THEN result: 1
+    ConstantColumn* thenResult = new ConstantColumn("1", ConstantColumn::NUM);
+    thenResult->sessionID(fSessionID);
+    
+    // Build the function parameters for CASE
+    funcexp::FunctionParm funcParms;
+    SPTP sptp;
+    
+    // Add the CASE expression (aux column)
+    sptp.reset(new ParseTree(auxCol->clone()));
+    funcParms.push_back(sptp);
+    
+    // Add the WHEN value
+    sptp.reset(new ParseTree(whenValue));
+    funcParms.push_back(sptp);
+    
+    // Add the THEN result
+    sptp.reset(new ParseTree(thenResult));
+    funcParms.push_back(sptp);
+    
+    // Set the function parameters
+    caseCol->functionParms(funcParms);
+
+    // Create the COUNT(CASE aux WHEN 1 THEN 1 END) AS count_aux_deleted aggregate column
+    AggregateColumn* countCaseCol = new AggregateColumn(fSessionID);
+    countCaseCol->alias("count_aux_deleted");
+    countCaseCol->aggOp(AggregateColumn::COUNT);
+    countCaseCol->functionName("count");
+    countCaseCol->expressionId(3);
+    CalpontSystemCatalog::ColType countCaseColType;
+    countCaseColType.colDataType = CalpontSystemCatalog::INT;
+    countCaseColType.colWidth = 4;
+    countCaseCol->resultType(countCaseColType);
+
+    SRCP caseSRCP(caseCol->clone());
+    countCaseCol->aggParms().push_back(caseSRCP);
+
     // Add the base 'aux' column to ColumnMap (used for reference resolution)
-    // Note: The aggregate result "count_aux" does NOT go in ColumnMap
-    // Add "aux" twice since it's referenced in both COUNT(aux) and idbPartition(aux)
+    // Note: The aggregate results do NOT go in ColumnMap
+    // Add "aux" multiple times since it's referenced in COUNT(aux), CASE expression, and idbPartition(aux)
+    colMap.insert(CMVT_(tableName.schema + "." + tableName.table + "." + "aux", auxSRCP));
+    auxSRCP.reset(auxCol->clone());
     colMap.insert(CMVT_(tableName.schema + "." + tableName.table + "." + "aux", auxSRCP));
     auxSRCP.reset(auxCol->clone());
     colMap.insert(CMVT_(tableName.schema + "." + tableName.table + "." + "aux", auxSRCP));
 
-    // Add the COUNT column to ReturnedColumnList (what gets returned by SELECT)
+    // Add both COUNT columns to ReturnedColumnList (what gets returned by SELECT)
     SRCP countSRCP(countAuxCol->clone());
     returnedColumnList.push_back(countSRCP);
+    SRCP countCaseSRCP(countCaseCol->clone());
+    returnedColumnList.push_back(countCaseSRCP);
 
     csep.columnMapNonStatic(colMap);
     csep.returnedCols(returnedColumnList);
@@ -1242,23 +1306,23 @@ void CommandPackageProcessor::analyzePartitionBloat(const dmlpackage::CalpontDML
 
     // Create a FunctionColumn for idbPartition(aux)
     // parms: psueducolumn dbroot, segmentdir, segment
-    SPTP sptp;
+    SPTP sptp2;
     FunctionColumn* fc = new FunctionColumn();
     fc->functionName("idbpartition");
     fc->sessionID(fSessionID);
     fc->expressionId(0);
     funcexp::FunctionParm parms;
     PseudoColumn* dbroot = new PseudoColumn(*auxCol, PSEUDO_DBROOT, fSessionID);
-    sptp.reset(new ParseTree(dbroot));
-    parms.push_back(sptp);
+    sptp2.reset(new ParseTree(dbroot));
+    parms.push_back(sptp2);
 
     PseudoColumn* pp = new PseudoColumn(*auxCol, PSEUDO_SEGMENTDIR, fSessionID);
-    sptp.reset(new ParseTree(pp));
-    parms.push_back(sptp);
+    sptp2.reset(new ParseTree(pp));
+    parms.push_back(sptp2);
 
     PseudoColumn* seg = new PseudoColumn(*auxCol, PSEUDO_SEGMENT, fSessionID);
-    sptp.reset(new ParseTree(seg));
-    parms.push_back(sptp);
+    sptp2.reset(new ParseTree(seg));
+    parms.push_back(sptp2);
 
     fc->functionParms(parms);
 
@@ -1295,26 +1359,23 @@ void CommandPackageProcessor::analyzePartitionBloat(const dmlpackage::CalpontDML
     csep.tableName(tableName.table, 0);
 
     // Send CSEP to ExeMgr
-    auto csepStr = csep.toString();
-    cout << "csep: " << csepStr << endl;
     CalpontSystemCatalog::NJLSysDataList sysDataList;
     systemCatalogPtr->getQueryData(csep, sysDataList);
 
-    cout << "Done getSysData" << endl;
-
-    cout << "result size: " << sysDataList.sysDataVec.size() << endl;
-
-    // parse the result
+    int64_t countAux = 0;
+    int64_t countAuxDeleted = 0;
+    
     for (auto it = sysDataList.begin(); it != sysDataList.end(); it++)
     {
-      cout << "result: " << (*it)->GetData(0) << endl;
+      if (it == sysDataList.begin()) {
+        countAux = (*it)->GetData(0);
+      } else {
+        countAuxDeleted = (*it)->GetData(0);
+      }
     }
 
-    // Return the result - use toString() to get the full plan representation
-    analysisResults << sysDataList.sysDataVec.front()->GetData(0);
-
+    analysisResults << std::fixed << std::setprecision(2) << (static_cast<double>(countAuxDeleted) / countAux) * 100 << "%";
     result.bloatAnalysis = analysisResults.str();
-    cout << "analysisResults: " << analysisResults.str() << endl;
   }
   catch (std::exception& ex)
   {

--- a/dbcon/dmlpackageproc/commandpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/commandpackageprocessor.cpp
@@ -1286,13 +1286,19 @@ void CommandPackageProcessor::analyzePartitionBloat(const dmlpackage::CalpontDML
     BRM::TxnID txnID;
     txnID = fSessionManager.getTxnID(fSessionID);
     csep.txnID(txnID.id);
-    
+
+    // Set the table list
+    CalpontSelectExecutionPlan::TableList tablelist;
+    tablelist.push_back(make_aliastable(tableName.schema, tableName.table, ""));
+    csep.tableList(tablelist);
+    csep.schemaName(tableName.schema, 0);
+    csep.tableName(tableName.table, 0);
 
     // Send CSEP to ExeMgr
     auto csepStr = csep.toString();
     cout << "csep: " << csepStr << endl;
     CalpontSystemCatalog::NJLSysDataList sysDataList;
-    systemCatalogPtr->getSysData(csep, sysDataList, tableName);
+    systemCatalogPtr->getQueryData(csep, sysDataList);
 
     cout << "Done getSysData" << endl;
 
@@ -1305,7 +1311,7 @@ void CommandPackageProcessor::analyzePartitionBloat(const dmlpackage::CalpontDML
     }
 
     // Return the result - use toString() to get the full plan representation
-    analysisResults << "80 (for testing)";
+    analysisResults << sysDataList.sysDataVec.front()->GetData(0);
 
     result.bloatAnalysis = analysisResults.str();
     cout << "analysisResults: " << analysisResults.str() << endl;

--- a/dbcon/dmlpackageproc/commandpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/commandpackageprocessor.cpp
@@ -38,6 +38,13 @@
 #include "oamcache.h"
 #include "liboamcpp.h"
 #include "resourcemanager.h"
+#include "simplecolumn.h"
+#include "functioncolumn.h"
+#include "aggregatecolumn.h"
+#include "simplefilter.h"
+#include "constantcolumn.h"
+#include "pseudocolumn.h"
+#include "functor_str.h"
 
 using namespace std;
 using namespace WriteEngine;
@@ -46,9 +53,12 @@ using namespace execplan;
 using namespace logging;
 using namespace boost;
 using namespace BRM;
+using namespace funcexp;
 
 namespace dmlpackageprocessor
 {
+typedef CalpontSelectExecutionPlan::ColumnMap::value_type CMVT_;
+
 // Tracks active cleartablelock commands by storing set of table lock IDs
 /*static*/ std::set<uint64_t> CommandPackageProcessor::fActiveClearTableLockCmds;
 /*static*/ boost::mutex CommandPackageProcessor::fActiveClearTableLockCmdMutex;
@@ -461,6 +471,10 @@ DMLPackageProcessor::DMLResult CommandPackageProcessor::processPackageInternal(
     {
       clearTableLock(uniqueId, cpackage, result);
     }
+    else if (stmt == "ANALYZEPARTITIONBLOAT")
+    {
+      analyzePartitionBloat(cpackage, result);
+    }
     else if (!cpackage.get_Logging())
     {
       BRM::TxnID txnid = fSessionManager.getTxnID(cpackage.get_SessionID());
@@ -774,7 +788,7 @@ void CommandPackageProcessor::viewTableLock(const dmlpackage::CalpontDMLPackage&
 
       found = true;
     }  // end of displaying a table lock match
-  }    // end of loop through all table locks
+  }  // end of loop through all table locks
 
   if (!found)
   {
@@ -1151,6 +1165,164 @@ void CommandPackageProcessor::establishTableLockToClear(uint64_t tableLockID, BR
 
   // Add this cleartablelock command to the list of active cleartablelock cmds
   fActiveClearTableLockCmds.insert(tableLockID);
+}
+
+void CommandPackageProcessor::analyzePartitionBloat(const dmlpackage::CalpontDMLPackage& cpackage,
+                                                    DMLPackageProcessor::DMLResult& result)
+{
+  boost::shared_ptr<CalpontSystemCatalog> systemCatalogPtr =
+      CalpontSystemCatalog::makeCalpontSystemCatalog(fSessionID);
+  systemCatalogPtr->identity(CalpontSystemCatalog::EC);
+  CalpontSystemCatalog::TableName tableName;
+  tableName.schema = cpackage.get_SchemaName();
+  tableName.table = cpackage.get_TableName();
+  std::string partitionStr = cpackage.get_SQLStatement();
+
+  std::ostringstream analysisResults;
+  bool bErrFlag = false;
+  std::string errorMsg;
+
+  try
+  {
+    // Get AUX column OID for the table
+    CalpontSystemCatalog::OID auxColumnOid = systemCatalogPtr->tableAUXColumnOID(tableName);
+
+    if (auxColumnOid <= 3000)
+    {
+      analysisResults << "Table " << tableName.toString()
+                      << " does not have an AUX column for bloat analysis.";
+      result.bloatAnalysis = analysisResults.str();
+      return;
+    }
+
+    // SELECT COUNT(aux) AS count_aux FROM schema.table WHERE idbPartition(aux) = partitionStr;
+    CalpontSelectExecutionPlan csep;
+    CalpontSelectExecutionPlan::ReturnedColumnList returnedColumnList;
+    CalpontSelectExecutionPlan::FilterTokenList filterTokenList;
+    CalpontSelectExecutionPlan::ColumnMap colMap;
+
+    // Create the base SimpleColumn for 'aux'
+    SimpleColumn* auxCol = new SimpleColumn(tableName.schema, tableName.table, "aux", fSessionID);
+    auxCol->alias("aux");
+    CalpontSystemCatalog::ColType auxColType;
+    auxColType.colDataType = CalpontSystemCatalog::INT;
+    auxColType.colWidth = 4;
+    auxCol->resultType(auxColType);
+
+    // Create the COUNT(aux) AS count_aux aggregate column
+    AggregateColumn* countAuxCol = new AggregateColumn(fSessionID);
+    countAuxCol->alias("count_aux");
+    countAuxCol->aggOp(AggregateColumn::COUNT);
+    countAuxCol->functionName("count");
+    countAuxCol->expressionId(1);
+    CalpontSystemCatalog::ColType countAuxColType;
+    countAuxColType.colDataType = CalpontSystemCatalog::INT;
+    countAuxColType.colWidth = 4;
+    countAuxCol->resultType(countAuxColType);
+
+    SRCP auxSRCP(auxCol->clone());
+    countAuxCol->aggParms().push_back(auxSRCP);
+
+    // Add the base 'aux' column to ColumnMap (used for reference resolution)
+    // Note: The aggregate result "count_aux" does NOT go in ColumnMap
+    // Add "aux" twice since it's referenced in both COUNT(aux) and idbPartition(aux)
+    colMap.insert(CMVT_(tableName.schema + "." + tableName.table + "." + "aux", auxSRCP));
+    auxSRCP.reset(auxCol->clone());
+    colMap.insert(CMVT_(tableName.schema + "." + tableName.table + "." + "aux", auxSRCP));
+
+    // Add the COUNT column to ReturnedColumnList (what gets returned by SELECT)
+    SRCP countSRCP(countAuxCol->clone());
+    returnedColumnList.push_back(countSRCP);
+
+    csep.columnMapNonStatic(colMap);
+    csep.returnedCols(returnedColumnList);
+
+    // Define the filter using FunctionColumn for idbPartition()
+    const SOP opeq(new Operator("="));
+
+    // Create a FunctionColumn for idbPartition(aux)
+    // parms: psueducolumn dbroot, segmentdir, segment
+    SPTP sptp;
+    FunctionColumn* fc = new FunctionColumn();
+    fc->functionName("idbpartition");
+    fc->sessionID(fSessionID);
+    fc->expressionId(0);
+    funcexp::FunctionParm parms;
+    PseudoColumn* dbroot = new PseudoColumn(*auxCol, PSEUDO_DBROOT, fSessionID);
+    sptp.reset(new ParseTree(dbroot));
+    parms.push_back(sptp);
+
+    PseudoColumn* pp = new PseudoColumn(*auxCol, PSEUDO_SEGMENTDIR, fSessionID);
+    sptp.reset(new ParseTree(pp));
+    parms.push_back(sptp);
+
+    PseudoColumn* seg = new PseudoColumn(*auxCol, PSEUDO_SEGMENT, fSessionID);
+    sptp.reset(new ParseTree(seg));
+    parms.push_back(sptp);
+
+    fc->functionParms(parms);
+
+    CalpontSystemCatalog::ColType resultType;
+    resultType.colDataType = CalpontSystemCatalog::VARCHAR;
+    resultType.colWidth = 256;
+    fc->resultType(resultType);
+
+    funcexp::Func_idbpartition* idbpartition = new funcexp::Func_idbpartition();
+    fc->operationType(idbpartition->operationType(parms, fc->resultType()));
+    delete idbpartition;
+
+    // Set up the filter
+    ConstantColumn* partitionConstCol = new ConstantColumn(partitionStr, ConstantColumn::LITERAL);
+    SimpleFilter* f1 = new SimpleFilter(opeq, fc, partitionConstCol);
+    filterTokenList.push_back(f1);
+    csep.filterTokenList(filterTokenList);
+
+
+    // Set the session ID, transaction ID and version Id
+    BRM::QueryContext verID;
+    verID = fSessionManager.verID();
+    csep.verID(verID);
+    csep.sessionID(fSessionID);
+    BRM::TxnID txnID;
+    txnID = fSessionManager.getTxnID(fSessionID);
+    csep.txnID(txnID.id);
+    
+
+    // Send CSEP to ExeMgr
+    auto csepStr = csep.toString();
+    cout << "csep: " << csepStr << endl;
+    CalpontSystemCatalog::NJLSysDataList sysDataList;
+    systemCatalogPtr->getSysData(csep, sysDataList, tableName);
+
+    cout << "Done getSysData" << endl;
+
+    cout << "result size: " << sysDataList.sysDataVec.size() << endl;
+
+    // parse the result
+    for (auto it = sysDataList.begin(); it != sysDataList.end(); it++)
+    {
+      cout << "result: " << (*it)->GetData(0) << endl;
+    }
+
+    // Return the result - use toString() to get the full plan representation
+    analysisResults << "80 (for testing)";
+
+    result.bloatAnalysis = analysisResults.str();
+    cout << "analysisResults: " << analysisResults.str() << endl;
+  }
+  catch (std::exception& ex)
+  {
+    bErrFlag = true;
+    errorMsg = ex.what();
+  }
+
+  if (bErrFlag)
+  {
+    std::ostringstream oss;
+    oss << "Partition bloat analysis failed for table " << tableName.toString() << ", partition "
+        << partitionStr << ": " << errorMsg;
+    result.bloatAnalysis = oss.str();
+  }
 }
 
 }  // namespace dmlpackageprocessor

--- a/dbcon/dmlpackageproc/commandpackageprocessor.cpp
+++ b/dbcon/dmlpackageproc/commandpackageprocessor.cpp
@@ -1306,23 +1306,22 @@ void CommandPackageProcessor::analyzePartitionBloat(const dmlpackage::CalpontDML
 
     // Create a FunctionColumn for idbPartition(aux)
     // parms: psueducolumn dbroot, segmentdir, segment
-    SPTP sptp2;
     FunctionColumn* fc = new FunctionColumn();
     fc->functionName("idbpartition");
     fc->sessionID(fSessionID);
     fc->expressionId(0);
     funcexp::FunctionParm parms;
     PseudoColumn* dbroot = new PseudoColumn(*auxCol, PSEUDO_DBROOT, fSessionID);
-    sptp2.reset(new ParseTree(dbroot));
-    parms.push_back(sptp2);
+    sptp.reset(new ParseTree(dbroot));
+    parms.push_back(sptp);
 
     PseudoColumn* pp = new PseudoColumn(*auxCol, PSEUDO_SEGMENTDIR, fSessionID);
-    sptp2.reset(new ParseTree(pp));
-    parms.push_back(sptp2);
+    sptp.reset(new ParseTree(pp));
+    parms.push_back(sptp);
 
     PseudoColumn* seg = new PseudoColumn(*auxCol, PSEUDO_SEGMENT, fSessionID);
-    sptp2.reset(new ParseTree(seg));
-    parms.push_back(sptp2);
+    sptp.reset(new ParseTree(seg));
+    parms.push_back(sptp);
 
     fc->functionParms(parms);
 
@@ -1367,9 +1366,9 @@ void CommandPackageProcessor::analyzePartitionBloat(const dmlpackage::CalpontDML
     
     for (auto it = sysDataList.begin(); it != sysDataList.end(); it++)
     {
-      if (it == sysDataList.begin()) {
+      if ((*it)->ColumnOID() == static_cast<int>(countAuxCol->expressionId())) {
         countAux = (*it)->GetData(0);
-      } else {
+      } else if ((*it)->ColumnOID() == static_cast<int>(countCaseCol->expressionId())) {
         countAuxDeleted = (*it)->GetData(0);
       }
     }
@@ -1391,5 +1390,233 @@ void CommandPackageProcessor::analyzePartitionBloat(const dmlpackage::CalpontDML
     result.bloatAnalysis = oss.str();
   }
 }
+
+void CommandPackageProcessor::analyzeTableBloat(const dmlpackage::CalpontDMLPackage& cpackage,
+                                                DMLPackageProcessor::DMLResult& result)
+{
+boost::shared_ptr<CalpontSystemCatalog> systemCatalogPtr =
+      CalpontSystemCatalog::makeCalpontSystemCatalog(fSessionID);
+  systemCatalogPtr->identity(CalpontSystemCatalog::EC);
+  CalpontSystemCatalog::TableName tableName;
+  tableName.schema = cpackage.get_SchemaName();
+  tableName.table = cpackage.get_TableName();
+
+  std::ostringstream analysisResults;
+  bool bErrFlag = false;
+  std::string errorMsg;
+
+  try
+  {
+    // Get AUX column OID for the table
+    CalpontSystemCatalog::OID auxColumnOid = systemCatalogPtr->tableAUXColumnOID(tableName);
+
+    if (auxColumnOid <= 3000)
+    {
+      analysisResults << "Table " << tableName.toString()
+                      << " does not have an AUX column for bloat analysis.";
+      result.bloatAnalysis = analysisResults.str();
+      return;
+    }
+
+    // SELECT idbPartition(aux), COUNT(aux) AS count_aux, COUNT(CASE aux WHEN 1 THEN 1 END) AS count_aux_deleted FROM test GROUP BY idbPartition(aux);
+    CalpontSelectExecutionPlan csep;
+    CalpontSelectExecutionPlan::ReturnedColumnList returnedColumnList;
+    CalpontSelectExecutionPlan::ColumnMap colMap;
+
+    // Create the base SimpleColumn for 'aux'
+    SimpleColumn* auxCol = new SimpleColumn(tableName.schema, tableName.table, "aux", fSessionID);
+    auxCol->alias("aux");
+    auxCol->setOID();
+    CalpontSystemCatalog::ColType auxColType;
+    auxColType.colDataType = CalpontSystemCatalog::INT;
+    auxColType.colWidth = 4;
+    auxCol->resultType(auxColType);
+
+    // Create the COUNT(aux) AS count_aux aggregate column
+    AggregateColumn* countAuxCol = new AggregateColumn(fSessionID);
+    countAuxCol->alias("count_aux");
+    countAuxCol->aggOp(AggregateColumn::COUNT);
+    countAuxCol->functionName("count");
+    countAuxCol->expressionId(1);
+    CalpontSystemCatalog::ColType countAuxColType;
+    countAuxColType.colDataType = CalpontSystemCatalog::INT;
+    countAuxColType.colWidth = 4;
+    countAuxCol->resultType(countAuxColType);
+
+    SRCP auxSRCP(auxCol->clone());
+    countAuxCol->aggParms().push_back(auxSRCP);
+
+    // Create the CASE aux WHEN 1 THEN 1 END expression
+    FunctionColumn* caseCol = new FunctionColumn();
+    caseCol->functionName("case_simple");  // Use case_simple for expression comparison
+    caseCol->sessionID(fSessionID);
+    caseCol->expressionId(2);
+    caseCol->alias("case_aux_deleted");
+    
+    // Set the result type for the CASE expression
+    CalpontSystemCatalog::ColType caseColType;
+    caseColType.colDataType = CalpontSystemCatalog::INT;
+    caseColType.colWidth = 4;
+    caseCol->resultType(caseColType);
+    
+    // Create the WHEN value: 1
+    ConstantColumn* whenValue = new ConstantColumn("1", ConstantColumn::NUM);
+    whenValue->sessionID(fSessionID);
+    
+    // Create the THEN result: 1
+    ConstantColumn* thenResult = new ConstantColumn("1", ConstantColumn::NUM);
+    thenResult->sessionID(fSessionID);
+    
+    // Build the function parameters for CASE
+    funcexp::FunctionParm funcParms;
+    SPTP sptp;
+    
+    // Add the CASE expression (aux column)
+    sptp.reset(new ParseTree(auxCol->clone()));
+    funcParms.push_back(sptp);
+    
+    // Add the WHEN value
+    sptp.reset(new ParseTree(whenValue));
+    funcParms.push_back(sptp);
+    
+    // Add the THEN result
+    sptp.reset(new ParseTree(thenResult));
+    funcParms.push_back(sptp);
+    
+    // Set the function parameters
+    caseCol->functionParms(funcParms);
+
+    // Create the COUNT(CASE aux WHEN 1 THEN 1 END) AS count_aux_deleted aggregate column
+    AggregateColumn* countCaseCol = new AggregateColumn(fSessionID);
+    countCaseCol->alias("count_aux_deleted");
+    countCaseCol->aggOp(AggregateColumn::COUNT);
+    countCaseCol->functionName("count");
+    countCaseCol->expressionId(3);
+    CalpontSystemCatalog::ColType countCaseColType;
+    countCaseColType.colDataType = CalpontSystemCatalog::INT;
+    countCaseColType.colWidth = 4;
+    countCaseCol->resultType(countCaseColType);
+
+    SRCP caseSRCP(caseCol->clone());
+    countCaseCol->aggParms().push_back(caseSRCP);
+
+    // Add the base 'aux' column to ColumnMap (used for reference resolution)
+    // Note: The aggregate results do NOT go in ColumnMap
+    // Add "aux" multiple times since it's referenced in COUNT(aux), CASE expression, and idbPartition(aux)
+    colMap.insert(CMVT_(tableName.schema + "." + tableName.table + "." + "aux", auxSRCP));
+    auxSRCP.reset(auxCol->clone());
+    colMap.insert(CMVT_(tableName.schema + "." + tableName.table + "." + "aux", auxSRCP));
+    auxSRCP.reset(auxCol->clone());
+    colMap.insert(CMVT_(tableName.schema + "." + tableName.table + "." + "aux", auxSRCP));
+
+    // Add both COUNT columns to ReturnedColumnList (what gets returned by SELECT)
+    SRCP countSRCP(countAuxCol->clone());
+    returnedColumnList.push_back(countSRCP);
+    SRCP countCaseSRCP(countCaseCol->clone());
+    returnedColumnList.push_back(countCaseSRCP);
+
+    // Create a FunctionColumn for idbPartition(aux)
+    // parms: psueducolumn dbroot, segmentdir, segment
+    FunctionColumn* fc = new FunctionColumn();
+    fc->functionName("idbpartition");
+    fc->alias("idbPartition(aux)");
+    fc->sessionID(fSessionID);
+    fc->expressionId(0);
+    funcexp::FunctionParm parms;
+    PseudoColumn* dbroot = new PseudoColumn(*auxCol, PSEUDO_DBROOT, fSessionID);
+    sptp.reset(new ParseTree(dbroot));
+    parms.push_back(sptp);
+
+    PseudoColumn* pp = new PseudoColumn(*auxCol, PSEUDO_SEGMENTDIR, fSessionID);
+    sptp.reset(new ParseTree(pp));
+    parms.push_back(sptp);
+
+    PseudoColumn* seg = new PseudoColumn(*auxCol, PSEUDO_SEGMENT, fSessionID);
+    sptp.reset(new ParseTree(seg));
+    parms.push_back(sptp);
+
+    fc->functionParms(parms);
+
+    CalpontSystemCatalog::ColType resultType;
+    resultType.colDataType = CalpontSystemCatalog::VARCHAR;
+    resultType.colWidth = 256;
+    fc->resultType(resultType);
+
+    funcexp::Func_idbpartition* idbpartition = new funcexp::Func_idbpartition();
+    fc->operationType(idbpartition->operationType(parms, fc->resultType()));
+    delete idbpartition;
+
+    SRCP fcSRCP(fc->clone());
+    returnedColumnList.push_back(fcSRCP);
+
+    csep.columnMapNonStatic(colMap);
+    csep.returnedCols(returnedColumnList);
+
+    // Set the group by
+    CalpontSelectExecutionPlan::GroupByColumnList groupByList;
+    groupByList.push_back(fcSRCP);
+    csep.groupByCols(groupByList);
+
+    // Set the session ID, transaction ID and version Id
+    BRM::QueryContext verID;
+    verID = fSessionManager.verID();
+    csep.verID(verID);
+    csep.sessionID(fSessionID);
+    BRM::TxnID txnID;
+    txnID = fSessionManager.getTxnID(fSessionID);
+    csep.txnID(txnID.id);
+
+    // Set the table list
+    CalpontSelectExecutionPlan::TableList tablelist;
+    tablelist.push_back(make_aliastable(tableName.schema, tableName.table, ""));
+    csep.tableList(tablelist);
+    csep.schemaName(tableName.schema, 0);
+    csep.tableName(tableName.table, 0);
+
+    // Send CSEP to ExeMgr
+    CalpontSystemCatalog::NJLSysDataList sysDataList;
+    systemCatalogPtr->getQueryData(csep, sysDataList);
+
+    size_t countAuxIndex = static_cast<size_t>(-1);
+    size_t countAuxDeletedIndex = static_cast<size_t>(-1);
+    size_t idbPartitionIndex = static_cast<size_t>(-1);
+
+    for (size_t i = 0; i < sysDataList.sysDataVec.size(); ++i) {
+      if (sysDataList.sysDataVec[i]->ColumnOID() == static_cast<int>(countAuxCol->expressionId())) {
+        countAuxIndex = i;
+      } else if (sysDataList.sysDataVec[i]->ColumnOID() == static_cast<int>(countCaseCol->expressionId())) {
+        countAuxDeletedIndex = i;
+      } else if (sysDataList.sysDataVec[i]->ColumnOID() == static_cast<int>(fc->expressionId())) {
+        idbPartitionIndex = i;
+      }
+    }
+
+    if (countAuxIndex != static_cast<size_t>(-1) && countAuxDeletedIndex != static_cast<size_t>(-1) && idbPartitionIndex != static_cast<size_t>(-1)) {
+      for (int i = 0; i < sysDataList.sysDataVec[idbPartitionIndex]->dataCount(); i++) {
+        int64_t countAux = sysDataList.sysDataVec[countAuxIndex]->GetData(i);
+        int64_t countAuxDeleted = sysDataList.sysDataVec[countAuxDeletedIndex]->GetData(i);
+        string idbPartition = sysDataList.sysDataVec[idbPartitionIndex]->GetStringData(i).toString();
+
+        if (i > 0) {
+          analysisResults << ", ";
+        }
+        analysisResults << idbPartition << ": " << std::fixed << std::setprecision(2) << (static_cast<double>(countAuxDeleted) / countAux) * 100 << "%";
+      }
+    }
+
+    result.bloatAnalysis = analysisResults.str();
+  }
+  catch (std::exception& ex)
+  {
+    bErrFlag = true;
+    errorMsg = ex.what();
+  }
+
+  if (bErrFlag)
+  {
+    std::ostringstream oss;
+    oss << "Table bloat analysis failed for table " << tableName.toString() << ": " << errorMsg;
+    result.bloatAnalysis = oss.str();
+  }}
 
 }  // namespace dmlpackageprocessor

--- a/dbcon/dmlpackageproc/commandpackageprocessor.h
+++ b/dbcon/dmlpackageproc/commandpackageprocessor.h
@@ -54,6 +54,7 @@ class CommandPackageProcessor : public DMLPackageProcessor
   void clearTableLock(uint64_t uniqueId, const dmlpackage::CalpontDMLPackage& cpackage, DMLResult& result);
   void establishTableLockToClear(uint64_t tableLockID, BRM::TableLockInfo& lockInfo);
   void analyzePartitionBloat(const dmlpackage::CalpontDMLPackage& cpackage, DMLPackageProcessor::DMLResult& result);
+  void analyzeTableBloat(const dmlpackage::CalpontDMLPackage& cpackage, DMLPackageProcessor::DMLResult& result);
   DMLResult processPackageInternal(dmlpackage::CalpontDMLPackage& cpackage) override;
 
   // Tracks active cleartablelock commands by storing set of table lock IDs

--- a/dbcon/dmlpackageproc/commandpackageprocessor.h
+++ b/dbcon/dmlpackageproc/commandpackageprocessor.h
@@ -53,6 +53,7 @@ class CommandPackageProcessor : public DMLPackageProcessor
   void viewTableLock(const dmlpackage::CalpontDMLPackage& cpackage, DMLResult& result);
   void clearTableLock(uint64_t uniqueId, const dmlpackage::CalpontDMLPackage& cpackage, DMLResult& result);
   void establishTableLockToClear(uint64_t tableLockID, BRM::TableLockInfo& lockInfo);
+  void analyzePartitionBloat(const dmlpackage::CalpontDMLPackage& cpackage, DMLPackageProcessor::DMLResult& result);
   DMLResult processPackageInternal(dmlpackage::CalpontDMLPackage& cpackage) override;
 
   // Tracks active cleartablelock commands by storing set of table lock IDs

--- a/dbcon/dmlpackageproc/dmlpackageprocessor.h
+++ b/dbcon/dmlpackageproc/dmlpackageprocessor.h
@@ -129,6 +129,7 @@ class DMLPackageProcessor
     std::string extendedStats;
     std::string miniStats;
     querystats::QueryStats stats;
+    std::string bloatAnalysis;
 
     DMLResult() : result(NO_ERROR), rowCount(0){};
   };

--- a/dbcon/execplan/calpontsystemcatalog.cpp
+++ b/dbcon/execplan/calpontsystemcatalog.cpp
@@ -31,6 +31,7 @@ using namespace std;
 
 #include "messagequeue.h"
 #include "calpontsystemcatalog.h"
+#include "brmtypes.h"
 #include "dataconvert.h"
 #include "ddlpkg.h"
 #include "expressionparser.h"
@@ -449,7 +450,7 @@ CalpontSystemCatalog::OID CalpontSystemCatalog::lookupTableOID(const TableName& 
 
   try
   {
-    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
+    getSysData(csep, sysDataList, SYSTABLE_TABLE);
   }
   catch (IDBExcept&)
   {
@@ -662,7 +663,7 @@ CalpontSystemCatalog::OID CalpontSystemCatalog::lookupOID(const TableColName& ta
   TableColName tcn;
   ColType ct;
   OID coloid = -1;
-  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
+  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
 
   vector<ColumnResult*>::const_iterator it;
 
@@ -751,46 +752,28 @@ CalpontSystemCatalog::OID CalpontSystemCatalog::lookupOID(const TableColName& ta
 }
 
 void CalpontSystemCatalog::getSysData(CalpontSelectExecutionPlan& csep, NJLSysDataList& sysDataList,
-                                      const TableName& tableName)
+                                      const string& sysTableName)
 {
-  // start up new transaction
-
   BRM::TxnID txnID;
   int oldTxnID;
-  txnID = fSessionManager->getTxnID(fSessionID);
-
-  if (!txnID.valid)
-  {
-    txnID.id = 0;
-    txnID.valid = true;
-  }
-
   BRM::QueryContext verID, oldVerID;
-  verID = fSessionManager->verID();
-  oldTxnID = csep.txnID();
-  csep.txnID(txnID.id);
-  oldVerID = csep.verID();
-  csep.verID(verID);
+
   // We need to use a session ID that's separate from the actual query SID, because the dbcon runs queries
-  //  in the middle of receiving data bands for the real query.
   // TODO: we really need a flag or something to identify this as a syscat query: there are assumptions made
   // in joblist that a high-bit-set session id is always a syscat query. This will be okay for a long time,
   // but not forever...
+  csep.sessionID(fSessionID | 0x80000000);
+  setupQueryTxnCtx(csep, txnID, oldTxnID, verID, oldVerID);
 
-  if (tableName.schema == CALPONT_SCHEMA)
-  {
-    csep.sessionID(fSessionID | 0x80000000);
-  }
-  else
-  {
-    csep.sessionID(fSessionID);
-  }
   int tryCnt = 0;
+  //  in the middle of receiving data bands for the real query.
 
   // add the tableList to csep for tuple joblist to use
   CalpontSelectExecutionPlan::TableList tablelist;
-  tablelist.push_back(make_aliastable(tableName.schema, tableName.table, ""));
+  tablelist.push_back(make_aliastable("calpontsys", sysTableName, ""));
   csep.tableList(tablelist);
+  csep.schemaName(CALPONT_SCHEMA, 0);
+  csep.tableName(sysTableName, 0);
 
   // populate the returned column list as column map
   csep.returnedCols().clear();
@@ -805,7 +788,7 @@ void CalpontSystemCatalog::getSysData(CalpontSelectExecutionPlan& csep, NJLSysDa
   {
     try
     {
-      getSysData_EC(csep, sysDataList, tableName);
+      getSysData_EC(csep, sysDataList);
     }
     catch (IDBExcept&)
     {
@@ -824,7 +807,7 @@ void CalpontSystemCatalog::getSysData(CalpontSelectExecutionPlan& csep, NJLSysDa
 
       try
       {
-        getSysData_FE(csep, sysDataList, tableName);
+        getSysData_FE(csep, sysDataList);
         break;
       }
       catch (IDBExcept&)  // error already occurred. this is not a broken pipe
@@ -856,25 +839,106 @@ void CalpontSystemCatalog::getSysData(CalpontSelectExecutionPlan& csep, NJLSysDa
     }
   }
 
+  restoreQueryTxnCtx(csep, oldTxnID, oldVerID);
+}
+
+void CalpontSystemCatalog::getQueryData(execplan::CalpontSelectExecutionPlan& csep, NJLSysDataList& sysDataList)
+{
+  BRM::TxnID txnID;
+  int oldTxnID;
+  BRM::QueryContext verID, oldVerID;
+
+  setupQueryTxnCtx(csep, txnID, oldTxnID, verID, oldVerID);
+
+  int tryCnt = 0;
+
+  if (fIdentity == EC)
+  {
+    try
+    {
+      getSysData_EC(csep, sysDataList);
+    }
+    catch (IDBExcept&)
+    {
+      throw;
+    }
+    catch (runtime_error& e)
+    {
+      throw runtime_error(e.what());
+    }
+  }
+  else
+  {
+    while (tryCnt < 5)
+    {
+      tryCnt++;
+
+      try
+      {
+        getSysData_FE(csep, sysDataList);
+        break;
+      }
+      catch (IDBExcept&)  // error already occurred. this is not a broken pipe
+      {
+        throw;
+      }
+      catch (...)
+      {
+        // may be a broken pipe. re-establish exeMgr and send the message
+        delete fExeMgr;
+        fExeMgr = new ClientRotator(0, "ExeMgr");
+
+        try
+        {
+          fExeMgr->connect(5);
+        }
+        catch (...)
+        {
+          throw IDBExcept(ERR_LOST_CONN_EXEMGR);
+        }
+      }
+    }
+
+    if (tryCnt >= 5)
+      // throw runtime_error("Error occurred when calling system catalog. ExeMgr is not functioning.");
+      throw IDBExcept(ERR_SYSTEM_CATALOG);
+  }
+
+  restoreQueryTxnCtx(csep, oldTxnID, oldVerID);
+}
+
+void CalpontSystemCatalog::setupQueryTxnCtx(CalpontSelectExecutionPlan& csep, BRM::TxnID& txnID, int& oldTxnID, 
+                                               BRM::QueryContext& verID, BRM::QueryContext& oldVerID)
+{
+  // start up new transaction
+  txnID = fSessionManager->getTxnID(fSessionID);
+
+  if (!txnID.valid)
+  {
+    txnID.id = 0;
+    txnID.valid = true;
+  }
+
+  verID = fSessionManager->verID();
+  oldTxnID = csep.txnID();
+  csep.txnID(txnID.id);
+  oldVerID = csep.verID();
+  csep.verID(verID);
+}
+
+void CalpontSystemCatalog::restoreQueryTxnCtx(CalpontSelectExecutionPlan& csep, int oldTxnID, 
+                                                 const BRM::QueryContext& oldVerID)
+{
   csep.sessionID(fSessionID);
   csep.txnID(oldTxnID);
   csep.verID(oldVerID);
 }
 
-void CalpontSystemCatalog::getSysData_EC(CalpontSelectExecutionPlan& csep, NJLSysDataList& sysDataList,
-                                         const TableName& tableName)
+void CalpontSystemCatalog::getSysData_EC(CalpontSelectExecutionPlan& csep, NJLSysDataList& sysDataList)
 {
   DEBUG << "Enter getSysData_EC " << fSessionID << endl;
 
-  uint32_t tableOID;
-  if (tableName.schema == CALPONT_SCHEMA)
-  {
-    tableOID = IDB_VTABLE_ID;
-  }
-  else
-  {
-    tableOID = lookupTableOID(tableName);
-  }
+  uint32_t tableOID = IDB_VTABLE_ID;
   ByteStream bs;
   uint32_t status;
 
@@ -941,8 +1005,7 @@ void CalpontSystemCatalog::getSysData_EC(CalpontSelectExecutionPlan& csep, NJLSy
   }
 }
 
-void CalpontSystemCatalog::getSysData_FE(const CalpontSelectExecutionPlan& csep, NJLSysDataList& sysDataList,
-                                         const TableName& tableName)
+void CalpontSystemCatalog::getSysData_FE(CalpontSelectExecutionPlan& csep, NJLSysDataList& sysDataList)
 {
   DEBUG << "Enter getSysData_FE " << fSessionID << endl;
 
@@ -958,18 +1021,15 @@ void CalpontSystemCatalog::getSysData_FE(const CalpontSelectExecutionPlan& csep,
   csep.serialize(msg);
   fExeMgr->write(msg);
 
-  // Get the table oid for the table being queried.
-  // Use lookupTableOID for regular tables or fall back to IDB_VTABLE_ID for system catalog queries
+  // Get the table oid for the system table being queried.
   uint32_t tableOID;
-  if (tableName.schema == CALPONT_SCHEMA)
+  if (csep.schemaName() == CALPONT_SCHEMA)
   {
-    // System catalog tables still use virtual table ID for compatibility with existing infrastructure
     tableOID = IDB_VTABLE_ID;
   }
   else
   {
-    // Regular user tables - look up the actual table OID
-    tableOID = lookupTableOID(tableName);
+    tableOID = lookupTableOID(TableName(csep.schemaName(), csep.tableName()));
   }
   uint16_t status = 0;
 
@@ -1215,7 +1275,7 @@ const CalpontSystemCatalog::ColType CalpontSystemCatalog::colType(const OID& Oid
 
   csep.data(oss.str());
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
+  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
 
   TableColName tcn;
   vector<ColumnResult*>::const_iterator it;
@@ -1383,7 +1443,7 @@ const CalpontSystemCatalog::ColType CalpontSystemCatalog::colTypeDct(const OID& 
 
   csep.data(oss.str());
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
+  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
 
   vector<ColumnResult*>::const_iterator it;
 
@@ -1495,7 +1555,7 @@ const CalpontSystemCatalog::TableColName CalpontSystemCatalog::colName(const OID
 
   csep.data(oss.str());
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
+  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
 
   vector<ColumnResult*>::const_iterator it;
 
@@ -1596,7 +1656,7 @@ const CalpontSystemCatalog::TableColName CalpontSystemCatalog::dictColName(const
 
   csep.data(oss.str());
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
+  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
 
   vector<ColumnResult*>::const_iterator it;
 
@@ -1704,7 +1764,7 @@ uint64_t CalpontSystemCatalog::nextAutoIncrValue(TableName aTableName, int lower
 
   try
   {
-    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
+    getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
   }
   catch (runtime_error& e)
   {
@@ -1813,7 +1873,7 @@ int32_t CalpontSystemCatalog::autoColumOid(TableName aTableName, int lower_case_
 
   try
   {
-    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
+    getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
   }
   catch (runtime_error& e)
   {
@@ -1883,7 +1943,7 @@ const CalpontSystemCatalog::ROPair CalpontSystemCatalog::nextAutoIncrRid(const O
 
   try
   {
-    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
+    getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
   }
   catch (runtime_error& e)
   {
@@ -2854,7 +2914,7 @@ CalpontSystemCatalog::getTables(const std::string schema, int lower_case_table_n
   }
 
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
+  getSysData(csep, sysDataList, SYSTABLE_TABLE);
 
   vector<ColumnResult*>::const_iterator it;
   vector<string> tnl;
@@ -2934,7 +2994,7 @@ int CalpontSystemCatalog::getTableCount()
   OID oid1 = OID_SYSTABLE_OBJECTID;
 
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
+  getSysData(csep, sysDataList, SYSTABLE_TABLE);
 
   vector<ColumnResult*>::const_iterator it;
 
@@ -3203,7 +3263,7 @@ const CalpontSystemCatalog::RIDList CalpontSystemCatalog::columnRIDs(const Table
 
   csep.data(oss.str());
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
+  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
 
   vector<ColumnResult*>::const_iterator it;
   ColType ct;
@@ -3480,7 +3540,7 @@ const CalpontSystemCatalog::TableName CalpontSystemCatalog::tableName(const OID&
 
   try
   {
-    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
+    getSysData(csep, sysDataList, SYSTABLE_TABLE);
   }
   catch (runtime_error& e)
   {
@@ -3618,7 +3678,7 @@ const CalpontSystemCatalog::ROPair CalpontSystemCatalog::tableRID(const TableNam
 
   try
   {
-    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
+    getSysData(csep, sysDataList, SYSTABLE_TABLE);
   }
   catch (IDBExcept&)
   {
@@ -3761,7 +3821,7 @@ CalpontSystemCatalog::OID CalpontSystemCatalog::tableAUXColumnOID(const TableNam
 
   try
   {
-    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
+    getSysData(csep, sysDataList, SYSTABLE_TABLE);
   }
   catch (IDBExcept&)
   {
@@ -3860,7 +3920,7 @@ CalpontSystemCatalog::OID CalpontSystemCatalog::isAUXColumnOID(const OID& oid)
 
   try
   {
-    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
+    getSysData(csep, sysDataList, SYSTABLE_TABLE);
   }
   catch (IDBExcept&)
   {
@@ -5081,7 +5141,7 @@ const CalpontSystemCatalog::DictOIDList CalpontSystemCatalog::dictOIDs(const Tab
   csep.filterTokenList(filterTokenList);
 
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
+  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
 
   vector<ColumnResult*>::const_iterator it;
 
@@ -5694,7 +5754,7 @@ void CalpontSystemCatalog::getSchemaInfo(const string& in_schema, int lower_case
 
   csep.data(oss.str());
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
+  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
 
   vector<ColumnResult*>::const_iterator it;
   ColType ct;

--- a/dbcon/execplan/calpontsystemcatalog.cpp
+++ b/dbcon/execplan/calpontsystemcatalog.cpp
@@ -449,7 +449,7 @@ CalpontSystemCatalog::OID CalpontSystemCatalog::lookupTableOID(const TableName& 
 
   try
   {
-    getSysData(csep, sysDataList, SYSTABLE_TABLE);
+    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
   }
   catch (IDBExcept&)
   {
@@ -662,7 +662,7 @@ CalpontSystemCatalog::OID CalpontSystemCatalog::lookupOID(const TableColName& ta
   TableColName tcn;
   ColType ct;
   OID coloid = -1;
-  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
+  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
 
   vector<ColumnResult*>::const_iterator it;
 
@@ -751,7 +751,7 @@ CalpontSystemCatalog::OID CalpontSystemCatalog::lookupOID(const TableColName& ta
 }
 
 void CalpontSystemCatalog::getSysData(CalpontSelectExecutionPlan& csep, NJLSysDataList& sysDataList,
-                                      const string& sysTableName)
+                                      const TableName& tableName)
 {
   // start up new transaction
 
@@ -777,12 +777,19 @@ void CalpontSystemCatalog::getSysData(CalpontSelectExecutionPlan& csep, NJLSysDa
   // in joblist that a high-bit-set session id is always a syscat query. This will be okay for a long time,
   // but not forever...
 
-  csep.sessionID(fSessionID | 0x80000000);
+  if (tableName.schema == CALPONT_SCHEMA)
+  {
+    csep.sessionID(fSessionID | 0x80000000);
+  }
+  else
+  {
+    csep.sessionID(fSessionID);
+  }
   int tryCnt = 0;
 
   // add the tableList to csep for tuple joblist to use
   CalpontSelectExecutionPlan::TableList tablelist;
-  tablelist.push_back(make_aliastable("calpontsys", sysTableName, ""));
+  tablelist.push_back(make_aliastable(tableName.schema, tableName.table, ""));
   csep.tableList(tablelist);
 
   // populate the returned column list as column map
@@ -798,7 +805,7 @@ void CalpontSystemCatalog::getSysData(CalpontSelectExecutionPlan& csep, NJLSysDa
   {
     try
     {
-      getSysData_EC(csep, sysDataList, sysTableName);
+      getSysData_EC(csep, sysDataList, tableName);
     }
     catch (IDBExcept&)
     {
@@ -817,7 +824,7 @@ void CalpontSystemCatalog::getSysData(CalpontSelectExecutionPlan& csep, NJLSysDa
 
       try
       {
-        getSysData_FE(csep, sysDataList, sysTableName);
+        getSysData_FE(csep, sysDataList, tableName);
         break;
       }
       catch (IDBExcept&)  // error already occurred. this is not a broken pipe
@@ -855,11 +862,19 @@ void CalpontSystemCatalog::getSysData(CalpontSelectExecutionPlan& csep, NJLSysDa
 }
 
 void CalpontSystemCatalog::getSysData_EC(CalpontSelectExecutionPlan& csep, NJLSysDataList& sysDataList,
-                                         const string& /*sysTableName*/)
+                                         const TableName& tableName)
 {
   DEBUG << "Enter getSysData_EC " << fSessionID << endl;
 
-  uint32_t tableOID = IDB_VTABLE_ID;
+  uint32_t tableOID;
+  if (tableName.schema == CALPONT_SCHEMA)
+  {
+    tableOID = IDB_VTABLE_ID;
+  }
+  else
+  {
+    tableOID = lookupTableOID(tableName);
+  }
   ByteStream bs;
   uint32_t status;
 
@@ -927,7 +942,7 @@ void CalpontSystemCatalog::getSysData_EC(CalpontSelectExecutionPlan& csep, NJLSy
 }
 
 void CalpontSystemCatalog::getSysData_FE(const CalpontSelectExecutionPlan& csep, NJLSysDataList& sysDataList,
-                                         const string& sysTableName)
+                                         const TableName& tableName)
 {
   DEBUG << "Enter getSysData_FE " << fSessionID << endl;
 
@@ -943,11 +958,19 @@ void CalpontSystemCatalog::getSysData_FE(const CalpontSelectExecutionPlan& csep,
   csep.serialize(msg);
   fExeMgr->write(msg);
 
-  // Get the table oid for the system table being queried.
-  TableName tableName;
-  tableName.schema = CALPONT_SCHEMA;
-  tableName.table = sysTableName;
-  uint32_t tableOID = IDB_VTABLE_ID;
+  // Get the table oid for the table being queried.
+  // Use lookupTableOID for regular tables or fall back to IDB_VTABLE_ID for system catalog queries
+  uint32_t tableOID;
+  if (tableName.schema == CALPONT_SCHEMA)
+  {
+    // System catalog tables still use virtual table ID for compatibility with existing infrastructure
+    tableOID = IDB_VTABLE_ID;
+  }
+  else
+  {
+    // Regular user tables - look up the actual table OID
+    tableOID = lookupTableOID(tableName);
+  }
   uint16_t status = 0;
 
   // Send the request for the table.
@@ -1192,7 +1215,7 @@ const CalpontSystemCatalog::ColType CalpontSystemCatalog::colType(const OID& Oid
 
   csep.data(oss.str());
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
+  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
 
   TableColName tcn;
   vector<ColumnResult*>::const_iterator it;
@@ -1360,7 +1383,7 @@ const CalpontSystemCatalog::ColType CalpontSystemCatalog::colTypeDct(const OID& 
 
   csep.data(oss.str());
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
+  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
 
   vector<ColumnResult*>::const_iterator it;
 
@@ -1472,7 +1495,7 @@ const CalpontSystemCatalog::TableColName CalpontSystemCatalog::colName(const OID
 
   csep.data(oss.str());
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
+  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
 
   vector<ColumnResult*>::const_iterator it;
 
@@ -1573,7 +1596,7 @@ const CalpontSystemCatalog::TableColName CalpontSystemCatalog::dictColName(const
 
   csep.data(oss.str());
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
+  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
 
   vector<ColumnResult*>::const_iterator it;
 
@@ -1681,7 +1704,7 @@ uint64_t CalpontSystemCatalog::nextAutoIncrValue(TableName aTableName, int lower
 
   try
   {
-    getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
+    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
   }
   catch (runtime_error& e)
   {
@@ -1790,7 +1813,7 @@ int32_t CalpontSystemCatalog::autoColumOid(TableName aTableName, int lower_case_
 
   try
   {
-    getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
+    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
   }
   catch (runtime_error& e)
   {
@@ -1860,7 +1883,7 @@ const CalpontSystemCatalog::ROPair CalpontSystemCatalog::nextAutoIncrRid(const O
 
   try
   {
-    getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
+    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
   }
   catch (runtime_error& e)
   {
@@ -2831,7 +2854,7 @@ CalpontSystemCatalog::getTables(const std::string schema, int lower_case_table_n
   }
 
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, SYSTABLE_TABLE);
+  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
 
   vector<ColumnResult*>::const_iterator it;
   vector<string> tnl;
@@ -2911,7 +2934,7 @@ int CalpontSystemCatalog::getTableCount()
   OID oid1 = OID_SYSTABLE_OBJECTID;
 
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, SYSTABLE_TABLE);
+  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
 
   vector<ColumnResult*>::const_iterator it;
 
@@ -3180,7 +3203,7 @@ const CalpontSystemCatalog::RIDList CalpontSystemCatalog::columnRIDs(const Table
 
   csep.data(oss.str());
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
+  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
 
   vector<ColumnResult*>::const_iterator it;
   ColType ct;
@@ -3457,7 +3480,7 @@ const CalpontSystemCatalog::TableName CalpontSystemCatalog::tableName(const OID&
 
   try
   {
-    getSysData(csep, sysDataList, SYSTABLE_TABLE);
+    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
   }
   catch (runtime_error& e)
   {
@@ -3595,7 +3618,7 @@ const CalpontSystemCatalog::ROPair CalpontSystemCatalog::tableRID(const TableNam
 
   try
   {
-    getSysData(csep, sysDataList, SYSTABLE_TABLE);
+    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
   }
   catch (IDBExcept&)
   {
@@ -3738,7 +3761,7 @@ CalpontSystemCatalog::OID CalpontSystemCatalog::tableAUXColumnOID(const TableNam
 
   try
   {
-    getSysData(csep, sysDataList, SYSTABLE_TABLE);
+    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
   }
   catch (IDBExcept&)
   {
@@ -3837,7 +3860,7 @@ CalpontSystemCatalog::OID CalpontSystemCatalog::isAUXColumnOID(const OID& oid)
 
   try
   {
-    getSysData(csep, sysDataList, SYSTABLE_TABLE);
+    getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSTABLE_TABLE));
   }
   catch (IDBExcept&)
   {
@@ -5058,7 +5081,7 @@ const CalpontSystemCatalog::DictOIDList CalpontSystemCatalog::dictOIDs(const Tab
   csep.filterTokenList(filterTokenList);
 
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
+  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
 
   vector<ColumnResult*>::const_iterator it;
 
@@ -5671,7 +5694,7 @@ void CalpontSystemCatalog::getSchemaInfo(const string& in_schema, int lower_case
 
   csep.data(oss.str());
   NJLSysDataList sysDataList;
-  getSysData(csep, sysDataList, SYSCOLUMN_TABLE);
+  getSysData(csep, sysDataList, TableName(CALPONT_SCHEMA, SYSCOLUMN_TABLE));
 
   vector<ColumnResult*>::const_iterator it;
   ColType ct;

--- a/dbcon/execplan/calpontsystemcatalog.h
+++ b/dbcon/execplan/calpontsystemcatalog.h
@@ -45,6 +45,13 @@
 #include "joblisttypes.h"
 #include "stdexcept"
 
+namespace BRM
+{
+struct _TxnID;
+typedef struct _TxnID TxnID;
+class QueryContext;
+} // namespace BRM
+
 #undef min
 #undef max
 
@@ -901,6 +908,8 @@ class CalpontSystemCatalog : public datatypes::SystemCatalog
 
   void flushCache();
 
+  void getQueryData(execplan::CalpontSelectExecutionPlan&, NJLSysDataList&);
+
   /** Convert a MySQL thread id to an InfiniDB session id */
   static uint32_t idb_tid2sid(const uint32_t tid);
 
@@ -913,20 +922,26 @@ class CalpontSystemCatalog : public datatypes::SystemCatalog
   // e.g. in client UDFs like calshowpartitions().
   explicit CalpontSystemCatalog();
 
-  /** get system data for Front End */
-  void getSysData_FE(const execplan::CalpontSelectExecutionPlan&, NJLSysDataList&,
-                     const TableName& tableName);
-
-  /** get system data */
-  void getSysData(execplan::CalpontSelectExecutionPlan&, NJLSysDataList&, const TableName& tableName);
  private:
   /** Constuctors */
   explicit CalpontSystemCatalog(const CalpontSystemCatalog& rhs);
 
   CalpontSystemCatalog& operator=(const CalpontSystemCatalog& rhs);
 
+  /** get system data */
+  void getSysData(execplan::CalpontSelectExecutionPlan&, NJLSysDataList&, const std::string& sysTableName);
+
+  /** get system data for Front End */
+  void getSysData_FE(execplan::CalpontSelectExecutionPlan&, NJLSysDataList&);
   /** get system data for Engine Controller */
-  void getSysData_EC(execplan::CalpontSelectExecutionPlan&, NJLSysDataList&, const TableName& tableName);
+  void getSysData_EC(execplan::CalpontSelectExecutionPlan&, NJLSysDataList&);
+
+  /** setup context for getSysData/getQueryData (prolog) */
+  void setupQueryTxnCtx(execplan::CalpontSelectExecutionPlan& csep, BRM::TxnID& txnID, int& oldTxnID, 
+                          BRM::QueryContext& verID, BRM::QueryContext& oldVerID);
+  /** restore context after getSysData/getQueryData (epilog) */
+  void restoreQueryTxnCtx(execplan::CalpontSelectExecutionPlan& csep, int oldTxnID,
+                            const BRM::QueryContext& oldVerID);
 
   void buildSysColinfomap();
   void buildSysOIDmap();

--- a/dbcon/execplan/calpontsystemcatalog.h
+++ b/dbcon/execplan/calpontsystemcatalog.h
@@ -913,19 +913,20 @@ class CalpontSystemCatalog : public datatypes::SystemCatalog
   // e.g. in client UDFs like calshowpartitions().
   explicit CalpontSystemCatalog();
 
+  /** get system data for Front End */
+  void getSysData_FE(const execplan::CalpontSelectExecutionPlan&, NJLSysDataList&,
+                     const TableName& tableName);
+
+  /** get system data */
+  void getSysData(execplan::CalpontSelectExecutionPlan&, NJLSysDataList&, const TableName& tableName);
  private:
   /** Constuctors */
   explicit CalpontSystemCatalog(const CalpontSystemCatalog& rhs);
 
   CalpontSystemCatalog& operator=(const CalpontSystemCatalog& rhs);
 
-  /** get system data */
-  void getSysData(execplan::CalpontSelectExecutionPlan&, NJLSysDataList&, const std::string& sysTableName);
-  /** get system data for Front End */
-  void getSysData_FE(const execplan::CalpontSelectExecutionPlan&, NJLSysDataList&,
-                     const std::string& sysTableName);
   /** get system data for Engine Controller */
-  void getSysData_EC(execplan::CalpontSelectExecutionPlan&, NJLSysDataList&, const std::string& sysTableName);
+  void getSysData_EC(execplan::CalpontSelectExecutionPlan&, NJLSysDataList&, const TableName& tableName);
 
   void buildSysColinfomap();
   void buildSysOIDmap();

--- a/dbcon/mysql/ha_mcs_client_udfs.cpp
+++ b/dbcon/mysql/ha_mcs_client_udfs.cpp
@@ -1169,4 +1169,65 @@ extern "C"
   {
   }
 
+  my_bool analyze_partition_bloat_init(UDF_INIT* initid, UDF_ARGS* args, char* message, const char* funcname)
+  {
+    if (args->arg_count != 3 || 
+        args->arg_type[0] != STRING_RESULT || 
+        args->arg_type[1] != STRING_RESULT || 
+        args->arg_type[2] != STRING_RESULT)
+    {
+      sprintf(message, "%s() requires three string arguments", funcname);
+      return 1;
+    }
+
+    initid->maybe_null = 0;
+    initid->max_length = 3;
+
+    return 0;
+  }
+
+  my_bool mcs_analyze_partition_bloat_init(UDF_INIT* initid, UDF_ARGS* args, char* message)
+  {
+    return analyze_partition_bloat_init(initid, args, message, "MCSANALYZEPARTITIONBLOAT");
+  }
+
+  const char* mcs_analyze_partition_bloat(UDF_INIT* /*initid*/, UDF_ARGS* args, char* result, 
+                                         unsigned long* length, char* /*is_null*/, char* /*error*/)
+  {
+    THD* thd = current_thd;
+
+    if (get_fe_conn_info_ptr() == NULL)
+    {
+      set_fe_conn_info_ptr((void*)new cal_connection_info());
+      thd_set_ha_data(thd, mcs_hton, get_fe_conn_info_ptr());
+    }
+
+    cal_connection_info* ci = reinterpret_cast<cal_connection_info*>(get_fe_conn_info_ptr());
+    execplan::CalpontSystemCatalog::TableName tableName;
+
+    tableName.schema = args->args[0];
+    tableName.table = args->args[1];
+    std::string partition = args->args[2];
+
+    if (lower_case_table_names) {
+        boost::algorithm::to_lower(tableName.schema);
+        boost::algorithm::to_lower(tableName.table);
+    }
+
+    if (!ci->dmlProc)
+    {
+      ci->dmlProc = new MessageQueueClient("DMLProc");
+    }
+
+    std::string analysisResult = ha_mcs_impl_analyze_partition_bloat(*ci, tableName, partition);
+
+    memcpy(result, analysisResult.c_str(), analysisResult.length());
+    *length = analysisResult.length();
+    return result;
+  }
+
+  void mcs_analyze_partition_bloat_deinit(UDF_INIT* /*initid*/)
+  {
+  }
+
 }  // extern "C"

--- a/dbcon/mysql/ha_mcs_client_udfs.cpp
+++ b/dbcon/mysql/ha_mcs_client_udfs.cpp
@@ -1230,6 +1230,67 @@ extern "C"
   {
   }
 
+  my_bool vacuum_partition_init(UDF_INIT* initid, UDF_ARGS* args, char* message, const char* funcname)
+  {
+    if (args->arg_count != 3 || 
+        args->arg_type[0] != STRING_RESULT || 
+        args->arg_type[1] != STRING_RESULT || 
+        args->arg_type[2] != STRING_RESULT)
+    {
+      sprintf(message, "%s() requires three string arguments", funcname);
+      return 1;
+    }
+
+    initid->maybe_null = 0;
+    initid->max_length = 255;
+
+    return 0;
+  }
+
+  my_bool mcs_vacuum_partition_init(UDF_INIT* initid, UDF_ARGS* args, char* message)
+  {
+    return vacuum_partition_init(initid, args, message, "MCSVACUUMPARTITION");
+  }
+
+  const char* mcs_vacuum_partition(UDF_INIT* /*initid*/, UDF_ARGS* args, char* result, 
+                                   unsigned long* length, char* /*is_null*/, char* /*error*/)
+  {
+    THD* thd = current_thd;
+
+    if (get_fe_conn_info_ptr() == NULL)
+    {
+      set_fe_conn_info_ptr((void*)new cal_connection_info());
+      thd_set_ha_data(thd, mcs_hton, get_fe_conn_info_ptr());
+    }
+
+    cal_connection_info* ci = reinterpret_cast<cal_connection_info*>(get_fe_conn_info_ptr());
+    execplan::CalpontSystemCatalog::TableName tableName;
+
+    tableName.schema = args->args[0];
+    tableName.table = args->args[1];
+    std::string partition = args->args[2];
+
+    if (lower_case_table_names) {
+        boost::algorithm::to_lower(tableName.schema);
+        boost::algorithm::to_lower(tableName.table);
+    }
+
+    if (!ci->dmlProc)
+    {
+      ci->dmlProc = new MessageQueueClient("DMLProc");
+    }
+
+    std::string vacuumResult = ha_mcs_impl_vacuum_partition(*ci, tableName, partition);
+
+    memcpy(result, vacuumResult.c_str(), vacuumResult.length());
+    *length = vacuumResult.length();
+    return result;
+  }
+
+  void mcs_vacuum_partition_deinit(UDF_INIT* /*initid*/)
+  {
+  }
+
   my_bool analyze_table_bloat_init(UDF_INIT* initid, UDF_ARGS* args, char* message, const char* funcname)
   {
     if (args->arg_count != 2 || 

--- a/dbcon/mysql/ha_mcs_client_udfs.cpp
+++ b/dbcon/mysql/ha_mcs_client_udfs.cpp
@@ -1181,7 +1181,7 @@ extern "C"
     }
 
     initid->maybe_null = 0;
-    initid->max_length = 3;
+    initid->max_length = 255;
 
     return 0;
   }
@@ -1227,6 +1227,65 @@ extern "C"
   }
 
   void mcs_analyze_partition_bloat_deinit(UDF_INIT* /*initid*/)
+  {
+  }
+
+  my_bool analyze_table_bloat_init(UDF_INIT* initid, UDF_ARGS* args, char* message, const char* funcname)
+  {
+    if (args->arg_count != 2 || 
+        args->arg_type[0] != STRING_RESULT || 
+        args->arg_type[1] != STRING_RESULT)
+    {
+      sprintf(message, "%s() requires two string arguments", funcname);
+      return 1;
+    }
+
+    initid->maybe_null = 0;
+    initid->max_length = 255;
+
+    return 0;
+  }
+
+  my_bool mcs_analyze_table_bloat_init(UDF_INIT* initid, UDF_ARGS* args, char* message)
+  {
+    return analyze_table_bloat_init(initid, args, message, "MCSANALYZETABLEBLOAT");
+  }
+
+  const char* mcs_analyze_table_bloat(UDF_INIT* /*initid*/, UDF_ARGS* args, char* result, 
+                                         unsigned long* length, char* /*is_null*/, char* /*error*/)
+  {
+    THD* thd = current_thd;
+
+    if (get_fe_conn_info_ptr() == NULL)
+    {
+      set_fe_conn_info_ptr((void*)new cal_connection_info());
+      thd_set_ha_data(thd, mcs_hton, get_fe_conn_info_ptr());
+    }
+
+    cal_connection_info* ci = reinterpret_cast<cal_connection_info*>(get_fe_conn_info_ptr());
+    execplan::CalpontSystemCatalog::TableName tableName;
+
+    tableName.schema = args->args[0];
+    tableName.table = args->args[1];
+
+    if (lower_case_table_names) {
+        boost::algorithm::to_lower(tableName.schema);
+        boost::algorithm::to_lower(tableName.table);
+    }
+
+    if (!ci->dmlProc)
+    {
+      ci->dmlProc = new MessageQueueClient("DMLProc");
+    }
+
+    std::string analysisResult = ha_mcs_impl_analyze_table_bloat(*ci, tableName);
+
+    memcpy(result, analysisResult.c_str(), analysisResult.length());
+    *length = analysisResult.length();
+    return result;
+  }
+
+  void mcs_analyze_table_bloat_deinit(UDF_INIT* /*initid*/)
   {
   }
 

--- a/dbcon/mysql/ha_mcs_dml.cpp
+++ b/dbcon/mysql/ha_mcs_dml.cpp
@@ -1077,3 +1077,76 @@ std::string ha_mcs_impl_analyze_partition_bloat(cal_impl_if::cal_connection_info
   return analysisResult;
 }
 
+
+std::string ha_mcs_impl_analyze_table_bloat(cal_impl_if::cal_connection_info& ci,
+                                               execplan::CalpontSystemCatalog::TableName& tablename)
+{
+  THD* thd = current_thd;
+  ulong sessionID = tid2sid(thd->thread_id);
+  CalpontDMLPackage* pDMLPackage;
+  std::string dmlStatement("ANALYZETABLEBLOAT");
+  VendorDMLStatement cmdStmt(dmlStatement, DML_COMMAND, sessionID);
+  pDMLPackage = CalpontDMLFactory::makeCalpontDMLPackageFromMysqlBuffer(cmdStmt);
+  
+  if (lower_case_table_names)
+  {
+    boost::algorithm::to_lower(tablename.schema);
+    boost::algorithm::to_lower(tablename.table);
+  }
+  pDMLPackage->set_SchemaName(tablename.schema);
+  pDMLPackage->set_TableName(tablename.table);
+
+  ByteStream bytestream;
+  bytestream << static_cast<uint32_t>(sessionID);
+  pDMLPackage->write(bytestream);
+  delete pDMLPackage;
+
+  ByteStream::byte b = 0;
+  ByteStream::octbyte rows;
+  std::string errorMsg;
+  std::string analysisResult;
+
+  try
+  {
+    ci.dmlProc->write(bytestream);
+    bytestream = ci.dmlProc->read();
+
+    if (bytestream.length() == 0)
+    {
+      thd->get_stmt_da()->set_overwrite_status(true);
+      thd->raise_error_printf(ER_INTERNAL_ERROR, "Lost connection to DMLProc [9]");
+    }
+    else
+    {
+      bytestream >> b;
+      bytestream >> rows;
+      bytestream >> errorMsg;
+
+      // Skip tableLockInfo, queryStats, extendedStats, miniStats (not used for this command)
+      std::string tmp;
+      bytestream >> tmp;
+      bytestream >> tmp;
+      bytestream >> tmp;
+      bytestream >> tmp;
+      
+      // Read the bloatAnalysis result
+      bytestream >> analysisResult;
+    }
+  }
+  catch (runtime_error&)
+  {
+    thd->get_stmt_da()->set_overwrite_status(true);
+    thd->raise_error_printf(ER_INTERNAL_ERROR, "Lost connection to DMLProc [10]");
+  }
+  catch (...)
+  {
+    thd->get_stmt_da()->set_overwrite_status(true);
+    thd->raise_error_printf(ER_INTERNAL_ERROR, "Caught unknown error");
+  }
+
+  if (b != 0)
+    analysisResult = errorMsg;
+
+  return analysisResult;
+}
+

--- a/dbcon/mysql/ha_mcs_dml.cpp
+++ b/dbcon/mysql/ha_mcs_dml.cpp
@@ -28,6 +28,7 @@
 #include <unordered.h>
 #include <fstream>
 #include <sstream>
+#include <vector>
 #include <cerrno>
 #include <cstring>
 
@@ -1077,6 +1078,158 @@ std::string ha_mcs_impl_analyze_partition_bloat(cal_impl_if::cal_connection_info
   return analysisResult;
 }
 
+std::string ha_mcs_impl_vacuum_partition(cal_impl_if::cal_connection_info& ci,
+                                         execplan::CalpontSystemCatalog::TableName& tablename,
+                                         const std::string& partition)
+{
+  THD* thd = current_thd;
+  ulong sessionID = tid2sid(thd->thread_id);
+  std::string result;
+
+  try
+  {
+    // Parse partition triplet string: "dbroot.segment.partition"
+    uint16_t dbRoot;
+    uint16_t segmentNum;
+    uint32_t partitionNum;
+    
+    std::istringstream ss(partition);
+    std::string item;
+    std::vector<std::string> tokens;
+    
+    while (std::getline(ss, item, '.')) {
+      tokens.push_back(item);
+    }
+    
+    if (tokens.size() != 3) {
+      return "Error: Invalid partition triplet format. Expected: dbroot.segment.partition";
+    }
+    
+    try
+    {
+      dbRoot = static_cast<uint16_t>(std::stoul(tokens[0]));
+      segmentNum = static_cast<uint16_t>(std::stoul(tokens[1]));
+      partitionNum = std::stoul(tokens[2]);
+    }
+    catch (const std::exception&)
+    {
+      return "Error: Invalid numeric values in partition triplet";
+    }
+
+    // Get system catalog
+    boost::shared_ptr<execplan::CalpontSystemCatalog> systemCatalogPtr =
+        execplan::CalpontSystemCatalog::makeCalpontSystemCatalog(sessionID);
+    systemCatalogPtr->identity(execplan::CalpontSystemCatalog::EC);
+
+    // Get table information
+    execplan::CalpontSystemCatalog::TableName sysCatalogTableName;
+    sysCatalogTableName.schema = tablename.schema;
+    sysCatalogTableName.table = tablename.table;
+
+    // Check if table exists
+    execplan::CalpontSystemCatalog::RIDList ridList;
+    try
+    {
+      ridList = systemCatalogPtr->columnRIDs(sysCatalogTableName);
+    }
+    catch (const std::exception& ex)
+    {
+      return std::string("Error: Table not found - ") + ex.what();
+    }
+
+    if (ridList.empty())
+    {
+      return "Error: Table has no columns";
+    }
+
+    // Get AUX column OID
+    execplan::CalpontSystemCatalog::OID auxColumnOid = systemCatalogPtr->tableAUXColumnOID(sysCatalogTableName);
+
+    // Build column list for createHiddenStripeColumnExtents
+    std::vector<BRM::CreateStripeColumnExtentsArgIn> cols;
+
+    // Add regular columns
+    for (const auto& roPair : ridList)
+    {
+      BRM::CreateStripeColumnExtentsArgIn colArg;
+      colArg.oid = roPair.objnum;
+      
+      execplan::CalpontSystemCatalog::ColType colType = systemCatalogPtr->colType(roPair.objnum);
+      colArg.colDataType = colType.colDataType;
+      
+      // Set width based on whether it's a dictionary column
+      if (colType.ddn.dictOID > 3000)
+      {
+        colArg.width = 8; // Dictionary columns use 8-byte tokens
+      }
+      else
+      {
+        colArg.width = colType.colWidth;
+      }
+      
+      cols.push_back(colArg);
+    }
+
+    // Add AUX column if it exists
+    if (auxColumnOid > 3000)
+    {
+      BRM::CreateStripeColumnExtentsArgIn auxColArg;
+      auxColArg.oid = auxColumnOid;
+      execplan::CalpontSystemCatalog::ColType auxColType = systemCatalogPtr->colType(auxColumnOid);
+      auxColArg.colDataType = auxColType.colDataType;
+      auxColArg.width = auxColType.colWidth;
+      cols.push_back(auxColArg);
+    }
+
+    std::vector<BRM::CreateStripeColumnExtentsArgOut> extents;
+
+    // Store original values for comparison
+    uint16_t originalSegmentNum = segmentNum;
+    uint32_t originalPartitionNum = partitionNum;
+    
+    // Call createHiddenStripeColumnExtents
+    BRM::DBRM dbrm;
+    int rc = dbrm.createHiddenStripeColumnExtents(cols, dbRoot, partitionNum, segmentNum, extents);
+
+    if (rc != 0)
+    {
+      std::ostringstream oss;
+      oss << "Error: Failed to create hidden stripe column extents, error code: " << rc;
+      return oss.str();
+    }
+
+    // Build success message
+    std::ostringstream successMsg;
+    successMsg << "Successfully created hidden partition on DBRoot " << dbRoot;
+    
+    // Check if the function used our requested values or assigned different ones
+    if (partitionNum != originalPartitionNum || segmentNum != originalSegmentNum)
+    {
+      successMsg << " (requested: " << originalPartitionNum << "." << originalSegmentNum 
+                 << ", assigned: " << partitionNum << "." << segmentNum << ")";
+    }
+    else
+    {
+      successMsg << " at partition " << partitionNum << ", segment " << segmentNum;
+    }
+    
+    successMsg << " with " << extents.size() << " extents";
+
+    result = successMsg.str();
+  }
+  catch (const std::exception& ex)
+  {
+    std::ostringstream errorMsg;
+    errorMsg << "Error: " << ex.what();
+    result = errorMsg.str();
+  }
+  catch (...)
+  {
+    result = "Error: Unknown exception occurred during vacuum partition operation";
+  }
+
+  return result;
+}
 
 std::string ha_mcs_impl_analyze_table_bloat(cal_impl_if::cal_connection_info& ci,
                                                execplan::CalpontSystemCatalog::TableName& tablename)

--- a/dbcon/mysql/ha_mcs_dml.cpp
+++ b/dbcon/mysql/ha_mcs_dml.cpp
@@ -1001,3 +1001,79 @@ int ha_mcs_impl_close_connection_(handlerton* /*hton*/, THD* thd, cal_connection
   // transaction. Under either situation, system catalog cache for this session should be removed
   return rc;
 }
+
+std::string ha_mcs_impl_analyze_partition_bloat(cal_impl_if::cal_connection_info& ci,
+                                               execplan::CalpontSystemCatalog::TableName& tablename,
+                                               const std::string& partition)
+{
+  THD* thd = current_thd;
+  ulong sessionID = tid2sid(thd->thread_id);
+  CalpontDMLPackage* pDMLPackage;
+  std::string dmlStatement("ANALYZEPARTITIONBLOAT");
+  VendorDMLStatement cmdStmt(dmlStatement, DML_COMMAND, sessionID);
+  pDMLPackage = CalpontDMLFactory::makeCalpontDMLPackageFromMysqlBuffer(cmdStmt);
+  
+  if (lower_case_table_names)
+  {
+    boost::algorithm::to_lower(tablename.schema);
+    boost::algorithm::to_lower(tablename.table);
+  }
+  pDMLPackage->set_SchemaName(tablename.schema);
+  pDMLPackage->set_TableName(tablename.table);
+  
+  pDMLPackage->set_SQLStatement(partition);
+
+  ByteStream bytestream;
+  bytestream << static_cast<uint32_t>(sessionID);
+  pDMLPackage->write(bytestream);
+  delete pDMLPackage;
+
+  ByteStream::byte b = 0;
+  ByteStream::octbyte rows;
+  std::string errorMsg;
+  std::string analysisResult;
+
+  try
+  {
+    ci.dmlProc->write(bytestream);
+    bytestream = ci.dmlProc->read();
+
+    if (bytestream.length() == 0)
+    {
+      thd->get_stmt_da()->set_overwrite_status(true);
+      thd->raise_error_printf(ER_INTERNAL_ERROR, "Lost connection to DMLProc [9]");
+    }
+    else
+    {
+      bytestream >> b;
+      bytestream >> rows;
+      bytestream >> errorMsg;
+
+      // Skip tableLockInfo, queryStats, extendedStats, miniStats (not used for this command)
+      std::string tmp;
+      bytestream >> tmp;
+      bytestream >> tmp;
+      bytestream >> tmp;
+      bytestream >> tmp;
+      
+      // Read the bloatAnalysis result
+      bytestream >> analysisResult;
+    }
+  }
+  catch (runtime_error&)
+  {
+    thd->get_stmt_da()->set_overwrite_status(true);
+    thd->raise_error_printf(ER_INTERNAL_ERROR, "Lost connection to DMLProc [10]");
+  }
+  catch (...)
+  {
+    thd->get_stmt_da()->set_overwrite_status(true);
+    thd->raise_error_printf(ER_INTERNAL_ERROR, "Caught unknown error");
+  }
+
+  if (b != 0)
+    analysisResult = errorMsg;
+
+  return analysisResult;
+}
+

--- a/dbcon/mysql/ha_mcs_impl.h
+++ b/dbcon/mysql/ha_mcs_impl.h
@@ -80,4 +80,7 @@ extern std::string ha_mcs_impl_analyze_partition_bloat(cal_impl_if::cal_connecti
                                                         const std::string& partition);
 extern std::string ha_mcs_impl_analyze_table_bloat(cal_impl_if::cal_connection_info& ci,
                                                     execplan::CalpontSystemCatalog::TableName& tablename);
+extern std::string ha_mcs_impl_vacuum_partition(cal_impl_if::cal_connection_info& ci,
+                                                 execplan::CalpontSystemCatalog::TableName& tablename,
+                                                 const std::string& partition);
 #endif

--- a/dbcon/mysql/ha_mcs_impl.h
+++ b/dbcon/mysql/ha_mcs_impl.h
@@ -78,4 +78,6 @@ extern std::string ha_mcs_impl_cleartablelock(cal_impl_if::cal_connection_info& 
 extern std::string ha_mcs_impl_analyze_partition_bloat(cal_impl_if::cal_connection_info& ci,
                                                         execplan::CalpontSystemCatalog::TableName& tablename,
                                                         const std::string& partition);
+extern std::string ha_mcs_impl_analyze_table_bloat(cal_impl_if::cal_connection_info& ci,
+                                                    execplan::CalpontSystemCatalog::TableName& tablename);
 #endif

--- a/dbcon/mysql/ha_mcs_impl.h
+++ b/dbcon/mysql/ha_mcs_impl.h
@@ -75,4 +75,7 @@ extern std::string ha_mcs_impl_droppartition_(execplan::CalpontSystemCatalog::Ta
 extern std::string ha_mcs_impl_viewtablelock(cal_impl_if::cal_connection_info& ci,
                                              execplan::CalpontSystemCatalog::TableName& tablename);
 extern std::string ha_mcs_impl_cleartablelock(cal_impl_if::cal_connection_info& ci, uint64_t tableLockID);
+extern std::string ha_mcs_impl_analyze_partition_bloat(cal_impl_if::cal_connection_info& ci,
+                                                        execplan::CalpontSystemCatalog::TableName& tablename,
+                                                        const std::string& partition);
 #endif

--- a/dbcon/mysql/install_mcs_mysql.sh.in
+++ b/dbcon/mysql/install_mcs_mysql.sh.in
@@ -56,6 +56,7 @@ CREATE OR REPLACE FUNCTION mcssystemreadonly RETURNS INTEGER SONAME 'ha_columnst
 CREATE OR REPLACE FUNCTION mcssystemprimary RETURNS INTEGER SONAME 'ha_columnstore.so';
 CREATE OR REPLACE FUNCTION mcs_emindex_size RETURNS INTEGER SONAME 'ha_columnstore.so';
 CREATE OR REPLACE FUNCTION mcs_emindex_free RETURNS INTEGER SONAME 'ha_columnstore.so';
+CREATE OR REPLACE FUNCTION mcs_analyze_partition_bloat RETURNS STRING SONAME 'ha_columnstore.so';
 CREATE OR REPLACE FUNCTION columnstore_dataload RETURNS STRING SONAME 'ha_columnstore.so';
 CREATE OR REPLACE AGGREGATE FUNCTION regr_avgx RETURNS REAL SONAME 'libregr_mysql.so';
 CREATE OR REPLACE AGGREGATE FUNCTION regr_avgy RETURNS REAL SONAME 'libregr_mysql.so';

--- a/dbcon/mysql/install_mcs_mysql.sh.in
+++ b/dbcon/mysql/install_mcs_mysql.sh.in
@@ -57,6 +57,7 @@ CREATE OR REPLACE FUNCTION mcssystemprimary RETURNS INTEGER SONAME 'ha_columnsto
 CREATE OR REPLACE FUNCTION mcs_emindex_size RETURNS INTEGER SONAME 'ha_columnstore.so';
 CREATE OR REPLACE FUNCTION mcs_emindex_free RETURNS INTEGER SONAME 'ha_columnstore.so';
 CREATE OR REPLACE FUNCTION mcs_analyze_partition_bloat RETURNS STRING SONAME 'ha_columnstore.so';
+CREATE OR REPLACE FUNCTION mcs_analyze_table_bloat RETURNS STRING SONAME 'ha_columnstore.so';
 CREATE OR REPLACE FUNCTION columnstore_dataload RETURNS STRING SONAME 'ha_columnstore.so';
 CREATE OR REPLACE AGGREGATE FUNCTION regr_avgx RETURNS REAL SONAME 'libregr_mysql.so';
 CREATE OR REPLACE AGGREGATE FUNCTION regr_avgy RETURNS REAL SONAME 'libregr_mysql.so';

--- a/dbcon/mysql/install_mcs_mysql.sh.in
+++ b/dbcon/mysql/install_mcs_mysql.sh.in
@@ -58,6 +58,7 @@ CREATE OR REPLACE FUNCTION mcs_emindex_size RETURNS INTEGER SONAME 'ha_columnsto
 CREATE OR REPLACE FUNCTION mcs_emindex_free RETURNS INTEGER SONAME 'ha_columnstore.so';
 CREATE OR REPLACE FUNCTION mcs_analyze_partition_bloat RETURNS STRING SONAME 'ha_columnstore.so';
 CREATE OR REPLACE FUNCTION mcs_analyze_table_bloat RETURNS STRING SONAME 'ha_columnstore.so';
+CREATE OR REPLACE FUNCTION mcs_vacuum_partition RETURNS STRING SONAME 'ha_columnstore.so';
 CREATE OR REPLACE FUNCTION columnstore_dataload RETURNS STRING SONAME 'ha_columnstore.so';
 CREATE OR REPLACE AGGREGATE FUNCTION regr_avgx RETURNS REAL SONAME 'libregr_mysql.so';
 CREATE OR REPLACE AGGREGATE FUNCTION regr_avgy RETURNS REAL SONAME 'libregr_mysql.so';

--- a/dmlproc/dmlprocessor.cpp
+++ b/dmlproc/dmlprocessor.cpp
@@ -1199,6 +1199,7 @@ void PackageHandler::run()
   results << result.queryStats;
   results << result.extendedStats;
   results << result.miniStats;
+  results << result.bloatAnalysis;
   result.stats.serialize(results);
   fIos.write(results);
   // Bug 5226. dmlprocessor thread will close the socket to mysqld.

--- a/versioning/BRM/brmtypes.h
+++ b/versioning/BRM/brmtypes.h
@@ -481,6 +481,8 @@ const uint8_t MARK_ALL_PARTITION_FOR_DELETION = 41;
 const uint8_t CREATE_COLUMN_EXTENT_EXACT_FILE = 42;
 const uint8_t DELETE_DBROOT = 43;
 const uint8_t CREATE_STRIPE_COLUMN_EXTENTS = 44;
+const uint8_t CREATE_HIDDEN_STRIPE_COLUMN_EXTENTS = 107;
+const uint8_t MAKE_PARTITION_VISIBLE = 108;
 
 /* SessionManager interface */
 const uint8_t VER_ID = 45;

--- a/versioning/BRM/dbrm.cpp
+++ b/versioning/BRM/dbrm.cpp
@@ -992,6 +992,114 @@ int DBRM::createStripeColumnExtents(const std::vector<CreateStripeColumnExtentsA
 }
 
 //------------------------------------------------------------------------------
+// Send a request to create hidden stripe column extents
+//------------------------------------------------------------------------------
+int DBRM::createHiddenStripeColumnExtents(const std::vector<CreateStripeColumnExtentsArgIn>& cols, uint16_t dbRoot,
+                                          uint32_t& partitionNum, uint16_t& segmentNum,
+                                          std::vector<CreateStripeColumnExtentsArgOut>& extents) DBRM_THROW
+{
+#ifdef BRM_INFO
+
+  if (fDebug)
+  {
+    TRACER_WRITELATER("createHiddenStripeColumnExtents");
+    TRACER_WRITE;
+  }
+
+#endif
+
+  ByteStream command, response;
+  uint8_t err;
+  uint16_t tmp16;
+  uint32_t tmp32;
+
+  command << CREATE_HIDDEN_STRIPE_COLUMN_EXTENTS;
+  serializeInlineVector(command, cols);
+  command << dbRoot << partitionNum;
+
+  err = send_recv(command, response);
+
+  if (err != ERR_OK)
+    return err;
+
+  if (response.length() == 0)
+    return ERR_NETWORK;
+
+  try
+  {
+    response >> err;
+
+    if (err != 0)
+      return (int)err;
+
+    response >> tmp32;
+    partitionNum = tmp32;
+    response >> tmp16;
+    segmentNum = tmp16;
+    deserializeInlineVector(response, extents);
+  }
+  catch (exception& e)
+  {
+    cerr << e.what() << endl;
+    return ERR_FAILURE;
+  }
+
+  CHECK_EMPTY(response);
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// Send a request to make a hidden partition visible
+//------------------------------------------------------------------------------
+int DBRM::makePartitionVisible(const std::set<OID_t>& oids, uint16_t dbRoot, uint32_t partitionNum) DBRM_THROW
+{
+#ifdef BRM_INFO
+
+  if (fDebug)
+  {
+    TRACER_WRITELATER("makePartitionVisible");
+    TRACER_WRITE;
+  }
+
+#endif
+
+  ByteStream command, response;
+  uint8_t err;
+
+  command << MAKE_PARTITION_VISIBLE;
+  command << static_cast<uint32_t>(oids.size());
+  for (const auto& oid : oids)
+  {
+    command << oid;
+  }
+  command << dbRoot << partitionNum;
+
+  err = send_recv(command, response);
+
+  if (err != ERR_OK)
+    return err;
+
+  if (response.length() == 0)
+    return ERR_NETWORK;
+
+  try
+  {
+    response >> err;
+
+    if (err != 0)
+      return (int)err;
+  }
+  catch (exception& e)
+  {
+    cerr << e.what() << endl;
+    return ERR_FAILURE;
+  }
+
+  CHECK_EMPTY(response);
+  return 0;
+}
+
+//------------------------------------------------------------------------------
 // Send a request to create a column extent for the specified OID and DBRoot.
 //------------------------------------------------------------------------------
 int DBRM::createColumnExtent_DBroot(OID_t oid, uint32_t colWidth, uint16_t dbRoot, uint32_t& partitionNum,

--- a/versioning/BRM/dbrm.h
+++ b/versioning/BRM/dbrm.h
@@ -229,6 +229,35 @@ class DBRM
                                        uint16_t dbRoot, uint32_t& partitionNum, uint16_t& segmentNum,
                                        std::vector<CreateStripeColumnExtentsArgOut>& extents) DBRM_THROW;
 
+  /** @brief Allocate a "stripe" of hidden (out of service) extents for columns in a table (in DBRoot)
+   *
+   * Creates a new hidden partition that is not visible to normal query operations.
+   * The partition can be used as a destination for data movement operations like VACUUM.
+   * All extents are initially marked with EXTENTOUTOFSERVICE status.
+   *
+   * @param cols (in) List of column OIDs and column widths
+   * @param dbRoot (in) DBRoot for requested extents.
+   * @param partitionNum (in/out) Partition number in file path.
+   * @param segmentNum (out) Segment number selected for new extents.
+   * @param extents (out) list of lbids, numBlks, and fbo for new extents
+   */
+  EXPORT int createHiddenStripeColumnExtents(const std::vector<CreateStripeColumnExtentsArgIn>& cols,
+                                             uint16_t dbRoot, uint32_t& partitionNum, uint16_t& segmentNum,
+                                             std::vector<CreateStripeColumnExtentsArgOut>& extents) DBRM_THROW;
+
+  /** @brief Make a hidden partition visible to normal query operations
+   *
+   * Changes the status of all extents in the specified partition from
+   * EXTENTOUTOFSERVICE to EXTENTAVAILABLE, making them visible to queries.
+   * This is used to make partitions created with createHiddenStripeColumnExtents
+   * visible after data movement operations like VACUUM are complete.
+   *
+   * @param oids (in) Set of column OIDs in the partition
+   * @param dbRoot (in) The DBRoot containing the partition
+   * @param partitionNum (in) The partition number to make visible
+   */
+  EXPORT int makePartitionVisible(const std::set<OID_t>& oids, uint16_t dbRoot, uint32_t partitionNum) DBRM_THROW;
+
   /** @brief Allocate an extent for a column file
    *
    * Allocate a column extent for the specified OID and DBRoot.

--- a/versioning/BRM/extentmap.cpp
+++ b/versioning/BRM/extentmap.cpp
@@ -2594,6 +2594,93 @@ void ExtentMap::createStripeColumnExtents(const vector<CreateStripeColumnExtents
 }
 
 //------------------------------------------------------------------------------
+// Creates a "stripe" of hidden extents for columns in a table (in DBRoot).
+// These extents are marked as EXTENTOUTOFSERVICE and are not visible to
+// normal query operations until makePartitionVisible() is called.
+//------------------------------------------------------------------------------
+void ExtentMap::createHiddenStripeColumnExtents(const vector<CreateStripeColumnExtentsArgIn>& cols,
+                                                uint16_t dbRoot, uint32_t& partitionNum, uint16_t& segmentNum,
+                                                vector<CreateStripeColumnExtentsArgOut>& extents)
+{
+  LBID_t startLbid;
+  int allocSize;
+  uint32_t startBlkOffset;
+
+  grabEMEntryTable(WRITE);
+  grabEMIndex(WRITE);
+  grabFreeList(WRITE);
+
+  OID_t baselineOID = -1;
+  uint16_t baselineSegmentNum = -1;
+  uint32_t baselinePartNum = -1;
+
+  for (uint32_t i = 0; i < cols.size(); i++)
+  {
+    createColumnExtent_DBroot(cols[i].oid, cols[i].width, dbRoot, cols[i].colDataType, partitionNum,
+                              segmentNum, startLbid, allocSize, startBlkOffset, false);
+
+    auto emIter = fExtentMapRBTree->find(startLbid);
+    if (emIter != fExtentMapRBTree->end())
+    {
+      makeUndoRecordRBTree(UndoRecordType::DEFAULT, emIter->second);
+      emIter->second.status = EXTENTOUTOFSERVICE;
+    }
+
+    if (i == 0)
+    {
+      baselineOID = cols[i].oid;
+      baselinePartNum = partitionNum;
+      baselineSegmentNum = segmentNum;
+    }
+    else if ((partitionNum != baselinePartNum) || (segmentNum != baselineSegmentNum))
+    {
+      ostringstream oss;
+      oss << "ExtentMap::createHiddenStripeColumnExtents(): "
+             "Inconsistent segment extent creation: "
+          << "DBRoot: " << dbRoot << "OID1: " << baselineOID << "; Part#: " << baselinePartNum
+          << "; Seg#: " << baselineSegmentNum << " <versus> OID2: " << cols[i].oid
+          << "; Part#: " << partitionNum << "; Seg#: " << segmentNum;
+      log(oss.str(), logging::LOG_TYPE_CRITICAL);
+      throw invalid_argument(oss.str());
+    }
+
+    CreateStripeColumnExtentsArgOut extentInfo;
+    extentInfo.startLbid = startLbid;
+    extentInfo.allocSize = allocSize;
+    extentInfo.startBlkOffset = startBlkOffset;
+    extents.push_back(extentInfo);
+  }
+}
+
+//------------------------------------------------------------------------------
+// Makes a hidden partition visible to normal query operations by changing
+// the status of all extents from EXTENTOUTOFSERVICE to EXTENTAVAILABLE.
+//------------------------------------------------------------------------------
+void ExtentMap::makePartitionVisible(const set<OID_t>& oids, uint16_t dbRoot, uint32_t partitionNum)
+{
+  grabEMEntryTable(WRITE);
+
+  for (const auto& oid : oids)
+  {
+    const auto lbids = fPExtMapIndexImpl_->find(dbRoot, oid);
+    auto emIterators = getEmIteratorsByLbids(lbids);
+    
+    for (auto& emIter : emIterators)
+    {
+      EMEntry& emEntry = emIter->second;
+      if (emEntry.partitionNum == partitionNum && emEntry.dbRoot == dbRoot && 
+          emEntry.status == EXTENTOUTOFSERVICE)
+      {
+        makeUndoRecordRBTree(UndoRecordType::DEFAULT, emEntry);
+        emEntry.status = EXTENTAVAILABLE;
+      }
+    }
+  }
+
+  releaseEMEntryTable(WRITE);
+}
+
+//------------------------------------------------------------------------------
 // Creates an extent for a column file on the specified DBRoot.  This is the
 // external API function referenced by the dbrm wrapper class.
 // required input:

--- a/versioning/BRM/extentmap.h
+++ b/versioning/BRM/extentmap.h
@@ -639,6 +639,39 @@ class ExtentMap : public Undoable
                                         uint16_t dbRoot, uint32_t& partitionNum, uint16_t& segmentNum,
                                         std::vector<CreateStripeColumnExtentsArgOut>& extents);
 
+  /** @brief Allocate a "stripe" of hidden extents for columns in a table (in DBRoot)
+   *
+   * Creates a new hidden partition that is not visible to normal query operations.
+   * The partition can be used as a destination for data movement operations like VACUUM.
+   * All extents are initially marked with EXTENTOUTOFSERVICE status and remain
+   * hidden even when HWM is set, unlike normal extents which become visible
+   * when HWM is set.
+   *
+   * @param cols (in) List of column OIDs and column widths
+   * @param dbRoot (in) DBRoot for requested extents.
+   * @param partitionNum (in/out) Partition number in file path.
+   *        If allocating OID's first extent for this DBRoot, then
+   *        partitionNum is input, else it is an output arg.
+   * @param segmentNum (out) Segment number selected for new extents.
+   * @param extents (out) list of lbids, numBlks, and fbo for new extents
+   */
+  EXPORT void createHiddenStripeColumnExtents(const std::vector<CreateStripeColumnExtentsArgIn>& cols,
+                                              uint16_t dbRoot, uint32_t& partitionNum, uint16_t& segmentNum,
+                                              std::vector<CreateStripeColumnExtentsArgOut>& extents);
+
+  /** @brief Make a hidden partition visible to normal query operations
+   *
+   * Changes the status of all extents in the specified partition from
+   * EXTENTOUTOFSERVICE to EXTENTAVAILABLE, making them visible to queries.
+   * This is used to make partitions created with createHiddenStripeColumnExtents
+   * visible after data movement operations like VACUUM are complete.
+   *
+   * @param oids (in) Set of column OIDs in the partition
+   * @param dbRoot (in) The DBRoot containing the partition
+   * @param partitionNum (in) The partition number to make visible
+   */
+  EXPORT void makePartitionVisible(const std::set<OID_t>& oids, uint16_t dbRoot, uint32_t partitionNum);
+
   /** @brief Allocates an extent for a column file
    *
    * Allocates an extent for the specified OID and DBroot.

--- a/versioning/BRM/slavecomm.cpp
+++ b/versioning/BRM/slavecomm.cpp
@@ -293,6 +293,10 @@ void SlaveComm::processCommand(ByteStream& msg)
   {
     case CREATE_STRIPE_COLUMN_EXTENTS: do_createStripeColumnExtents(msg); break;
 
+    case CREATE_HIDDEN_STRIPE_COLUMN_EXTENTS: do_createHiddenStripeColumnExtents(msg); break;
+
+    case MAKE_PARTITION_VISIBLE: do_makePartitionVisible(msg); break;
+
     case CREATE_COLUMN_EXTENT_DBROOT: do_createColumnExtent_DBroot(msg); break;
 
     case CREATE_COLUMN_EXTENT_EXACT_FILE: do_createColumnExtentExactFile(msg); break;
@@ -430,6 +434,113 @@ void SlaveComm::do_createStripeColumnExtents(ByteStream& msg)
     takeSnapshot = true;
   else
     doSaveDelta = true;
+}
+
+//------------------------------------------------------------------------------
+// Process a request to create hidden stripe column extents
+//------------------------------------------------------------------------------
+void SlaveComm::do_createHiddenStripeColumnExtents(ByteStream& msg)
+{
+  int err;
+  uint16_t tmp16;
+  uint16_t tmp32;
+  uint16_t dbRoot;
+  uint32_t partitionNum;
+  uint16_t segmentNum;
+  std::vector<CreateStripeColumnExtentsArgIn> cols;
+  std::vector<CreateStripeColumnExtentsArgOut> extents;
+  ByteStream reply;
+
+#ifdef BRM_VERBOSE
+  cerr << "WorkerComm: do_createHiddenStripeColumnExtents()" << endl;
+#endif
+
+  deserializeInlineVector(msg, cols);
+  msg >> tmp16;
+  dbRoot = tmp16;
+  msg >> tmp32;
+  partitionNum = tmp32;
+
+  if (printOnly)
+  {
+    cout << "createHiddenStripeColumnExtents().  " << "DBRoot=" << dbRoot << "; Part#=" << partitionNum << endl;
+
+    for (uint32_t i = 0; i < cols.size(); i++)
+      cout << "HiddenStripeColExt arg " << i + 1 << ": oid=" << cols[i].oid << " width=" << cols[i].width << endl;
+
+    return;
+  }
+
+  err = slave->createHiddenStripeColumnExtents(cols, dbRoot, partitionNum, segmentNum, extents);
+  reply << (uint8_t)err;
+
+  if (err == ERR_OK)
+  {
+    reply << partitionNum;
+    reply << segmentNum;
+    serializeInlineVector(reply, extents);
+  }
+
+#ifdef BRM_VERBOSE
+  cerr << "WorkerComm: do_createHiddenStripeColumnExtents() err code is " << err << endl;
+#endif
+
+  if (!standalone)
+    master.write(reply);
+
+  // see bug 3596.  Need to make sure a snapshot file exists.
+  if ((cols.size() > 0) && (cols[0].oid < 3000))
+    takeSnapshot = true;
+  else
+    doSaveDelta = true;
+}
+
+//------------------------------------------------------------------------------
+// Process a request to make a hidden partition visible
+//------------------------------------------------------------------------------
+void SlaveComm::do_makePartitionVisible(ByteStream& msg)
+{
+  int err;
+  uint32_t numOids;
+  uint32_t partitionNum;
+  uint16_t dbRoot;
+  std::set<OID_t> oids;
+  ByteStream reply;
+
+#ifdef BRM_VERBOSE
+  cerr << "WorkerComm: do_makePartitionVisible()" << endl;
+#endif
+
+  msg >> numOids;
+  for (uint32_t i = 0; i < numOids; i++)
+  {
+    OID_t oid;
+    msg >> oid;
+    oids.insert(oid);
+  }
+  msg >> dbRoot;
+  msg >> partitionNum;
+
+  if (printOnly)
+  {
+    cout << "makePartitionVisible().  " << "DBRoot=" << dbRoot << "; Part#=" << partitionNum << "; OIDs: ";
+    for (const auto& oid : oids)
+      cout << oid << " ";
+    cout << endl;
+    return;
+  }
+
+  err = slave->makePartitionVisible(oids, dbRoot, partitionNum);
+  reply << (uint8_t)err;
+
+#ifdef BRM_VERBOSE
+  cerr << "WorkerComm: do_makePartitionVisible() err code is " << err << endl;
+#endif
+
+  if (!standalone)
+    master.write(reply);
+
+  doSaveDelta = true;
 }
 
 //------------------------------------------------------------------------------

--- a/versioning/BRM/slavecomm.h
+++ b/versioning/BRM/slavecomm.h
@@ -72,6 +72,8 @@ class SlaveComm
   void processCommand(messageqcpp::ByteStream& msg);
 
   void do_createStripeColumnExtents(messageqcpp::ByteStream& msg);
+  void do_createHiddenStripeColumnExtents(messageqcpp::ByteStream& msg);
+  void do_makePartitionVisible(messageqcpp::ByteStream& msg);
   void do_createColumnExtent_DBroot(messageqcpp::ByteStream& msg);
   void do_createColumnExtentExactFile(messageqcpp::ByteStream& msg);
   void do_createDictStoreExtent(messageqcpp::ByteStream& msg);

--- a/versioning/BRM/slavedbrmnode.cpp
+++ b/versioning/BRM/slavedbrmnode.cpp
@@ -96,6 +96,44 @@ int SlaveDBRMNode::createStripeColumnExtents(const std::vector<CreateStripeColum
 }
 
 //------------------------------------------------------------------------------
+// Create hidden stripe column extents
+//------------------------------------------------------------------------------
+int SlaveDBRMNode::createHiddenStripeColumnExtents(const std::vector<CreateStripeColumnExtentsArgIn>& cols,
+                                                   uint16_t dbRoot, uint32_t& partitionNum, uint16_t& segmentNum,
+                                                   std::vector<CreateStripeColumnExtentsArgOut>& extents) throw()
+{
+  try
+  {
+    em.createHiddenStripeColumnExtents(cols, dbRoot, partitionNum, segmentNum, extents);
+  }
+  catch (exception& e)
+  {
+    cerr << e.what() << endl;
+    return -1;
+  }
+
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// Make a hidden partition visible
+//------------------------------------------------------------------------------
+int SlaveDBRMNode::makePartitionVisible(const std::set<OID_t>& oids, uint16_t dbRoot, uint32_t partitionNum) throw()
+{
+  try
+  {
+    em.makePartitionVisible(oids, dbRoot, partitionNum);
+  }
+  catch (exception& e)
+  {
+    cerr << e.what() << endl;
+    return -1;
+  }
+
+  return 0;
+}
+
+//------------------------------------------------------------------------------
 // Create an extent for the specified OID and DBRoot.
 //------------------------------------------------------------------------------
 int SlaveDBRMNode::createColumnExtent_DBroot(OID_t oid, uint32_t colWidth, uint16_t dbRoot,

--- a/versioning/BRM/slavedbrmnode.h
+++ b/versioning/BRM/slavedbrmnode.h
@@ -104,6 +104,25 @@ class SlaveDBRMNode
                                        uint16_t dbRoot, uint32_t& partitionNum, uint16_t& segmentNum,
                                        std::vector<CreateStripeColumnExtentsArgOut>& extents) throw();
 
+  /** @brief Allocate a "stripe" of hidden (out of service) extents for columns in a table
+   *
+   * Allocate a "stripe" of hidden (out of service) extents for the specified columns and DBRoot
+   * @param cols (in) List of column OIDs and column widths
+   * @param dbRoot (in) DBRoot for requested extents.
+   * @param partitionNum (in/out) Partition number in file path.
+   *        If allocating OID's first extent for this DBRoot, then
+   *        partitionNum is input, else it is an output arg.
+   * @param segmentNum (out) Segment number selected for new extents.
+   * @param extents (out) list of lbids, numBlks, and fbo for new extents
+   * @return 0 on success, -1 on error   */
+  EXPORT int createHiddenStripeColumnExtents(const std::vector<CreateStripeColumnExtentsArgIn>& cols,
+                                             uint16_t dbRoot, uint32_t& partitionNum, uint16_t& segmentNum,
+                                             std::vector<CreateStripeColumnExtentsArgOut>& extents) throw();
+
+  /** @brief Make a hidden partition visible to normal query operations
+   */
+  EXPORT int makePartitionVisible(const std::set<OID_t>& oids, uint16_t dbRoot, uint32_t partitionNum) throw();
+
   /** @brief Allocate extent in the specified segment file
    *
    * Allocate column extent for the exact segment file specified by the

--- a/writeengine/bulk/we_bulkload.cpp
+++ b/writeengine/bulk/we_bulkload.cpp
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <vector>
 #include <sstream>
+#include <stdexcept>
 
 #include <boost/filesystem.hpp>
 #include <boost/uuid/uuid.hpp>
@@ -48,6 +49,7 @@
 #include "we_config.h"
 #include "we_dbrootextenttracker.h"
 #include "writeengine.h"
+#include "extentmap.h"
 #include "sys/time.h"
 #include "sys/types.h"
 #include "dataconvert.h"
@@ -630,14 +632,26 @@ int BulkLoad::preProcess(Job& job, int tableNo, std::shared_ptr<TableInfo>& tabl
 
     if (i == 0)  // select starting DBRoot/segment for column[0]
     {
-      std::string trkErrMsg;
-      rc =
-          pDBRootExtentTracker->selectFirstSegFile(dbRootExtent, bNoStartExtentOnThisPM, bEmptyPM, trkErrMsg);
-
-      if (rc != NO_ERROR)
+      if (hasTargetPartition())  // Use specified target partition
       {
-        fLog.logMsg(trkErrMsg, rc, MSGLVL_ERROR);
-        return rc;
+        rc = setTargetDBRootExtent(dbRootExtent, curJobCol.mapOid);
+        if (rc != NO_ERROR)
+        {
+          fLog.logMsg("Failed to set target partition", rc, MSGLVL_ERROR);
+          return rc;
+        }
+      }
+      else  // Use automatic selection
+      {
+        std::string trkErrMsg;
+        rc =
+            pDBRootExtentTracker->selectFirstSegFile(dbRootExtent, bNoStartExtentOnThisPM, bEmptyPM, trkErrMsg);
+
+        if (rc != NO_ERROR)
+        {
+          fLog.logMsg(trkErrMsg, rc, MSGLVL_ERROR);
+          return rc;
+        }
       }
     }
     else  // select starting DBRoot/segment based on column[0] selection
@@ -1611,6 +1625,134 @@ void BulkLoad::setDefaultJobUUID()
 {
   if (fUUID.is_nil())
     fUUID = boost::uuids::random_generator()();
+}
+
+//------------------------------------------------------------------------------
+// Set DBRootExtentInfo from target partition triple
+//------------------------------------------------------------------------------
+int BulkLoad::setTargetDBRootExtent(DBRootExtentInfo& dbRootExtent, OID columnOid)
+{
+  if (!fHasTargetPartition)
+    return ERR_INVALID_PARAM;
+    
+  // Set the basic partition info from target
+  dbRootExtent.fPartition = fTargetPartition.pp;      // physical partition
+  dbRootExtent.fDbRoot = fTargetPartition.dbroot;     // DBRoot
+  dbRootExtent.fSegment = fTargetPartition.seg;       // segment
+  
+  // Get extent information from BRM for this specific partition
+  std::vector<BRM::EMEntry> extents;
+  
+  try
+  {
+    // Get all extents for this OID on the target DBRoot
+    int rc = BRMWrapper::getInstance()->getExtents_dbroot(columnOid, extents, fTargetPartition.dbroot);
+    
+    if (rc != 0)
+    {
+      fLog.logMsg("Failed to get extents for target DBRoot", rc, MSGLVL_ERROR);
+      return rc;
+    }
+    
+    // Find extent with matching partition and segment
+    bool extentFound = false;
+    for (const auto& extent : extents)
+    {
+      if (extent.partitionNum == fTargetPartition.pp && 
+          extent.segmentNum == fTargetPartition.seg)
+      {
+        dbRootExtent.fStartLbid = extent.range.start;
+        dbRootExtent.fLocalHwm = extent.HWM;
+        
+        // Handle different extent states
+        if (extent.status == 2)  // EXTENTOUTOFSERVICE
+        {
+          // This is a hidden partition created by createHiddenStripeColumnExtents
+          // We can write to it directly since it's already allocated
+          dbRootExtent.fState = DBROOT_EXTENT_PARTIAL_EXTENT;
+          fLog.logMsg("Found hidden (out-of-service) target partition - ready for data loading", 
+                     NO_ERROR, MSGLVL_INFO1);
+        }
+        else if (extent.status == 0)  // EXTENTAVAILABLE
+        {
+          // This is a normal available extent
+          dbRootExtent.fState = DBROOT_EXTENT_PARTIAL_EXTENT;
+          fLog.logMsg("Found available target partition", NO_ERROR, MSGLVL_INFO1);
+        }
+        else
+        {
+          // Other status (e.g., invalid) - handle as error
+          fLog.logMsg("Target partition exists but has invalid status: " + 
+                     std::to_string(extent.status), ERR_INVALID_PARAM, MSGLVL_ERROR);
+          return ERR_INVALID_PARAM;
+        }
+        
+        extentFound = true;
+        break;
+      }
+    }
+    
+    if (!extentFound)
+    {
+      // This shouldn't happen for maintenance tasks using pre-created partitions
+      fLog.logMsg("Target partition not found - this may indicate the partition was not pre-created", 
+                 ERR_BRM_LOOKUP_START_LBID, MSGLVL_ERROR);
+      return ERR_BRM_LOOKUP_START_LBID;
+    }
+    
+    // Get total blocks for this DBRoot (approximate)
+    dbRootExtent.fDBRootTotalBlocks = 0;
+    
+    fLog.logMsg("Using target partition: " + fTargetPartition.toString(), 
+               NO_ERROR, MSGLVL_INFO1);
+    
+    return NO_ERROR;
+  }
+  catch (const std::exception& e)
+  {
+    fLog.logMsg(std::string("Failed to setup target partition: ") + e.what(), 
+               ERR_BRM_LOOKUP_START_LBID, MSGLVL_ERROR);
+    return ERR_BRM_LOOKUP_START_LBID;
+  }
+}
+
+//------------------------------------------------------------------------------
+// Parse and set target partition triple using LogicalPartition
+//------------------------------------------------------------------------------
+void BulkLoad::setTargetPartitionTriple(const std::string& partitionTriple)
+{
+  fHasTargetPartition = false;
+  
+  if (partitionTriple.empty())
+    return;
+  
+  try
+  {
+    // Use the existing LogicalPartition parsing
+    std::istringstream iss(partitionTriple);
+    iss >> fTargetPartition;
+    
+    if (iss.fail())
+    {
+      throw std::runtime_error("Failed to parse partition triple format");
+    }
+    
+    // Basic validation - LogicalPartition uses (uint16_t)-1 and (uint32_t)-1 as invalid values
+    if (fTargetPartition.pp == (uint32_t)-1 || 
+        fTargetPartition.seg == (uint16_t)-1 || 
+        fTargetPartition.dbroot == (uint16_t)-1)
+    {
+      throw std::runtime_error("Invalid partition values detected");
+    }
+    
+    fHasTargetPartition = true;
+  }
+  catch (const std::exception& e)
+  {
+    std::ostringstream oss;
+    oss << "Failed to parse partition triple '" << partitionTriple << "': " << e.what();
+    throw std::runtime_error(oss.str());
+  }
 }
 
 }  // namespace WriteEngine

--- a/writeengine/bulk/we_bulkload.h
+++ b/writeengine/bulk/we_bulkload.h
@@ -38,6 +38,7 @@
 
 #include "we_tableinfo.h"
 #include "brmtypes.h"
+#include "logicalpartition.h"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "boost/ptr_container/ptr_vector.hpp"
@@ -150,6 +151,11 @@ class BulkLoad : public FileOp
   void setS3Host(const std::string& host);
   void setS3Region(const std::string& region);
   void setUsername(const std::string& username);
+
+  void setTargetPartitionTriple(const std::string& partitionTriple);
+  const BRM::LogicalPartition& getTargetPartition() const;
+  bool hasTargetPartition() const;
+  
   // Timer functions
   void startTimer();
   void stopTimer();
@@ -237,6 +243,8 @@ class BulkLoad : public FileOp
   std::string fS3Bucket;                              // S3 Bucket
   std::string fS3Region;                              // S3 Region
   std::string fUsername{"mysql"};                     // data files owner name mysql by default
+  BRM::LogicalPartition fTargetPartition;             // Target partition for -a flag
+  bool fHasTargetPartition{false};                    // Whether target partition is specified
 
   //--------------------------------------------------------------------------
   // Private Functions
@@ -261,6 +269,9 @@ class BulkLoad : public FileOp
 
   // Map specified DBRoot to it's first segment file number
   int mapDBRootToFirstSegment(OID columnOid, uint16_t dbRoot, uint16_t& segment);
+  
+  // Set DBRootExtentInfo from target partition triple
+  int setTargetDBRootExtent(DBRootExtentInfo& dbRootExtent, OID columnOid);
 
   // The thread method for the read thread.
   void read(int id);
@@ -522,6 +533,16 @@ inline void BulkLoad::setS3Region(const std::string& region)
 inline void BulkLoad::setUsername(const std::string& username)
 {
   fUsername = username;
+}
+
+inline const BRM::LogicalPartition& BulkLoad::getTargetPartition() const
+{
+  return fTargetPartition;
+}
+
+inline bool BulkLoad::hasTargetPartition() const
+{
+  return fHasTargetPartition;
 }
 
 inline void BulkLoad::startTimer()

--- a/writeengine/bulk/we_cmdargs.cpp
+++ b/writeengine/bulk/we_cmdargs.cpp
@@ -134,6 +134,8 @@ WECmdArgs::WECmdArgs(int argc, char** argv)
         "Directory for the output .err and .bad files")
       ("job-uuid,u", po::value<string>(&fUUID), "import job UUID")
       ("username,U", po::value<string>(&fUsername), "Username of the files owner.")
+      ("target-partition,a", po::value<string>(&fTargetPartitionTriple),
+        "Target partition triple in format Directory.Segment.DBRoot ")
       ("dbname", po::value<string>(), "Name of the database to load")
       ("table", po::value<string>(), "Name of table to load")
       ("load-file", po::value<string>(),
@@ -186,7 +188,7 @@ void WECmdArgs::usage() const
        << "    [-E encloseChar] [-C escapeChar] [-I binaryOpt] [-S] "
           "[-d debugLevel] [-i] "
        << endl
-       << "     [-D] [-N] [-L rejectDir] [-T timeZone]" << endl
+       << "     [-D] [-N] [-L rejectDir] [-T timeZone] [-a Directory.Segment.DBRoot]" << endl
        << "    [-U username]" << endl
        << endl;
 
@@ -201,7 +203,7 @@ void WECmdArgs::usage() const
           "[-d debugLevel] [-i] "
        << endl
        << "    [-p path] [-l loadFile]" << endl
-       << "     [-D] [-N] [-L rejectDir] [-T timeZone]" << endl
+       << "     [-D] [-N] [-L rejectDir] [-T timeZone] [-a Directory.Segment.DBRoot]" << endl
        << "    [-U username]" << endl
        << endl;
 
@@ -212,7 +214,9 @@ void WECmdArgs::usage() const
        << "    Example2: Some column values are enclosed within double quotes." << endl
        << "        " << fPrgmName << " -j 3000 -E '\"'" << endl
        << "    Example3: Import a nation table without a Job XML file" << endl
-       << "        " << fPrgmName << " -j 301 tpch nation nation.tbl" << endl;
+       << "        " << fPrgmName << " -j 301 tpch nation nation.tbl" << endl
+       << "    Example4: Import to specific partition (maintenance tasks)" << endl
+       << "        " << fPrgmName << " -j 302 -a 100.0.1 tpch nation nation.tbl" << endl;
 
   exit(1);
 }
@@ -410,6 +414,12 @@ void WECmdArgs::fillParams(BulkLoad& curJob, std::string& sJobIdStr, std::string
     curJob.setUsername(fUsername);
   }
   curJob.setSkipRows(fSkipRows);
+  
+  // Set target partition if specified
+  if (!fTargetPartitionTriple.empty())
+  {
+    curJob.setTargetPartitionTriple(fTargetPartitionTriple);
+  }
 
   curJob.setDefaultJobUUID();
 

--- a/writeengine/bulk/we_cmdargs.h
+++ b/writeengine/bulk/we_cmdargs.h
@@ -116,6 +116,7 @@ private:
   bool fDisableTableLockTimeOut{false};
   bool fSilent{false};
   std::string fModuleIDandPID;
+  std::string fTargetPartitionTriple;  // Directory.Segment.DBRoot for -a flag
 
   std::string fReportFilename;
   bool fKeepRollbackMetaData{false};


### PR DESCRIPTION
## New Functionality

This PR introduces three new **User-Defined Functions (UDFs)** to expose new capabilities to database users:

- **`mcs_analyze_partition_bloat('schema', 'table', partition_number)`**  
  Analyzes a single specified partition within a table and returns information about the percentage of empty records (bloat).

- **`mcs_analyze_table_bloat('schema', 'table')`**  
  Extends the analysis to all partitions within a given table, providing a comprehensive view of bloat across the entire table.

- **`mcs_vacuum_partition('schema', 'table', partition_number)`**  
  Serves as the entry point for manually triggering the partition cleanup process.  
  This PR implements the initial framework required for this operation, including creating hidden partitions and enabling targeted data loading.

---

## Code Changes and Implementation Details

The implementation spans several components of the ColumnStore engine:

### 1. Bloat Analysis Engine
- Core logic for bloat analysis is implemented in:  
  `dbcon/execplan/commandpackageprocessor.cpp`  
  with new methods: **`analyzePartitionBloat`** and **`analyzeTableBloat`**.
- The analysis works by executing SQL queries against the system catalog to count empty values and determine the bloat factor.
- Enhancements in:  
  `dbcon/execplan/CalpontSystemCatalog.cpp`  
  - New functions: **`getQueryData`**, **`setupQueryTxnCtx`**  
  - Provide querying any data within a from the system catalog which is used for analyze and is useful for future work.

---

### 2. Vacuuming Framework
The foundation for the vacuuming process is built upon two key changes:

#### a. Hidden Partition Management
- **DBRM** and **SlaveComm** updated to support "hidden" partitions.  
  - Enables background data copy without affecting concurrent `SELECT` queries.
- New functions:  
  - **`createHiddenStripeColumnExtents`** → creates hidden partitions.  
  - **`makePartitionVisible`** → atomic swap to make compacted partition visible.  
- Changes implemented across:  
  - `storage-manager/dbrm/`  
  - `utils/slavecomm/`  
  - `utils/slavecomm/slavedbrmnode.cpp`  
  Ensures functionality in both single-node and distributed environments.

#### b. Targeted Bulk Loading
- **`cpimport` utility** enhanced to support targeted partition loading.
- Changes in:  
  - `writeengine/bulk/we_cmdargs.cpp` → new CLI argument for target partition (`Directory.Segment.DBRoot`).  
  - `writeengine/bulk/we_bulkload.cpp` (BulkLoad class) → processes new argument.  
- Enables vacuum process to `SELECT` data from bloated partition and pipe it directly into the hidden partition via **cpimport**.

---

### 3. UDF Interface
- New UDFs registered and implemented in:  
  - `dbcon/mysql/ha_mcs_client_udfs.cpp`  
  - `dbcon/mysql/ha_mcs_impl.cpp`
- These act as the bridge between **MariaDB server** and **ColumnStore engine**, handling:  
  - Input validation  
  - Invoking backend implementation  

---

## Future Work
This PR provides the foundational components for **bloat analysis** and **vacuuming**.  
Upcoming work will address:

- Finishing vacuum partition.
- Implementing vacuum table.
- Use AUX columns in analyze UDFs when they are added as actual queryable columns.
