### PR TITLE
MCOL-5974 chore: mcol-5480 test in bugfixes now works

### DIFF
--- a/dbcon/mysql/ha_mcs_ddl.cpp
+++ b/dbcon/mysql/ha_mcs_ddl.cpp
@@ -867,12 +867,14 @@ int ProcessDDLStatement(string& ddlStatement, string& schema, const string& /*ta
           return rc;
         }
 
+#if MYSQL_VERSION_ID < 110400
         // For TIMESTAMP, if no constraint is given, default to NOT NULL
         if (createTable->fTableDef->fColumns[i]->fType->fType == ddlpackage::DDL_TIMESTAMP &&
             createTable->fTableDef->fColumns[i]->fConstraints.empty())
         {
           createTable->fTableDef->fColumns[i]->fConstraints.push_back(new ColumnConstraintDef(DDL_NOT_NULL));
         }
+#endif
 
         if (createTable->fTableDef->fColumns[i]->fDefaultValue)
         {

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -6292,7 +6292,7 @@ int processLimitAndOffset(SELECT_LEX& select_lex, gp_walk_info& gwi, SCSEP& csep
 // for the first column of the index if any.
 // Statistics is stored in GWI context.
 // Mock for ES 10.6
-#if MYSQL_VERSION_ID >= 110401
+#if MYSQL_VERSION_ID >= 120401
 void extractColumnStatistics(Item_field* ifp, gp_walk_info& gwi)
 {
   for (uint j = 0; j < ifp->field->table->s->keys; j++)

--- a/mysql-test/columnstore/bugfixes/mcol-5480.test
+++ b/mysql-test/columnstore/bugfixes/mcol-5480.test
@@ -2,7 +2,6 @@
 # MCOL-5480 LDI loads values incorrectly for MEDIUMINT, TIME and TIMESTAMP
 # when cpimport is used for batch insert
 #
---source ../include/disable_11.4.inc
 --source ../include/have_columnstore.inc
 --source ../include/detect_maxscale.inc
 


### PR DESCRIPTION
There are two parts of changeset, the most pertinent is in ha_mcs_ddl.cpp. The change there is to remove forsing TIMESTAMP columns to be NOT NULL if no constraints were given. This particular forcing made server to provide a NULL value bit that is not processed by our batch insert procedures.

E.g., for triple (TIMESTAMP,INT,STRING) server provided three isNull bits, let's say, 010, but we read only two first, but for INT and STRING. TIMESTAMP column was recorded as NOT NULL in Calpont System Catalog tables and thus is not processed and/or accounted for. Thus, for triple (2020-10-20 11:22:33, NULL 'asd') with 010 null bits, we read  (2020-10-20 11:22:33, 0 NULL because null mask is 001 for us. Zero is some random value we incorrectly read.

The second part of changes is due to ROB unable to compile under 11.4. I disabled the transformation.

I see a lot of MTR problems with stable-23.10 under 11.4-enterprise, though. My changes appear as not changing much in that regard.