### PR TITLE
Add forward/reverse DNS validation when adding nodes by hostname

### DIFF
--- a/cmapi/cmapi_server/controllers/endpoints.py
+++ b/cmapi/cmapi_server/controllers/endpoints.py
@@ -12,7 +12,7 @@ import cherrypy
 import pyotp
 import requests
 
-from cmapi_server.exceptions import CMAPIBasicError
+from cmapi_server.exceptions import CMAPIBasicError, cmapi_error_to_422
 from cmapi_server.constants import (
     DEFAULT_MCS_CONF_PATH, DEFAULT_SM_CONF_PATH, EM_PATH_SUFFIX,
     MCS_BRM_CURRENT_PATH, MCS_EM_PATH, S3_BRM_CURRENT_PATH, SECRET_KEY,
@@ -924,14 +924,12 @@ class ClusterController:
         if node is None:
             raise_422_error(module_logger, func_name, 'missing node argument')
 
-        try:
+        with cmapi_error_to_422(module_logger, func_name):
             if not in_transaction:
                 with TransactionManager(extra_nodes=[node]):
                     response = ClusterHandler.add_node(node, config)
             else:
                 response = ClusterHandler.add_node(node, config)
-        except CMAPIBasicError as err:
-            raise_422_error(module_logger, func_name, err.message)
 
         module_logger.debug(f'{func_name} returns {str(response)}')
         return response
@@ -953,14 +951,12 @@ class ClusterController:
         if node is None:
             raise_422_error(module_logger, func_name, 'missing node argument')
 
-        try:
+        with cmapi_error_to_422(module_logger, func_name):
             if not in_transaction:
                 with TransactionManager(remove_nodes=[node]):
                     response = ClusterHandler.remove_node(node, config)
             else:
                 response = ClusterHandler.remove_node(node, config)
-        except CMAPIBasicError as err:
-            raise_422_error(module_logger, func_name, err.message)
 
         module_logger.debug(f'{func_name} returns {str(response)}')
         return response
@@ -1079,10 +1075,8 @@ class ClusterController:
                 module_logger, func_name, 'Wrong verification key.'
             )
 
-        try:
+        with cmapi_error_to_422(module_logger, func_name):
             response = ClusterHandler.set_api_key(new_api_key, totp_key)
-        except CMAPIBasicError as err:
-            raise_422_error(module_logger, func_name, err.message)
 
         module_logger.debug(f'{func_name} returns {str(response)}')
         return response

--- a/cmapi/cmapi_server/exceptions.py
+++ b/cmapi/cmapi_server/exceptions.py
@@ -1,5 +1,11 @@
 """Module contains custom exceptions."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Optional
+
+from cmapi_server.controllers.error import APIError
+
 
 class CMAPIBasicError(Exception):
     """Basic exception raised for CMAPI related processes.
@@ -20,3 +26,35 @@ class CEJError(CMAPIBasicError):
     Attributes:
         message -- explanation of the error
     """
+
+
+@contextmanager
+def exc_to_cmapi_error(prefix: Optional[str] = None) -> Iterator[None]:
+    """Context manager to standardize error wrapping into CMAPIBasicError.
+
+    Re-raises existing CMAPIBasicError untouched (to preserve detailed
+    messages). Any other exception type is wrapped into CMAPIBasicError with an
+    optional prefix and the original exception string appended as details.
+
+    :param prefix: Optional message prefix for wrapped errors
+    :raises CMAPIBasicError: for any wrapped non-CMAPIBasicError exceptions
+    """
+    try:
+        yield
+    except CMAPIBasicError:
+        # Preserve detailed messages from deeper layers (e.g., validation)
+        raise
+    except Exception as err:
+        msg = f"{prefix}. Details: {err}" if prefix else str(err)
+        raise CMAPIBasicError(msg) from err
+
+
+@contextmanager
+def cmapi_error_to_422(logger, func_name: str) -> Iterator[None]:
+    """Convert CMAPIBasicError to HTTP 422 APIError."""
+    try:
+        yield
+    except CMAPIBasicError as err:
+        # mirror raise_422_error behavior locally to avoid circular imports
+        logger.error(f'{func_name} {err.message}', exc_info=False)
+        raise APIError(422, err.message) from err

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -61,7 +61,6 @@ def switch_node_maintenance(
     node_config.write_config(config_root, filename=output_config_filename)
     # TODO: probably move publishing to cherrypy.engine failover channel here?
 
-
 def add_node(
     node: str, input_config_filename: str = DEFAULT_MCS_CONF_PATH,
     output_config_filename: Optional[str] = None,
@@ -95,6 +94,11 @@ def add_node(
     """
     node_config = NodeConfig()
     c_root = node_config.get_current_config_root(input_config_filename)
