### PR TITLE
MCOL-6018: cleanup stacks on error

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -2223,8 +2223,10 @@ void setError(THD* thd, uint32_t errcode, string errmsg)
   ci->expressionId = 0;
 }
 
-void setError(THD* thd, uint32_t errcode, string errmsg, gp_walk_info& /*gwi*/)
+void setError(THD* thd, uint32_t errcode, string errmsg, gp_walk_info& gwi)
 {
+  // Clean up any allocated objects in the work stacks to prevent memory leaks
+  clearDeleteStacks(gwi);
   setError(thd, errcode, errmsg);
 }
 
@@ -2236,6 +2238,8 @@ int setErrorAndReturn(gp_walk_info& gwi)
   // processing.
   if (gwi.thd->derived_tables_processing)
   {
+    // Clean up work stacks even for derived table processing to prevent leaks
+    clearDeleteStacks(gwi);
     gwi.cs_vtable_is_update_with_derive = true;
     return -1;
   }
@@ -7126,7 +7130,7 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, SCSEP& csep, bool i
     if (funcFieldVec.size() != 0 && !gwi.fatalParseError)
     {
       string emsg("Fatal parse error in vtable mode: Unsupported Items in union or sub select unit");
-      setError(gwi.thd, ER_CHECK_NOT_IMPLEMENTED, emsg);
+      setError(gwi.thd, ER_CHECK_NOT_IMPLEMENTED, emsg, gwi);
       return ER_CHECK_NOT_IMPLEMENTED;
     }
   }

--- a/dbcon/mysql/ha_mcs_execplan_walks.cpp
+++ b/dbcon/mysql/ha_mcs_execplan_walks.cpp
@@ -980,7 +980,7 @@ void parse_item(Item* item, vector<Item_field*>& field_vec, bool& hasNonSupportI
       // ERR_CORRELATED_SUB_OR
       string parseErrorText =
           logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_NON_SUPPORT_SUB_QUERY_TYPE);
-      setError(gwi->thd, ER_CHECK_NOT_IMPLEMENTED, parseErrorText);
+      setError(gwi->thd, ER_CHECK_NOT_IMPLEMENTED, parseErrorText, *gwi);
       break;
     }
 

--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -424,7 +424,7 @@ int cs_get_select_plan(ha_columnstore_select_handler* handler, THD* thd, execpla
 int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, execplan::SCSEP& csep, bool isUnion = false,
                   bool isSelectHandlerTop = false, bool isSelectLexUnit = false,
                   const std::vector<COND*>& condStack = std::vector<COND*>());
-void setError(THD* thd, uint32_t errcode, const std::string errmsg, gp_walk_info* gwi);
+void setError(THD* thd, uint32_t errcode, const std::string errmsg, gp_walk_info& gwi);
 void setError(THD* thd, uint32_t errcode, const std::string errmsg);
 void gp_walk(const Item* item, void* arg);
 void clearDeleteStacks(gp_walk_info& gwi);

--- a/dbcon/mysql/ha_window_function.cpp
+++ b/dbcon/mysql/ha_window_function.cpp
@@ -61,13 +61,13 @@ ReturnedColumn* nullOnError(gp_walk_info& gwi)
   if (gwi.hasSubSelect)
   {
     gwi.parseErrorText = logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_NON_SUPPORT_SELECT_SUB);
-    setError(gwi.thd, ER_CHECK_NOT_IMPLEMENTED, gwi.parseErrorText);
+    setError(gwi.thd, ER_CHECK_NOT_IMPLEMENTED, gwi.parseErrorText, gwi);
   }
 
   if (gwi.parseErrorText.empty())
   {
     gwi.parseErrorText = logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_WF_NON_SUPPORT);
-    setError(gwi.thd, ER_CHECK_NOT_IMPLEMENTED, gwi.parseErrorText);
+    setError(gwi.thd, ER_CHECK_NOT_IMPLEMENTED, gwi.parseErrorText, gwi);
   }
 
   return NULL;
@@ -879,7 +879,7 @@ ReturnedColumn* buildWindowFunctionColumn(Item* item, gp_walk_info& gwi, bool& n
     if (gwi.parseErrorText.empty())
       gwi.parseErrorText = logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_WF_NON_SUPPORT);
 
