### PR TITLE
fix(CEJ, segfault): MCOL-6198 - segfault during crossengine join

### DIFF
--- a/mysql-test/columnstore/bugfixes/MCOL-6198-segfault-crossengine-join.result
+++ b/mysql-test/columnstore/bugfixes/MCOL-6198-segfault-crossengine-join.result
@@ -1,0 +1,17 @@
+DROP DATABASE IF EXISTS MCOL_6198;
+CREATE DATABASE MCOL_6198;
+SELECT 
+v.c36 AS hst,
+m.p6 AS g,
+COALESCE(g0.eg_id,'MARIA') AS g01,
+COALESCE(g1.eg_id,'MARIA') AS g02,
+SUM(v.c758 * m.p42 / 100 + v.c759 * m.p42 / 100 + v.c760 * m.p42 / 100) AS sval
+FROM 
+c AS v 
+JOIN p m on (v.c4 = m.a4)
+LEFT OUTER JOIN group_g01 AS g0 ON g0.key_id=m.p6 
+LEFT OUTER JOIN group_g02 AS g1 ON g1.key_id=m.p6 
+WHERE 
+1=1 
+GROUP BY c36,p6,g01,g02;
+DROP DATABASE MCOL_6198;

--- a/mysql-test/columnstore/bugfixes/MCOL-6198-segfault-crossengine-join.test
+++ b/mysql-test/columnstore/bugfixes/MCOL-6198-segfault-crossengine-join.test
@@ -1,0 +1,1234 @@
+# Note this test check a completion of query, nothing else.
+# Thus, almost all of logging and most of warnings are disabled.
+-- source ../include/have_columnstore.inc
+-- source include/have_innodb.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS MCOL_6198;
+CREATE DATABASE MCOL_6198;
+--disable_query_log
+--disable_result_log
+USE MCOL_6198;
+#
+# Enable cross engine join
+# Configure user and password in Columnstore.xml file
+#
+if (!$MASTER_MYPORT)
+{
+  # Running with --extern
+  let $MASTER_MYPORT=`SELECT @@port`;
+}
+
+--exec $MCS_MCSSETCONFIG CrossEngineSupport User 'cejuser'
+--exec $MCS_MCSSETCONFIG CrossEngineSupport Password 'Vagrant1|0000001'
+--exec $MCS_MCSSETCONFIG CrossEngineSupport Port $MASTER_MYPORT
+#
+# Create corresponding in the server
+#
+CREATE USER IF NOT EXISTS'cejuser'@'localhost' IDENTIFIED BY 'Vagrant1|0000001';
+GRANT ALL PRIVILEGES ON *.* TO 'cejuser'@'localhost';
+FLUSH PRIVILEGES;
+CREATE TABLE IF NOT EXISTS `p` (
+  `a1` int(11) DEFAULT NULL,
+  `a2` varchar(8) DEFAULT NULL,
+  `a3` int(11) DEFAULT NULL,
+  `a4` decimal(22,0) DEFAULT NULL,
+  `a5` varchar(50) DEFAULT NULL,
+  `a6` int(11) DEFAULT NULL,
+  `a7` int(11) DEFAULT NULL,
+  `p1` int(11) DEFAULT NULL,
+  `p2` int(11) DEFAULT NULL,
+  `p3` int(11) DEFAULT NULL,
+  `p4` int(11) DEFAULT NULL,
+  `p5` int(11) DEFAULT NULL,
+  `p6` int(11) DEFAULT NULL,
+  `p7` int(11) DEFAULT NULL,
+  `p8` int(11) DEFAULT NULL,
+  `p9` int(11) DEFAULT NULL,
+  `p10` int(11) DEFAULT NULL,
+  `p11` int(11) DEFAULT NULL,
+  `p12` int(11) DEFAULT NULL,
+  `p13` int(11) DEFAULT NULL,
+  `p14` int(11) DEFAULT NULL,
+  `p15` int(11) DEFAULT NULL,
+  `p16` int(11) DEFAULT NULL,
+  `p17` int(11) DEFAULT NULL,
+  `p18` int(11) DEFAULT NULL,
+  `p19` int(11) DEFAULT NULL,
+  `p20` int(11) DEFAULT NULL,
+  `p21` int(11) DEFAULT NULL,
+  `p22` int(11) DEFAULT NULL,
+  `p23` int(11) DEFAULT NULL,
+  `p24` int(11) DEFAULT NULL,
+  `p25` int(11) DEFAULT NULL,
+  `p26` int(11) DEFAULT NULL,
+  `p27` int(11) DEFAULT NULL,
+  `p28` int(11) DEFAULT NULL,
+  `p29` int(11) DEFAULT NULL,
+  `p30` int(11) DEFAULT NULL,
+  `p31` int(11) DEFAULT NULL,
+  `p32` int(11) DEFAULT NULL,
+  `p33` int(11) DEFAULT NULL,
+  `p34` int(11) DEFAULT NULL,
+  `p35` int(11) DEFAULT NULL,
+  `p36` int(11) DEFAULT NULL,
+  `p37` int(11) DEFAULT NULL,
+  `p38` int(11) DEFAULT NULL,
+  `p39` int(11) DEFAULT NULL,
+  `p40` int(11) DEFAULT NULL,
+  `p41` int(11) DEFAULT NULL,
+  `p42` int(11) DEFAULT NULL,
+  `p43` int(11) DEFAULT NULL,
+  `p44` int(11) DEFAULT NULL
+) ENGINE=Columnstore DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+
+CREATE TABLE IF NOT EXISTS `c` (
+  `c1` tinyint(3) unsigned DEFAULT NULL,
+  `c2` int(11) DEFAULT NULL,
+  `c3` tinyint(3) unsigned DEFAULT NULL,
+  `c4` int(11) DEFAULT NULL,
+  `c5` int(11) DEFAULT NULL,
+  `c6` int(11) DEFAULT NULL,
+  `c7` int(11) DEFAULT NULL,
+  `c8` int(11) DEFAULT NULL,
+  `c9` int(11) DEFAULT NULL,
+  `c10` int(11) DEFAULT NULL,
+  `c11` int(11) DEFAULT NULL,
+  `c12` int(11) DEFAULT NULL,
+  `c13` int(11) DEFAULT NULL,
+  `c14` int(11) DEFAULT NULL,
+  `c15` int(11) DEFAULT NULL,
+  `c16` int(11) DEFAULT NULL,
+  `c17` int(11) DEFAULT NULL,
+  `c18` int(11) DEFAULT NULL,
+  `c19` int(11) DEFAULT NULL,
+  `c20` int(11) DEFAULT NULL,
+  `c21` int(11) DEFAULT NULL,
+  `c22` int(10) unsigned DEFAULT NULL,
+  `c23` int(11) DEFAULT NULL,
+  `c24` int(11) DEFAULT NULL,
+  `c25` int(11) DEFAULT NULL,
+  `c26` smallint(5) unsigned DEFAULT NULL,
+  `c27` decimal(10,3) DEFAULT NULL,
+  `c28` int(11) DEFAULT NULL,
+  `c29` int(11) DEFAULT NULL,
+  `c30` int(11) DEFAULT NULL,
+  `c31` int(11) DEFAULT NULL,
+  `c32` int(11) DEFAULT NULL,
+  `c33` tinyint(3) unsigned DEFAULT NULL,
+  `c34` int(10) unsigned DEFAULT NULL,
+  `c35` int(11) DEFAULT NULL,
+  `c36` int(10) unsigned DEFAULT NULL,
+  `c37` int(11) DEFAULT NULL,
+  `c38` int(11) DEFAULT NULL,
+  `c39` int(11) DEFAULT NULL,
+  `c40` int(11) DEFAULT NULL,
+  `c41` int(11) DEFAULT NULL,
+  `c42` int(11) DEFAULT NULL,
+  `c43` tinyint(3) unsigned DEFAULT NULL,
+  `c44` smallint(5) unsigned DEFAULT NULL,
+  `c45` int(10) unsigned DEFAULT NULL,
+  `c46` int(11) DEFAULT NULL,
+  `c47` tinyint(3) unsigned DEFAULT NULL,
+  `c48` tinyint(3) unsigned DEFAULT NULL,
+  `c49` smallint(5) unsigned DEFAULT NULL,
+  `c50` tinyint(3) unsigned DEFAULT NULL,
+  `c51` tinyint(3) unsigned DEFAULT NULL,
+  `c52` smallint(6) DEFAULT NULL,
+  `c53` int(11) DEFAULT NULL,
+  `c54` int(11) DEFAULT NULL,
+  `c55` int(11) DEFAULT NULL,
+  `c56` int(11) DEFAULT NULL,
+  `c57` int(11) DEFAULT NULL,
+  `c58` int(11) DEFAULT NULL,
+  `c59` int(11) DEFAULT NULL,
+  `c60` int(11) DEFAULT NULL,
+  `c61` int(11) DEFAULT NULL,
+  `c62` int(11) DEFAULT NULL,
+  `c63` int(11) DEFAULT NULL,
+  `c64` int(10) unsigned DEFAULT NULL,
+  `c65` tinyint(3) unsigned DEFAULT NULL,
+  `c66` smallint(6) DEFAULT NULL,
+  `c67` int(11) DEFAULT NULL,
+  `c68` int(11) DEFAULT NULL,
+  `c69` int(11) DEFAULT NULL,
+  `c70` smallint(5) unsigned DEFAULT NULL,
+  `c71` smallint(5) unsigned DEFAULT NULL,
+  `c72` int(11) DEFAULT NULL,
+  `c73` int(11) DEFAULT NULL,
+  `c74` int(11) DEFAULT NULL,
+  `c75` int(11) DEFAULT NULL,
+  `c76` int(11) DEFAULT NULL,
+  `c77` int(11) DEFAULT NULL,
+  `c78` int(11) DEFAULT NULL,
+  `c79` int(11) DEFAULT NULL,
+  `c80` int(11) DEFAULT NULL,
+  `c81` int(11) DEFAULT NULL,
+  `c82` int(11) DEFAULT NULL,
+  `c83` int(11) DEFAULT NULL,
+  `c84` int(11) DEFAULT NULL,
+  `c85` int(11) DEFAULT NULL,
+  `c86` int(11) DEFAULT NULL,
+  `c87` int(11) DEFAULT NULL,
+  `c88` int(11) DEFAULT NULL,
+  `c89` int(11) DEFAULT NULL,
+  `c90` int(11) DEFAULT NULL,
+  `c91` decimal(12,2) DEFAULT NULL,
+  `c92` int(11) DEFAULT NULL,
+  `c93` int(11) DEFAULT NULL,
+  `c94` int(11) DEFAULT NULL,
+  `c95` int(11) DEFAULT NULL,
+  `c96` int(11) DEFAULT NULL,
+  `c97` int(11) DEFAULT NULL,
+  `c98` int(11) DEFAULT NULL,
+  `c99` int(11) DEFAULT NULL,
+  `c100` int(11) DEFAULT NULL,
+  `c101` int(11) DEFAULT NULL,
+  `c102` int(11) DEFAULT NULL,
+  `c103` int(11) DEFAULT NULL,
+  `c104` int(11) DEFAULT NULL,
+  `c105` int(11) DEFAULT NULL,
+  `c106` int(11) DEFAULT NULL,
+  `c107` int(11) DEFAULT NULL,
+  `c108` int(11) DEFAULT NULL,
+  `c109` int(11) DEFAULT NULL,
+  `c110` int(11) DEFAULT NULL,
+  `c111` int(11) DEFAULT NULL,
+  `c112` int(11) DEFAULT NULL,
+  `c113` int(11) DEFAULT NULL,
+  `c114` int(11) DEFAULT NULL,
+  `c115` int(11) DEFAULT NULL,
+  `c116` int(11) DEFAULT NULL,
+  `c117` int(11) DEFAULT NULL,
+  `c118` int(11) DEFAULT NULL,
+  `c119` int(11) DEFAULT NULL,
+  `c120` decimal(12,2) DEFAULT NULL,
+  `c121` int(11) DEFAULT NULL,
+  `c122` int(11) DEFAULT NULL,
+  `c123` int(11) DEFAULT NULL,
+  `c124` int(11) DEFAULT NULL,
+  `c125` int(11) DEFAULT NULL,
+  `c126` int(11) DEFAULT NULL,
+  `c127` int(11) DEFAULT NULL,
+  `c128` int(11) DEFAULT NULL,
+  `c129` int(11) DEFAULT NULL,
+  `c130` int(11) DEFAULT NULL,
+  `c131` int(11) DEFAULT NULL,
+  `c132` int(11) DEFAULT NULL,
+  `c133` int(11) DEFAULT NULL,
+  `c134` int(11) DEFAULT NULL,
+  `c135` int(11) DEFAULT NULL,
+  `c136` int(11) DEFAULT NULL,
+  `c137` int(11) DEFAULT NULL,
+  `c138` int(11) DEFAULT NULL,
+  `c139` decimal(12,2) DEFAULT NULL,
+  `c140` int(11) DEFAULT NULL,
+  `c141` int(11) DEFAULT NULL,
+  `c142` int(11) DEFAULT NULL,
+  `c143` int(11) DEFAULT NULL,
+  `c144` int(11) DEFAULT NULL,
+  `c145` int(11) DEFAULT NULL,
+  `c146` int(11) DEFAULT NULL,
+  `c147` int(11) DEFAULT NULL,
+  `c148` int(11) DEFAULT NULL,
+  `c149` int(11) DEFAULT NULL,
+  `c150` int(11) DEFAULT NULL,
+  `c151` int(11) DEFAULT NULL,
+  `c152` int(11) DEFAULT NULL,
+  `c153` int(11) DEFAULT NULL,
+  `c154` int(11) DEFAULT NULL,
+  `c155` int(11) DEFAULT NULL,
+  `c156` int(11) DEFAULT NULL,
+  `c157` int(11) DEFAULT NULL,
+  `c158` decimal(12,2) DEFAULT NULL,
+  `c159` int(11) DEFAULT NULL,
+  `c160` int(11) DEFAULT NULL,
+  `c161` int(11) DEFAULT NULL,
+  `c162` int(11) DEFAULT NULL,
+  `c163` int(11) DEFAULT NULL,
+  `c164` int(11) DEFAULT NULL,
+  `c165` int(11) DEFAULT NULL,
+  `c166` int(11) DEFAULT NULL,
+  `c167` int(11) DEFAULT NULL,
+  `c168` int(11) DEFAULT NULL,
+  `c169` int(11) DEFAULT NULL,
+  `c170` int(11) DEFAULT NULL,
+  `c171` int(11) DEFAULT NULL,
+  `c172` int(11) DEFAULT NULL,
+  `c173` int(11) DEFAULT NULL,
+  `c174` int(11) DEFAULT NULL,
+  `c175` int(11) DEFAULT NULL,
+  `c176` int(11) DEFAULT NULL,
+  `c177` decimal(12,2) DEFAULT NULL,
+  `c178` int(11) DEFAULT NULL,
+  `c179` int(11) DEFAULT NULL,
+  `c180` int(11) DEFAULT NULL,
+  `c181` int(11) DEFAULT NULL,
+  `c182` int(11) DEFAULT NULL,
+  `c183` int(11) DEFAULT NULL,
+  `c184` int(11) DEFAULT NULL,
+  `c185` int(11) DEFAULT NULL,
+  `c186` int(11) DEFAULT NULL,
+  `c187` int(11) DEFAULT NULL,
+  `c188` int(11) DEFAULT NULL,
+  `c189` int(11) DEFAULT NULL,
+  `c190` int(11) DEFAULT NULL,
+  `c191` int(11) DEFAULT NULL,
+  `c192` int(11) DEFAULT NULL,
+  `c193` int(11) DEFAULT NULL,
+  `c194` int(11) DEFAULT NULL,
+  `c195` int(11) DEFAULT NULL,
+  `c196` decimal(12,2) DEFAULT NULL,
+  `c197` int(11) DEFAULT NULL,
+  `c198` int(11) DEFAULT NULL,
+  `c199` int(11) DEFAULT NULL,
+  `c200` int(11) DEFAULT NULL,
+  `c201` int(11) DEFAULT NULL,
+  `c202` int(11) DEFAULT NULL,
+  `c203` int(11) DEFAULT NULL,
+  `c204` int(11) DEFAULT NULL,
+  `c205` int(11) DEFAULT NULL,
+  `c206` int(11) DEFAULT NULL,
+  `c207` int(11) DEFAULT NULL,
+  `c208` int(11) DEFAULT NULL,
+  `c209` int(11) DEFAULT NULL,
+  `c210` int(11) DEFAULT NULL,
+  `c211` int(11) DEFAULT NULL,
+  `c212` int(11) DEFAULT NULL,
+  `c213` int(11) DEFAULT NULL,
+  `c214` int(11) DEFAULT NULL,
+  `c215` decimal(12,2) DEFAULT NULL,
+  `c216` int(11) DEFAULT NULL,
+  `c217` int(11) DEFAULT NULL,
+  `c218` int(11) DEFAULT NULL,
+  `c219` int(11) DEFAULT NULL,
+  `c220` int(11) DEFAULT NULL,
+  `c221` int(11) DEFAULT NULL,
+  `c222` int(11) DEFAULT NULL,
+  `c223` int(11) DEFAULT NULL,
+  `c224` int(11) DEFAULT NULL,
+  `c225` int(11) DEFAULT NULL,
+  `c226` int(11) DEFAULT NULL,
+  `c227` int(11) DEFAULT NULL,
+  `c228` int(11) DEFAULT NULL,
+  `c229` int(11) DEFAULT NULL,
+  `c230` int(11) DEFAULT NULL,
+  `c231` int(11) DEFAULT NULL,
+  `c232` int(11) DEFAULT NULL,
+  `c233` int(11) DEFAULT NULL,
+  `c234` decimal(12,2) DEFAULT NULL,
+  `c235` int(11) DEFAULT NULL,
+  `c236` int(11) DEFAULT NULL,
+  `c237` int(11) DEFAULT NULL,
+  `c238` int(11) DEFAULT NULL,
+  `c239` int(11) DEFAULT NULL,
+  `c240` int(11) DEFAULT NULL,
+  `c241` int(11) DEFAULT NULL,
+  `c242` int(11) DEFAULT NULL,
+  `c243` int(11) DEFAULT NULL,
+  `c244` int(11) DEFAULT NULL,
+  `c245` int(11) DEFAULT NULL,
+  `c246` int(11) DEFAULT NULL,
+  `c247` int(11) DEFAULT NULL,
+  `c248` int(11) DEFAULT NULL,
+  `c249` int(11) DEFAULT NULL,
+  `c250` int(11) DEFAULT NULL,
+  `c251` int(11) DEFAULT NULL,
+  `c252` int(11) DEFAULT NULL,
+  `c253` int(11) DEFAULT NULL,
+  `c254` int(11) DEFAULT NULL,
+  `c255` int(11) DEFAULT NULL,
+  `c256` int(11) DEFAULT NULL,
+  `c257` int(11) DEFAULT NULL,
+  `c258` int(11) DEFAULT NULL,
+  `c259` int(11) DEFAULT NULL,
+  `c260` int(11) DEFAULT NULL,
+  `c261` decimal(12,2) DEFAULT NULL,
+  `c262` int(11) DEFAULT NULL,
+  `c263` int(11) DEFAULT NULL,
+  `c264` int(11) DEFAULT NULL,
+  `c265` int(11) DEFAULT NULL,
+  `c266` int(11) DEFAULT NULL,
+  `c267` int(11) DEFAULT NULL,
+  `c268` int(11) DEFAULT NULL,
+  `c269` int(11) DEFAULT NULL,
+  `c270` int(11) DEFAULT NULL,
+  `c271` int(11) DEFAULT NULL,
+  `c272` decimal(12,2) DEFAULT NULL,
+  `c273` int(11) DEFAULT NULL,
+  `c274` int(11) DEFAULT NULL,
+  `c275` int(11) DEFAULT NULL,
+  `c276` int(11) DEFAULT NULL,
+  `c277` int(11) DEFAULT NULL,
+  `c278` int(11) DEFAULT NULL,
+  `c279` int(11) DEFAULT NULL,
+  `c280` int(11) DEFAULT NULL,
+  `c281` decimal(12,2) DEFAULT NULL,
+  `c282` int(11) DEFAULT NULL,
+  `c283` int(11) DEFAULT NULL,
+  `c284` int(11) DEFAULT NULL,
+  `c285` int(11) DEFAULT NULL,
+  `c286` int(11) DEFAULT NULL,
+  `c287` int(11) DEFAULT NULL,
+  `c288` int(11) DEFAULT NULL,
+  `c289` int(11) DEFAULT NULL,
+  `c290` int(11) DEFAULT NULL,
+  `c291` int(11) DEFAULT NULL,
+  `c292` int(11) DEFAULT NULL,
+  `c293` int(11) DEFAULT NULL,
+  `c294` int(11) DEFAULT NULL,
+  `c295` int(11) DEFAULT NULL,
+  `c296` int(11) DEFAULT NULL,
+  `c297` int(11) DEFAULT NULL,
+  `c298` int(11) DEFAULT NULL,
+  `c299` int(11) DEFAULT NULL,
+  `c300` decimal(12,2) DEFAULT NULL,
+  `c301` int(11) DEFAULT NULL,
+  `c302` int(11) DEFAULT NULL,
+  `c303` int(11) DEFAULT NULL,
+  `c304` int(11) DEFAULT NULL,
+  `c305` int(11) DEFAULT NULL,
+  `c306` int(11) DEFAULT NULL,
+  `c307` int(11) DEFAULT NULL,
+  `c308` int(11) DEFAULT NULL,
+  `c309` int(11) DEFAULT NULL,
+  `c310` int(11) DEFAULT NULL,
+  `c311` int(11) DEFAULT NULL,
+  `c312` int(11) DEFAULT NULL,
+  `c313` int(11) DEFAULT NULL,
+  `c314` int(11) DEFAULT NULL,
+  `c315` int(11) DEFAULT NULL,
+  `c316` int(11) DEFAULT NULL,
+  `c317` int(11) DEFAULT NULL,
+  `c318` int(11) DEFAULT NULL,
+  `c319` int(11) DEFAULT NULL,
+  `c320` int(11) DEFAULT NULL,
+  `c321` int(11) DEFAULT NULL,
+  `c322` int(11) DEFAULT NULL,
+  `c323` int(11) DEFAULT NULL,
+  `c324` int(11) DEFAULT NULL,
+  `c325` int(11) DEFAULT NULL,
+  `c326` int(11) DEFAULT NULL,
+  `c327` int(11) DEFAULT NULL,
+  `c328` int(11) DEFAULT NULL,
+  `c329` decimal(12,2) DEFAULT NULL,
+  `c330` int(11) DEFAULT NULL,
+  `c331` int(11) DEFAULT NULL,
+  `c332` int(11) DEFAULT NULL,
+  `c333` int(11) DEFAULT NULL,
+  `c334` int(11) DEFAULT NULL,
+  `c335` int(11) DEFAULT NULL,
+  `c336` int(11) DEFAULT NULL,
+  `c337` int(11) DEFAULT NULL,
+  `c338` int(11) DEFAULT NULL,
+  `c339` int(11) DEFAULT NULL,
+  `c340` int(11) DEFAULT NULL,
+  `c341` int(11) DEFAULT NULL,
+  `c342` int(11) DEFAULT NULL,
+  `c343` int(11) DEFAULT NULL,
+  `c344` int(11) DEFAULT NULL,
+  `c345` int(11) DEFAULT NULL,
+  `c346` int(11) DEFAULT NULL,
+  `c347` int(11) DEFAULT NULL,
+  `c348` decimal(12,2) DEFAULT NULL,
+  `c349` int(11) DEFAULT NULL,
+  `c350` int(11) DEFAULT NULL,
+  `c351` int(11) DEFAULT NULL,
+  `c352` int(11) DEFAULT NULL,
+  `c353` int(11) DEFAULT NULL,
+  `c354` int(11) DEFAULT NULL,
+  `c355` int(11) DEFAULT NULL,
+  `c356` int(11) DEFAULT NULL,
+  `c357` int(11) DEFAULT NULL,
+  `c358` int(11) DEFAULT NULL,
+  `c359` int(11) DEFAULT NULL,
+  `c360` int(11) DEFAULT NULL,
+  `c361` int(11) DEFAULT NULL,
+  `c362` int(11) DEFAULT NULL,
+  `c363` int(11) DEFAULT NULL,
+  `c364` int(11) DEFAULT NULL,
+  `c365` int(11) DEFAULT NULL,
+  `c366` int(11) DEFAULT NULL,
+  `c367` decimal(12,2) DEFAULT NULL,
+  `c368` int(11) DEFAULT NULL,
+  `c369` int(11) DEFAULT NULL,
+  `c370` int(11) DEFAULT NULL,
+  `c371` int(11) DEFAULT NULL,
+  `c372` int(11) DEFAULT NULL,
+  `c373` int(11) DEFAULT NULL,
+  `c374` int(11) DEFAULT NULL,
+  `c375` int(11) DEFAULT NULL,
+  `c376` int(11) DEFAULT NULL,
+  `c377` int(11) DEFAULT NULL,
+  `c378` int(11) DEFAULT NULL,
+  `c379` int(11) DEFAULT NULL,
+  `c380` int(11) DEFAULT NULL,
+  `c381` int(11) DEFAULT NULL,
+  `c382` int(11) DEFAULT NULL,
+  `c383` int(11) DEFAULT NULL,
+  `c384` int(11) DEFAULT NULL,
+  `c385` int(11) DEFAULT NULL,
+  `c386` decimal(12,2) DEFAULT NULL,
+  `c387` int(11) DEFAULT NULL,
+  `c388` int(11) DEFAULT NULL,
+  `c389` int(11) DEFAULT NULL,
+  `c390` int(11) DEFAULT NULL,
+  `c391` int(11) DEFAULT NULL,
+  `c392` int(11) DEFAULT NULL,
+  `c393` int(11) DEFAULT NULL,
+  `c394` int(11) DEFAULT NULL,
+  `c395` int(11) DEFAULT NULL,
+  `c396` int(11) DEFAULT NULL,
+  `c397` int(11) DEFAULT NULL,
+  `c398` int(11) DEFAULT NULL,
+  `c399` int(11) DEFAULT NULL,
+  `c400` int(11) DEFAULT NULL,
+  `c401` int(11) DEFAULT NULL,
+  `c402` int(11) DEFAULT NULL,
+  `c403` int(11) DEFAULT NULL,
+  `c404` int(11) DEFAULT NULL,
+  `c405` decimal(12,2) DEFAULT NULL,
+  `c406` int(11) DEFAULT NULL,
+  `c407` int(11) DEFAULT NULL,
+  `c408` int(11) DEFAULT NULL,
+  `c409` int(11) DEFAULT NULL,
+  `c410` int(11) DEFAULT NULL,
+  `c411` int(11) DEFAULT NULL,
+  `c412` int(11) DEFAULT NULL,
+  `c413` int(11) DEFAULT NULL,
+  `c414` int(11) DEFAULT NULL,
+  `c415` int(11) DEFAULT NULL,
+  `c416` int(11) DEFAULT NULL,
+  `c417` int(11) DEFAULT NULL,
+  `c418` int(11) DEFAULT NULL,
+  `c419` int(11) DEFAULT NULL,
+  `c420` int(11) DEFAULT NULL,
+  `c421` int(11) DEFAULT NULL,
+  `c422` int(11) DEFAULT NULL,
+  `c423` int(11) DEFAULT NULL,
+  `c424` decimal(12,2) DEFAULT NULL,
+  `c425` int(11) DEFAULT NULL,
+  `c426` int(11) DEFAULT NULL,
+  `c427` int(11) DEFAULT NULL,
+  `c428` int(11) DEFAULT NULL,
+  `c429` int(11) DEFAULT NULL,
+  `c430` int(11) DEFAULT NULL,
+  `c431` int(11) DEFAULT NULL,
+  `c432` int(11) DEFAULT NULL,
+  `c433` int(11) DEFAULT NULL,
+  `c434` int(11) DEFAULT NULL,
+  `c435` int(11) DEFAULT NULL,
+  `c436` int(11) DEFAULT NULL,
+  `c437` int(11) DEFAULT NULL,
+  `c438` int(11) DEFAULT NULL,
+  `c439` int(11) DEFAULT NULL,
+  `c440` int(11) DEFAULT NULL,
+  `c441` int(11) DEFAULT NULL,
+  `c442` int(11) DEFAULT NULL,
+  `c443` decimal(12,2) DEFAULT NULL,
+  `c444` int(11) DEFAULT NULL,
+  `c445` int(11) DEFAULT NULL,
+  `c446` int(11) DEFAULT NULL,
+  `c447` int(11) DEFAULT NULL,
+  `c448` int(11) DEFAULT NULL,
+  `c449` int(11) DEFAULT NULL,
+  `c450` int(11) DEFAULT NULL,
+  `c451` int(11) DEFAULT NULL,
+  `c452` int(11) DEFAULT NULL,
+  `c453` int(11) DEFAULT NULL,
+  `c454` int(11) DEFAULT NULL,
+  `c455` int(11) DEFAULT NULL,
+  `c456` int(11) DEFAULT NULL,
+  `c457` int(11) DEFAULT NULL,
+  `c458` int(11) DEFAULT NULL,
+  `c459` int(11) DEFAULT NULL,
+  `c460` int(11) DEFAULT NULL,
+  `c461` int(11) DEFAULT NULL,
+  `c462` int(11) DEFAULT NULL,
+  `c463` int(11) DEFAULT NULL,
+  `c464` int(11) DEFAULT NULL,
+  `c465` int(11) DEFAULT NULL,
+  `c466` int(11) DEFAULT NULL,
+  `c467` int(11) DEFAULT NULL,
+  `c468` int(11) DEFAULT NULL,
+  `c469` int(11) DEFAULT NULL,
+  `c470` decimal(12,2) DEFAULT NULL,
+  `c471` int(11) DEFAULT NULL,
+  `c472` int(11) DEFAULT NULL,
+  `c473` int(11) DEFAULT NULL,
+  `c474` int(11) DEFAULT NULL,
+  `c475` int(11) DEFAULT NULL,
+  `c476` int(11) DEFAULT NULL,
+  `c477` int(11) DEFAULT NULL,
+  `c478` int(11) DEFAULT NULL,
+  `c479` int(11) DEFAULT NULL,
+  `c480` int(11) DEFAULT NULL,
+  `c481` decimal(12,2) DEFAULT NULL,
+  `c482` int(11) DEFAULT NULL,
+  `c483` int(11) DEFAULT NULL,
+  `c484` int(11) DEFAULT NULL,
+  `c485` int(11) DEFAULT NULL,
+  `c486` int(11) DEFAULT NULL,
+  `c487` int(11) DEFAULT NULL,
+  `c488` int(11) DEFAULT NULL,
+  `c489` int(11) DEFAULT NULL,
+  `c490` decimal(12,2) DEFAULT NULL,
+  `c491` int(11) DEFAULT NULL,
+  `c492` int(11) DEFAULT NULL,
+  `c493` int(11) DEFAULT NULL,
+  `c494` int(11) DEFAULT NULL,
+  `c495` int(11) DEFAULT NULL,
+  `c496` int(11) DEFAULT NULL,
+  `c497` int(11) DEFAULT NULL,
+  `c498` int(11) DEFAULT NULL,
+  `c499` int(11) DEFAULT NULL,
+  `c500` int(11) DEFAULT NULL,
+  `c501` int(11) DEFAULT NULL,
+  `c502` int(11) DEFAULT NULL,
+  `c503` int(11) DEFAULT NULL,
+  `c504` int(11) DEFAULT NULL,
+  `c505` int(11) DEFAULT NULL,
+  `c506` int(11) DEFAULT NULL,
+  `c507` int(11) DEFAULT NULL,
+  `c508` int(11) DEFAULT NULL,
+  `c509` decimal(12,2) DEFAULT NULL,
+  `c510` int(11) DEFAULT NULL,
+  `c511` int(11) DEFAULT NULL,
+  `c512` int(11) DEFAULT NULL,
+  `c513` int(11) DEFAULT NULL,
+  `c514` int(11) DEFAULT NULL,
+  `c515` int(11) DEFAULT NULL,
+  `c516` int(11) DEFAULT NULL,
+  `c517` int(11) DEFAULT NULL,
+  `c518` int(11) DEFAULT NULL,
+  `c519` int(11) DEFAULT NULL,
+  `c520` int(11) DEFAULT NULL,
+  `c521` int(11) DEFAULT NULL,
+  `c522` int(11) DEFAULT NULL,
+  `c523` int(11) DEFAULT NULL,
+  `c524` int(11) DEFAULT NULL,
+  `c525` int(11) DEFAULT NULL,
+  `c526` int(11) DEFAULT NULL,
+  `c527` int(11) DEFAULT NULL,
+  `c528` int(11) DEFAULT NULL,
+  `c529` int(11) DEFAULT NULL,
+  `c530` int(11) DEFAULT NULL,
+  `c531` int(11) DEFAULT NULL,
+  `c532` int(11) DEFAULT NULL,
+  `c533` int(11) DEFAULT NULL,
+  `c534` int(11) DEFAULT NULL,
+  `c535` int(11) DEFAULT NULL,
+  `c536` int(11) DEFAULT NULL,
+  `c537` int(11) DEFAULT NULL,
+  `c538` decimal(12,2) DEFAULT NULL,
+  `c539` int(11) DEFAULT NULL,
+  `c540` int(11) DEFAULT NULL,
+  `c541` int(11) DEFAULT NULL,
+  `c542` int(11) DEFAULT NULL,
+  `c543` int(11) DEFAULT NULL,
+  `c544` int(11) DEFAULT NULL,
+  `c545` int(11) DEFAULT NULL,
+  `c546` int(11) DEFAULT NULL,
+  `c547` int(11) DEFAULT NULL,
+  `c548` int(11) DEFAULT NULL,
+  `c549` int(11) DEFAULT NULL,
+  `c550` int(11) DEFAULT NULL,
+  `c551` int(11) DEFAULT NULL,
+  `c552` int(11) DEFAULT NULL,
+  `c553` int(11) DEFAULT NULL,
+  `c554` int(11) DEFAULT NULL,
+  `c555` int(11) DEFAULT NULL,
+  `c556` int(11) DEFAULT NULL,
+  `c557` decimal(12,2) DEFAULT NULL,
+  `c558` int(11) DEFAULT NULL,
+  `c559` int(11) DEFAULT NULL,
+  `c560` int(11) DEFAULT NULL,
+  `c561` int(11) DEFAULT NULL,
+  `c562` int(11) DEFAULT NULL,
+  `c563` int(11) DEFAULT NULL,
+  `c564` int(11) DEFAULT NULL,
+  `c565` int(11) DEFAULT NULL,
+  `c566` int(11) DEFAULT NULL,
+  `c567` int(11) DEFAULT NULL,
+  `c568` int(11) DEFAULT NULL,
+  `c569` int(11) DEFAULT NULL,
+  `c570` int(11) DEFAULT NULL,
+  `c571` int(11) DEFAULT NULL,
+  `c572` int(11) DEFAULT NULL,
+  `c573` int(11) DEFAULT NULL,
+  `c574` int(11) DEFAULT NULL,
+  `c575` int(11) DEFAULT NULL,
+  `c576` decimal(12,2) DEFAULT NULL,
+  `c577` int(11) DEFAULT NULL,
+  `c578` int(11) DEFAULT NULL,
+  `c579` int(11) DEFAULT NULL,
+  `c580` int(11) DEFAULT NULL,
+  `c581` int(11) DEFAULT NULL,
+  `c582` int(11) DEFAULT NULL,
+  `c583` int(11) DEFAULT NULL,
+  `c584` int(11) DEFAULT NULL,
+  `c585` int(11) DEFAULT NULL,
+  `c586` int(11) DEFAULT NULL,
+  `c587` int(11) DEFAULT NULL,
+  `c588` int(11) DEFAULT NULL,
+  `c589` int(11) DEFAULT NULL,
+  `c590` int(11) DEFAULT NULL,
+  `c591` int(11) DEFAULT NULL,
+  `c592` int(11) DEFAULT NULL,
+  `c593` int(11) DEFAULT NULL,
+  `c594` int(11) DEFAULT NULL,
+  `c595` decimal(12,2) DEFAULT NULL,
+  `c596` int(11) DEFAULT NULL,
+  `c597` int(11) DEFAULT NULL,
+  `c598` int(11) DEFAULT NULL,
+  `c599` int(11) DEFAULT NULL,
+  `c600` int(11) DEFAULT NULL,
+  `c601` int(11) DEFAULT NULL,
+  `c602` int(11) DEFAULT NULL,
+  `c603` int(11) DEFAULT NULL,
+  `c604` int(11) DEFAULT NULL,
+  `c605` int(11) DEFAULT NULL,
+  `c606` int(11) DEFAULT NULL,
+  `c607` int(11) DEFAULT NULL,
+  `c608` int(11) DEFAULT NULL,
+  `c609` int(11) DEFAULT NULL,
+  `c610` int(11) DEFAULT NULL,
+  `c611` int(11) DEFAULT NULL,
+  `c612` int(11) DEFAULT NULL,
+  `c613` int(11) DEFAULT NULL,
+  `c614` decimal(12,2) DEFAULT NULL,
+  `c615` int(11) DEFAULT NULL,
+  `c616` int(11) DEFAULT NULL,
+  `c617` int(11) DEFAULT NULL,
+  `c618` int(11) DEFAULT NULL,
+  `c619` int(11) DEFAULT NULL,
+  `c620` int(11) DEFAULT NULL,
+  `c621` int(11) DEFAULT NULL,
+  `c622` int(11) DEFAULT NULL,
+  `c623` int(11) DEFAULT NULL,
+  `c624` int(11) DEFAULT NULL,
+  `c625` int(11) DEFAULT NULL,
+  `c626` int(11) DEFAULT NULL,
+  `c627` int(11) DEFAULT NULL,
+  `c628` int(11) DEFAULT NULL,
+  `c629` int(11) DEFAULT NULL,
+  `c630` int(11) DEFAULT NULL,
+  `c631` int(11) DEFAULT NULL,
+  `c632` int(11) DEFAULT NULL,
+  `c633` decimal(12,2) DEFAULT NULL,
+  `c634` int(11) DEFAULT NULL,
+  `c635` int(11) DEFAULT NULL,
+  `c636` int(11) DEFAULT NULL,
+  `c637` int(11) DEFAULT NULL,
+  `c638` int(11) DEFAULT NULL,
+  `c639` int(11) DEFAULT NULL,
+  `c640` int(11) DEFAULT NULL,
+  `c641` int(11) DEFAULT NULL,
+  `c642` int(11) DEFAULT NULL,
+  `c643` int(11) DEFAULT NULL,
+  `c644` int(11) DEFAULT NULL,
+  `c645` int(11) DEFAULT NULL,
+  `c646` int(11) DEFAULT NULL,
+  `c647` int(11) DEFAULT NULL,
+  `c648` int(11) DEFAULT NULL,
+  `c649` int(11) DEFAULT NULL,
+  `c650` int(11) DEFAULT NULL,
+  `c651` int(11) DEFAULT NULL,
+  `c652` decimal(12,2) DEFAULT NULL,
+  `c653` int(11) DEFAULT NULL,
+  `c654` int(11) DEFAULT NULL,
+  `c655` int(11) DEFAULT NULL,
+  `c656` int(11) DEFAULT NULL,
+  `c657` int(11) DEFAULT NULL,
+  `c658` int(11) DEFAULT NULL,
+  `c659` int(11) DEFAULT NULL,
+  `c660` int(11) DEFAULT NULL,
+  `c661` int(11) DEFAULT NULL,
+  `c662` int(11) DEFAULT NULL,
+  `c663` int(11) DEFAULT NULL,
+  `c664` int(11) DEFAULT NULL,
+  `c665` int(11) DEFAULT NULL,
+  `c666` int(11) DEFAULT NULL,
+  `c667` int(11) DEFAULT NULL,
+  `c668` int(11) DEFAULT NULL,
+  `c669` int(11) DEFAULT NULL,
+  `c670` int(11) DEFAULT NULL,
+  `c671` int(11) DEFAULT NULL,
+  `c672` int(11) DEFAULT NULL,
+  `c673` int(11) DEFAULT NULL,
+  `c674` int(11) DEFAULT NULL,
+  `c675` int(11) DEFAULT NULL,
+  `c676` int(11) DEFAULT NULL,
+  `c677` int(11) DEFAULT NULL,
+  `c678` int(11) DEFAULT NULL,
+  `c679` decimal(12,2) DEFAULT NULL,
+  `c680` int(11) DEFAULT NULL,
+  `c681` int(11) DEFAULT NULL,
+  `c682` int(11) DEFAULT NULL,
+  `c683` int(11) DEFAULT NULL,
+  `c684` int(11) DEFAULT NULL,
+  `c685` int(11) DEFAULT NULL,
+  `c686` int(11) DEFAULT NULL,
+  `c687` int(11) DEFAULT NULL,
+  `c688` int(11) DEFAULT NULL,
+  `c689` int(11) DEFAULT NULL,
+  `c690` decimal(12,2) DEFAULT NULL,
+  `c691` int(11) DEFAULT NULL,
+  `c692` int(11) DEFAULT NULL,
+  `c693` int(11) DEFAULT NULL,
+  `c694` int(11) DEFAULT NULL,
+  `c695` int(11) DEFAULT NULL,
+  `c696` int(11) DEFAULT NULL,
+  `c697` int(11) DEFAULT NULL,
+  `c698` int(11) DEFAULT NULL,
+  `c699` decimal(12,2) DEFAULT NULL,
+  `c700` int(11) DEFAULT NULL,
+  `c701` int(11) DEFAULT NULL,
+  `c702` int(11) DEFAULT NULL,
+  `c703` int(11) DEFAULT NULL,
+  `c704` int(11) DEFAULT NULL,
+  `c705` int(11) DEFAULT NULL,
+  `c706` int(11) DEFAULT NULL,
+  `c707` int(11) DEFAULT NULL,
+  `c708` int(11) DEFAULT NULL,
+  `c709` int(11) DEFAULT NULL,
+  `c710` int(11) DEFAULT NULL,
+  `c711` int(11) DEFAULT NULL,
+  `c712` int(11) DEFAULT NULL,
+  `c713` int(11) DEFAULT NULL,
+  `c714` int(11) DEFAULT NULL,
+  `c715` int(11) DEFAULT NULL,
+  `c716` int(11) DEFAULT NULL,
+  `c717` int(11) DEFAULT NULL,
+  `c718` decimal(12,2) DEFAULT NULL,
+  `c719` int(11) DEFAULT NULL,
+  `c720` int(11) DEFAULT NULL,
+  `c721` int(11) DEFAULT NULL,
+  `c722` int(11) DEFAULT NULL,
+  `c723` int(11) DEFAULT NULL,
+  `c724` int(11) DEFAULT NULL,
+  `c725` int(11) DEFAULT NULL,
+  `c726` int(11) DEFAULT NULL,
+  `c727` int(11) DEFAULT NULL,
+  `c728` int(11) DEFAULT NULL,
+  `c729` int(11) DEFAULT NULL,
+  `c730` int(11) DEFAULT NULL,
+  `c731` int(11) DEFAULT NULL,
+  `c732` int(11) DEFAULT NULL,
+  `c733` int(11) DEFAULT NULL,
+  `c734` int(11) DEFAULT NULL,
+  `c735` int(11) DEFAULT NULL,
+  `c736` int(11) DEFAULT NULL,
+  `c737` int(11) DEFAULT NULL,
+  `c738` int(11) DEFAULT NULL,
+  `c739` int(11) DEFAULT NULL,
+  `c740` int(11) DEFAULT NULL,
+  `c741` int(11) DEFAULT NULL,
+  `c742` int(11) DEFAULT NULL,
+  `c743` int(11) DEFAULT NULL,
+  `c744` int(11) DEFAULT NULL,
+  `c745` int(11) DEFAULT NULL,
+  `c746` int(11) DEFAULT NULL,
+  `c747` decimal(12,2) DEFAULT NULL,
+  `c748` int(11) DEFAULT NULL,
+  `c749` int(11) DEFAULT NULL,
+  `c750` int(11) DEFAULT NULL,
+  `c751` int(11) DEFAULT NULL,
+  `c752` int(11) DEFAULT NULL,
+  `c753` int(11) DEFAULT NULL,
+  `c754` int(11) DEFAULT NULL,
+  `c755` int(11) DEFAULT NULL,
+  `c756` int(11) DEFAULT NULL,
+  `c757` int(11) DEFAULT NULL,
+  `c758` int(11) DEFAULT NULL,
+  `c759` int(11) DEFAULT NULL,
+  `c760` int(11) DEFAULT NULL,
+  `c761` int(11) DEFAULT NULL,
+  `c762` int(11) DEFAULT NULL,
+  `c763` int(11) DEFAULT NULL,
+  `c764` int(11) DEFAULT NULL,
+  `c765` int(11) DEFAULT NULL,
+  `c766` decimal(12,2) DEFAULT NULL,
+  `c767` int(11) DEFAULT NULL,
+  `c768` int(11) DEFAULT NULL,
+  `c769` int(11) DEFAULT NULL,
+  `c770` int(11) DEFAULT NULL,
+  `c771` int(11) DEFAULT NULL,
+  `c772` int(11) DEFAULT NULL,
+  `c773` int(11) DEFAULT NULL,
+  `c774` int(11) DEFAULT NULL,
+  `c775` int(11) DEFAULT NULL,
+  `c776` int(11) DEFAULT NULL,
+  `c777` int(11) DEFAULT NULL,
+  `c778` int(11) DEFAULT NULL,
+  `c779` int(11) DEFAULT NULL,
+  `c780` int(11) DEFAULT NULL,
+  `c781` int(11) DEFAULT NULL,
+  `c782` int(11) DEFAULT NULL,
+  `c783` int(11) DEFAULT NULL,
+  `c784` int(11) DEFAULT NULL,
+  `c785` decimal(12,2) DEFAULT NULL,
+  `c786` int(11) DEFAULT NULL,
+  `c787` int(11) DEFAULT NULL,
+  `c788` int(11) DEFAULT NULL,
+  `c789` int(11) DEFAULT NULL,
+  `c790` int(11) DEFAULT NULL,
+  `c791` int(11) DEFAULT NULL,
+  `c792` int(11) DEFAULT NULL,
+  `c793` int(11) DEFAULT NULL,
+  `c794` int(11) DEFAULT NULL,
+  `c795` int(11) DEFAULT NULL,
+  `c796` int(11) DEFAULT NULL,
+  `c797` int(11) DEFAULT NULL,
+  `c798` int(11) DEFAULT NULL,
+  `c799` int(11) DEFAULT NULL,
+  `c800` int(11) DEFAULT NULL,
+  `c801` int(11) DEFAULT NULL,
+  `c802` int(11) DEFAULT NULL,
+  `c803` int(11) DEFAULT NULL,
+  `c804` decimal(12,2) DEFAULT NULL,
+  `c805` int(11) DEFAULT NULL,
+  `c806` int(11) DEFAULT NULL,
+  `c807` int(11) DEFAULT NULL,
+  `c808` int(11) DEFAULT NULL,
+  `c809` int(11) DEFAULT NULL,
+  `c810` int(11) DEFAULT NULL,
+  `c811` int(11) DEFAULT NULL,
+  `c812` int(11) DEFAULT NULL,
+  `c813` decimal(12,2) DEFAULT NULL,
+  `c814` int(11) DEFAULT NULL,
+  `c815` int(11) DEFAULT NULL,
+  `c816` int(11) DEFAULT NULL,
+  `c817` int(11) DEFAULT NULL,
+  `c818` int(11) DEFAULT NULL,
+  `c819` int(11) DEFAULT NULL,
+  `c820` int(11) DEFAULT NULL,
+  `c821` int(11) DEFAULT NULL,
+  `c822` int(11) DEFAULT NULL,
+  `c823` int(11) DEFAULT NULL,
+  `c824` int(11) DEFAULT NULL,
+  `c825` int(11) DEFAULT NULL,
+  `c826` int(11) DEFAULT NULL,
+  `c827` int(11) DEFAULT NULL,
+  `c828` int(11) DEFAULT NULL,
+  `c829` int(11) DEFAULT NULL,
+  `c830` int(11) DEFAULT NULL,
+  `c831` int(11) DEFAULT NULL,
+  `c832` decimal(12,2) DEFAULT NULL,
+  `c833` int(11) DEFAULT NULL,
+  `c834` int(11) DEFAULT NULL,
+  `c835` int(11) DEFAULT NULL,
+  `c836` int(11) DEFAULT NULL,
+  `c837` int(11) DEFAULT NULL,
+  `c838` int(11) DEFAULT NULL,
+  `c839` int(11) DEFAULT NULL,
+  `c840` int(11) DEFAULT NULL,
+  `c841` int(11) DEFAULT NULL,
+  `c842` int(11) DEFAULT NULL,
+  `c843` int(11) DEFAULT NULL,
+  `c844` int(11) DEFAULT NULL,
+  `c845` int(11) DEFAULT NULL,
+  `c846` int(11) DEFAULT NULL,
+  `c847` int(11) DEFAULT NULL,
+  `c848` int(11) DEFAULT NULL,
+  `c849` int(11) DEFAULT NULL,
+  `c850` int(11) DEFAULT NULL,
+  `c851` decimal(12,2) DEFAULT NULL,
+  `c852` int(11) DEFAULT NULL,
+  `c853` int(11) DEFAULT NULL,
+  `c854` int(11) DEFAULT NULL,
+  `c855` int(11) DEFAULT NULL,
+  `c856` int(11) DEFAULT NULL,
+  `c857` int(11) DEFAULT NULL,
+  `c858` int(11) DEFAULT NULL,
+  `c859` int(11) DEFAULT NULL,
+  `c860` int(11) DEFAULT NULL,
+  `c861` int(11) DEFAULT NULL,
+  `c862` int(11) DEFAULT NULL,
+  `c863` int(11) DEFAULT NULL,
+  `c864` int(11) DEFAULT NULL,
+  `c865` int(11) DEFAULT NULL,
+  `c866` int(11) DEFAULT NULL,
+  `c867` int(11) DEFAULT NULL,
+  `c868` int(11) DEFAULT NULL,
+  `c869` int(11) DEFAULT NULL,
+  `c870` decimal(12,2) DEFAULT NULL,
+  `c871` int(11) DEFAULT NULL,
+  `c872` int(11) DEFAULT NULL,
+  `c873` int(11) DEFAULT NULL,
+  `c874` int(11) DEFAULT NULL,
+  `c875` int(11) DEFAULT NULL,
+  `c876` int(11) DEFAULT NULL,
+  `c877` int(11) DEFAULT NULL,
+  `c878` int(11) DEFAULT NULL,
+  `c879` int(11) DEFAULT NULL,
+  `c880` int(11) DEFAULT NULL,
+  `c881` int(11) DEFAULT NULL,
+  `c882` int(11) DEFAULT NULL,
+  `c883` int(11) DEFAULT NULL,
+  `c884` int(11) DEFAULT NULL,
+  `c885` int(11) DEFAULT NULL,
+  `c886` int(11) DEFAULT NULL,
+  `c887` int(11) DEFAULT NULL,
+  `c888` int(11) DEFAULT NULL,
+  `c889` decimal(12,2) DEFAULT NULL,
+  `c890` int(11) DEFAULT NULL,
+  `c891` int(11) DEFAULT NULL,
+  `c892` int(11) DEFAULT NULL,
+  `c893` int(11) DEFAULT NULL,
+  `c894` int(11) DEFAULT NULL,
+  `c895` int(11) DEFAULT NULL,
+  `c896` int(11) DEFAULT NULL,
+  `c897` int(11) DEFAULT NULL,
+  `c898` int(11) DEFAULT NULL,
+  `c899` int(11) DEFAULT NULL,
+  `c900` int(11) DEFAULT NULL,
+  `c901` int(11) DEFAULT NULL,
+  `c902` int(11) DEFAULT NULL,
+  `c903` int(11) DEFAULT NULL,
+  `c904` int(11) DEFAULT NULL,
+  `c905` int(11) DEFAULT NULL,
+  `c906` int(11) DEFAULT NULL,
+  `c907` int(11) DEFAULT NULL,
+  `c908` decimal(12,2) DEFAULT NULL,
+  `c909` decimal(25,17) DEFAULT NULL,
+  `c910` int(10) unsigned DEFAULT NULL,
+  `c911` int(11) DEFAULT NULL,
+  `c912` int(11) DEFAULT NULL,
+  `c913` int(11) DEFAULT NULL,
+  `c914` int(11) DEFAULT NULL,
+  `c915` int(11) DEFAULT NULL,
+  `c916` smallint(5) unsigned DEFAULT NULL,
+  `c917` smallint(5) unsigned DEFAULT NULL,
+  `c918` smallint(5) unsigned DEFAULT NULL,
+  `c919` smallint(5) unsigned DEFAULT NULL,
+  `c920` smallint(5) unsigned DEFAULT NULL,
+  `c921` int(10) unsigned DEFAULT NULL,
+  `c922` int(11) DEFAULT NULL,
+  `c923` decimal(10,3) DEFAULT NULL,
+  `c924` decimal(13,4) DEFAULT NULL,
+  `c925` tinyint(3) unsigned DEFAULT NULL,
+  `c926` tinyint(3) unsigned DEFAULT NULL
+) ENGINE=Columnstore DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+
+--delimiter ==STOP==
+CREATE or replace PROCEDURE `filltablecol`(
+    IN `databasenamer` VARCHAR(50),
+    IN `tablenamer` VARCHAR(50),
+    IN `amountrows` INT
+)
+LANGUAGE SQL
+NOT DETERMINISTIC
+MODIFIES SQL DATA
+SQL SECURITY DEFINER
+COMMENT 'written by Richard Stracke MariaDB 2025'
+BEGIN
+    DECLARE done, ai_flag,enumcount INT DEFAULT FALSE;
+    DECLARE ischemaname,itablename,icolumnname,idatatype,icharmax,icoltype,iextra VARCHAR(500);
+    DECLARE iNUMERIC_PRECISION,iNUMERIC_SCALE INT;
+    DECLARE psql MEDIUMTEXT;
+    DECLARE p1 MEDIUMTEXT;
+    DECLARE p2 MEDIUMTEXT;
+    DECLARE pcols MEDIUMTEXT;
+
+     DECLARE cur CURSOR FOR SELECT table_schema,TABLE_NAME,COLUMN_NAME,DATA_type,character_maximum_length,extra,NUMERIC_PRECISION,NUMERIC_SCALE,(LENGTH(column_type) - LENGTH(REPLACE(column_type, ',', ''))) +1 FROM information_schema.`columns` WHERE table_schema = databasenamer and TABLE_NAME = tablenamer;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+    
+    set psql = CONCAT("INSERT INTO ",databasenamer,".",tablenamer, " ( " );
+    SET psql = CONCAT(psql,"with recursive series as (") ;
+    SET p1 = "select ";
+    SET p2 = "select ";
+    SET pcols = "";
+    SET ai_flag = 0;
+    
+   set session max_recursive_iterations = amountrows +1;
+    
+    OPEN cur;
+    
+    user_loop: LOOP
+    
+        FETCH cur INTO ischemaname,itablename,icolumnname,idatatype,icharmax,iextra,iNUMERIC_PRECISION,iNUMERIC_SCALE,enumcount;
+        IF done THEN
+          LEAVE user_loop;
+        END IF;
+ 
+        if idatatype = "tinyint" then
+        
+        SET p1 = CONCAT (p1, "FLOOR(1 + (RAND() * 125)) as ", icolumnname,"," );
+        SET p2 = CONCAT (p2, "FLOOR(1 + (RAND() * 125)) as ", icolumnname,"," );
+        
+        SET pcols = CONCAT(pcols,icolumnname,",");
+        
+        
+        END if;
+        
+              if idatatype = "smallint" then
+        
+        SET p1 = CONCAT (p1, "FLOOR(1 + (RAND() * 125)) as ", icolumnname,"," );
+        SET p2 = CONCAT (p2, "FLOOR(1 + (RAND() * 125)) as ", icolumnname,"," );
+        
+        SET pcols = CONCAT(pcols,icolumnname,",");
+        
+        
+        END if;
+        
+        
+        
+        if idatatype = "enum" then
+        
+        SET p1 = CONCAT (p1, "FLOOR(1 + (RAND() * ",enumcount," )) as ", icolumnname,"," );
+        SET p2 = CONCAT (p2, "FLOOR(1 + (RAND() * ",enumcount," )) as ", icolumnname,"," );
+        SET pcols = CONCAT(pcols,icolumnname,",");
+        
+        
+        END if;
+        
+        if idatatype = "bigint"  then
+        
+        SET p1 = CONCAT (p1, "FLOOR(1 + (RAND() * 50000)) as ", icolumnname,"," );
+        SET p2 = CONCAT (p2, "FLOOR(1 + (RAND() * 50000)) as ", icolumnname,"," );
+        
+        SET pcols = CONCAT(pcols,icolumnname,",");
+        
+        
+        END if;
+        
+        
+        if idatatype = "date" OR idatatype = "datetime" OR idatatype = "timestamp" then
+        
+        SET p1 = CONCAT (p1, "subdate(NOW() ,INTERVAL (FLOOR(1 + (RAND() * 15)) ) DAY) as ", icolumnname,"," );
+        SET p2 = CONCAT (p2, "subdate(NOW() ,INTERVAL (FLOOR(1 + (RAND() * 15)) ) DAY) as ", icolumnname,"," );
+        
+        SET pcols = CONCAT(pcols,icolumnname,",");
+        
+        
+        END if;
+        
+        
+        if idatatype = "int"  then
+        
+        SET p1 = CONCAT (p1, "FLOOR(1 + (RAND() * 50000)) as ", icolumnname,"," );
+        SET p2 = CONCAT (p2, "FLOOR(1 + (RAND() * 50000)) as ", icolumnname,"," );
+        
+        SET pcols = CONCAT(pcols,icolumnname,",");
+        
+        
+        END if;
+        
+        if idatatype = "double"  then
+        
+        SET p1 = CONCAT (p1, "FLOOR(1 + (RAND() * 50000))/100 as ", icolumnname,"," );
+        SET p2 = CONCAT (p2, "FLOOR(1 + (RAND() * 50000))/100 as ", icolumnname,"," );
+        
+        SET pcols = CONCAT(pcols,icolumnname,",");
+        
+        
+        END if;
+        
+          if idatatype = "decimal"  then
+        
+        SET p1 = CONCAT (p1, "FLOOR(1 + (RAND() * 50000))/100 as ", icolumnname,"," );
+        SET p2 = CONCAT (p2, "FLOOR(1 + (RAND() * 50000))/100 as ", icolumnname,"," );
+        
+        SET pcols = CONCAT(pcols,icolumnname,",");
+        
+        
+        END if;
+        
+        
+        if idatatype = "varchar" OR idatatype = "char" then
+        
+        SET p1 = CONCAT (p1, "LEFT(MD5(RAND()),",icharmax,") as ", icolumnname,"," );
+        SET p2 = CONCAT (p2, "LEFT(MD5(RAND()),",icharmax,") as ", icolumnname,"," );
+        
+        SET pcols = CONCAT(pcols,icolumnname,",");
+        
+        END if;
+        
+        
+        
+         if idatatype = "mediumblob" OR idatatype = "text"  then
+        
+        SET p1 = CONCAT (p1, "LPAD('Database',1000,'MariadB') as ", icolumnname,"," );
+        SET p2 = CONCAT (p2, "LPAD('Database',1000,'MariadB') as ", icolumnname,"," );
+        
+        SET pcols = CONCAT(pcols,icolumnname,",");
+        
+        END if;
+        
+        
+        
+         if iextra = "auto_increment" then
+        
+        SET p1 = CONCAT (p1, "1 as ", icolumnname,"," );
+        SET p2 = CONCAT (p2," ", icolumnname,  " +1 as ", icolumnname,"," );
+        
+        SET ai_flag = 1;
+        
+        SET pcols = CONCAT(pcols,icolumnname,",");
+        
+        END if;
+        
+        
+        
+        
+    END LOOP;
+    
+     SET p1 = CONCAT (p1, "1 as mariadbid " );
+     SET p2 = CONCAT (p2,"mariadbid  +1 as mariadbid " );
+     SET pcols = LEFT(pcols,LENGTH(pcols)-1);
+     
+    
+   #SELECT psql,p1,p2,pcols;
+    SET psql = CONCAT(psql,p1, " union all " ,p2);
+    SET psql = concat(psql, " from series where mariadbid < ",amountrows,"  )");
+    SET psql = concat(psql, " select ",pcols, " from series);");
+    CLOSE cur;
+
+
+PREPARE stmt FROM psql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+    
+END
+==STOP==
+--delimiter ;
+
+call filltablecol("MCOL_6198","c",100000);
+call filltablecol("MCOL_6198","c",100000);
+
+call filltablecol("MCOL_6198","p",100000);
+call filltablecol("MCOL_6198","p",100000);
+call filltablecol("MCOL_6198","p",100000);
+call filltablecol("MCOL_6198","p",100000);
+
+
+CREATE TABLE group_g01(key_id BIGINT, eg_id VARCHAR(40)) ENGINE=innoDB;
+INSERT INTO group_g01 VALUES (1,'$46');  
+CREATE TABLE group_g02(key_id BIGINT, eg_id VARCHAR(40)) ENGINE=innoDB;
+INSERT INTO group_g02 VALUES (1,'$45');  
+
+# We are not interested in results per se, we are looking for sccessful query completion.
+--enable_query_log
+SELECT 
+ v.c36 AS hst,
+ m.p6 AS g,
+ COALESCE(g0.eg_id,'MARIA') AS g01,
+ COALESCE(g1.eg_id,'MARIA') AS g02,
+ SUM(v.c758 * m.p42 / 100 + v.c759 * m.p42 / 100 + v.c760 * m.p42 / 100) AS sval
+FROM 
+ c AS v 
+ JOIN p m on (v.c4 = m.a4)
+ LEFT OUTER JOIN group_g01 AS g0 ON g0.key_id=m.p6 
+ LEFT OUTER JOIN group_g02 AS g1 ON g1.key_id=m.p6 
+WHERE 
+ 1=1 
+GROUP BY c36,p6,g01,g02;
+
+--disable_query_log
+DROP USER 'cejuser'@'localhost';
+--enable_query_log
+--enable_result_log
+--enable_warnings
+
+DROP DATABASE MCOL_6198;

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -370,7 +370,6 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
         }
         else
         {
-          auto allocator = exemgr::globServiceExeMgr->getRm().getAllocator<TLJoiner::value_type>();
 
           deserializeVector<uint32_t>(bs, tlLargeSideKeyColumns[i]);
           bs >> tlSmallSideKeyLengths[i];
@@ -386,15 +385,6 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
             mSmallSideKeyColumnsPtr = &(*tlSmallSideKeyColumns);
             smallSideRGRecvd = true;
           }