+
+    # If a hostname (not IP) is provided, ensure fwd/rev DNS consistency.
+    # Skip validation for localhost aliases to preserve legacy single-node flows.
+    if not NetworkManager.is_ip(node) and node not in LOCALHOSTS:
+        NetworkManager.validate_hostname_fwd_rev(node)
 
     try:
         if not _replace_localhost(c_root, node):

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -97,7 +97,7 @@ def add_node(
 
     # If a hostname (not IP) is provided, ensure fwd/rev DNS consistency.
     # Skip validation for localhost aliases to preserve legacy single-node flows.
-    if not NetworkManager.is_ip(node) and node not in LOCALHOSTS:
+    if not NetworkManager.is_ip(node) and not NetworkManager.is_only_loopback_hostname(node):
         NetworkManager.validate_hostname_fwd_rev(node)
 
     try:

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -15,6 +15,7 @@ from typing import Optional
 import requests
 from lxml import etree
 from mcs_node_control.models.node_config import NodeConfig
+from tracing.traced_session import get_traced_session
 
 from cmapi_server import helpers
 from cmapi_server.constants import (
@@ -25,7 +26,6 @@ from cmapi_server.constants import (
     MCS_DATA_PATH,
 )
 from cmapi_server.managers.network import NetworkManager
-from tracing.traced_session import get_traced_session
 
 PMS_NODE_PORT = '8620'
 EXEMGR_NODE_PORT = '8601'
@@ -640,7 +640,7 @@ def _rebalance_dbroots(root, test_mode=False):
                         # timed out
                         # possible node is not ready, leave retry as-is
                         pass
-                    except Exception as e:
+                    except Exception:
                         retry = False
 
                 if not found_master:

--- a/cmapi/cmapi_server/test/test_failover_agent.py
+++ b/cmapi/cmapi_server/test/test_failover_agent.py
@@ -1,13 +1,13 @@
 import logging
 import socket
+from unittest.mock import patch
+
+from mcs_node_control.models.node_config import NodeConfig
 
 from cmapi_server.failover_agent import FailoverAgent
+from cmapi_server.managers.network import NetworkManager
 from cmapi_server.node_manipulation import add_node, remove_node
-from mcs_node_control.models.node_config import NodeConfig
-from cmapi_server.test.unittest_global import (
-    tmp_mcs_config_filename, BaseNodeManipTestCase
-)
-
+from cmapi_server.test.unittest_global import BaseNodeManipTestCase, tmp_mcs_config_filename
 
 logging.basicConfig(level='DEBUG')
 
@@ -18,10 +18,12 @@ class TestFailoverAgent(BaseNodeManipTestCase):
         self.tmp_files = ('./activate0.xml', './activate1.xml')
         hostaddr = socket.gethostbyname(socket.gethostname())
         fa = FailoverAgent()
-        fa.activateNodes(
-            [self.NEW_NODE_NAME], tmp_mcs_config_filename, self.tmp_files[0],
-            test_mode=True
-        )
+        # Bypass DNS validation for hostname-based addition in tests
+        with patch.object(NetworkManager, 'validate_hostname_fwd_rev', return_value=None):
+            fa.activateNodes(
+                [self.NEW_NODE_NAME], tmp_mcs_config_filename, self.tmp_files[0],
+                test_mode=True
+            )
         add_node(
             hostaddr, self.tmp_files[0], self.tmp_files[1]
         )
@@ -50,10 +52,11 @@ class TestFailoverAgent(BaseNodeManipTestCase):
         add_node(
             hostaddr, tmp_mcs_config_filename, self.tmp_files[0]
         )
-        fa.activateNodes(
-            [self.NEW_NODE_NAME], self.tmp_files[0], self.tmp_files[1],
-            test_mode=True
-        )
+        with patch.object(NetworkManager, 'validate_hostname_fwd_rev', return_value=None):
+            fa.activateNodes(
+                [self.NEW_NODE_NAME], self.tmp_files[0], self.tmp_files[1],
+                test_mode=True
+            )
         fa.deactivateNodes(
             [self.NEW_NODE_NAME], self.tmp_files[1], self.tmp_files[2],
             test_mode=True
@@ -89,10 +92,11 @@ class TestFailoverAgent(BaseNodeManipTestCase):
         )
         fa = FailoverAgent()
         hostaddr = socket.gethostbyname(socket.gethostname())
-        fa.activateNodes(
-            [self.NEW_NODE_NAME], tmp_mcs_config_filename, self.tmp_files[0],
-            test_mode=True
-        )
+        with patch.object(NetworkManager, 'validate_hostname_fwd_rev', return_value=None):
+            fa.activateNodes(
+                [self.NEW_NODE_NAME], tmp_mcs_config_filename, self.tmp_files[0],
+                test_mode=True
+            )
         add_node(
             hostaddr, self.tmp_files[0], self.tmp_files[1]
         )


### PR DESCRIPTION
Sometimes there is no reverse DNS for the IP of the host, in this case IP isn't interchangeable with a host name.

In the case shown in [MCOL-6159](https://jira.mariadb.org/browse/MCOL-6159), CMAPI instance could not find matching hostname for its IP in the ActiveNodes and decided that it will not start MCS processes.

In this PR I added a check, that if node is added to the cluster by a host name, at least one of its IPs must resolve back to the passed hostname. If it's not true, we return an error and propose to add node by the IP.

Also the error i added was not visible in the API response, so i added couple of context managers to fix it and to minimize code duplication.

And i started converting logs from f-strings to %s syntax, because Sentry groups logs by the format strings, so if we use f-strings, it creates a separate error for each record. I love f-strings, but we have to do it. 