### PR TITLE
fix(shmem leak) MCOL-6064: excessive memory use

### DIFF
--- a/versioning/BRM/brmshmimpl.cpp
+++ b/versioning/BRM/brmshmimpl.cpp
@@ -422,6 +422,10 @@ BRMManagedShmImplRBTree::BRMManagedShmImplRBTree(unsigned key, off_t size, bool 
 
 BRMManagedShmImplRBTree::~BRMManagedShmImplRBTree()
 {
+  if (fShmSegment)
+  {
+    delete fShmSegment;
+  }
 }
 
 void BRMManagedShmImplRBTree::setReadOnly()


### PR DESCRIPTION
This three-liner releases shared memory object, which is N*16M in size, and its' leakage quickly grows memory use.