### PR TITLE
fix(plugin): MCOL-6029 use the right field from the rows_stats struct…

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -8,7 +8,7 @@ local servers = {
 };
 
 local extra_servers = {
-  [current_branch]: ["11.4-enterprise"],
+  [current_branch]: ["11.4-enterprise", "11.8-enterprise"],
 };
 
 

--- a/dbcon/mysql/ha_mcs.cpp
+++ b/dbcon/mysql/ha_mcs.cpp
@@ -77,11 +77,6 @@ pthread_mutex_t mcs_mutex;
 #endif
 #define DEBUG_RETURN return
 
-#if MYSQL_VERSION_ID >= 110500
-/* because of renames in the handler class */
-#define rows_changed rows_stats.updated
-#endif
-
 /**
   @brief
   Function we use in the creation of our hash to get key.
@@ -335,7 +330,7 @@ int ha_mcs::write_row(const uchar* buf)
   int rc;
   try
   {
-    rc = ha_mcs_impl_write_row(buf, table, rows_changed, time_zone);
+    rc = ha_mcs_impl_write_row(buf, table, rows_inserted(), time_zone);
   }
   catch (std::runtime_error& e)
   {
@@ -2008,7 +2003,7 @@ int ha_mcs_cache::flush_insert_cache()
     copied_rows++;
     if ((error = parent::write_row(record)))
       goto end;
-    rows_changed++;
+    rows_inserted()++;
   }
   if (error == HA_ERR_END_OF_FILE)
     error = 0;

--- a/dbcon/mysql/ha_mcs.h
+++ b/dbcon/mysql/ha_mcs.h
@@ -59,6 +59,16 @@ class ha_mcs : public handler
   int impl_external_lock(THD* thd, TABLE* table, int lock_type);
   int impl_rnd_init(TABLE* table, const std::vector<COND*>& condStack);
 
+protected:
+  ha_rows& rows_inserted()
+  {
+#if MYSQL_VERSION_ID >= 110500
+    return rows_stats.inserted;
+#else
+    return rows_changed;
+#endif
+  }
+
  public:
   ha_mcs(handlerton* hton, TABLE_SHARE* table_arg);
   ~ha_mcs() override = default;

--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -2891,7 +2891,7 @@ int ha_mcs_impl_delete_table(const char* name)
   int rc = ha_mcs_impl_delete_table_(dbName, name, *ci);
   return rc;
 }
-int ha_mcs_impl_write_row(const uchar* buf, TABLE* table, uint64_t rows_changed, long timeZone)
+int ha_mcs_impl_write_row(const uchar* buf, TABLE* table, uint64_t rows_inserted, long timeZone)
 {
   THD* thd = current_thd;
 
@@ -2921,7 +2921,7 @@ int ha_mcs_impl_write_row(const uchar* buf, TABLE* table, uint64_t rows_changed,
 
   // At the beginning of insert, make sure there are no
   // left-over values from a previously possibly failed insert.
-  if (rows_changed == 0)
+  if (rows_inserted == 0)
     ci->tableValuesMap.clear();
 
   if (ci->alterTableState > 0)

--- a/dbcon/mysql/ha_mcs_impl.h
+++ b/dbcon/mysql/ha_mcs_impl.h
@@ -31,7 +31,7 @@ extern int ha_mcs_impl_open(const char* name, int mode, uint32_t test_if_locked)
 extern int ha_mcs_impl_close(void);
 extern int ha_mcs_impl_rnd_next(uchar* buf, TABLE* table, long timeZone);
 extern int ha_mcs_impl_rnd_end(TABLE* table, bool is_derived_hand = false);
-extern int ha_mcs_impl_write_row(const uchar* buf, TABLE* table, uint64_t rows_changed, long timeZone);
+extern int ha_mcs_impl_write_row(const uchar* buf, TABLE* table, uint64_t rows_inserted, long timeZone);
 extern void ha_mcs_impl_start_bulk_insert(ha_rows rows, TABLE* table, bool is_cache_insert = false);
 extern int ha_mcs_impl_end_bulk_insert(bool abort, TABLE* table);
 extern int ha_mcs_impl_rename_table(const char* from, const char* to);


### PR DESCRIPTION
… for inserts when building with the server version >=11.8 