### PR TITLE
MCOL-6150:  buckets ranges

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -7601,7 +7601,7 @@ int cs_get_select_plan(ha_columnstore_select_handler* handler, THD* thd, SCSEP& 
   derivedTableOptimization(&gwi, csep);
 
   {
-    optimizer::RBOptimizerContext ctx(gwi, *thd, csep->traceOn());
+    optimizer::RBOptimizerContext ctx(gwi, *thd, csep->traceOn(), get_ces_optimization_parallel_factor(thd));
     // TODO RBO can crash or fail leaving CSEP in an invalid state, so there must be a valid CSEP copy
     // TBD There is a tradeoff b/w copy per rule and copy per optimizer run.
     bool csepWasOptimized = optimizer::optimizeCSEP(*csep, ctx, get_unstable_optimizer(&ctx.thd));

--- a/dbcon/mysql/ha_mcs_sysvars.cpp
+++ b/dbcon/mysql/ha_mcs_sysvars.cpp
@@ -85,6 +85,12 @@ static MYSQL_THDVAR_UINT(orderby_threads, PLUGIN_VAR_RQCMDARG,
                          "Number of parallel threads used by ORDER BY. (default to 16)", NULL, NULL, 16, 0,
                          2048, 1);
 
+static constexpr uint DEFAULT_CES_OPTIMIZATION_PARALLEL_FACTOR = 50;
+
+static MYSQL_THDVAR_UINT(ces_optimization_parallel_factor, PLUGIN_VAR_RQCMDARG,
+                         "Maximum parallel factor for parallel CES optimization. (default to 50)", NULL, NULL, DEFAULT_CES_OPTIMIZATION_PARALLEL_FACTOR, 1,
+                         1000, 1);
+
 // legacy system variables
 static MYSQL_THDVAR_ULONG(decimal_scale, PLUGIN_VAR_RQCMDARG,
                           "The default decimal precision for calculated column sub-operations ", NULL, NULL,
@@ -236,6 +242,7 @@ st_mysql_sys_var* mcs_system_variables[] = {
     MYSQL_SYSVAR(derived_handler),
     MYSQL_SYSVAR(select_handler_in_stored_procedures),
     MYSQL_SYSVAR(orderby_threads),
+    MYSQL_SYSVAR(ces_optimization_parallel_factor),
     MYSQL_SYSVAR(decimal_scale),
     MYSQL_SYSVAR(use_decimal_scale),
     MYSQL_SYSVAR(ordered_only),
@@ -366,6 +373,15 @@ uint get_orderby_threads(THD* thd)
 void set_orderby_threads(THD* thd, uint value)
 {
   THDVAR(thd, orderby_threads) = value;
+}
+
+uint get_ces_optimization_parallel_factor(THD* thd)
+{
+  return (thd == NULL) ? DEFAULT_CES_OPTIMIZATION_PARALLEL_FACTOR : THDVAR(thd, ces_optimization_parallel_factor);
+}
+void set_ces_optimization_parallel_factor(THD* thd, uint value)
+{
+  THDVAR(thd, ces_optimization_parallel_factor) = value;
 }
 
 bool get_use_decimal_scale(THD* thd)

--- a/dbcon/mysql/ha_mcs_sysvars.h
+++ b/dbcon/mysql/ha_mcs_sysvars.h
@@ -81,6 +81,9 @@ void set_select_handler_in_stored_procedures(THD* thd, bool value);
 uint get_orderby_threads(THD* thd);
 void set_orderby_threads(THD* thd, uint value);
 
+uint get_ces_optimization_parallel_factor(THD* thd);
+void set_ces_optimization_parallel_factor(THD* thd, uint value);
+
 bool get_use_decimal_scale(THD* thd);
 void set_use_decimal_scale(THD* thd, bool value);
 

--- a/dbcon/rbo/rulebased_optimizer.h
+++ b/dbcon/rbo/rulebased_optimizer.h
@@ -34,8 +34,8 @@ class RBOptimizerContext
 {
  public:
   RBOptimizerContext() = delete;
-  RBOptimizerContext(cal_impl_if::gp_walk_info& walk_info, THD& thd, bool logRules)
-   : gwi(walk_info), thd(thd), logRules(logRules)
+  RBOptimizerContext(cal_impl_if::gp_walk_info& walk_info, THD& thd, bool logRules, uint cesOptimizationParallelFactor = 50)
+   : gwi(walk_info), thd(thd), logRules(logRules), cesOptimizationParallelFactor(cesOptimizationParallelFactor)
   {
   }
   // gwi lifetime should be longer than optimizer context.
@@ -44,6 +44,7 @@ class RBOptimizerContext
   THD& thd;
   uint64_t uniqueId{0};
   bool logRules{false};
+  uint cesOptimizationParallelFactor;
 };
 
 struct Rule


### PR DESCRIPTION
tested with the scale factors that are avaliable from session variable
SF=5, histogram_size=50
SF=50, histogram_size=50
SF=100, histogram_size=50

```
MariaDB [mysql]> set columnstore_ces_optimization_parallel_factor=4;
Query OK, 0 rows affected (0.000 sec)

MariaDB [mysql]> select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge, avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, avg(l_discount) as avg_disc, count(*) as count_order from lineitem where l_shipdate <= date '1998-12-01' - interval 60 day group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus;
+--------------+--------------+---------+----------------+----------------+------------+---------+-----------+----------+-------------+
| l_returnflag | l_linestatus | sum_qty | sum_base_price | sum_disc_price | sum_charge | avg_qty | avg_price | avg_disc | count_order |
+--------------+--------------+---------+----------------+----------------+------------+---------+-----------+----------+-------------+
| A            | F            | 37734107.00 | 56586554400.73 | 53758257134.8700 | 55909065222.827692 | 25.522006 | 38273.129735 | 0.049985 |     1478493 |
| N            | F            | 991417.00 |  1487504710.38 | 1413082168.0541 | 1469649223.194375 | 25.516472 | 38284.467761 | 0.050093 |       38854 |
| N            | O            | 75669043.00 | 113487916444.67 | 107814847309.1223 | 112131228309.266683 | 25.502075 | 38247.838833 | 0.049998 |     2967172 |
| R            | F            | 37719753.00 | 56568041380.90 | 53741292684.6040 | 55889619119.831932 | 25.505794 | 38250.854626 | 0.050009 |     1478870 |
+--------------+--------------+---------+----------------+----------------+------------+---------+-----------+----------+-------------+
4 rows in set (18.189 sec)

MariaDB [mysql]> set columnstore_ces_optimization_parallel_factor=100;
Query OK, 0 rows affected (0.000 sec)

MariaDB [mysql]> select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge, avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, avg(l_discount) as avg_disc, count(*) as count_order from lineitem where l_shipdate <= date '1998-12-01' - interval 60 day group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus;
+--------------+--------------+---------+----------------+----------------+------------+---------+-----------+----------+-------------+
| l_returnflag | l_linestatus | sum_qty | sum_base_price | sum_disc_price | sum_charge | avg_qty | avg_price | avg_disc | count_order |
+--------------+--------------+---------+----------------+----------------+------------+---------+-----------+----------+-------------+
| A            | F            | 37734107.00 | 56586554400.73 | 53758257134.8700 | 55909065222.827692 | 25.522006 | 38273.129735 | 0.049985 |     1478493 |
| N            | F            | 991417.00 |  1487504710.38 | 1413082168.0541 | 1469649223.194375 | 25.516472 | 38284.467761 | 0.050093 |       38854 |
| N            | O            | 75669043.00 | 113487916444.67 | 107814847309.1223 | 112131228309.266683 | 25.502075 | 38247.838833 | 0.049998 |     2967172 |
| R            | F            | 37719753.00 | 56568041380.90 | 53741292684.6040 | 55889619119.831932 | 25.505794 | 38250.854626 | 0.050009 |     1478870 |
+--------------+--------------+---------+----------------+----------------+------------+---------+-----------+----------+-------------+
4 rows in set (22.403 sec)

MariaDB [mysql]> set columnstore_ces_optimization_parallel_factor=50;
Query OK, 0 rows affected (0.000 sec)

MariaDB [mysql]> select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge, avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, avg(l_discount) as avg_disc, count(*) as count_order from lineitem where l_shipdate <= date '1998-12-01' - interval 60 day group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus;
+--------------+--------------+---------+----------------+----------------+------------+---------+-----------+----------+-------------+
| l_returnflag | l_linestatus | sum_qty | sum_base_price | sum_disc_price | sum_charge | avg_qty | avg_price | avg_disc | count_order |
+--------------+--------------+---------+----------------+----------------+------------+---------+-----------+----------+-------------+
| A            | F            | 37734107.00 | 56586554400.73 | 53758257134.8700 | 55909065222.827692 | 25.522006 | 38273.129735 | 0.049985 |     1478493 |
| N            | F            | 991417.00 |  1487504710.38 | 1413082168.0541 | 1469649223.194375 | 25.516472 | 38284.467761 | 0.050093 |       38854 |
| N            | O            | 75669043.00 | 113487916444.67 | 107814847309.1223 | 112131228309.266683 | 25.502075 | 38247.838833 | 0.049998 |     2967172 |
| R            | F            | 37719753.00 | 56568041380.90 | 53741292684.6040 | 55889619119.831932 | 25.505794 | 38250.854626 | 0.050009 |     1478870 |
+--------------+--------------+---------+----------------+----------------+------------+---------+-----------+----------+-------------+
4 rows in set (22.320 sec)
```

having logs
```
Aug 22 02:36:32 ip-172-31-44-131 mariadbd[2927805]: populateRangeBounds() columnStatistics->buckets.size() 50
Aug 22 02:36:32 ip-172-31-44-131 mariadbd[2927805]: Bounds generated: 4
Aug 22 02:36:57 ip-172-31-44-131 mariadbd[2927805]: populateRangeBounds() columnStatistics->buckets.size() 50
Aug 22 02:36:57 ip-172-31-44-131 mariadbd[2927805]: Bounds generated: 50
Aug 22 02:37:31 ip-172-31-44-131 mariadbd[2927805]: populateRangeBounds() columnStatistics->buckets.size() 50
Aug 22 02:37:31 ip-172-31-44-131 mariadbd[2927805]: Bounds generated: 50
```