### PR TITLE
MCOL-6100: Extremely large primloc logs generated after upgrade

### DIFF
--- a/primitives/primproc/serviceexemgr.cpp
+++ b/primitives/primproc/serviceexemgr.cpp
@@ -237,7 +237,7 @@ const std::string ServiceExeMgr::prettyPrintMiniInfo(const std::string& in)
 
       std::string part(*iter3);
 
-      if (j != 0 && i == 8)
+      if (j != 0 && i == 8 && part.size() >= 3)
         part.resize(part.size() - 3);
 
       assert(i < header_parts);


### PR DESCRIPTION
[MCOL-6100](https://jira.mariadb.org/browse/MCOL-6100)
Extremely large primloc logs generated after upgrade from 23.10.3 to 23.10.4

The excessively large log was caused by calling resize on a string variable without checking the size of the variable, resulting in overflow.