### PR TITLE
 MCOL-5843: fix(extents): print corrent N/A for temporal extents

### DIFF
--- a/datatypes/mcs_datatype.cpp
+++ b/datatypes/mcs_datatype.cpp
@@ -23,6 +23,7 @@
 #include <sstream>
 #include <cerrno>
 #include <cstring>
+#include <limits>
 
 #include <utility>
 #include <cassert>
@@ -780,6 +781,32 @@ string TypeHandlerVarchar::formatPartitionInfo(const SystemCatalog::TypeAttribut
   if (attr.colWidth <= 7)
     return formatPartitionInfoSmallCharVarchar(attr, pi);
   return formatPartitionInfoSInt64(attr, pi);
+}
+
+string TypeHandlerTemporal::formatPartitionInfo(const SystemCatalog::TypeAttributesStd& attr,
+                                                const MinMaxInfo& pi) const
+{
+  ostringstreamL output;
+  // Check for empty/null partition
+  // For 4-byte temporal types (DATE), check int32 sentinels
+  // For 8-byte temporal types (DATETIME/TIMESTAMP), check int64 sentinels
+  bool isEmpty = false;
+
+  if (attr.colWidth == 4)
+  {
+    isEmpty = pi.isEmptyOrNullSInt32();
+  }
+  else
+  {
+    isEmpty = pi.isEmptyOrNullSInt64();
+  }
+
+  if (isEmpty)
+    output << setw(30) << "N/A" << setw(30) << "N/A";
+  else
+    output << setw(30) << format(SimpleValueSInt64(pi.min), attr) << setw(30)
+           << format(SimpleValueSInt64(pi.max), attr);
+  return output.str();
 }
 
 /****************************************************************************/

--- a/datatypes/mcs_datatype.h
+++ b/datatypes/mcs_datatype.h
@@ -745,6 +745,11 @@ class MinMaxInfo
                                  : greaterThan<int64_t, int64_t>(mm.min, mm.max);
     }
   }
+  bool isEmptyOrNullSInt32() const
+  {
+    return min == std::numeric_limits<int32_t>::max() && max == std::numeric_limits<int32_t>::min();
+
+  }
   bool isEmptyOrNullSInt64() const
   {
     return min == std::numeric_limits<int64_t>::max() && max == std::numeric_limits<int64_t>::min();
@@ -2414,10 +2419,7 @@ class TypeHandlerTemporal : public TypeHandler
 {
  public:
   std::string formatPartitionInfo(const SystemCatalog::TypeAttributesStd& attr,
-                                  const MinMaxInfo& i) const override
-  {
-    return formatPartitionInfoSInt64(attr, i);
-  }
+                                  const MinMaxInfo& i) const override;
   execplan::SimpleColumn* newSimpleColumn(const DatabaseQualifiedColumnName& name,
                                           SystemCatalog::TypeHolderStd& ct,
                                           const SimpleColumnParam& prm) const override;

--- a/mysql-test/columnstore/bugfixes/mcs_calshowpartitions_empty_date.result
+++ b/mysql-test/columnstore/bugfixes/mcs_calshowpartitions_empty_date.result
@@ -1,0 +1,42 @@
+DROP DATABASE IF EXISTS test_empty_date;
+CREATE DATABASE test_empty_date;
+USE test_empty_date;
+CREATE TABLE td (d DATE) ENGINE=ColumnStore;
+SELECT calShowPartitions('td','d');
+calShowPartitions('td','d')
+Part#     Min                           Max                           Status
+  0.0.1     N/A                           N/A                           Enabled
+SELECT MIN(d) FROM td;
+MIN(d)
+NULL
+SELECT calShowPartitions('td','d');
+calShowPartitions('td','d')
+Part#     Min                           Max                           Status
+  0.0.1     N/A                           N/A                           Enabled
+# Test with DATETIME as well
+CREATE TABLE tdt (dt DATETIME) ENGINE=ColumnStore;
+SELECT calShowPartitions('tdt','dt');
+calShowPartitions('tdt','dt')
+Part#     Min                           Max                           Status
+  0.0.1     N/A                           N/A                           Enabled
+SELECT MIN(dt) FROM tdt;
+MIN(dt)
+NULL
+SELECT calShowPartitions('tdt','dt');
+calShowPartitions('tdt','dt')
+Part#     Min                           Max                           Status
+  0.0.1     N/A                           N/A                           Enabled
+# Test with TIMESTAMP
+CREATE TABLE tts (ts TIMESTAMP) ENGINE=ColumnStore;
+SELECT calShowPartitions('tts','ts');
+calShowPartitions('tts','ts')
+Part#     Min                           Max                           Status
+  0.0.1     N/A                           N/A                           Enabled
+SELECT MIN(ts) FROM tts;
+MIN(ts)
+NULL
+SELECT calShowPartitions('tts','ts');
+calShowPartitions('tts','ts')
+Part#     Min                           Max                           Status
+  0.0.1     N/A                           N/A                           Enabled
+DROP DATABASE test_empty_date;

--- a/mysql-test/columnstore/bugfixes/mcs_calshowpartitions_empty_date.test
+++ b/mysql-test/columnstore/bugfixes/mcs_calshowpartitions_empty_date.test
@@ -1,0 +1,38 @@
+--source ../include/have_columnstore.inc
+--source ../include/functions.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS test_empty_date;
+--enable_warnings
+
+CREATE DATABASE test_empty_date;
+USE test_empty_date;
+
+CREATE TABLE td (d DATE) ENGINE=ColumnStore;
+--replace_regex / 0\.0\.. / 0.0.1 /
+SELECT calShowPartitions('td','d');
+SELECT MIN(d) FROM td;
+--replace_regex / 0\.0\.. / 0.0.1 /
+SELECT calShowPartitions('td','d');
+
+--echo # Test with DATETIME as well
+CREATE TABLE tdt (dt DATETIME) ENGINE=ColumnStore;
+--replace_regex / 0\.0\.. / 0.0.1 /
+SELECT calShowPartitions('tdt','dt');
+SELECT MIN(dt) FROM tdt;
+--replace_regex / 0\.0\.. / 0.0.1 /
+SELECT calShowPartitions('tdt','dt');
+
+
+--echo # Test with TIMESTAMP
+CREATE TABLE tts (ts TIMESTAMP) ENGINE=ColumnStore;
+--replace_regex / 0\.0\.. / 0.0.1 /
+SELECT calShowPartitions('tts','ts');
+SELECT MIN(ts) FROM tts;
+--replace_regex / 0\.0\.. / 0.0.1 /
+SELECT calShowPartitions('tts','ts');
+
+DROP DATABASE test_empty_date;
+
+--source ../include/drop_functions.inc
+


### PR DESCRIPTION
we could see that
```
| Part#     Min                           Max                           Status
 0.0.3     32767-15-63                   32768-00-00                   Enabled |
```
here the the invalid values "32767-15-63" and "32768-00-00" come from `INT32_MAX` and `INT32_MIN`  being interpreted as dates.