### PR TITLE
MCOL-6147: on node removal, really remove it

### DIFF
--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -123,7 +123,7 @@ def add_node(
 def remove_node(
     node: str, input_config_filename: str = DEFAULT_MCS_CONF_PATH,
     output_config_filename: Optional[str] = None,
-    deactivate_only: bool = True,
+    deactivate_only: bool = False,
     use_rebalance_dbroots: bool = True, **kwargs
 ):
     """Remove node from a cluster.


### PR DESCRIPTION
Even when asked `mcs cluster node remove --node <node>`, cmapi wasn't removing it. Instead it was moving it into DesiredNodes, and failover was adding it back, which is a very frustrating and non-intuitive behavior