### PR TITLE
fix(leak): MCOL-6018: cleanup stacks on error again

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan_walks.cpp
+++ b/dbcon/mysql/ha_mcs_execplan_walks.cpp
@@ -815,6 +815,12 @@ void gp_walk(const Item* item, void* arg)
     }
   }
 
+  // Clean up allocated objects if a fatal parse error occurred
+  if (gwip->fatalParseError)
+  {
+    clearDeleteStacks(*gwip);
+  }
+
   return;
 }
 


### PR DESCRIPTION
```
=================================================================
==6895==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 3168 byte(s) in 3 object(s) allocated from:
    #0 0x783a8d516548 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x783a8042c912 in cal_impl_if::newConstantColumnNotNullUsingValNativeNoTz(Item*, cal_impl_if::gp_walk_info&) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_helpers.cpp:134
    #2 0x783a8042cd04 in cal_impl_if::buildConstantColumnNotNullUsingValNative(Item*, cal_impl_if::gp_walk_info&) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_helpers.cpp:98
    #3 0x783a804d213e in cal_impl_if::buildReturnedColumnBody(Item*, cal_impl_if::gp_walk_info&, bool&, bool) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:2766
    #4 0x783a804d303e in cal_impl_if::buildReturnedColumn(Item*, cal_impl_if::gp_walk_info&, bool&, bool) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:2929
    #5 0x783a80448196 in cal_impl_if::gp_walk(Item const*, void*) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_walks.cpp:158
    #6 0x625d852a6576 in Item_func::traverse_cond(void (*)(Item const*, void*), void*, Item::traverse_order) (/usr/sbin/mariadbd+0x192a576) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #7 0x783a804a4d99 in cal_impl_if::processWhere(st_select_lex&, cal_impl_if::gp_walk_info&, boost::shared_ptr<execplan::CalpontSelectExecutionPlan>&, std::vector<Item*, std::allocator<Item*> > const&) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:5903
    #8 0x783a804f8b75 in cal_impl_if::getSelectPlan(cal_impl_if::gp_walk_info&, st_select_lex&, boost::shared_ptr<execplan::CalpontSelectExecutionPlan>&, bool, bool, bool, std::vector<Item*, std::allocator<Item*> > const&) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:7103
    #9 0x783a8050435e in cal_impl_if::cs_get_select_plan(ha_columnstore_select_handler*, THD*, boost::shared_ptr<execplan::CalpontSelectExecutionPlan>&, cal_impl_if::gp_walk_info&, bool) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:7467
    #10 0x783a8030a139 in ha_mcs_impl_pushdown_init(mcs_handler_info*, TABLE*, bool) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_impl.cpp:4247
    #11 0x783a802a4aeb in create_columnstore_select_handler_(THD*, st_select_lex*, st_select_lex_unit*) /usr/src/mariadb-10.6-1:10.6.23.18+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_pushdown.cpp:845
    #12 0x625d848e372d  (/usr/sbin/mariadbd+0xf6772d) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #13 0x625d84a086ff in mysql_select(THD*, TABLE_LIST*, List<Item>&, Item*, unsigned int, st_order*, st_order*, Item*, st_order*, unsigned long long, select_result*, st_select_lex_unit*, st_select_lex*) (/usr/sbin/mariadbd+0x108c6ff) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #14 0x625d84a0a438 in handle_select(THD*, LEX*, select_result*, unsigned long) (/usr/sbin/mariadbd+0x108e438) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #15 0x625d84839b64 in mysql_execute_command(THD*, bool) (/usr/sbin/mariadbd+0xebdb64) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #16 0x625d8483bce1 in mysql_parse(THD*, char*, unsigned int, Parser_state*) (/usr/sbin/mariadbd+0xebfce1) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #17 0x625d8483ffd5 in dispatch_command(enum_server_command, THD*, char*, unsigned int, bool) (/usr/sbin/mariadbd+0xec3fd5) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #18 0x625d84846210 in do_command(THD*, bool) (/usr/sbin/mariadbd+0xeca210) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #19 0x625d84ca041c in do_handle_one_connection(CONNECT*, bool) (/usr/sbin/mariadbd+0x132441c) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #20 0x625d84ca0c44 in handle_one_connection (/usr/sbin/mariadbd+0x1324c44) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #21 0x625d85986c85  (/usr/sbin/mariadbd+0x200ac85) (BuildId: 687b72e1ee8df85b2b81c2a83f8373bcfc123540)
    #22 0x783a8d476a41 in asan_thread_start ../../../../src/libsanitizer/asan/asan_interceptors.cpp:234
    #23 0x783a8c719aa3 in start_thread nptl/pthread_create.c:447
```