### PR TITLE
fix(QA): Multiple changes to fix TPC-H Q4, Q14

### DIFF
--- a/dbcon/execplan/calpontselectexecutionplan.cpp
+++ b/dbcon/execplan/calpontselectexecutionplan.cpp
@@ -1182,10 +1182,15 @@ execplan::SCSEP CalpontSelectExecutionPlan::cloneForTableWORecursiveSelectsGbObH
   // Deep copy of column map
   for (const auto& entry : fColumnMap)
   {
-    // WIP only relevant RCs must be copied
-    if (entry.second)
+    auto tableAlias = entry.second->singleTable();
+    // TODO We insert multiple times if there are multiple SCs for the same RC.
+    if (tableAlias && targetTableAlias.weakerEq(*tableAlias))
     {
-      newColumnMap.insert({entry.first, SRCP(entry.second->clone())});
+      auto it = fColumnMap.find(entry.first);
+      if (it == fColumnMap.end())
+      {
+        newColumnMap.insert({entry.first, SRCP(entry.second->clone())});
+      }
     }
   }
 

--- a/dbcon/execplan/calpontselectexecutionplan.cpp
+++ b/dbcon/execplan/calpontselectexecutionplan.cpp
@@ -1144,8 +1144,6 @@ execplan::SCSEP CalpontSelectExecutionPlan::cloneForTableWORecursiveSelectsGbObH
   newPlan->fPron = fPron;
   newPlan->fWithRollup = fWithRollup;
 
-  ColumnMap newColumnMap;
-
   // Deep copy of ReturnedColumnList
   ReturnedColumnList newReturnedCols;
 
@@ -1159,7 +1157,6 @@ execplan::SCSEP CalpontSelectExecutionPlan::cloneForTableWORecursiveSelectsGbObH
       {
         // TODO We insert multiple times if there are multiple SCs for the same RC.
         newReturnedCols.push_back(SRCP(rc->clone()));
-        newColumnMap.insert({simpleColumn->columnName(), SRCP(simpleColumn->clone())});
       }
     }
   }
@@ -1181,6 +1178,7 @@ execplan::SCSEP CalpontSelectExecutionPlan::cloneForTableWORecursiveSelectsGbObH
   // Deep copy of filter token list
   newPlan->filterTokenList(fFilterTokenList);
 
+  ColumnMap newColumnMap;
   // Deep copy of column map
   for (const auto& entry : fColumnMap)
   {

--- a/dbcon/execplan/returnedcolumn.h
+++ b/dbcon/execplan/returnedcolumn.h
@@ -49,6 +49,7 @@ class Row;
 namespace execplan
 {
 // Join info bit mask
+const uint64_t NO_JOIN = 0x0000;
 // const uint64_t JOIN_OUTER = 0x0001;
 const uint64_t JOIN_SEMI = 0x0002;
 const uint64_t JOIN_ANTI = 0x0004;

--- a/dbcon/mysql/ha_exists_sub.cpp
+++ b/dbcon/mysql/ha_exists_sub.cpp
@@ -127,6 +127,9 @@ execplan::ParseTree* ExistsSub::transform()
     return NULL;
   }
 
+  // Insert column statistics
+  fGwip.mergeTableStatistics(gwi.tableStatisticsMap);
+
   // remove outer query tables
   CalpontSelectExecutionPlan::TableList tblist;
 

--- a/dbcon/rbo/rbo_apply_parallel_ces.cpp
+++ b/dbcon/rbo/rbo_apply_parallel_ces.cpp
@@ -441,6 +441,8 @@ execplan::SCSEP createDerivedTableFromTable(execplan::CalpontSelectExecutionPlan
   }
 
   {
+    derivedCSEP->tableAlias(tableAlias, true);
+
     auto additionalUnionVec = makeUnionFromTable(
         *derivedCSEP, const_cast<execplan::CalpontSystemCatalog::TableAliasName&>(table), ctx);
 


### PR DESCRIPTION
Some SimpleColumn contain join type that triggers a phantom table creation whilst creating JobList. The phantom table causes `not joined` error running TPC-H Q4.
In some cases queries EXISTS/IN failed b/c SCs in CSEP that describes EXISTS/IN are not updated with new derived tables added. 