### PR TITLE
MCOL-5963: null handling in IF with datetime

### DIFF
--- a/datatypes/mcs_datatype.h
+++ b/datatypes/mcs_datatype.h
@@ -313,6 +313,18 @@ class SystemCatalog
       }
     }
 
+    bool isTemporal() const
+    {
+      switch (colDataType)
+      {
+        case datatypes::SystemCatalog::DATE:
+        case datatypes::SystemCatalog::DATETIME:
+        case datatypes::SystemCatalog::TIMESTAMP:
+        case datatypes::SystemCatalog::TIME: return true;
+        default: return false;
+      }
+    }
+
     bool isSignedInteger() const
     {
       switch (colDataType)

--- a/mysql-test/columnstore/basic/r/mcol-5963.result
+++ b/mysql-test/columnstore/basic/r/mcol-5963.result
@@ -1,0 +1,130 @@
+DROP DATABASE IF EXISTS mcol5963;
+CREATE DATABASE mcol5963;
+USE mcol5963;
+create table FOO(foo datetime) engine = columnstore;
+insert into FOO(foo) values ('2025-08-27 15:26:25');
+select if(0 = 1, '2025-08-27 15:26:25', foo) from FOO;
+if(0 = 1, '2025-08-27 15:26:25', foo)
+2025-08-27 15:26:25
+select if(0 = 1, null, foo) from FOO;
+if(0 = 1, null, foo)
+2025-08-27 15:26:25
+select if(0 = 1, true, foo) from FOO;
+if(0 = 1, true, foo)
+2025-08-27 15:26:25
+select if(0 = 1, 5, foo) from FOO;
+if(0 = 1, 5, foo)
+2025-08-27 15:26:25
+select if(0 = 1, null, "text");
+if(0 = 1, null, "text")
+text
+drop table FOO;
+create table FOO(foo datetime) engine = innodb;
+insert into FOO(foo) values ('2025-08-27 15:26:25');
+select if(0 = 1, '2025-08-27 15:26:25', foo) from FOO;
+if(0 = 1, '2025-08-27 15:26:25', foo)
+2025-08-27 15:26:25
+select if(0 = 1, null, foo) from FOO;
+if(0 = 1, null, foo)
+2025-08-27 15:26:25
+select if(0 = 1, true, foo) from FOO;
+if(0 = 1, true, foo)
+2025-08-27 15:26:25
+select if(0 = 1, 5, foo) from FOO;
+if(0 = 1, 5, foo)
+2025-08-27 15:26:25
+select if(0 = 1, null, "text");
+if(0 = 1, null, "text")
+text
+drop table FOO;
+create table FOO_DATE(foo date) engine = columnstore;
+insert into FOO_DATE(foo) values ('2025-08-27');
+select if(0 = 1, true, foo) from FOO_DATE;
+if(0 = 1, true, foo)
+2025-08-27
+select if(0 = 1, 5, foo) from FOO_DATE;
+if(0 = 1, 5, foo)
+2025-08-27
+select if(0 = 1, null, foo) from FOO_DATE;
+if(0 = 1, null, foo)
+2025-08-27
+drop table FOO_DATE;
+create table FOO_DATE(foo date) engine = innodb;
+insert into FOO_DATE(foo) values ('2025-08-27');
+select if(0 = 1, true, foo) from FOO_DATE;
+if(0 = 1, true, foo)
+2025-08-27
+select if(0 = 1, 5, foo) from FOO_DATE;
+if(0 = 1, 5, foo)
+2025-08-27
+select if(0 = 1, null, foo) from FOO_DATE;
+if(0 = 1, null, foo)
+2025-08-27
+drop table FOO_DATE;
+create table FOO_TIME(foo time) engine = columnstore;
+insert into FOO_TIME(foo) values ('15:26:25');
+select if(0 = 1, true, foo) from FOO_TIME;
+if(0 = 1, true, foo)
+15:26:25
+select if(0 = 1, 5, foo) from FOO_TIME;
+if(0 = 1, 5, foo)
+15:26:25
+select if(0 = 1, null, foo) from FOO_TIME;
+if(0 = 1, null, foo)
+15:26:25
+drop table FOO_TIME;
+create table FOO_TIME(foo time) engine = innodb;
+insert into FOO_TIME(foo) values ('15:26:25');
+select if(0 = 1, true, foo) from FOO_TIME;
+if(0 = 1, true, foo)
+15:26:25
+select if(0 = 1, 5, foo) from FOO_TIME;
+if(0 = 1, 5, foo)
+15:26:25
+select if(0 = 1, null, foo) from FOO_TIME;
+if(0 = 1, null, foo)
+15:26:25
+drop table FOO_TIME;
+create table FOO_TS(foo timestamp) engine = columnstore;
+insert into FOO_TS(foo) values ('2025-08-27 15:26:25');
+select if(0 = 1, true, foo) from FOO_TS;
+if(0 = 1, true, foo)
+2025-08-27 15:26:25
+select if(0 = 1, 5, foo) from FOO_TS;
+if(0 = 1, 5, foo)
+2025-08-27 15:26:25
+select if(0 = 1, null, foo) from FOO_TS;
+if(0 = 1, null, foo)
+2025-08-27 15:26:25
+drop table FOO_TS;
+create table FOO_TS(foo timestamp) engine = innodb;
+insert into FOO_TS(foo) values ('2025-08-27 15:26:25');
+select if(0 = 1, true, foo) from FOO_TS;
+if(0 = 1, true, foo)
+2025-08-27 15:26:25
+select if(0 = 1, 5, foo) from FOO_TS;
+if(0 = 1, 5, foo)
+2025-08-27 15:26:25
+select if(0 = 1, null, foo) from FOO_TS;
+if(0 = 1, null, foo)
+2025-08-27 15:26:25
+drop table FOO_TS;
+create table FOO(foo varchar(30)) engine = columnstore;
+insert into FOO(foo) values ("text1");
+select if(0 = 1, true, foo) from FOO;
+if(0 = 1, true, foo)
+text1
+select if(0 = 1, NULL, foo) from FOO;
+if(0 = 1, NULL, foo)
+text1
+drop table FOO;
+create table FOO(foo int) engine = columnstore;
+insert into FOO(foo) values (123);
+select if(0 = 1, true, foo) from FOO;
+if(0 = 1, true, foo)
+123
+select if(0 = 1, NULL, foo) from FOO;
+if(0 = 1, NULL, foo)
+123
+drop table FOO;
+DROP DATABASE mcol5963;

--- a/mysql-test/columnstore/basic/t/mcol-5963.test
+++ b/mysql-test/columnstore/basic/t/mcol-5963.test
@@ -1,0 +1,110 @@
+-- source ../include/have_columnstore.inc
+-- source include/have_innodb.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol5963;
+--enable_warnings
+
+CREATE DATABASE mcol5963;
+
+USE mcol5963;
+
+create table FOO(foo datetime) engine = columnstore;
+insert into FOO(foo) values ('2025-08-27 15:26:25');
+ 
+select if(0 = 1, '2025-08-27 15:26:25', foo) from FOO;
+select if(0 = 1, null, foo) from FOO;
+select if(0 = 1, true, foo) from FOO;
+select if(0 = 1, 5, foo) from FOO;
+select if(0 = 1, null, "text");
+
+drop table FOO;
+
+# InnoDB comparison for DATETIME
+create table FOO(foo datetime) engine = innodb;
+insert into FOO(foo) values ('2025-08-27 15:26:25');
+
+select if(0 = 1, '2025-08-27 15:26:25', foo) from FOO;
+select if(0 = 1, null, foo) from FOO;
+select if(0 = 1, true, foo) from FOO;
+select if(0 = 1, 5, foo) from FOO;
+select if(0 = 1, null, "text");
+
+drop table FOO;
+
+# Additional temporal types: DATE
+create table FOO_DATE(foo date) engine = columnstore;
+insert into FOO_DATE(foo) values ('2025-08-27');
+
+select if(0 = 1, true, foo) from FOO_DATE;
+select if(0 = 1, 5, foo) from FOO_DATE;
+select if(0 = 1, null, foo) from FOO_DATE;
+
+drop table FOO_DATE;
+
+# InnoDB comparison for DATE
+create table FOO_DATE(foo date) engine = innodb;
+insert into FOO_DATE(foo) values ('2025-08-27');
+
+select if(0 = 1, true, foo) from FOO_DATE;
+select if(0 = 1, 5, foo) from FOO_DATE;
+select if(0 = 1, null, foo) from FOO_DATE;
+
+drop table FOO_DATE;
+
+# Additional temporal types: TIME
+
+create table FOO_TIME(foo time) engine = columnstore;
+insert into FOO_TIME(foo) values ('15:26:25');
+
+select if(0 = 1, true, foo) from FOO_TIME;
+select if(0 = 1, 5, foo) from FOO_TIME;
+select if(0 = 1, null, foo) from FOO_TIME;
+drop table FOO_TIME;
+
+# InnoDB comparison for TIME
+create table FOO_TIME(foo time) engine = innodb;
+insert into FOO_TIME(foo) values ('15:26:25');
+
+select if(0 = 1, true, foo) from FOO_TIME;
+select if(0 = 1, 5, foo) from FOO_TIME;
+select if(0 = 1, null, foo) from FOO_TIME;
+
+drop table FOO_TIME;
+
+# Additional temporal types: TIMESTAMP
+create table FOO_TS(foo timestamp) engine = columnstore;
+
+insert into FOO_TS(foo) values ('2025-08-27 15:26:25');
+select if(0 = 1, true, foo) from FOO_TS;
+select if(0 = 1, 5, foo) from FOO_TS;
+select if(0 = 1, null, foo) from FOO_TS;
+
+drop table FOO_TS;
+
+# InnoDB comparison for TIMESTAMP
+create table FOO_TS(foo timestamp) engine = innodb;
+insert into FOO_TS(foo) values ('2025-08-27 15:26:25');
+
+select if(0 = 1, true, foo) from FOO_TS;
+select if(0 = 1, 5, foo) from FOO_TS;
+select if(0 = 1, null, foo) from FOO_TS;
+
+drop table FOO_TS;
+
+create table FOO(foo varchar(30)) engine = columnstore;
+insert into FOO(foo) values ("text1");
+
+select if(0 = 1, true, foo) from FOO;
+select if(0 = 1, NULL, foo) from FOO;
+
+drop table FOO;
+
+create table FOO(foo int) engine = columnstore;
+insert into FOO(foo) values (123);
+
+select if(0 = 1, true, foo) from FOO;
+select if(0 = 1, NULL, foo) from FOO;
+
+drop table FOO;
+DROP DATABASE mcol5963;


### PR DESCRIPTION
Fix:  IF function returninng a wrong value when the first expression is FALSE, the second expression is NULL, the third expression is a datetime, and the table engine is Columnstore. 