-
-          for (uint j = 0; j < processorThreads; ++j)
-          {
-            auto tlHasher = TupleJoiner::TypelessDataHasher(&outputRG, &tlLargeSideKeyColumns[i],
-                                                            mSmallSideKeyColumnsPtr, mSmallSideRGPtr);
-            auto tlComparator = TupleJoiner::TypelessDataComparator(&outputRG, &tlLargeSideKeyColumns[i],
-                                                                    mSmallSideKeyColumnsPtr, mSmallSideRGPtr);
-            tlJoiners[i][j].reset(new TLJoiner(10, tlHasher, tlComparator, allocator));
-          }
         }
       }
 
@@ -408,6 +398,7 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
       {
         deserializeVector(bs, smallSideRGs);
         idbassert(smallSideRGs.size() == joinerCount);
+        mSmallSideRGPtr = mSmallSideRGPtr ? &smallSideRGs[0] : nullptr;
         smallSideRowLengths.reset(new uint32_t[joinerCount]);
         smallSideRowData.reset(new RGData[joinerCount]);
         smallNullRowData.reset(new RGData[joinerCount]);
@@ -438,6 +429,25 @@ void BatchPrimitiveProcessor::initBPP(ByteStream& bs)
         bs >> largeSideRG;
         bs >> joinedRG;
       }
