### PR TITLE
MCOL-6018: fix(leak) One more memory leak in plugin

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan_walks.cpp
+++ b/dbcon/mysql/ha_mcs_execplan_walks.cpp
@@ -70,6 +70,31 @@ class RecursionCounter
   cal_impl_if::gp_walk_info* fgwip;
 };
 
+// RAII guard to automatically clean up work stacks on error.
+// If a fatal parse error occurs, this ensures allocated objects
+// are deleted when the guard goes out of scope, preventing memory leaks.
+class CleanupGuard
+{
+ private:
+  CleanupGuard() = delete;
+  CleanupGuard(const CleanupGuard&) = delete;
+  CleanupGuard& operator=(const CleanupGuard&) = delete;
+
+ public:
+  explicit CleanupGuard(cal_impl_if::gp_walk_info* gwip) : fgwip(gwip)
+  {
+  }
+  ~CleanupGuard()
+  {
+    if (fgwip->fatalParseError)
+    {
+      clearDeleteStacks(*fgwip);
+    }
+  }
+
+  cal_impl_if::gp_walk_info* fgwip;
+};
+
 bool isSecondArgumentConstItem(Item_func* ifp)
 {
   return (ifp->argument_count() == 2 && ifp->arguments()[1]->type() == Item::CONST_ITEM);
@@ -88,6 +113,9 @@ void gp_walk(const Item* item, void* arg)
 {
   cal_impl_if::gp_walk_info* gwip = static_cast<cal_impl_if::gp_walk_info*>(arg);
   idbassert(gwip);
+
+  // RAII guard: automatically cleans up work stacks on error when guard goes out of scope
+  CleanupGuard cleanup(gwip);
 
   // Bailout...
   if (gwip->fatalParseError)
@@ -815,12 +843,7 @@ void gp_walk(const Item* item, void* arg)
     }
   }
 
-  // Clean up allocated objects if a fatal parse error occurred
-  if (gwip->fatalParseError)
-  {
-    clearDeleteStacks(*gwip);
-  }
-
+  // CleanupGuard will automatically clean up if fatalParseError is set
   return;
 }
 


### PR DESCRIPTION
```
==6903==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 3264 byte(s) in 3 object(s) allocated from:
    #0 0x7b03a15e2548 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x7b039444a1c2 in cal_impl_if::newConstantColumnNotNullUsingValNativeNoTz(Item*, cal_impl_if::gp_walk_info&) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_helpers.cpp:136
    #2 0x7b039444a5b4 in cal_impl_if::buildConstantColumnNotNullUsingValNative(Item*, cal_impl_if::gp_walk_info&) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_helpers.cpp:100
    #3 0x7b03944e187e in cal_impl_if::buildReturnedColumnBody(Item*, cal_impl_if::gp_walk_info&, bool&, bool, execplan::IDBQueryType) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:2830
    #4 0x7b03944e27ae in cal_impl_if::buildReturnedColumn(Item*, cal_impl_if::gp_walk_info&, bool&, bool, execplan::IDBQueryType) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:2996
    #5 0x7b0394465ca6 in cal_impl_if::gp_walk(Item const*, void*) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_walks.cpp:158
    #6 0x5a332d137676 in Item_func::traverse_cond(void (*)(Item const*, void*), void*, Item::traverse_order) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/sql/item_func.cc:478
    #7 0x7b039450ebd9 in cal_impl_if::processWhere(st_select_lex&, cal_impl_if::gp_walk_info&, boost::shared_ptr<execplan::CalpontSelectExecutionPlan>&, std::vector<Item*, std::allocator<Item*> > const&) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:6092
    #8 0x7b039451ef55 in cal_impl_if::getSelectPlan(cal_impl_if::gp_walk_info&, st_select_lex&, boost::shared_ptr<execplan::CalpontSelectExecutionPlan>&, bool, bool, bool, std::vector<Item*, std::allocator<Item*> > const&) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:7265
    #9 0x7b0394523ee2 in cal_impl_if::cs_get_select_plan(ha_columnstore_select_handler*, THD*, boost::shared_ptr<execplan::CalpontSelectExecutionPlan>&, cal_impl_if::gp_walk_info&, bool) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:7631
    #10 0x7b0394329589 in ha_mcs_impl_pushdown_init(mcs_handler_info*, TABLE*, bool) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_impl.cpp:4223
    #11 0x7b03942c3e98 in create_columnstore_select_handler_(THD*, st_select_lex*, st_select_lex_unit*) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_pushdown.cpp:836
    #12 0x5a332c7756fd in find_select_handler_inner /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/sql/sql_select.cc:5116
    #13 0x5a332c89a78f in mysql_select(THD*, TABLE_LIST*, List<Item>&, Item*, unsigned int, st_order*, st_order*, Item*, st_order*, unsigned long long, select_result*, st_select_lex_unit*, st_select_lex*) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/sql/sql_select.cc:5267
    #14 0x5a332c89c4c8 in handle_select(THD*, LEX*, select_result*, unsigned long) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/sql/sql_select.cc:575
    #15 0x5a332c6cb034 in mysql_execute_command(THD*, bool) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/sql/sql_parse.cc:4842
    #16 0x5a332c6cd1b1 in mysql_parse(THD*, char*, unsigned int, Parser_state*) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/sql/sql_parse.cc:8229
    #17 0x5a332c6d14a5 in dispatch_command(enum_server_command, THD*, char*, unsigned int, bool) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/sql/sql_parse.cc:1915
    #18 0x5a332c6d76e0 in do_command(THD*, bool) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/sql/sql_parse.cc:1428
    #19 0x5a332cb2f6cc in do_handle_one_connection(CONNECT*, bool) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/sql/sql_connect.cc:1386
    #20 0x5a332cb2fef4 in handle_one_connection /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/sql/sql_connect.cc:1298
    #21 0x5a332d817b25 in pfs_spawn_thread /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/perfschema/pfs.cc:2201
    #22 0x7b03a1542a41 in asan_thread_start ../../../../src/libsanitizer/asan/asan_interceptors.cpp:234
    #23 0x7b03a07e5aa3 in start_thread nptl/pthread_create.c:447
    ```