### PR TITLE
Fix mariadb crash. Install dbg symbols for test stages

### DIFF
--- a/build/prepare_test_container.sh
+++ b/build/prepare_test_container.sh
@@ -130,7 +130,8 @@ prepare_container() {
     if [[ "$RESULT" == *rocky* ]]; then
         execInnerDockerWithRetry "$CONTAINER_NAME" 'yum install -y MariaDB-columnstore-engine MariaDB-test'
     else
-        execInnerDockerWithRetry "$CONTAINER_NAME" 'apt update -y && apt install -y mariadb-plugin-columnstore mariadb-test mariadb-test-data mariadb-plugin-columnstore-dbgsym'
+        #TODO think about server version!
+        execInnerDockerWithRetry "$CONTAINER_NAME" 'apt update -y && apt install -y mariadb-plugin-columnstore mariadb-test mariadb-test-data mariadb-plugin-columnstore-dbgsym mariadb-client-10.6-dbgsym mariadb-client-core-10.6-dbgsym mariadb-server-10.6-dbgsym mariadb-server-core-10.6-dbgsym mariadb-test-dbgsym '
     fi
 
     sleep 5

--- a/dbcon/mysql/is_columnstore_columns.cpp
+++ b/dbcon/mysql/is_columnstore_columns.cpp
@@ -62,11 +62,24 @@ static int is_columnstore_columns_fill(THD* thd, TABLE_LIST* tables, COND* cond)
   InformationSchemaCond isCond;
 
   execplan::CalpontSystemCatalog csc;
-  const std::vector<
-      std::pair<execplan::CalpontSystemCatalog::OID, execplan::CalpontSystemCatalog::TableName> >
-      catalog_tables = csc.getTables();
-
+  // Use FE path for syscat queries issued from mysqld
   csc.identity(execplan::CalpontSystemCatalog::FE);
+
+  std::vector<
+      std::pair<execplan::CalpontSystemCatalog::OID, execplan::CalpontSystemCatalog::TableName> >
+      catalog_tables;
+  try
+  {
+    catalog_tables = csc.getTables("", lower_case_table_names);
+  }
+  catch (IDBExcept&)
+  {
+    return 1;
+  }
+  catch (std::exception&)
+  {
+    return 1;
+  }
 
   if (cond)
   {


### PR DESCRIPTION
```
#1  __pthread_kill_internal (signo=0x6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
No locals.
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=0x6) at ./nptl/pthread_kill.c:89
No locals.
#3  0x000075cffb10827e in __GI_raise (sig=sig@entry=0x6) at ../sysdeps/posix/raise.c:26
        ret = <optimized out>
#4  0x000075cffb0eb98f in __GI_abort () at ./stdlib/abort.c:100
        act = {__sigaction_handler = {sa_handler = 0x0, sa_sigaction = 0x0}, sa_mask = {__val = {0xffffffffffffffff, 0x0 <repeats 15 times>}}, sa_flags = 0x0, sa_restorer = 0x0}
#5  0x000075cffb463ff5 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
No symbol table info available.
#6  0x000075cffb4790da in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
No symbol table info available.
#7  0x000075cffb463a55 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
No symbol table info available.
#8  0x000075cffb463a6f in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
No symbol table info available.
#9  0x000075cfee46a90d in execplan::CalpontSystemCatalog::getSysData (this=this@entry=0x75cfc1185520, csep=..., sysDataList=..., sysTableName="systable") at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/execplan/calpontsystemcatalog.cpp:805
        txnID = <optimized out>
        oldTxnID = 0xffffffff
        verID = <optimized out>
        oldVerID = <optimized out>
        tryCnt = 0x0
        tablelist = <optimized out>
        it = <optimized out>
#10 0x000075cfee4ef00a in execplan::CalpontSystemCatalog::getTables (this=this@entry=0x75cfc1185520, schema="", lower_case_table_names=lower_case_table_names@entry=0x0) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/execplan/calpontsystemcatalog.cpp:2834
        schemaname = <optimized out>
        tables = std::vector of length 0, capacity 0
        csep = <optimized out>
        returnedColumnList = <optimized out>
        filterTokenList = <optimized out>
        colMap = <optimized out>
        c1 = 0x51a0004ab280
        c2 = 0x51a0003df880
        c3 = 0x51a000789c80
        c4 = 0x51a00006b480
        srcp = <optimized out>
        oid1 = 0x7d1
        oid2 = 0x7d4
        sysDataList = <optimized out>
        it = <optimized out>
        tnl = <optimized out>
        rp = <optimized out>
#11 0x000075cfeefdead6 in is_columnstore_columns_fill (thd=<optimized out>, tables=<optimized out>, cond=0x52d0000ed160) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/is_columnstore_columns.cpp:67
        cs = 0x634624da5360 <my_charset_utf8mb3_general_ci>
        table = 0x52d005cda438
        isCond = <optimized out>
        csc = <optimized out>
        catalog_tables = <optimized out>
#12 0x00006346226e0a8d in get_schema_tables_result (join=join@entry=0x52d0000e9750, executed_place=executed_place@entry=PROCESSED_BY_JOIN_EXEC) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/sql/sql_show.cc:9234
        is_subselect = <optimized out>
        cond = <optimized out>
        backup_ctx = <optimized out>
        check_level_save = <optimized out>
        table_list = 0x52d0000e6f68
        thd = 0x52b00015e218
        lex = 0x52b000162340
        result = 0x0
        org_stage = <optimized out>
        err_handler = <optimized out>
        tab = 0x52d0000ec310
#13 0x000063462266806d in JOIN::exec_inner (this=this@entry=0x52d0000e9750) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/sql/sql_select.cc:4926
        columns_list = <optimized out>
        trace_wrapper = <optimized out>
        trace_exec = <optimized out>
        trace_steps = <optimized out>
#14 0x000063462266a9a1 in JOIN::exec (this=this@entry=0x52d0000e9750) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/sql/sql_select.cc:4747
No locals.
#15 0x0000634622662872 in mysql_select (thd=thd@entry=0x52b00015e218, tables=<optimized out>, fields=..., conds=0x52d0000e8408, og_num=0x0, order=0x0, group=0x0, having=0x0, proc_param=0x0, select_options=0xa0040b00, result=0x52d0000e9720, unit=0x52b000162408, select_lex=0x52d0000e65f0) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/sql/sql_select.cc:5283
        err = 0x0
        free_join = 0x1
        join = 0x52d0000e9750
#16 0x0000634622664439 in handle_select (thd=thd@entry=0x52b00015e218, lex=lex@entry=0x52b000162340, result=result@entry=0x52d0000e9720, setup_tables_done_option=setup_tables_done_option@entry=0x0) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/sql/sql_select.cc:575
        unit = 0x52b000162408
        res = <optimized out>
        select_lex = 0x52d0000e65f0
#17 0x000063462245f761 in execute_sqlcom_select (thd=thd@entry=0x52b00015e218, all_tables=<optimized out>) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/sql/sql_parse.cc:6450
        save_protocol = 0x0
        lex = 0x52b000162340
        result = 0x52d0000e9720
        res = <optimized out>
#18 0x00006346224925a7 in mysql_execute_command (thd=thd@entry=0x52b00015e218, is_called_from_prepared_stmt=is_called_from_prepared_stmt@entry=0x0) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/sql/sql_parse.cc:4030
        privileges_requested = <optimized out>
        res = <optimized out>
        up_result = 0x0
        lex = 0x52b000162340
        select_lex = 0x52d0000e65f0
        first_table = 0x52d0000e6f68
        all_tables = <optimized out>
        unit = 0x52b000162408
        have_table_map_for_update = 0x0
        rpl_filter = <optimized out>
        ots = <optimized out>
        orig_binlog_format = <optimized out>
        orig_current_stmt_binlog_format = <optimized out>
#19 0x0000634622495ce2 in mysql_parse (thd=thd@entry=0x52b00015e218, rawbuf=<optimized out>, length=<optimized out>, parser_state=parser_state@entry=0x75cfc117f410) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/sql/sql_parse.cc:8229
        found_semicolon = <optimized out>
        error = <optimized out>
        lex = 0x52b000162340
        err = <optimized out>
#20 0x0000634622499fd6 in dispatch_command (command=command@entry=COM_QUERY, thd=thd@entry=0x52b00015e218, packet=packet@entry=0x529000e51219 "SELECT column_name, data_type, column_length FROM information_schema.columnstore_columns WHERE hex(table_schema)=hex('mcol_4758') and hex(table_name)=hex('src')", packet_length=<optimized out>, blocking=blocking@entry=0x1) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/sql/sql_parse.cc:1915
        packet_end = 0x52d0000e64d8 ""
        parser_state = <optimized out>
        net = 0x52b00015e4d0
        error = 0x0
        do_end_of_statement = 0x1
        drop_more_results = 0x0
        res = <optimized out>
#21 0x00006346224a0211 in do_command (thd=thd@entry=0x52b00015e218, blocking=blocking@entry=0x1) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/sql/sql_parse.cc:1428
        return_value = <optimized out>
        packet = 0x529000e51218 "\003SELECT column_name, data_type, column_length FROM information_schema.columnstore_columns WHERE hex(table_schema)=hex('mcol_4758') and hex(table_name)=hex('src')"
        packet_length = 0xa1
        net = 0x52b00015e4d0
        command = COM_QUERY
#22 0x00006346228fa41d in do_handle_one_connection (connect=<optimized out>, connect@entry=0x50800000c8b8, put_in_cache=put_in_cache@entry=0x1) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/sql/sql_connect.cc:1386
        create_user = 0x1
        thr_create_utime = <optimized out>
        thd = 0x52b00015e218
#23 0x00006346228fac45 in handle_one_connection (arg=arg@entry=0x50800000c8b8) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/sql/sql_connect.cc:1298
        connect = 0x50800000c8b8
#24 0x00006346235e0c86 in pfs_spawn_thread (arg=arg@entry=0x517000009018) at /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/perfschema/pfs.cc:2201
        typed_arg = 0x517000009018
        user_arg = 0x50800000c8b8
        user_start_routine = 0x6346228fabd0 <handle_one_connection(void*)>
        pfs = <optimized out>
        klass = <optimized out>
#25 0x000075cffbebca42 in asan_thread_start (arg=0x75cfde308000) at ../../../../src/libsanitizer/asan/asan_interceptors.cpp:234
        t = 0x75cfde308000
        self = 0x75cfc2a016c0
        args = {routine = 0x6346235e0a80 <pfs_spawn_thread(void*)>, arg_retval = 0x517000009018}
        sigset = {val = {0x87007, 0x0, 0x7ffe35d64840, 0x75cffbe9cb8f, 0x1, 0x0, 0x7ffe35d65090, 0x75cffbf5b982, 0x7ffe35d64860, 0xa, 0x75cffbf5b9c8, 0x634623f84c68, 0x6346235e0d26, 0x634622172485, 0x634622180f39, 0x634622181bd8}}
        retval = <optimized out>
#26 0x000075cffb15faa4 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:447
        ret = <optimized out>
        pd = <optimized out>
        out = <optimized out>
        unwind_buf = {cancel_jmp_buf = {{jmp_buf = {0x75cfc2a016c0, 0x9183c4498943eb26, 0x75cfc2a016c0, 0xfffffffffffffdc8, 0x1, 0x7ffe35d64570, 0x9183c4498803eb26, 0x9183b7227dd9eb26}, mask_was_saved = 0x0}}, priv = {pad = {0x0, 0x0, 0x0, 0x0}, data = {prev = 0x0, cleanup = 0x0, canceltype = 0x0}}}
        not_first_call = <optimized out>
#27 0x000075cffb1ecc3c in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```
That was the crash we had before. Now coredump is from journalctl. Looks we need to work on environment