+
+      auto allocator = exemgr::globServiceExeMgr->getRm().getAllocator<TLJoiner::value_type>();
+
+      for (i = 0; i < joinerCount; i++)
+      {
+        if (!typelessJoin[i])
+        {
+          continue;
+        }
+        for (uint j = 0; j < processorThreads; ++j)
+        {
+          auto tlHasher = TupleJoiner::TypelessDataHasher(&outputRG, &tlLargeSideKeyColumns[i],
+                                                          mSmallSideKeyColumnsPtr, mSmallSideRGPtr);
+          auto tlComparator = TupleJoiner::TypelessDataComparator(&outputRG, &tlLargeSideKeyColumns[i],
+                                                                  mSmallSideKeyColumnsPtr, mSmallSideRGPtr);
+          tlJoiners[i][j].reset(new TLJoiner(10, tlHasher, tlComparator, allocator));
+        }
+      }
+
     }
 
     pthread_mutex_unlock(&objLock);
@@ -2400,8 +2410,7 @@ SBPP BatchPrimitiveProcessor::duplicate()
     bpp->hasJoinFEFilters = hasJoinFEFilters;
     bpp->hasSmallOuterJoin = hasSmallOuterJoin;
     bpp->mJOINHasSkewedKeyColumn = mJOINHasSkewedKeyColumn;
-    bpp->mSmallSideRGPtr = mSmallSideRGPtr;
-    bpp->mSmallSideKeyColumnsPtr = mSmallSideKeyColumnsPtr;
+    bpp->mSmallSideKeyColumnsPtr = &(*bpp->tlSmallSideKeyColumns);
     if (!getTupleJoinRowGroupData && mJOINHasSkewedKeyColumn)
     {
       idbassert(!smallSideRGs.empty());
@@ -2428,6 +2437,7 @@ SBPP BatchPrimitiveProcessor::duplicate()
       bpp->smallNullPointers = smallNullPointers;
       bpp->joinedRG = joinedRG;
     }
+    bpp->mSmallSideRGPtr = &bpp->smallSideRGs[0];
 
 #ifdef __FreeBSD__
     pthread_mutex_unlock(&bpp->objLock);


### PR DESCRIPTION
The patch moves joiners' initialization to a place after all possible allocations of smallSideRGs vector so pointer to it's data does not change anymore. This makes crash to cease.

An appropriate test is added to bugfixes suite.