### PR TITLE
Speed up columnstore CI packaging

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -563,7 +563,7 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
                          "--build-path " + "/mdb/" + builddir + "/builddir " +
                          " " + customBootstrapParamsForExisitingPipelines(platform) +
                          " " + customBuildFlags(customBootstrapParamsKey) +
-                         " | " + get_build_command("ansi2txt.sh") +
+                         " 2>&1 | " + get_build_command("ansi2txt.sh") +
                          "/mdb/" + builddir + "/" + result + '/build.log "',
                        ],
            },

--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -1,4 +1,7 @@
-find_package(Boost 1.88.0 COMPONENTS chrono filesystem program_options regex system thread)
+# Single source of truth for Boost components we need
+set(BOOST_COMPONENTS chrono filesystem program_options regex system thread)
+
+find_package(Boost 1.88.0 COMPONENTS ${BOOST_COMPONENTS})
 
 if(Boost_FOUND)
     add_custom_target(external_boost)
@@ -35,11 +38,20 @@ elseif(COLUMNSTORE_WITH_LIBCPP)
 endif()
 
 set(_b2args cxxflags=${_cxxargs};cflags=-fPIC;threading=multi;${_extra};toolset=${_toolset}
-            --without-mpi;--without-charconv;--without-python;--prefix=${INSTALL_LOCATION} linkflags=${_linkflags}
+            --prefix=${INSTALL_LOCATION} linkflags=${_linkflags}
 )
 
+# Derived helper strings from BOOST_COMPONENTS
+set(_boost_with_libs_list ${BOOST_COMPONENTS})
+string(REPLACE ";" "," _boost_with_libs_csv "${_boost_with_libs_list}")
+set(_boost_b2_with_args)
+foreach(_lib ${BOOST_COMPONENTS})
+    list(APPEND _boost_b2_with_args "--with-${_lib}")
+endforeach()
+string(REPLACE ";" " " _boost_b2_with_args_str "${_boost_b2_with_args}")
+
 set(byproducts)
-foreach(name chrono filesystem program_options regex system thread)
+foreach(name ${BOOST_COMPONENTS})
     set(lib boost_${name})
     add_library(${lib} STATIC IMPORTED GLOBAL)
     add_dependencies(${lib} external_boost)
@@ -50,7 +62,7 @@ endforeach()
 
 set(LOG_BOOST_INSTEAD_OF_SCREEN "")
 if(COLUMNSTORE_MAINTAINER_MODE)
