### PR TITLE
fix(perf): add reserves for fill after creation containers pattern

### DIFF
--- a/dbcon/ddlpackage/serialize.cpp
+++ b/dbcon/ddlpackage/serialize.cpp
@@ -125,6 +125,8 @@ int AlterTableStatement::unserialize(ByteStream& bytestream)
   // read alter action list
   quadbyte action_count;
   bytestream >> action_count;
+  // Reserve space for actions
+  fActions.reserve(action_count);
 
   for (unsigned int i = 0; i < action_count; i++)
   {
@@ -749,6 +751,8 @@ int AtaDropColumns::unserialize(ByteStream& bytestream)
 
   quadbyte count;
   bytestream >> count;
+  // Reserve space for columns
+  fColumns.reserve(count);
   string colName;
 
   while (count--)
@@ -1628,6 +1632,8 @@ int TableDef::unserialize(ByteStream& bytestream)
   // read column constraint list
   quadbyte count;
   bytestream >> count;
+  // Reserve space for constraints
+  fConstraints.reserve(count);
   TableConstraintDef* constraint;
 
   while (count-- > 0)

--- a/dbcon/ddlpackageproc/ddlindexpopulator.cpp
+++ b/dbcon/ddlpackageproc/ddlindexpopulator.cpp
@@ -148,6 +148,9 @@ void DDLIndexPopulator::makeCsep(CalpontSelectExecutionPlan& csep)
   string tableName(fTable.fSchema + "." + fTable.fName + ".");
 
   ColumnNameList::const_iterator cend = fColNames.end();
+  // Reserve space for column list and OIDs
+  colList.reserve(fColNames.size());
+  fOidList.reserve(fColNames.size());
 
   for (ColumnNameList::const_iterator cname = fColNames.begin(); cname != cend; ++cname)
   {
@@ -199,6 +202,8 @@ void DDLIndexPopulator::addColumnData(const execplan::ColumnResult* cr,
                                       const CalpontSystemCatalog::ColType colType, int added)
 {
   WriteEngine::IdxTupleList tupleList;
+  // Reserve space for tuples
+  tupleList.reserve(cr->dataCount());
   WriteEngine::IdxTuple tuple;
 
   for (int i = 0; i < cr->dataCount(); ++i)

--- a/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
+++ b/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
@@ -459,6 +459,11 @@ void DDLPackageProcessor::flushPrimprocCache(std::vector<execplan::CalpontSystem
       }
 
       blockList.clear();
+      // Reserve space for all LBIDs in ranges
+      size_t totalSize = 0;
+      for (it = lbidRanges.begin(); it != lbidRanges.end(); it++)
+        totalSize += it->size;
+      blockList.reserve(totalSize);
 
       for (it = lbidRanges.begin(); it != lbidRanges.end(); it++)
       {

--- a/dbcon/ddlpackageproc/droptableprocessor.cpp
+++ b/dbcon/ddlpackageproc/droptableprocessor.cpp
@@ -315,6 +315,8 @@ DropTableProcessor::DDLResult DropTableProcessor::processPackageInternal(ddlpack
     Oam oam;
 
     // Save qualified tablename, all column, dictionary OIDs, and transaction ID into a file in ASCII format
+    // Reserve space for OIDs
+    oidList.reserve(tableColRidList.size() + dictOIDList.size());
     for (unsigned i = 0; i < tableColRidList.size(); i++)
     {
       if (tableColRidList[i].objnum > 3000)
@@ -965,6 +967,9 @@ TruncTableProcessor::DDLResult TruncTableProcessor::processPackageInternal(ddlpa
 
     dictOIDList = systemCatalogPtr->dictOIDs(userTableName);
 
+    // Reserve space for OIDs (columns + aux column + dictionaries)
+    columnOidList.reserve(tableColRidList.size() + 1);
+    allOidList.reserve(tableColRidList.size() + 1 + dictOIDList.size());
     for (unsigned i = 0; i < tableColRidList.size(); i++)
     {
       if (tableColRidList[i].objnum > 3000)

--- a/dbcon/dmlpackage/deletedmlpackage.cpp
+++ b/dbcon/dmlpackage/deletedmlpackage.cpp
@@ -154,6 +154,8 @@ int DeleteDMLPackage::buildFromBuffer(std::string& buffer, int /*columns*/, int 
   initializeTable();
 
   std::vector<std::string> dataList;
+  // Reserve space for row IDs
+  dataList.reserve(rows);
   typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
   boost::char_separator<char> sep(":");
   tokenizer tokens(buffer, sep);

--- a/dbcon/dmlpackage/updatedmlpackage.cpp
+++ b/dbcon/dmlpackage/updatedmlpackage.cpp
@@ -138,6 +138,8 @@ int UpdateDMLPackage::buildFromSqlStatement(SqlStatement& sqlStatement)
 
   // Push one row always and let the filter happen on the proc side.
   Row* rowPtr = new Row();
+  // Reserve space for columns
+  rowPtr->get_ColumnList().reserve(updateStmt.fColAssignmentListPtr->size());
   ColumnAssignmentList::const_iterator iter = updateStmt.fColAssignmentListPtr->begin();
 
   while (iter != updateStmt.fColAssignmentListPtr->end())
@@ -176,6 +178,8 @@ int UpdateDMLPackage::buildFromBuffer(std::string& buffer, int columns, int rows
   initializeTable();
 
   std::vector<std::string> dataList;
+  // Reserve space: each row has rowid + columns * 2 (name + value)
+  dataList.reserve(rows * (1 + columns * 2));
   typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
   boost::char_separator<char> sep(":,");
   tokenizer tokens(buffer, sep);
@@ -186,11 +190,15 @@ int UpdateDMLPackage::buildFromBuffer(std::string& buffer, int columns, int rows
   }
 
   int n = 0;
+  // Reserve space for rows
+  fTable->get_RowList().reserve(rows);
 
   for (int i = 0; i < rows; i++)
   {
     // get a new row
     Row* aRowPtr = new Row();
+    // Reserve space for columns
+    aRowPtr->get_ColumnList().reserve(columns);
     std::string colName;
     std::string colValue;
     // get row ID from the buffer
@@ -229,6 +237,8 @@ int UpdateDMLPackage::buildFromMysqlBuffer(ColNameList& colNameList, TableValues
 
   initializeTable();
   Row* aRowPtr = new Row();
+  // Reserve space for columns
+  aRowPtr->get_ColumnList().reserve(columns);
   std::string colName;
   ColValuesList colValList;
 
@@ -259,6 +269,8 @@ void UpdateDMLPackage::buildUpdateFromMysqlBuffer(UpdateSqlStatement& updateStmt
 
   // Push one row always and let the filter happen on the proc side.
   Row* rowPtr = new Row();
+  // Reserve space for columns
+  rowPtr->get_ColumnList().reserve(updateStmt.fColAssignmentListPtr->size());
   ColumnAssignmentList::const_iterator iter = updateStmt.fColAssignmentListPtr->begin();
 
   while (iter != updateStmt.fColAssignmentListPtr->end())

--- a/dbcon/execplan/calpontselectexecutionplan.cpp
+++ b/dbcon/execplan/calpontselectexecutionplan.cpp
@@ -167,6 +167,7 @@ void CalpontSelectExecutionPlan::filterTokenList(FilterTokenList& filterTokenLis
 
   Parser parser;
   std::vector<Token> tokens;
+  tokens.reserve(filterTokenList.size());
   Token t;
 
   for (unsigned int i = 0; i < filterTokenList.size(); i++)
@@ -185,6 +186,7 @@ void CalpontSelectExecutionPlan::havingTokenList(const FilterTokenList& havingTo
 
   Parser parser;
   std::vector<Token> tokens;
+  tokens.reserve(havingTokenList.size());
   Token t;
 
   for (unsigned int i = 0; i < havingTokenList.size(); i++)

--- a/dbcon/execplan/calpontsystemcatalog.cpp
+++ b/dbcon/execplan/calpontsystemcatalog.cpp
@@ -6335,6 +6335,13 @@ vector<CalpontSystemCatalog::OID> getAllSysCatOIDs()
   vector<CalpontSystemCatalog::OID> ret;
   CalpontSystemCatalog::OID oid;
 
+  // Reserve space for all OIDs from all system catalogs
+  size_t totalSize = (SYSTABLE_MAX - SYSTABLE_BASE - 1) +
+                     (SYSCOLUMN_MAX - SYSCOLUMN_BASE - 1) +
+                     (SYSTABLE_DICT_MAX - SYSTABLE_DICT_BASE - 1) +
+                     (SYSCOLUMN_DICT_MAX - SYSCOLUMN_DICT_BASE - 1);
+  ret.reserve(totalSize);
+
   for (oid = SYSTABLE_BASE + 1; oid < SYSTABLE_MAX; oid++)
     ret.push_back(oid);
 

--- a/dbcon/joblist/jlf_tuplejoblist.cpp
+++ b/dbcon/joblist/jlf_tuplejoblist.cpp
@@ -246,9 +246,30 @@ void constructJoinedRowGroup(RowGroup& rg, uint32_t large, uint32_t prev, bool r
   if (root == false)  // not root
   {
     vector<uint32_t>& joinKeys = jobInfo.tableJoinMap[make_pair(large, prev)].fLeftKeys;
+    // Reserve space for vectors (estimate based on join keys + tables)
+    size_t estimatedSize = joinKeys.size() + tableSet.size() * 8;  // rough estimate
+    pos.reserve(estimatedSize + 1);
+    oids.reserve(estimatedSize);
+    keys.reserve(estimatedSize);
+    scale.reserve(estimatedSize);
+    precision.reserve(estimatedSize);
+    types.reserve(estimatedSize);
+    csNums.reserve(estimatedSize);
 
     for (vector<uint32_t>::iterator i = joinKeys.begin(); i != joinKeys.end(); i++)
       addColumnToRG(*i, pos, oids, keys, scale, precision, types, csNums, jobInfo);
+  }
+  else
+  {
+    // Reserve space for vectors when root
+    size_t estimatedSize = tableSet.size() * 8;  // rough estimate
+    pos.reserve(estimatedSize + 1);
+    oids.reserve(estimatedSize);
+    keys.reserve(estimatedSize);
+    scale.reserve(estimatedSize);
+    precision.reserve(estimatedSize);
+    types.reserve(estimatedSize);
+    csNums.reserve(estimatedSize);
   }
 
   // -- followed by the columns in select or expression
@@ -346,6 +367,16 @@ void adjustLastStep(JobStepVector& querySteps, DeliveredTableMap& deliverySteps,
   vector<CalpontSystemCatalog::ColDataType> types;
   vector<uint32_t> csNums;
   pos.push_back(2);
+
+  // Reserve space for all vectors
+  size_t vSize = v.size();
+  pos.reserve(vSize + 1);
+  oids.reserve(vSize);
+  keys.reserve(vSize);
+  types.reserve(vSize);
+  csNums.reserve(vSize);
+  scale.reserve(vSize);
+  precision.reserve(vSize);
 
   for (unsigned i = 0; i < v.size(); i++)
   {
@@ -602,6 +633,16 @@ void addProjectStepsToBps(TableInfoMap::iterator& mit, BatchPrimitive* bps, JobI
   psv.insert(psv.begin(), keySteps.begin(), keySteps.end());  // add joinkeys to project
   psv.insert(psv.end(), expSteps.begin(), expSteps.end());    // add expressions to project
   set<uint32_t> seenCols;                                     // columns already processed
+
+  // Reserve space for output rowgroup vectors (psv.size() + fjKeys is upper bound)
+  size_t estimatedSize = psv.size() + fjKeys.size();
+  pos.reserve(estimatedSize + 1);
+  oids.reserve(estimatedSize);
+  keys.reserve(estimatedSize);
+  scale.reserve(estimatedSize);
+  precision.reserve(estimatedSize);
+  types.reserve(estimatedSize);
+  csNums.reserve(estimatedSize);
 
   // for passthru conversion
   // passthru is disabled (default lastTupleId to -1) unless the TupleBPS::bop is BOP_AND.
@@ -1293,6 +1334,16 @@ bool combineJobStepsByTable(TableInfoMap::iterator& mit, JobInfo& jobInfo)
         vector<CalpontSystemCatalog::ColDataType> types;
         vector<uint32_t> csNums;
         pos.push_back(2);
+
+        // Reserve space for all vectors
+        size_t tisSize = tis.size();
+        pos.reserve(tisSize + 1);
+        oids.reserve(tisSize);
+        keys.reserve(tisSize);
+        types.reserve(tisSize);
+        csNums.reserve(tisSize);
+        scale.reserve(tisSize);
+        precision.reserve(tisSize);
 
         for (unsigned i = 0; i < tis.size(); i++)
         {

--- a/dbcon/joblist/joblistfactory.cpp
+++ b/dbcon/joblist/joblistfactory.cpp
@@ -420,6 +420,7 @@ void preProcessFunctionOnAggregation(const vector<SimpleColumn*>& scs, const vec
 
 void checkReturnedColumns(CalpontSelectExecutionPlan* csep, JobInfo& jobInfo)
 {
+  jobInfo.nonConstCols.reserve(jobInfo.deliveredCols.size());
   for (uint64_t i = 0; i < jobInfo.deliveredCols.size(); i++)
   {
     if (NULL == dynamic_cast<const ConstantColumn*>(jobInfo.deliveredCols[i].get()))

--- a/dbcon/joblist/tupleaggregatestep.cpp
+++ b/dbcon/joblist/tupleaggregatestep.cpp
@@ -994,6 +994,7 @@ void TupleAggregateStep::prep1PhaseAggregate(JobInfo& jobInfo, vector<RowGroup>&
 
   // collect the projected column info, prepare for aggregation
   vector<uint32_t> width;
+  width.reserve(keysProj.size());
   map<uint32_t, int> projColPosMap;
 
   for (uint64_t i = 0; i < keysProj.size(); i++)
@@ -1004,6 +1005,7 @@ void TupleAggregateStep::prep1PhaseAggregate(JobInfo& jobInfo, vector<RowGroup>&
 
   // for groupby column
   map<uint32_t, int> groupbyMap;
+  groupBy.reserve(jobInfo.groupByColVec.size() + jobInfo.distinctColVec.size());
 
   for (uint64_t i = 0; i < jobInfo.groupByColVec.size(); i++)
   {
@@ -1029,6 +1031,16 @@ void TupleAggregateStep::prep1PhaseAggregate(JobInfo& jobInfo, vector<RowGroup>&
   // populate the aggregate rowgroup
   AGG_MAP aggFuncMap;
   uint64_t outIdx = 0;
+
+  // Reserve space for all aggregate vectors
+  oidsAgg.reserve(returnedColVec.size());
+  keysAgg.reserve(returnedColVec.size());
+  scaleAgg.reserve(returnedColVec.size());
+  precisionAgg.reserve(returnedColVec.size());
+  typeAgg.reserve(returnedColVec.size());
+  csNumAgg.reserve(returnedColVec.size());
+  widthAgg.reserve(returnedColVec.size());
+  functionVec.reserve(returnedColVec.size());
 
   for (uint64_t i = 0; i < returnedColVec.size(); i++)
   {
@@ -1519,6 +1531,7 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(JobInfo& jobInfo, vector<Ro
   // check if there are any aggregate columns
   vector<pair<uint32_t, int>> aggColVec;
   vector<std::pair<uint32_t, int>>& returnedColVec = jobInfo.returnedColVec;
+  aggColVec.reserve(returnedColVec.size());
 
   for (uint64_t i = 0; i < returnedColVec.size(); i++)
   {
@@ -1566,6 +1579,7 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(JobInfo& jobInfo, vector<Ro
 
   // collect the projected column info, prepare for aggregation
   vector<uint32_t> width;
+  width.reserve(keysProj.size());
   for (uint64_t i = 0; i < keysProj.size(); i++)
   {
     width.push_back(projRG.getColumnWidth(i));
@@ -1580,6 +1594,7 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(JobInfo& jobInfo, vector<Ro
     // collect the projected column info, prepare for aggregation
     map<uint32_t, int> projColPosMap;
 
+    widthProj.reserve(keysProj.size());
     for (uint64_t i = 0; i < keysProj.size(); i++)
     {
       projColPosMap.insert(make_pair(keysProj[i], i));
@@ -1588,6 +1603,28 @@ void TupleAggregateStep::prep1PhaseDistinctAggregate(JobInfo& jobInfo, vector<Ro
 
     // column index for aggregate rowgroup
     uint64_t colAgg = 0;
+
+    // Reserve space for all aggregate vectors
+    size_t reserveSize = returnedColVec.size();
+    oidsAgg.reserve(reserveSize);
+    keysAgg.reserve(reserveSize);
+    scaleAgg.reserve(reserveSize);
+    precisionAgg.reserve(reserveSize);
+    typeAgg.reserve(reserveSize);
+    csNumAgg.reserve(reserveSize);
+    widthAgg.reserve(reserveSize);
+    oidsAggDist.reserve(reserveSize);
+    keysAggDist.reserve(reserveSize);
+    scaleAggDist.reserve(reserveSize);
+    precisionAggDist.reserve(reserveSize);
+    typeAggDist.reserve(reserveSize);
+    csNumAggDist.reserve(reserveSize);
+    widthAggDist.reserve(reserveSize);
+    groupBy.reserve(jobInfo.groupByColVec.size() + jobInfo.distinctColVec.size());
+    groupByNoDist.reserve(jobInfo.groupByColVec.size());
+    functionVec1.reserve(reserveSize);
+    functionVec2.reserve(reserveSize);
+    functionNoDistVec.reserve(reserveSize);
 
     // for groupby column
     for (uint64_t i = 0; i < jobInfo.groupByColVec.size(); i++)
@@ -2919,6 +2956,7 @@ void TupleAggregateStep::prep2PhasesAggregate(JobInfo& jobInfo, vector<RowGroup>
   vector<pair<uint32_t, int>> aggColVec;
   set<uint32_t> avgSet;
   vector<std::pair<uint32_t, int>>& returnedColVec = jobInfo.returnedColVec;
+  aggColVec.reserve(returnedColVec.size());
   // For UDAF
   uint32_t projColsUDAFIdx = 0;
   uint32_t udafcParamIdx = 0;
@@ -2977,6 +3015,7 @@ void TupleAggregateStep::prep2PhasesAggregate(JobInfo& jobInfo, vector<RowGroup>
     // project only unique oids, but they may be repeated in aggregation
     // collect the projected column info, prepare for aggregation
     vector<uint32_t> width;
+    width.reserve(keysProj.size());
     map<uint32_t, int> projColPosMap;
 
     for (uint64_t i = 0; i < keysProj.size(); i++)
@@ -2987,6 +3026,18 @@ void TupleAggregateStep::prep2PhasesAggregate(JobInfo& jobInfo, vector<RowGroup>
 
     // column index for PM aggregate rowgroup
     uint64_t colAggPm = 0;
+
+    // Reserve space for PM aggregate vectors
+    size_t reserveSize = returnedColVec.size() + jobInfo.groupByColVec.size();
+    oidsAggPm.reserve(reserveSize);
+    keysAggPm.reserve(reserveSize);
+    scaleAggPm.reserve(reserveSize);
+    precisionAggPm.reserve(reserveSize);
+    typeAggPm.reserve(reserveSize);
+    csNumAggPm.reserve(reserveSize);
+    widthAggPm.reserve(reserveSize);
+    groupByPm.reserve(jobInfo.groupByColVec.size());
+    functionVecPm.reserve(reserveSize);
 
     // for groupby column
     for (uint64_t i = 0; i < jobInfo.groupByColVec.size(); i++)
@@ -3877,6 +3928,7 @@ void TupleAggregateStep::prep2PhasesDistinctAggregate(JobInfo& jobInfo, vector<R
     // project only unique oids, but they may be repeated in aggregation
     // collect the projected column info, prepare for aggregation
     vector<uint32_t> width;
+    width.reserve(keysProj.size());
     map<uint32_t, int> projColPosMap;
 
     for (uint64_t i = 0; i < keysProj.size(); i++)

--- a/dbcon/joblist/windowfunctionstep.cpp
+++ b/dbcon/joblist/windowfunctionstep.cpp
@@ -629,6 +629,7 @@ void WindowFunctionStep::initialize(const RowGroup& rg, JobInfo& jobInfo)
     vector<int64_t> fields;
     fields.push_back(ridx);  // result
     const RetColsVector& parms = wc->functionParms();
+    fields.reserve(1 + parms.size());
 
     for (uint64_t i = 0; i < parms.size(); i++)  // arguments
     {
@@ -641,9 +642,13 @@ void WindowFunctionStep::initialize(const RowGroup& rg, JobInfo& jobInfo)
 
     // partition & order by
     const RetColsVector& partitions = wc->partitions();
+    const RetColsVector& orders = wc->orderBy().fOrders;
     vector<uint64_t> eqIdx;
+    eqIdx.reserve(partitions.size());
     vector<uint64_t> peerIdx;
+    peerIdx.reserve(orders.size());
     vector<IdbSortSpec> sorts;
+    sorts.reserve(partitions.size() + orders.size());
 
     for (uint64_t i = 0; i < partitions.size(); i++)
     {
@@ -656,8 +661,6 @@ void WindowFunctionStep::initialize(const RowGroup& rg, JobInfo& jobInfo)
       eqIdx.push_back(idx);
       sorts.push_back(IdbSortSpec(idx, partitions[i]->asc(), partitions[i]->nullsFirst()));
     }
-
-    const RetColsVector& orders = wc->orderBy().fOrders;
 
     for (uint64_t i = 0; i < orders.size(); i++)
     {

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -6956,6 +6956,7 @@ int processSelect(SELECT_LEX& select_lex, gp_walk_info& gwi, SCSEP& csep, vector
     for (uint32_t i = 0; i < gwi.returnedCols.size(); i++)
     {
       vector<CalpontSystemCatalog::ColType> coltypes;
+      coltypes.reserve(csep->unionVec().size());
 
       for (uint32_t j = 0; j < csep->unionVec().size(); j++)
       {

--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -3134,6 +3134,7 @@ void ha_mcs_impl_start_bulk_insert(ha_rows rows, TABLE* table, bool is_cache_ins
       //@bug 6122 Check how many columns have not null constraint. columnn with not null constraint will not
       // show up in header.
       unsigned int numberNotNull = 0;
+      ci->columnTypes.reserve(colrids.size());
 
       for (unsigned int j = 0; j < colrids.size(); j++)
       {

--- a/dbcon/mysql/ha_window_function.cpp
+++ b/dbcon/mysql/ha_window_function.cpp
@@ -327,6 +327,8 @@ ReturnedColumn* buildWindowFunctionColumn(Item* item, gp_walk_info& gwi, bool& n
   CalpontSystemCatalog::ColType ct;  // For return type
   // arguments
   vector<SRCP> funcParms;
+  // Reserve space for arguments (may add more constants later in switch statement)
+  funcParms.reserve(item_sum->argument_count() + 3);
 
   for (uint32_t i = 0; i < item_sum->argument_count(); i++)
   {

--- a/primitives/primproc/columncommand.cpp
+++ b/primitives/primproc/columncommand.cpp
@@ -954,6 +954,12 @@ void ColumnCommand::getLBIDList(uint32_t loopCount, vector<int64_t>* lbids)
 {
   int64_t firstLBID = lbid, lastLBID = firstLBID + (loopCount * colType.colWidth) - 1, i;
 
+  // Reserve space for all LBIDs we'll add
+  size_t lbidCount = (loopCount * colType.colWidth);
+  if (hasAuxCol_)
+    lbidCount += (loopCount * execplan::AUX_COL_WIDTH);
+  lbids->reserve(lbids->size() + lbidCount);
+
   for (i = firstLBID; i <= lastLBID; i++)
     lbids->push_back(i);
 

--- a/utils/batchloader/batchloader.cpp
+++ b/utils/batchloader/batchloader.cpp
@@ -461,6 +461,7 @@ void BatchLoader::buildBatchDistSeqVector(uint32_t StartPm)
     aPms = fPMs;
   else
   {
+    aPms.reserve(1 + fPMs.size());  // Reserve for StartPm + all potential PMs
     aPms.push_back(StartPm);
     uint32_t aLast = fPMs.back();
     uint32_t aFirst = fPMs.front();

--- a/utils/joiner/joinpartition.cpp
+++ b/utils/joiner/joinpartition.cpp
@@ -327,6 +327,8 @@ bool JoinPartition::canConvertToSplitMode()
   RGData rgData;
   uint64_t totalRowCount = 0;
   std::unordered_map<uint32_t, uint32_t> rowDist;
+  // Reserve space for hash distribution (one entry per bucket)
+  rowDist.reserve(bucketCount);
 
   nextSmallOffset = 0;
   while (1)

--- a/utils/joiner/tuplejoiner.cpp
+++ b/utils/joiner/tuplejoiner.cpp
@@ -769,7 +769,8 @@ void TupleJoiner::doneInserting()
         smallRow.setPointer(sthit->second);
         ++sthit;
       }
-
+      // Reserve space up to uniqueLimit+1 to avoid reallocations during unique value tracking
+      uniquer.reserve(std::min(uniqueLimit + 1, rowCount));
       if (isLongDouble(smallSideColType))
       {
         double dval = (double)roundl(smallRow.getLongDoubleField(smallSideColIdx));

--- a/utils/rowgroup/rowgroup.cpp
+++ b/utils/rowgroup/rowgroup.cpp
@@ -1599,6 +1599,16 @@ RowGroup& RowGroup::operator+=(const RowGroup& rhs)
   forceInline.swap(tmp);
 
   columnCount += rhs.columnCount;
+  // Reserve space for all vectors that will be appended
+  oids.reserve(oids.size() + rhs.oids.size());
+  keys.reserve(keys.size() + rhs.keys.size());
+  types.reserve(types.size() + rhs.types.size());
+  charsetNumbers.reserve(charsetNumbers.size() + rhs.charsetNumbers.size());
+  charsets.reserve(charsets.size() + rhs.charsets.size());
+  scale.reserve(scale.size() + rhs.scale.size());
+  precision.reserve(precision.size() + rhs.precision.size());
+  colWidths.reserve(colWidths.size() + rhs.colWidths.size());
+
   oids.insert(oids.end(), rhs.oids.begin(), rhs.oids.end());
   keys.insert(keys.end(), rhs.keys.begin(), rhs.keys.end());
   types.insert(types.end(), rhs.types.begin(), rhs.types.end());
@@ -1610,6 +1620,12 @@ RowGroup& RowGroup::operator+=(const RowGroup& rhs)
 
   //    +4  +4  +8       +2 +4  +8
   // (2, 6, 10, 18) + (2, 4, 8, 16) = (2, 6, 10, 18, 20, 24, 32)
+  // Reserve space for additional offsets from rhs (starting from index 1)
+  if (rhs.stOffsets.size() > 1)
+  {
+    stOffsets.reserve(stOffsets.size() + rhs.stOffsets.size() - 1);
+    oldOffsets.reserve(oldOffsets.size() + rhs.oldOffsets.size() - 1);
+  }
   for (i = 1; i < rhs.stOffsets.size(); i++)
   {
     stOffsets.push_back(stOffsets.back() + rhs.stOffsets[i] - rhs.stOffsets[i - 1]);

--- a/utils/rowgroup/rowstorage.cpp
+++ b/utils/rowgroup/rowstorage.cpp
@@ -1234,6 +1234,8 @@ class RowGroupStorage
   void getTmpFilePrefixes(std::vector<std::string>& prefixes) const
   {
     char buf[PATH_MAX];
+    // Reserve space for 2 prefixes
+    prefixes.reserve(prefixes.size() + 2);
     snprintf(buf, sizeof(buf), "Agg-p%u-t%p-rg", getpid(), fUniqId);
     prefixes.emplace_back(buf);
 

--- a/versioning/BRM/extentmap.cpp
+++ b/versioning/BRM/extentmap.cpp
@@ -1412,6 +1412,7 @@ int ExtentMap::getMaxMin(const LBID_t lbid, T& max, T& min, int32_t& seqNum)
 std::vector<EMEntry> ExtentMap::getEmIdentsByLbids(const bi::vector<LBID_t>& lbids)
 {
   std::vector<EMEntry> emEntries;
+  emEntries.reserve(lbids.size());
   for (auto lbid : lbids)
   {
     auto emIt = findByLBID(lbid);
@@ -1427,6 +1428,7 @@ std::vector<ExtentMapRBTree::iterator> ExtentMap::getEmIteratorsByLbids(const bi
 {
   // ExtentMapRBTree::iterator
   std::vector<ExtentMapRBTree::iterator> emEntries;
+  emEntries.reserve(lbids.size());
   for (auto lbid : lbids)
   {
     auto emIt = findByLBID(lbid);

--- a/writeengine/bulk/we_bulkload.cpp
+++ b/writeengine/bulk/we_bulkload.cpp
@@ -329,7 +329,7 @@ int BulkLoad::loadJobInfo(const string& fullName, bool bUseTempJobFile, int argc
       fLog.logMsg(oss.str(), rc, MSGLVL_ERROR);
       return rc;
     }
-    catch(std::exception& ex)
+    catch (std::exception& ex)
     {
       rc = ERR_UNKNOWN;
       std::ostringstream oss;
@@ -338,7 +338,7 @@ int BulkLoad::loadJobInfo(const string& fullName, bool bUseTempJobFile, int argc
       fLog.logMsg(oss.str(), rc, MSGLVL_ERROR);
       return rc;
     }
-    catch(...)
+    catch (...)
     {
       rc = ERR_UNKNOWN;
       std::ostringstream oss;
@@ -352,10 +352,10 @@ int BulkLoad::loadJobInfo(const string& fullName, bool bUseTempJobFile, int argc
     // tableAUXColOid = 0
     if (tableAUXColOid > 3000)
     {
-      JobColumn curColumn("aux", tableAUXColOid, execplan::AUX_COL_DATATYPE_STRING,
-        execplan::AUX_COL_WIDTH, execplan::AUX_COL_WIDTH,
-        execplan::AUX_COL_COMPRESSION_TYPE, execplan::AUX_COL_COMPRESSION_TYPE,
-        execplan::AUX_COL_MINVALUE, execplan::AUX_COL_MAXVALUE, true, 1);
+      JobColumn curColumn("aux", tableAUXColOid, execplan::AUX_COL_DATATYPE_STRING, execplan::AUX_COL_WIDTH,
+                          execplan::AUX_COL_WIDTH, execplan::AUX_COL_COMPRESSION_TYPE,
+                          execplan::AUX_COL_COMPRESSION_TYPE, execplan::AUX_COL_MINVALUE,
+                          execplan::AUX_COL_MAXVALUE, true, 1);
       curColumn.fFldColRelation = BULK_FLDCOL_COLUMN_DEFAULT;
       curJob.jobTableList[i].colList.push_back(curColumn);
       JobFieldRef fieldRef(BULK_FLDCOL_COLUMN_DEFAULT, curJob.jobTableList[i].colList.size() - 1);
@@ -711,7 +711,8 @@ int BulkLoad::preProcess(Job& job, int tableNo, std::shared_ptr<TableInfo>& tabl
                                       tableInfo.get());
     // tableInfo->rbMetaWriter());
     else
-      info = new ColumnInfo(&fLog, i, job.jobTableList[tableNo].colList[i], pDBRootExtentTracker, tableInfo.get());
+      info = new ColumnInfo(&fLog, i, job.jobTableList[tableNo].colList[i], pDBRootExtentTracker,
+                            tableInfo.get());
 
     if (pwd)
       info->setUIDGID(pwd->pw_uid, pwd->pw_gid);
@@ -877,7 +878,8 @@ int BulkLoad::preProcessAutoInc(const std::string& fullTableName, ColumnInfo* co
 //    NO_ERROR if success
 //    other if fail
 //------------------------------------------------------------------------------
-int BulkLoad::preProcessHwmLbid(const ColumnInfo* info, int /*minWidth*/, uint32_t partition, uint16_t segment,
+int BulkLoad::preProcessHwmLbid(const ColumnInfo* info, int /*minWidth*/, uint32_t partition,
+                                uint16_t segment,
                                 HWM& hwm,                   // input/output
                                 BRM::LBID_t& lbid,          // output
                                 bool& bSkippedToNewExtent)  // output
@@ -1020,11 +1022,13 @@ int BulkLoad::processJob()
   // Validate the existence of the import data files
   //--------------------------------------------------------------------------
   std::vector<std::shared_ptr<TableInfo>> tables;
+  tables.reserve(curJob.jobTableList.size());
 
   for (i = 0; i < curJob.jobTableList.size(); i++)
   {
-    std::shared_ptr<TableInfo> tableInfo(new TableInfo(&fLog, fTxnID, fProcessName, curJob.jobTableList[i].mapOid,
-                                         curJob.jobTableList[i].tblName, fKeepRbMetaFiles));
+    std::shared_ptr<TableInfo> tableInfo(new TableInfo(&fLog, fTxnID, fProcessName,
+                                                       curJob.jobTableList[i].mapOid,
+                                                       curJob.jobTableList[i].tblName, fKeepRbMetaFiles));
 
     if ((fBulkMode == BULK_MODE_REMOTE_SINGLE_SRC) || (fBulkMode == BULK_MODE_REMOTE_MULTIPLE_SRC))
       tableInfo->setBulkLoadMode(fBulkMode, fBRMRptFileName);
@@ -1364,7 +1368,6 @@ int BulkLoad::buildImportDataFileList(const std::string& location, const std::st
       fullPath = location;
       fullPath += token;
     }
-
 
     // If running mode2, then support a filename with wildcards
     if (fBulkMode == BULK_MODE_REMOTE_MULTIPLE_SRC)

--- a/writeengine/bulk/we_colbufcompressed.cpp
+++ b/writeengine/bulk/we_colbufcompressed.cpp
@@ -572,6 +572,7 @@ int ColumnBufferCompressed::saveCompressionHeaders()
     compress::CompressInterface::setLBIDByIndex(hdrBuf, fColInfo->getLastUpdatedLBID(), 0);
 
   std::vector<uint64_t> ptrs;
+  ptrs.reserve(fChunkPtrs.size() + 1);  // +1 for the final ptr after the loop
 
   for (unsigned i = 0; i < fChunkPtrs.size(); i++)
   {

--- a/writeengine/bulk/we_extentstripealloc.cpp
+++ b/writeengine/bulk/we_extentstripealloc.cpp
@@ -155,6 +155,7 @@ int ExtentStripeAlloc::allocateExtent(OID oid, uint16_t dbRoot,
     fLog->logMsg(oss1.str(), MSGLVL_INFO2);
 
     std::vector<BRM::CreateStripeColumnExtentsArgIn> cols;
+    cols.reserve(fColOIDs.size());
     std::vector<BRM::CreateStripeColumnExtentsArgOut> extents;
 
     for (unsigned int j = 0; j < fColOIDs.size(); ++j)

--- a/writeengine/server/we_ddlcommandproc.cpp
+++ b/writeengine/server/we_ddlcommandproc.cpp
@@ -363,6 +363,7 @@ uint8_t WE_DDLCommandProc::writeCreateSyscolumn(ByteStream& bs, std::string& err
 
   // deserialize column Oid and dictionary oid
   vector<uint32_t> coloids;
+  coloids.reserve(columnSize);
   vector<uint32_t> dictoids;
 
   for (i = 0; i < columnSize; ++i)
@@ -372,6 +373,7 @@ uint8_t WE_DDLCommandProc::writeCreateSyscolumn(ByteStream& bs, std::string& err
   }
 
   bs >> dictSize;
+  dictoids.reserve(dictSize);
 
   for (i = 0; i < dictSize; ++i)
   {
@@ -2089,6 +2091,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnAuto(ByteStream& bs, std::string& err)
   dctnryStructList.push_back(dctnryStruct);
   cscColTypeList.push_back(column.colType);
 
+  aColList.reserve(roList.size());
   for (unsigned int i = 0; i < roList.size(); i++)
   {
     aColList.push_back(colTuple);
@@ -2276,6 +2279,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnNextvalCol(ByteStream& bs, std::string
   dctnryStructList.push_back(dctnryStruct);
   cscColTypeList.push_back(column.colType);
 
+  aColList.reserve(roList.size());
   for (unsigned int i = 0; i < roList.size(); i++)
   {
     aColList.push_back(colTuple);
@@ -2449,6 +2453,7 @@ uint8_t WE_DDLCommandProc::updateSystableEntryForSysColumn(int32_t /*sessionID*/
   dctnryStructList.push_back(dctnryStruct);
   cscColTypeList.push_back(column.colType);
 
+  aColList.reserve(roList.size());
   for (unsigned int i = 0; i < roList.size(); i++)
   {
     aColList.push_back(colTuple);

--- a/writeengine/server/we_dmlcommandproc.cpp
+++ b/writeengine/server/we_dmlcommandproc.cpp
@@ -502,6 +502,7 @@ uint8_t WE_DMLCommandProc::processSingleInsert(messageqcpp::ByteStream& bs, std:
 
       // First gather HWM BRM information for all columns
       std::vector<int> colWidths;
+      colWidths.reserve(ridList.size());
 
       for (unsigned i = 0; i < ridList.size(); i++)
       {
@@ -609,6 +610,7 @@ uint8_t WE_DMLCommandProc::processSingleInsert(messageqcpp::ByteStream& bs, std:
 
   std::map<uint32_t, uint32_t> oids;
   std::vector<BRM::OID_t> oidsToFlush;
+  oidsToFlush.reserve(colStructs.size() + dctnryStructList.size());
 
   for (unsigned i = 0; i < colStructs.size(); i++)
   {
@@ -950,6 +952,7 @@ uint8_t WE_DMLCommandProc::processBatchInsert(messageqcpp::ByteStream& bs, std::
 
       // First gather HWM BRM information for all columns
       std::vector<int> colWidths;
+      colWidths.reserve(ridList.size() + 1);  // +1 for potential AUX column
       for (unsigned i = 0; i < ridList.size(); i++)
       {
         rc = BRMWrapper::getInstance()->getDbRootHWMInfo(ridList[i].objnum, dbRootHWMInfoColVec[i]);

--- a/writeengine/wrapper/writeengine.cpp
+++ b/writeengine/wrapper/writeengine.cpp
@@ -1392,6 +1392,7 @@ int WriteEngineWrapper::insertColumnRecs(
     if (bFirstExtentOnThisPM)
     {
       std::vector<BRM::CreateStripeColumnExtentsArgIn> cols;
+      cols.reserve(colStructList.size());
       BRM::CreateStripeColumnExtentsArgIn createStripeColumnExtentsArgIn;
 
       for (i = 0; i < colStructList.size(); i++)
@@ -2202,6 +2203,7 @@ int WriteEngineWrapper::insertColumnRecsBinary(
     {
       // cout << "bFirstExtentOnThisPM is " << bFirstExtentOnThisPM << endl;
       std::vector<BRM::CreateStripeColumnExtentsArgIn> cols;
+      cols.reserve(colStructList.size());
       BRM::CreateStripeColumnExtentsArgIn createStripeColumnExtentsArgIn;
 
       for (i = 0; i < colStructList.size(); i++)

--- a/writeengine/xml/we_xmljob.cpp
+++ b/writeengine/xml/we_xmljob.cpp
@@ -757,6 +757,12 @@ void XMLJob::postProcessTableNode()
     bValidateNoDefColWithoutDefValue = true;
     int tableNo = fJob.jobTableList.size() - 1;
 
+    // Reserve space for default columns
+    fJob.jobTableList[tableNo].colList.reserve(fJob.jobTableList[tableNo].colList.size() +
+                                               fDefaultColumns.size());
+    fJob.jobTableList[tableNo].fFldRefs.reserve(fJob.jobTableList[tableNo].fFldRefs.size() +
+                                                fDefaultColumns.size());
+
     for (unsigned k = 0; k < fDefaultColumns.size(); k++)
     {
       // Add to list of db columns to be loaded


### PR DESCRIPTION
Added reserve() calls to prevent unnecessary  reallocations throughout the Columnstore codebase.