-    setError(gwi.thd, ER_CHECK_NOT_IMPLEMENTED, gwi.parseErrorText);
+    setError(gwi.thd, ER_CHECK_NOT_IMPLEMENTED, gwi.parseErrorText, gwi);
     return NULL;
   }
 #if 0


### PR DESCRIPTION
Try to address the ASAN leak report 
```
Direct leak of 3168 byte(s) in 3 object(s) allocated from:
    #0 0x75c804728548 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x75c7f762c8f2 in cal_impl_if::newConstantColumnNotNullUsingValNativeNoTz(Item*, cal_impl_if::gp_walk_info&) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_helpers.cpp:134
    #2 0x75c7f762cce4 in cal_impl_if::buildConstantColumnNotNullUsingValNative(Item*, cal_impl_if::gp_walk_info&) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_helpers.cpp:98
    #3 0x75c7f76d1e9e in cal_impl_if::buildReturnedColumnBody(Item*, cal_impl_if::gp_walk_info&, bool&, bool) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:2762
    #4 0x75c7f76d2d9e in cal_impl_if::buildReturnedColumn(Item*, cal_impl_if::gp_walk_info&, bool&, bool) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:2925
    #5 0x75c7f7648178 in cal_impl_if::gp_walk(Item const*, void*) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_walks.cpp:157
    #6 0x5948287a6576 in Item_func::traverse_cond(void (*)(Item const*, void*), void*, Item::traverse_order) (/usr/sbin/mariadbd+0x192a576) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #7 0x75c7f76a4af9 in cal_impl_if::processWhere(st_select_lex&, cal_impl_if::gp_walk_info&, boost::shared_ptr<execplan::CalpontSelectExecutionPlan>&, std::vector<Item*, std::allocator<Item*> > const&) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:5899
    #8 0x75c7f76f8895 in cal_impl_if::getSelectPlan(cal_impl_if::gp_walk_info&, st_select_lex&, boost::shared_ptr<execplan::CalpontSelectExecutionPlan>&, bool, bool, bool, std::vector<Item*, std::allocator<Item*> > const&) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:7099
    #9 0x75c7f770407e in cal_impl_if::cs_get_select_plan(ha_columnstore_select_handler*, THD*, boost::shared_ptr<execplan::CalpontSelectExecutionPlan>&, cal_impl_if::gp_walk_info&, bool) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:7463
    #10 0x75c7f750a119 in ha_mcs_impl_pushdown_init(mcs_handler_info*, TABLE*, bool) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_impl.cpp:4247
    #11 0x75c7f74a4acb in create_columnstore_select_handler_(THD*, st_select_lex*, st_select_lex_unit*) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_pushdown.cpp:845
    #12 0x594827de372d  (/usr/sbin/mariadbd+0xf6772d) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #13 0x594827f086ff in mysql_select(THD*, TABLE_LIST*, List<Item>&, Item*, unsigned int, st_order*, st_order*, Item*, st_order*, unsigned long long, select_result*, st_select_lex_unit*, st_select_lex*) (/usr/sbin/mariadbd+0x108c6ff) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #14 0x594827f0a438 in handle_select(THD*, LEX*, select_result*, unsigned long) (/usr/sbin/mariadbd+0x108e438) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #15 0x594827d39b64 in mysql_execute_command(THD*, bool) (/usr/sbin/mariadbd+0xebdb64) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #16 0x594827d3bce1 in mysql_parse(THD*, char*, unsigned int, Parser_state*) (/usr/sbin/mariadbd+0xebfce1) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #17 0x594827d3ffd5 in dispatch_command(enum_server_command, THD*, char*, unsigned int, bool) (/usr/sbin/mariadbd+0xec3fd5) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #18 0x594827d46210 in do_command(THD*, bool) (/usr/sbin/mariadbd+0xeca210) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #19 0x5948281a041c in do_handle_one_connection(CONNECT*, bool) (/usr/sbin/mariadbd+0x132441c) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #20 0x5948281a0c44 in handle_one_connection (/usr/sbin/mariadbd+0x1324c44) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #21 0x594828e86c85  (/usr/sbin/mariadbd+0x200ac85) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #22 0x75c804688a41 in asan_thread_start ../../../../src/libsanitizer/asan/asan_interceptors.cpp:234
    #23 0x75c80392baa3 in start_thread nptl/pthread_create.c:447
    ```