-    set(LOG_BOOST_INSTEAD_OF_SCREEN "LOG_BUILD TRUE LOG_INSTALL TRUE")
+    set(LOG_BOOST_INSTEAD_OF_SCREEN "LOG_BUILD TRUE LOG_INSTALL TRUE LOG_CONFIGURE TRUE")
 endif()
 
 ExternalProject_Add(
@@ -58,13 +70,13 @@ ExternalProject_Add(
     PREFIX .boost
     URL https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz
     URL_HASH SHA256=3621533e820dcab1e8012afd583c0c73cf0f77694952b81352bf38c1488f9cb4
-    CONFIGURE_COMMAND ./bootstrap.sh
+    CONFIGURE_COMMAND ./bootstrap.sh --with-libraries=${_boost_with_libs_csv}
     UPDATE_COMMAND ""
     PATCH_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> patch -p1 -i
                   ${CMAKE_SOURCE_DIR}/storage/columnstore/columnstore/cmake/boost.1.88.named_proxy.hpp.patch
-    BUILD_COMMAND ./b2 -q ${_b2args}
+    BUILD_COMMAND ./b2 -q -d0 ${_b2args} ${_boost_b2_with_args}
     BUILD_IN_SOURCE TRUE
-    INSTALL_COMMAND ./b2 -q install ${_b2args}
+    INSTALL_COMMAND ./b2 -q -d0 install ${_b2args} ${_boost_b2_with_args}
     ${LOG_BOOST_INSTEAD_OF_SCREEN}
     EXCLUDE_FROM_ALL TRUE
     ${byproducts}

--- a/cmake/cpack_manage.cmake
+++ b/cmake/cpack_manage.cmake
@@ -28,7 +28,7 @@ macro(columnstore_add_rpm_deps)
     columnstore_append_for_cpack(CPACK_RPM_columnstore-engine_PACKAGE_REQUIRES ${ARGN})
 endmacro()
 
-if(NOT COLUMNSTORE_MAINTAINER_MODE)
+if(NOT COLUMNSTORE_MAINTAINER)
     return()
 endif()
 

--- a/cmake/cpack_manage.cmake
+++ b/cmake/cpack_manage.cmake
@@ -28,6 +28,27 @@ macro(columnstore_add_rpm_deps)
     columnstore_append_for_cpack(CPACK_RPM_columnstore-engine_PACKAGE_REQUIRES ${ARGN})
 endmacro()
 
-if(RPM)
-    columnstore_add_rpm_deps("snappy" "jemalloc" "procps-ng" "gawk")
-endif()
+# Columnstore-specific RPM packaging overrides 1) Use fast compression to speed up packaging
+set(CPACK_RPM_COMPRESSION_TYPE
+    "zstd"
+    CACHE STRING "RPM payload compression" FORCE
+)
+# 2) Disable debuginfo/debugsource to avoid slow packaging and duplicate file warnings
+set(CPACK_RPM_DEBUGINFO_PACKAGE
+    OFF
+    CACHE BOOL "Disable debuginfo package" FORCE
+)
+set(CPACK_RPM_PACKAGE_DEBUG
+    0
+    CACHE STRING "Disable RPM debug package" FORCE
+)
+unset(CPACK_RPM_BUILD_SOURCE_DIRS_PREFIX CACHE)
+
+# Ensure our overrides are applied by CPack at packaging time CPACK_PROJECT_CONFIG_FILE is included by cpack after
+# CPackConfig.cmake is loaded
+set(CPACK_PROJECT_CONFIG_FILE
+    "${CMAKE_CURRENT_LIST_DIR}/cpack_overrides.cmake"
+    CACHE FILEPATH "Columnstore CPack overrides" FORCE
+)
+
+columnstore_add_rpm_deps("snappy" "jemalloc" "procps-ng" "gawk")

--- a/cmake/cpack_manage.cmake
+++ b/cmake/cpack_manage.cmake
@@ -1,3 +1,7 @@
+if(NOT COLUMNSTORE_MAINTAINER_MODE)
+    return()
+endif()
+
 macro(columnstore_append_for_cpack var_name)
     # Get current value from parent scope or use empty string
     if(DEFINED ${var_name})

--- a/cmake/cpack_manage.cmake
+++ b/cmake/cpack_manage.cmake
@@ -1,7 +1,3 @@
-if(NOT COLUMNSTORE_MAINTAINER_MODE)
-    return()
-endif()
-
 macro(columnstore_append_for_cpack var_name)
     # Get current value from parent scope or use empty string
     if(DEFINED ${var_name})
@@ -31,6 +27,10 @@ endmacro()
 macro(columnstore_add_rpm_deps)
     columnstore_append_for_cpack(CPACK_RPM_columnstore-engine_PACKAGE_REQUIRES ${ARGN})
 endmacro()
+
+if(NOT COLUMNSTORE_MAINTAINER_MODE)
+    return()
+endif()
 
 # Columnstore-specific RPM packaging overrides 1) Use fast compression to speed up packaging
 set(CPACK_RPM_COMPRESSION_TYPE

--- a/cmake/cpack_overrides.cmake
+++ b/cmake/cpack_overrides.cmake
@@ -1,0 +1,31 @@
+# Columnstore-specific CPack overrides applied at package time
+# This file is referenced via CPACK_PROJECT_CONFIG_FILE and is included by CPack
+# after it reads the generated CPackConfig.cmake, letting these settings win.
+
+# Faster payload compression
+set(CPACK_RPM_COMPRESSION_TYPE "zstd")
+
+# Control debuginfo generation (symbols) without debugsource (sources)
+option(CS_RPM_DEBUGINFO "Build Columnstore -debuginfo RPM (symbols only)" OFF)
+
+if(CS_RPM_DEBUGINFO)
+    # Generate debuginfo RPM (symbols)
+    set(CPACK_RPM_DEBUGINFO_PACKAGE ON)
+    set(CPACK_RPM_PACKAGE_DEBUG 1)
+else()
+    # No debuginfo RPM
+    set(CPACK_RPM_DEBUGINFO_PACKAGE OFF)
+    set(CPACK_RPM_PACKAGE_DEBUG 0)
+    set(CPACK_STRIP_FILES OFF)
+    # Prevent rpmbuild from stripping binaries and running debug post scripts.
+    # CPACK_STRIP_FILES only affects CPack's own stripping; rpmbuild still
+    # executes brp-strip and find-debuginfo by default unless we override macros.
+    if(DEFINED CPACK_RPM_SPEC_MORE_DEFINE)
+        set(CPACK_RPM_SPEC_MORE_DEFINE "${CPACK_RPM_SPEC_MORE_DEFINE}\n%define __strip /bin/true\n%define __objdump /bin/true\n%define __os_install_post %nil\n%define __debug_install_post %nil")
+    else()
+        set(CPACK_RPM_SPEC_MORE_DEFINE "%define __strip /bin/true\n%define __objdump /bin/true\n%define __os_install_post %nil\n%define __debug_install_post %nil")
+    endif()
+endif()
+
+# Always disable debugsource by not mapping sources
+unset(CPACK_RPM_BUILD_SOURCE_DIRS_PREFIX)

--- a/cmake/thrift.cmake
+++ b/cmake/thrift.cmake
@@ -68,6 +68,7 @@ ExternalProject_Add(
                -DCMAKE_EXE_LINKER_FLAGS=${linkflags}
                -DCMAKE_SHARED_LINKER_FLAGS=${linkflags}
                -DCMAKE_MODULE_LINKER_FLAGS=${linkflags}
+               -DCMAKE_INSTALL_MESSAGE=NEVER
     BUILD_BYPRODUCTS "${THRIFT_LIBRARY_DIRS}/${CMAKE_STATIC_LIBRARY_PREFIX}thrift${CMAKE_STATIC_LIBRARY_SUFFIX}"
     EXCLUDE_FROM_ALL TRUE
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ if(WITH_UNITTESTS)
         GIT_REPOSITORY https://github.com/google/googletest
         GIT_TAG release-1.12.0
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION} -DBUILD_SHARED_LIBS=ON
+                   -DCMAKE_INSTALL_MESSAGE=NEVER
                    -DCMAKE_CXX_FLAGS:STRING=${cxxflags} -DCMAKE_EXE_LINKER_FLAGS=${linkflags}
                    -DCMAKE_SHARED_LINKER_FLAGS=${linkflags} -DCMAKE_MODULE_LINKER_FLAGS=${linkflags}
     )


### PR DESCRIPTION
Debug packages for rocky were build extra 45 mins and never used. To have debug symbols, I just do not strip binaries on CI builds + boost now compiling only required components 