### PR TITLE
Cherry picks 0a84f04e8

### DIFF
--- a/primitives/blockcache/filebuffermgr.cpp
+++ b/primitives/blockcache/filebuffermgr.cpp
@@ -293,8 +293,11 @@ void FileBufferMgr::flushOIDs(const uint32_t* oids, uint32_t count)
         {
           fbList.erase(fFBPool[tmpIt->second->poolIdx].listLoc());
           fEmptyPoolSlots.push_back(tmpIt->second->poolIdx);
-          fbSet.erase(tmpIt->second);
           fCacheSize--;
+        }
+        for (byLBID_t::iterator tmpIt = itList.first; tmpIt != itList.second; tmpIt++)
+        {
+          fbSet.erase(tmpIt->second);
         }
       }
     }


### PR DESCRIPTION
This simple patch splits loop which invalidated iterators used, causing use-after-free, potential production crash and actual crash under ASAN.