### PR TITLE
MCOL-5778: sum returning null value

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan_helpers.cpp
+++ b/dbcon/mysql/ha_mcs_execplan_helpers.cpp
@@ -30,6 +30,8 @@ bool nonConstFunc(Item_func* ifp)
   {
     if (ifp->arguments()[i]->type() == Item::FUNC_ITEM && nonConstFunc(((Item_func*)ifp->arguments()[i])))
       return true;
+    if (ifp->arguments()[i]->type() == Item::CACHE_ITEM)
+      return true;
   }
 
   return false;

--- a/mysql-test/columnstore/bugfixes/mcol-5778.result
+++ b/mysql-test/columnstore/bugfixes/mcol-5778.result
@@ -1,0 +1,16 @@
+DROP DATABASE IF EXISTS mcol5778;
+CREATE DATABASE mcol5778;
+USE mcol5778;
+create table test ( a double, b double ) engine=columnstore;
+insert into test values (100,100);
+select sum(a)/NULLIF(sum(b),0) from test;
+sum(a)/NULLIF(sum(b),0)
+1
+select sum(a)/NULLIF(b,0) from test;
+sum(a)/NULLIF(b,0)
+1
+select sum(a)/NULLIF(100,0) from test;
+sum(a)/NULLIF(100,0)
+1
+drop table test;
+DROP DATABASE mcol5778;

--- a/mysql-test/columnstore/bugfixes/mcol-5778.test
+++ b/mysql-test/columnstore/bugfixes/mcol-5778.test
@@ -1,0 +1,21 @@
+-- source ../include/have_columnstore.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol5778;
+--enable_warnings
+
+CREATE DATABASE mcol5778;
+
+USE mcol5778;
+
+create table test ( a double, b double ) engine=columnstore;
+insert into test values (100,100);
+
+select sum(a)/NULLIF(sum(b),0) from test;
+
+select sum(a)/NULLIF(b,0) from test;
+
+select sum(a)/NULLIF(100,0) from test;
+
+drop table test;
+DROP DATABASE mcol5778;


### PR DESCRIPTION
MCOL-5778: SUM return NULL value due to NULLIF Function

(sum(a)/nullif(sum(b), 0)) was not considered a FunctionColumn, but a ConstantColumn, resulting in not calling Func_nullif::getDoubleVal.