### PR TITLE
Basic host identity manager

### DIFF
--- a/cmapi/cmapi_server/__main__.py
+++ b/cmapi/cmapi_server/__main__.py
@@ -17,24 +17,26 @@ from cherrypy.process import plugins
 # TODO: fix dispatcher choose logic because code executing in endpoints.py
 #       while import process, this cause module logger misconfiguration
 from cmapi_server.logging_management import config_cmapi_server_logging
+config_cmapi_server_logging()
+
 from tracing.sentry import maybe_init_sentry
 from tracing.traceparent_backend import TraceparentBackend
 from tracing.tracer import get_tracer
+from tracing.trace_tool import register_tracing_tools
 
-config_cmapi_server_logging()
 from cmapi_server import helpers
-from cmapi_server.constants import CMAPI_CONF_PATH, DEFAULT_MCS_CONF_PATH
-from cmapi_server.controllers.dispatcher import dispatcher, jsonify_404, jsonify_error
+from cmapi_server.constants import DEFAULT_MCS_CONF_PATH, CMAPI_CONF_PATH
+from cmapi_server.controllers.dispatcher import dispatcher, jsonify_error, jsonify_404
 from cmapi_server.failover_agent import FailoverAgent
-from cmapi_server.invariant_checks import run_invariant_checks
 from cmapi_server.managers.application import AppManager
-from cmapi_server.managers.certificate import CertificateManager
+from cmapi_server.managers.host_identity import get_host_address_manager
 from cmapi_server.managers.process import MCSProcessManager
+from cmapi_server.managers.certificate import CertificateManager
+from cmapi_server.invariant_checks import run_invariant_checks
 from failover.node_monitor import NodeMonitor
 from failover.config import Config
 from mcs_node_control.models.dbrm_socket import SOCK_TIMEOUT, DBRMSocketHandler
 from mcs_node_control.models.node_config import NodeConfig
-from tracing.trace_tool import register_tracing_tools
 
 
 def worker(app):
@@ -160,6 +162,9 @@ if __name__ == '__main__':
     if diag:
         logging.error('Invariant checks failed, exiting')
         sys.exit(1)
+
+    my_identity = get_host_address_manager().get_local_identity()
+    logging.info('My identity: %s', my_identity)
 
     app = cherrypy.tree.mount(root=None, config=CMAPI_CONF_PATH)
     root_config = {

--- a/cmapi/cmapi_server/exceptions.py
+++ b/cmapi/cmapi_server/exceptions.py
@@ -30,6 +30,14 @@ class CEJError(CMAPIBasicError):
     """
 
 
+class ResolutionError(CMAPIBasicError):
+    """Errors related to DNS resolution"""
+
+
+class ResolutionPolicyViolationError(CMAPIBasicError):
+    """Errors where results are rejected by the current resolving policy."""
+
+
 @contextmanager
 def exc_to_cmapi_error(prefix: Optional[str] = None) -> Iterator[None]:
     """Context manager to standardize error wrapping into CMAPIBasicError.

--- a/cmapi/cmapi_server/managers/host_identity.py
+++ b/cmapi/cmapi_server/managers/host_identity.py
@@ -99,7 +99,7 @@ class ResolutionPolicy:
 class HostIdentity:
     """Normalized result of host resolution (after policy is enforced)"""
     input: str
-    addresses: list[str]
+    ips: list[str]
     names: list[str]
     primary_ip: str
     primary_name: Optional[str]
@@ -113,11 +113,11 @@ class HostIdentity:
         ]
         if self.primary_name is not None:
             parts.append(f'primary_name={self.primary_name!r}')
-        if self.addresses != [self.primary_ip]:
-            parts.append(f'addresses={self.addresses!r}')
+        if self.ips != [self.primary_ip]:
+            parts.append(f'ips={self.ips!r}')
         if self.names != [self.primary_name]:
             parts.append(f'names={self.names!r}')
-        parts.append(f'unique_key={self.unique_key}')
+        parts.append(f'unique_key={self.unique_key[:4]}')
         parts.append(f'observed_at={self.observed_at.replace(microsecond=0).isoformat()!r}')
         return 'HostIdentity(' + ', '.join(parts) + ')'
 
@@ -145,7 +145,7 @@ class HostIdentity:
         primary_name = names[0] if names else None
         return HostIdentity(
             input=input,
-            addresses=addresses,
+            ips=addresses,
             names=list(names),
             primary_ip=primary_ip,
             primary_name=primary_name,
@@ -265,6 +265,33 @@ class HostAddressManager:
                 logger.exception('Local identity candidate failed resolution: %s', candidate)
                 continue
         raise ResolutionPolicyViolationError('Could not determine any acceptable local IP addresses under current policy.')
+
+    def check_hostname_rev_lookup(self, hostname: str) -> tuple[HostIdentity, bool]:
+        """Resolve hostname and check that at least one of its IPs resolves back to it.
+
+        Returns identity and boolean, true means that roundtrip check was successful.
+        """
+        identity = self.get_identity(hostname)
+
+        normalized = hostname.strip().lower()
+        if not normalized:
+            return identity, False
+
+        for ip_text in identity.ips:
+            try:
+                ip_obj = ipaddress.ip_address(ip_text)
+            except ValueError:
+                continue
+            try:
+                reverse_names = self._reverse_dns_names(ip_obj)
+            except Exception:
+                continue
+            if normalized in reverse_names:
+                logger.debug('Roundtrip check passed for %s: %s', hostname, ip_obj)
+                return identity, True
+
+        logger.warning('Roundtrip check failed for %s', hostname)
+        return identity, False
 
     def _resolve_dns(self, hostname: str) -> tuple[list[IPAddress], list[str]]:
         """Resolve the given hostname using DNS and return (addresses, names)."""

--- a/cmapi/cmapi_server/managers/host_identity.py
+++ b/cmapi/cmapi_server/managers/host_identity.py
@@ -9,10 +9,9 @@ And some sources are more reliable than the others (DNS > /etc/hosts), so we mus
 So:
 1. We must choose 1 IP address and 0/1 hostnames as primary (of many)
 2. We need to filter out unreliable names
-3. We must order IPs/hostnames by source reliability
+3. We must order IPs/hostnames by source reliability (DNS > /etc/hosts)
 4. There can be very many resolving sources, so we cannot resolve everything ourselves, and must rely on OS resolving
   (see /etc/nsswitch.conf, there are local /etc/hosts, DNS, mDNS, systemd-resolved, LDAP, myhostname, etc)
-5. But most important sources (DNS and /etc/hosts, recommended by our manual...) must be checked and ordered by our policy
 """
 import hashlib
 import ipaddress
@@ -21,14 +20,11 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import lru_cache
-from typing import Optional, Union
-
-import dns.resolver
-import dns.reversename
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from cmapi_server.exceptions import CMAPIBasicError, ResolutionError, ResolutionPolicyViolationError
 from cmapi_server.managers.network import NetworkManager
-from cmapi_server.managers.resolving_sources import get_resolving_source
+from cmapi_server.managers.resolving_sources import ResolvingSourceName, get_resolving_source
 
 IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 
@@ -42,8 +38,8 @@ class HostIdentity:
     # The first, most important IP addr and host name (ordering is done by policy)
     primary_ip: str
     primary_name: Optional[str]  # Name can be missing (but policy can make it required)
-    ips: list[str]  # All IP addrs
-    names: list[str]  # All host names (only those that are visible to other hosts)
+    ips: List[str]  # All IP addrs
+    names: List[str]  # All host names (only those that are visible to other hosts)
     unique_key: str  # unique id of this host, will be used later for aliases
     observed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -113,9 +109,9 @@ class ResolutionPolicy:
     allow_ipv6: bool = False
     require_hostname: bool = False
 
-    def filter_addresses(self, addrs: Iterable[str]) -> list[IPAddress]:
+    def filter_addresses(self, addrs: Iterable[str]) -> List[IPAddress]:
         """Filter out IP addresses that don't match the policy."""
-        ips: list[IPAddress] = []
+        ips: List[IPAddress] = []
         logger.debug(
             'Filtering addresses: %s (allow_private_ips=%s, allow_ipv6=%s)',
             list(addrs), self.allow_private_ips, self.allow_ipv6
@@ -155,7 +151,21 @@ class ResolutionPolicy:
             logger.debug('Accept %s', addr)
         return ips
 
-    def order_addresses(self, ips: Sequence[IPAddress]) -> list[IPAddress]:
+    def order_hostnames(
+        self,
+        names: Sequence[str],
+        name_sources: Dict[str, ResolvingSourceName],
+    ) -> List[str]:
+        """Order hostnames so that DNS-sourced names come first."""
+
+        def key(name: str) -> Tuple[int, str]:
+            src = name_sources.get(name, ResolvingSourceName.OS)
+            is_dns = 0 if src is ResolvingSourceName.DNS else 1
+            return (is_dns, name.lower())
+
+        return sorted(names, key=key)
+
+    def order_addresses(self, ips: Sequence[IPAddress]) -> List[IPAddress]:
         """Order IPs deterministically to choose the primary IP."""
         def key(ip: IPAddress) -> tuple[int, int, int, int, int, int, int, int]:
             is_global = 0 if ip.is_global else 1
@@ -173,7 +183,7 @@ class HostAddressManager:
 
     def __init__(self, policy: Optional[ResolutionPolicy] = None) -> None:
         self._policy = policy if policy is not None else ResolutionPolicy()
-        self._cache: dict[str, HostIdentity] = {}
+        self._cache: Dict[str, HostIdentity] = {}
 
     def get_identity(self, target: str) -> HostIdentity:
         """Resolve and normalize a hostname or IP."""
@@ -249,12 +259,15 @@ class HostAddressManager:
         if not self._policy.filter_addresses([str(ip)]):
             raise ResolutionPolicyViolationError('Input IP address was rejected by policy')
 
-        names: list[str] = self._get_names_of_ip(ip)
+        names: List[str] = self._get_names_of_ip(ip)
         if self._policy.require_hostname and not names:
             logger.warning('Reject %s: no names found for this IP and policy requires hostname', original_input)
             raise ResolutionPolicyViolationError('Policy requires a hostname for the input IP address (no PTR record found).')
 
-        return HostIdentity.from_policy(original_input, self._policy, [ip], sorted(names))
+        name_sources: Dict[str, ResolvingSourceName] = {name: ResolvingSourceName.DNS for name in names}
+        ordered_names = self._policy.order_hostnames(sorted(names), name_sources)
+
+        return HostIdentity.from_policy(original_input, self._policy, [ip], ordered_names)
 
     def _get_identity_from_hostname(self, hostname: str) -> HostIdentity:
         normalized = hostname.strip().lower()
@@ -271,13 +284,16 @@ class HostAddressManager:
         filtered_ips = self._policy.filter_addresses([str(ip) for ip in addrs])
 
         # Resolve each IP back to names and check if there is any that resolved back to passed fqdn
-        names: set[str] = {fqdn}
+        names: Set[str] = {fqdn}
+        name_sources: Dict[str, ResolvingSourceName] = {fqdn: ResolvingSourceName.OS}
         roundtrip_found = False
         for ip in filtered_ips:
             names_of_ip = self._get_names_of_ip(ip)
             if fqdn in names_of_ip:
                 roundtrip_found = True
-            names.update(names_of_ip)
+            for n in names_of_ip:
+                names.add(n)
+                name_sources[n] = ResolvingSourceName.DNS
 
         if not roundtrip_found:
             logger.warning(
@@ -290,30 +306,30 @@ class HostAddressManager:
         if not filtered_ips:
             raise ResolutionPolicyViolationError('All resolved addresses were rejected by policy.')
 
-        return HostIdentity.from_policy(fqdn, self._policy, filtered_ips, sorted(names))
+        ordered_names = self._policy.order_hostnames(sorted(names), name_sources)
+
+        return HostIdentity.from_policy(fqdn, self._policy, filtered_ips, ordered_names)
 
     def _get_identity_from_non_fqdn(self, hostname: str) -> HostIdentity:
         # Like FQDN version, but we know that nothing will resolve back to passed hostname
-        candidate_ips: set[str] = set(
-            NetworkManager.resolve_hostname_to_ips(
-                hostname,
-                only_ipv4=not self._policy.allow_ipv6,
-                exclude_loopback=False,
-            )
-        )
+        os_resolver = get_resolving_source(ResolvingSourceName.OS)
+        candidate_ips: Set[str] = set(str(ip) for ip in os_resolver.resolve(hostname))
 
         ips = self._policy.filter_addresses(candidate_ips)
         if not ips:
             raise ResolutionPolicyViolationError('All resolved addresses were rejected by policy.')
 
         # Collect names of IPs
-        names: set[str] = set()
+        names: Set[str] = set()
+        name_sources: Dict[str, ResolvingSourceName] = {}
         for ip_text in list(candidate_ips):
             ip = _ip_or_none(ip_text)
             if ip is None:
                 logger.error('Invalid IP address: %s', ip_text)
                 continue
-            names.update(self._get_names_of_ip(ip))
+            for n in self._get_names_of_ip(ip):
+                names.add(n)
+                name_sources[n] = ResolvingSourceName.DNS
 
         if self._policy.require_hostname and not names:
             logger.error(
@@ -323,65 +339,23 @@ class HostAddressManager:
             )
             raise ResolutionPolicyViolationError('Policy requires a hostname for the input host, but DNS did not return any FQDN names.')
 
-        return HostIdentity.from_policy(hostname, self._policy, ips, sorted(names))
+        ordered_names = self._policy.order_hostnames(sorted(names), name_sources)
 
-    def _resolve_dns(self, hostname: str) -> list[IPAddress]:
+        return HostIdentity.from_policy(hostname, self._policy, ips, ordered_names)
+
+    def _resolve_dns(self, hostname: str) -> List[IPAddress]:
         """Resolve the given hostname using DNS and return addresses."""
-        resolver = get_resolving_source('dns')
+        resolver = get_resolving_source(ResolvingSourceName.DNS)
         return resolver.resolve(hostname)
 
-    def _get_names_of_ip(self, ip: IPAddress) -> list[str]:
+    def _get_names_of_ip(self, ip: IPAddress) -> List[str]:
         """Fetch PTR names for an IP via DNS."""
         try:
-            resolver = get_resolving_source('dns')
+            resolver = get_resolving_source(ResolvingSourceName.DNS)
             return resolver.reverse(ip)
         except Exception:
             logger.exception('ip-to-name lookup unexpected failure for %s', ip)
             raise
-
-    # DNS abstraction methods for easier mocking
-    def _dns_resolve_ipv4(self, hostname: str) -> list[str]:
-        resolver = dns.resolver.Resolver(configure=True)
-        results: list[str] = []
-        for rdata in resolver.resolve(hostname, 'A', raise_on_no_answer=False):
-            try:
-                results.append(rdata.to_text())
-            except Exception:
-                continue
-        return results
-
-    def _dns_resolve_ipv6(self, hostname: str) -> list[str]:
-        resolver = dns.resolver.Resolver(configure=True)
-        results: list[str] = []
-        for rdata in resolver.resolve(hostname, 'AAAA', raise_on_no_answer=False):
-            try:
-                results.append(rdata.to_text())
-            except Exception:
-                continue
-        return results
-
-    def _dns_reverse(self, ip_text: str) -> list[str]:
-        reverse_name = dns.reversename.from_address(ip_text)
-        answer = dns.resolver.resolve(reverse_name, 'PTR', raise_on_no_answer=False)
-        names: list[str] = []
-        for ptr_rdata in answer:
-            try:
-                name = str(ptr_rdata.target).rstrip('.').lower()
-                if name:
-                    names.append(name)
-            except Exception:
-                continue
-        return names
-
-    def _contains_private(self, addrs: list[str]) -> bool:
-        """Return True if any resolvable address string is a private IP."""
-        for addr in addrs:
-            ip = _ip_or_none(addr)
-            if ip is None:
-                continue
-            if ip.is_private:
-                return True
-        return False
 
 
 @lru_cache(maxsize=1)  # singleton
@@ -394,9 +368,6 @@ def _ip_or_none(val: str) -> Optional[IPAddress]:
         return ipaddress.ip_address(val)
     except ValueError:
         return None
-
-def _is_ip_address(val: str) -> bool:
-    return _ip_or_none(val) is not None
 
 def _is_fqdn(name: str) -> bool:
     """Return True if the string is a valid FQDN (lower-cased, no trailing dot).

--- a/cmapi/cmapi_server/managers/host_identity.py
+++ b/cmapi/cmapi_server/managers/host_identity.py
@@ -250,42 +250,85 @@ class HostAddressManager:
 
     def _resolve_dns(self, hostname: str) -> tuple[list[IPAddress], list[str]]:
         """Resolve the given hostname using DNS and return (addresses, names)."""
-        resolver = dns.resolver.Resolver(configure=True)
-
-        # IPv4
-        a_records: list[IPAddress] = []
+        ipv4_texts: list[str] = []
+        ipv6_texts: list[str] = []
         try:
-            for a_rdata in resolver.resolve(hostname, 'A', raise_on_no_answer=False):
-                a_records.append(ipaddress.ip_address(a_rdata.to_text()))
+            ipv4_texts = self._dns_resolve_ipv4(hostname)
+        except dns.resolver.NoAnswer:
+            logger.debug('IPv4 lookup returned no records for %s', hostname)
+            ipv4_texts = []
         except Exception:
-            logger.exception('A lookup failed for %s', hostname)
-
-        # IPv6
-        aaaa_records: list[IPAddress] = []
+            logger.exception('IPv4 lookup unexpected failure for %s', hostname)
+            raise
         if self._policy.allow_ipv6:
             try:
-                for aaaa_rdata in resolver.resolve(hostname, 'AAAA', raise_on_no_answer=False):
-                    aaaa_records.append(ipaddress.ip_address(aaaa_rdata.to_text()))
+                ipv6_texts = self._dns_resolve_ipv6(hostname)
+            except dns.resolver.NoAnswer:
+                logger.debug('IPv6 lookup returned no records for %s', hostname)
+                ipv6_texts = []
             except Exception:
-                logger.exception('AAAA lookup failed for %s', hostname)
+                logger.exception('IPv6 lookup unexpected failure for %s', hostname)
+                raise
+
+        addrs: list[IPAddress] = []
+        for t in ipv4_texts:
+            try:
+                addrs.append(ipaddress.ip_address(t))
+            except ValueError:
+                continue
+        for t in ipv6_texts:
+            try:
+                addrs.append(ipaddress.ip_address(t))
+            except ValueError:
+                continue
 
         names = [hostname]
-        return a_records + aaaa_records, names
+        return addrs, names
 
     def _reverse_dns_names(self, ip: IPAddress) -> list[str]:
         """Fetch PTR names for an IP via DNS."""
         try:
-            reverse_name = dns.reversename.from_address(str(ip))
-            answer = dns.resolver.resolve(reverse_name, 'PTR', raise_on_no_answer=False)
-            names: list[str] = []
-            for ptr_rdata in answer:
+            return self._dns_reverse(str(ip))
+        except dns.resolver.NoAnswer:
+            logger.debug('PTR lookup returned no records for %s', ip)
+            return []
+        except Exception:
+            logger.exception('PTR lookup unexpected failure for %s', ip)
+            raise
+
+    # DNS abstraction methods for easier mocking
+    def _dns_resolve_ipv4(self, hostname: str) -> list[str]:
+        resolver = dns.resolver.Resolver(configure=True)
+        results: list[str] = []
+        for rdata in resolver.resolve(hostname, 'A', raise_on_no_answer=False):
+            try:
+                results.append(rdata.to_text())
+            except Exception:
+                continue
+        return results
+
+    def _dns_resolve_ipv6(self, hostname: str) -> list[str]:
+        resolver = dns.resolver.Resolver(configure=True)
+        results: list[str] = []
+        for rdata in resolver.resolve(hostname, 'AAAA', raise_on_no_answer=False):
+            try:
+                results.append(rdata.to_text())
+            except Exception:
+                continue
+        return results
+
+    def _dns_reverse(self, ip_text: str) -> list[str]:
+        reverse_name = dns.reversename.from_address(ip_text)
+        answer = dns.resolver.resolve(reverse_name, 'PTR', raise_on_no_answer=False)
+        names: list[str] = []
+        for ptr_rdata in answer:
+            try:
                 fqdn_name = str(ptr_rdata.target).rstrip('.').lower()
                 if _is_fqdn(fqdn_name):
                     names.append(fqdn_name)
-            return names
-        except Exception:
-            logger.exception('PTR lookup failed for %s', ip)
-            return []
+            except Exception:
+                continue
+        return names
 
     def _contains_private(self, addrs: list[str]) -> bool:
         """Return True if any resolvable address string is a private IP."""

--- a/cmapi/cmapi_server/managers/host_identity.py
+++ b/cmapi/cmapi_server/managers/host_identity.py
@@ -97,32 +97,15 @@ class ResolutionPolicy:
 
 @dataclass
 class HostIdentity:
-    """Normalized result of host resolution (after policy is enforced)"""
+    """Host's network identity, IP addrs and hostnames that are visible from other hosts"""
     input: str
-    ips: list[str]
-    names: list[str]
+    # The first, most important IP addr and host name (ordering is done by policy)
     primary_ip: str
     primary_name: Optional[str]
+    ips: list[str]  # All IP addrs
+    names: list[str]  # All host names (only those that are visible to other hosts)
     unique_key: str  # unique id of this host, will be used later for aliases
     observed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
-
-    def __repr__(self) -> str:
-        parts: list[str] = [
-            f'input={self.input!r}',
-            f'primary_ip={self.primary_ip!r}',
-        ]
-        if self.primary_name is not None:
-            parts.append(f'primary_name={self.primary_name!r}')
-        if self.ips != [self.primary_ip]:
-            parts.append(f'ips={self.ips!r}')
-        if self.names != [self.primary_name]:
-            parts.append(f'names={self.names!r}')
-        parts.append(f'unique_key={self.unique_key[:4]}')
-        parts.append(f'observed_at={self.observed_at.replace(microsecond=0).isoformat()!r}')
-        return 'HostIdentity(' + ', '.join(parts) + ')'
-
-    def __str__(self) -> str:
-        return repr(self)
 
     @staticmethod
     def from_policy(input: str, policy: ResolutionPolicy, ips: Sequence[IPAddress], names: Sequence[str]) -> 'HostIdentity':
@@ -151,6 +134,30 @@ class HostIdentity:
             primary_name=primary_name,
             unique_key=unique_key,
         )
+
+    @property
+    def effective_hostname(self) -> str:
+        """Hostname or primary IP if hostname is not set"""
+        return self.primary_name or self.primary_ip
+
+    def __repr__(self) -> str:
+        parts: list[str] = [
+            f'input={self.input!r}',
+            f'primary_ip={self.primary_ip!r}',
+        ]
+        if self.primary_name is not None:
+            parts.append(f'primary_name={self.primary_name!r}')
+        # Don't show addrs and hostnames if there is only one addr or hostname
+        if self.ips != [self.primary_ip]:
+            parts.append(f'ips={self.ips!r}')
+        if self.names != [self.primary_name]:
+            parts.append(f'names={self.names!r}')
+        parts.append(f'unique_key={self.unique_key[:4]}')
+        parts.append(f'observed_at={self.observed_at.replace(microsecond=0).isoformat()!r}')
+        return 'HostIdentity(' + ', '.join(parts) + ')'
+
+    def __str__(self) -> str:
+        return repr(self)
 
 
 class HostAddressManager:

--- a/cmapi/cmapi_server/managers/host_identity.py
+++ b/cmapi/cmapi_server/managers/host_identity.py
@@ -1,3 +1,19 @@
+"""
+This module implements hostname <-> IP addr resolution logic (it is not as simple as it may look).
+
+Most of CMAPI/Columnstore code assumes that each node has 1 IP address and 1 hostname.
+But in reality it can have N IP addresses and M hostnames, and we need some way to choose which IP/hostname will be primary.
+Also some of these names will not be visible from the other hosts (like local aliases from systemd).
+And some sources are more reliable than the others (DNS > /etc/hosts), so we must order them by reliablity and choose the most reliable.
+
+So:
+1. We must choose 1 IP address and 0/1 hostnames as primary (of many)
+2. We need to filter out unreliable names
+3. We must order IPs/hostnames by source reliability
+4. There can be very many resolving sources, so we cannot resolve everything ourselves, and must rely on OS resolving
+  (see /etc/nsswitch.conf, there are local /etc/hosts, DNS, mDNS, systemd-resolved, LDAP, myhostname, etc)
+5. But most important sources (DNS and /etc/hosts, recommended by our manual...) must be checked and ordered by our policy
+"""
 import hashlib
 import ipaddress
 import logging
@@ -12,6 +28,7 @@ import dns.reversename
 
 from cmapi_server.exceptions import CMAPIBasicError, ResolutionError, ResolutionPolicyViolationError
 from cmapi_server.managers.network import NetworkManager
+from cmapi_server.managers.resolving_sources import get_resolving_source
 
 IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 
@@ -310,44 +327,14 @@ class HostAddressManager:
 
     def _resolve_dns(self, hostname: str) -> list[IPAddress]:
         """Resolve the given hostname using DNS and return addresses."""
-        ipv4_texts: list[str] = []
-        ipv6_texts: list[str] = []
-        try:
-            ipv4_texts = self._dns_resolve_ipv4(hostname)
-        except dns.resolver.NoAnswer:
-            logger.warning('IPv4 lookup returned no records for %s', hostname)
-            ipv4_texts = []
-        except Exception:
-            logger.exception('IPv4 lookup unexpected failure for %s', hostname)
-            raise
-
-        if self._policy.allow_ipv6:
-            try:
-                ipv6_texts = self._dns_resolve_ipv6(hostname)
-            except dns.resolver.NoAnswer:
-                logger.warning('IPv6 lookup returned no records for %s', hostname)
-                ipv6_texts = []
-            except Exception:
-                logger.exception('IPv6 lookup unexpected failure for %s', hostname)
-                raise
-
-        addrs: list[IPAddress] = []
-        for ip_text in ipv4_texts + ipv6_texts:
-            ip = _ip_or_none(ip_text)
-            if ip is None:
-                logger.error('DNS returned invalid IP address %s for host name %s, skipping', ip_text, hostname)
-                continue
-            addrs.append(ip)
-
-        return addrs
+        resolver = get_resolving_source('dns')
+        return resolver.resolve(hostname)
 
     def _get_names_of_ip(self, ip: IPAddress) -> list[str]:
         """Fetch PTR names for an IP via DNS."""
         try:
-            return self._dns_reverse(str(ip))
-        except dns.resolver.NoAnswer:
-            logger.warning('ip-to-name lookup returned no records for %s', ip)
-            return []
+            resolver = get_resolving_source('dns')
+            return resolver.reverse(ip)
         except Exception:
             logger.exception('ip-to-name lookup unexpected failure for %s', ip)
             raise

--- a/cmapi/cmapi_server/managers/host_identity.py
+++ b/cmapi/cmapi_server/managers/host_identity.py
@@ -217,9 +217,13 @@ class HostAddressManager:
                 logger.exception('Failed to get reverse names for %s', ip)
                 continue
 
-            if normalized in reverse_names:
-                logger.debug('Roundtrip check passed for %s: %s', hostname, ip)
-                return identity, True
+            for rev_name in reverse_names:
+                # Count reverse names like "mcs1.<domain>" as a match for "mcs"
+                # It is true because of search_domain/ndots (in /etc/resolv.conf)
+                # Resolvers respect these options and will add them to the hostname
+                if rev_name == normalized or rev_name.startswith(normalized + '.'):
+                    logger.debug('Roundtrip check passed for %s: %s', hostname, ip)
+                    return identity, True
 
         logger.warning('Roundtrip check failed for %s', hostname)
         return identity, False

--- a/cmapi/cmapi_server/managers/host_identity.py
+++ b/cmapi/cmapi_server/managers/host_identity.py
@@ -2,9 +2,9 @@ import hashlib
 import ipaddress
 import logging
 import socket
-import time
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from functools import lru_cache
 from typing import Optional, Union
 
@@ -104,7 +104,25 @@ class HostIdentity:
     primary_ip: str
     primary_name: Optional[str]
     unique_key: str  # unique id of this host, will be used later for aliases
-    observed_at: float = field(default_factory=lambda: time.time())
+    observed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def __repr__(self) -> str:
+        parts: list[str] = [
+            f'input={self.input!r}',
+            f'primary_ip={self.primary_ip!r}',
+        ]
+        if self.primary_name is not None:
+            parts.append(f'primary_name={self.primary_name!r}')
+        if self.addresses != [self.primary_ip]:
+            parts.append(f'addresses={self.addresses!r}')
+        if self.names != [self.primary_name]:
+            parts.append(f'names={self.names!r}')
+        parts.append(f'unique_key={self.unique_key}')
+        parts.append(f'observed_at={self.observed_at.replace(microsecond=0).isoformat()!r}')
+        return 'HostIdentity(' + ', '.join(parts) + ')'
+
+    def __str__(self) -> str:
+        return repr(self)
 
     @staticmethod
     def from_policy(input: str, policy: ResolutionPolicy, ips: Sequence[IPAddress], names: Sequence[str]) -> 'HostIdentity':

--- a/cmapi/cmapi_server/managers/host_identity.py
+++ b/cmapi/cmapi_server/managers/host_identity.py
@@ -18,79 +18,6 @@ IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 logger = logging.getLogger(__name__)
 
 
-@lru_cache(maxsize=1)  # singleton
-def get_host_address_manager() -> 'HostAddressManager':
-    return HostAddressManager()
-
-
-@dataclass(frozen=True)
-class ResolutionPolicy:
-    """Class to represent our requirements for the addresses, how are they resolved,
-      what must be filtered out, how addresses are ordered, etc.
-
-    It's nice to separate these concerns from the resolving itself.
-    Also maybe in the future we'll make it configurable by users.
-    """
-
-    allow_private_ips: bool = True
-    allow_ipv6: bool = False
-    require_hostname: bool = False
-
-    def filter_addresses(self, addrs: Iterable[str]) -> list[IPAddress]:
-        """Filter out IP addresses that don't match the policy."""
-        ips: list[IPAddress] = []
-        logger.debug(
-            'Filtering addresses: %s (allow_private_ips=%s, allow_ipv6=%s)',
-            list(addrs), self.allow_private_ips, self.allow_ipv6
-        )
-        for addr in addrs:
-            ip = ip_or_none(addr)
-            if ip is None:
-                logger.debug('Skip %s: not a valid IP literal', addr)
-                continue
-
-            # Fixed rejections first
-            if ip.is_loopback:
-                logger.debug('Skip %s: loopback address', addr)
-                continue
-            if ip.is_link_local:
-                logger.debug('Skip %s: link-local address', addr)
-                continue
-            if ip.is_multicast:
-                logger.debug('Skip %s: multicast address', addr)
-                continue
-            if isinstance(ip, ipaddress.IPv4Address) and int(ip) == int(ipaddress.IPv4Address('255.255.255.255')):
-                logger.debug('Skip %s: IPv4 broadcast address', addr)
-                continue
-
-            # Policy conditionals
-            if not self.allow_ipv6 and isinstance(ip, ipaddress.IPv6Address):
-                logger.debug('Skip %s: IPv6 not allowed by policy', addr)
-                continue
-            if not ip.is_global and not ip.is_private:
-                logger.debug('Skip %s: neither global nor private address', addr)
-                continue
-            if ip.is_private and not self.allow_private_ips:
-                logger.debug('Skip %s: private address but private use disabled', addr)
-                continue
-
-            ips.append(ip)
-            logger.debug('Accept %s', addr)
-        return ips
-
-    def order_addresses(self, ips: Sequence[IPAddress]) -> list[IPAddress]:
-        """Order IPs deterministically to choose the primary IP."""
-        def key(ip: IPAddress) -> tuple[int, int, int, int, int, int, int, int]:
-            is_global = 0 if ip.is_global else 1
-            is_ipv4 = 0 if isinstance(ip, ipaddress.IPv4Address) else 1
-            return (
-                is_global,
-                is_ipv4,
-                *list(ip.packed)
-            )
-        return sorted(ips, key=key)
-
-
 @dataclass
 class HostIdentity:
     """Host's network identity, IP addrs and hostnames that are visible from other hosts"""
@@ -104,7 +31,7 @@ class HostIdentity:
     observed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
     @staticmethod
-    def from_policy(input: str, policy: ResolutionPolicy, ips: Sequence[IPAddress], names: Sequence[str]) -> 'HostIdentity':
+    def from_policy(input: str, policy: 'ResolutionPolicy', ips: Sequence[IPAddress], names: Sequence[str]) -> 'HostIdentity':
         """Construct a HostIdentity from filtered addresses and names using policy ordering."""
         if not ips:
             raise ResolutionPolicyViolationError('All resolved addresses were rejected by policy.')
@@ -156,6 +83,74 @@ class HostIdentity:
         return repr(self)
 
 
+@dataclass(frozen=True)
+class ResolutionPolicy:
+    """Class to represent our requirements for the addresses, how are they resolved,
+      what must be filtered out, how addresses are ordered, etc.
+
+    It's nice to separate these concerns from the resolving itself.
+    Also maybe in the future we'll make it configurable by users.
+    """
+
+    allow_private_ips: bool = True
+    allow_ipv6: bool = False
+    require_hostname: bool = False
+
+    def filter_addresses(self, addrs: Iterable[str]) -> list[IPAddress]:
+        """Filter out IP addresses that don't match the policy."""
+        ips: list[IPAddress] = []
+        logger.debug(
+            'Filtering addresses: %s (allow_private_ips=%s, allow_ipv6=%s)',
+            list(addrs), self.allow_private_ips, self.allow_ipv6
+        )
+        for addr in addrs:
+            ip = _ip_or_none(addr)
+            if ip is None:
+                logger.error('Skip %s: not a valid IP literal', addr)
+                continue
+
+            # Fixed rejections first
+            if ip.is_loopback:
+                logger.debug('Skip %s: loopback address', addr)
+                continue
+            if ip.is_link_local:
+                logger.debug('Skip %s: link-local address', addr)
+                continue
+            if ip.is_multicast:
+                logger.debug('Skip %s: multicast address', addr)
+                continue
+            if isinstance(ip, ipaddress.IPv4Address) and int(ip) == int(ipaddress.IPv4Address('255.255.255.255')):
+                logger.debug('Skip %s: IPv4 broadcast address', addr)
+                continue
+
+            # Policy conditionals
+            if not self.allow_ipv6 and isinstance(ip, ipaddress.IPv6Address):
+                logger.debug('Skip %s: IPv6 not allowed by policy', addr)
+                continue
+            if not ip.is_global and not ip.is_private:
+                logger.debug('Skip %s: neither global nor private address', addr)
+                continue
+            if ip.is_private and not self.allow_private_ips:
+                logger.debug('Skip %s: private address but private use disabled', addr)
+                continue
+
+            ips.append(ip)
+            logger.debug('Accept %s', addr)
+        return ips
+
+    def order_addresses(self, ips: Sequence[IPAddress]) -> list[IPAddress]:
+        """Order IPs deterministically to choose the primary IP."""
+        def key(ip: IPAddress) -> tuple[int, int, int, int, int, int, int, int]:
+            is_global = 0 if ip.is_global else 1
+            is_ipv4 = 0 if isinstance(ip, ipaddress.IPv4Address) else 1
+            return (
+                is_global,
+                is_ipv4,
+                *list(ip.packed)
+            )
+        return sorted(ips, key=key)
+
+
 class HostAddressManager:
     """Calculates HostIdentity from passed hostname or IP address."""
 
@@ -170,7 +165,7 @@ class HostAddressManager:
 
         target = target.strip()
 
-        ip = ip_or_none(target)
+        ip = _ip_or_none(target)
         if ip is not None:
             identity = self._get_identity_from_ip(ip, target)
         else:
@@ -195,7 +190,7 @@ class HostAddressManager:
             try:
                 return self.get_identity(ip_text)
             except CMAPIBasicError:
-                logger.exception('Local identity candidate %s failed resolution', ip_text)
+                logger.debug('Local identity candidate %s failed resolution', ip_text)
                 continue
         raise ResolutionPolicyViolationError('Could not determine any acceptable local IP addresses under current policy.')
 
@@ -211,7 +206,7 @@ class HostAddressManager:
             return identity, False
 
         for ip_text in identity.ips:
-            ip = ip_or_none(ip_text)
+            ip = _ip_or_none(ip_text)
             if ip is None:
                 logger.error('Invalid IP address: %s', ip_text)
                 continue
@@ -229,10 +224,6 @@ class HostAddressManager:
         logger.warning('Roundtrip check failed for %s', hostname)
         return identity, False
 
-    @property
-    def policy(self) -> ResolutionPolicy:
-        return self._policy
-
     def _get_identity_from_ip(self, ip: IPAddress, original_input: str) -> HostIdentity:
         if not self._policy.filter_addresses([str(ip)]):
             raise ResolutionPolicyViolationError('Input IP address was rejected by policy')
@@ -246,9 +237,10 @@ class HostAddressManager:
 
     def _get_identity_from_hostname(self, hostname: str) -> HostIdentity:
         normalized = hostname.strip().lower()
-        if not _is_fqdn(normalized):
+        if _is_fqdn(normalized):
+            return self._get_identity_from_fqdn(normalized)
+        else:
             return self._get_identity_from_non_fqdn(hostname)
-        return self._get_identity_from_fqdn(normalized)
 
     def _get_identity_from_fqdn(self, fqdn: str) -> HostIdentity:
         # Get IPs from hostname (via DNS), filter them, then get names from each IP
@@ -296,7 +288,7 @@ class HostAddressManager:
         # Collect names of IPs
         names: set[str] = set()
         for ip_text in list(candidate_ips):
-            ip = ip_or_none(ip_text)
+            ip = _ip_or_none(ip_text)
             if ip is None:
                 logger.error('Invalid IP address: %s', ip_text)
                 continue
@@ -337,7 +329,7 @@ class HostAddressManager:
 
         addrs: list[IPAddress] = []
         for ip_text in ipv4_texts + ipv6_texts:
-            ip = ip_or_none(ip_text)
+            ip = _ip_or_none(ip_text)
             if ip is None:
                 logger.error('DNS returned invalid IP address %s for host name %s, skipping', ip_text, hostname)
                 continue
@@ -383,9 +375,9 @@ class HostAddressManager:
         names: list[str] = []
         for ptr_rdata in answer:
             try:
-                fqdn_name = str(ptr_rdata.target).rstrip('.').lower()
-                if _is_fqdn(fqdn_name):
-                    names.append(fqdn_name)
+                name = str(ptr_rdata.target).rstrip('.').lower()
+                if name:
+                    names.append(name)
             except Exception:
                 continue
         return names
@@ -393,21 +385,27 @@ class HostAddressManager:
     def _contains_private(self, addrs: list[str]) -> bool:
         """Return True if any resolvable address string is a private IP."""
         for addr in addrs:
-            ip = ip_or_none(addr)
+            ip = _ip_or_none(addr)
             if ip is None:
                 continue
             if ip.is_private:
                 return True
         return False
 
-def ip_or_none(val: str) -> Optional[IPAddress]:
+
+@lru_cache(maxsize=1)  # singleton
+def get_host_address_manager() -> 'HostAddressManager':
+    return HostAddressManager()
+
+
+def _ip_or_none(val: str) -> Optional[IPAddress]:
     try:
         return ipaddress.ip_address(val)
     except ValueError:
         return None
 
-def is_ip_address(val: str) -> bool:
-    return ip_or_none(val) is not None
+def _is_ip_address(val: str) -> bool:
+    return _ip_or_none(val) is not None
 
 def _is_fqdn(name: str) -> bool:
     """Return True if the string is a valid FQDN (lower-cased, no trailing dot).

--- a/cmapi/cmapi_server/managers/host_identity.py
+++ b/cmapi/cmapi_server/managers/host_identity.py
@@ -1,0 +1,325 @@
+import hashlib
+import ipaddress
+import logging
+import socket
+import time
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Optional, Union
+
+import dns.resolver
+import dns.reversename
+
+from cmapi_server.exceptions import CMAPIBasicError, ResolutionError, ResolutionPolicyViolationError
+from cmapi_server.managers.network import NetworkManager
+
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)  # singleton
+def get_host_address_manager() -> 'HostAddressManager':
+    return HostAddressManager()
+
+
+@dataclass(frozen=True)
+class ResolutionPolicy:
+    """Rules controlling how hosts are resolved, what is/isn't allowed (like IPv6)."""
+
+    allow_private_ips: bool = True
+    allow_ipv6: bool = False
+    require_hostname: bool = False
+
+    def validate_hostname(self, name: str) -> str:
+        """Validate and normalize a hostname to FQDN."""
+        normalized = name.strip().lower()
+        if not _is_fqdn(normalized):
+            raise ResolutionPolicyViolationError(f'The name {name} is not a fully qualified domain name.')
+        return normalized
+
+    def filter_addresses(self, addrs: Iterable[str]) -> list[IPAddress]:
+        """Filter out IP addresses that don't match the policy."""
+        ips: list[IPAddress] = []
+        logger.debug(
+            'Filtering addresses: %s (allow_private_ips=%s, allow_ipv6=%s)',
+            list(addrs), self.allow_private_ips, self.allow_ipv6
+        )
+        for addr in addrs:
+            try:
+                ip = ipaddress.ip_address(addr)
+            except ValueError:
+                logger.debug('Skip %s: not a valid IP literal', addr)
+                continue
+
+            # Fixed rejections first
+            if ip.is_loopback:
+                logger.debug('Skip %s: loopback address', addr)
+                continue
+            if ip.is_link_local:
+                logger.debug('Skip %s: link-local address', addr)
+                continue
+            if ip.is_multicast:
+                logger.debug('Skip %s: multicast address', addr)
+                continue
+            if isinstance(ip, ipaddress.IPv4Address) and int(ip) == int(ipaddress.IPv4Address('255.255.255.255')):
+                logger.debug('Skip %s: IPv4 broadcast address', addr)
+                continue
+
+            # Policy conditionals
+            if not self.allow_ipv6 and isinstance(ip, ipaddress.IPv6Address):
+                logger.debug('Skip %s: IPv6 not allowed by policy', addr)
+                continue
+            if not ip.is_global and not ip.is_private:
+                logger.debug('Skip %s: neither global nor private address', addr)
+                continue
+            if ip.is_private and not self.allow_private_ips:
+                logger.debug('Skip %s: private address but private use disabled', addr)
+                continue
+
+            ips.append(ip)
+            logger.debug('Accept %s', addr)
+        return ips
+
+    def order_addresses(self, ips: Sequence[IPAddress]) -> list[IPAddress]:
+        """Deterministic ordering: global first, then IPv4 before IPv6, then sort by numeric value."""
+        def key(ip: IPAddress) -> tuple[int, int, int, int, int, int, int, int]:
+            is_global = 0 if ip.is_global else 1
+            is_ipv4 = 0 if isinstance(ip, ipaddress.IPv4Address) else 1
+            return (
+                is_global,
+                is_ipv4,
+                *list(ip.packed)
+            )
+        return sorted(ips, key=key)
+
+
+@dataclass
+class HostIdentity:
+    """Normalized result of host resolution (after policy is enforced)"""
+    input: str
+    addresses: list[str]
+    names: list[str]
+    primary_ip: str
+    primary_name: Optional[str]
+    unique_key: str  # unique id of this host, will be used later for aliases
+    observed_at: float = field(default_factory=lambda: time.time())
+
+    @staticmethod
+    def from_policy(input: str, policy: ResolutionPolicy, ips: Sequence[IPAddress], names: Sequence[str]) -> 'HostIdentity':
+        """Construct a HostIdentity from filtered addresses and names using policy ordering and hashing rules."""
+        if not ips:
+            raise ResolutionPolicyViolationError('All resolved addresses were rejected by policy (loopback / link-local / multicast).')
+        ordered = policy.order_addresses(ips)
+        addresses = [str(ip) for ip in ordered]
+
+        # Calculate host unique key from its addresses (we prefer globals as more stable ones)
+        globals_sorted = [str(ip) for ip in ordered if ip.is_global]
+        privates_sorted = [str(ip) for ip in ordered if ip.is_private]
+        basis = globals_sorted if globals_sorted else privates_sorted
+        hasher = hashlib.sha256()
+        for address_text in basis:
+            hasher.update(address_text.encode('utf-8'))
+        unique_key = hasher.hexdigest()
+
+        primary_ip = addresses[0]
+        primary_name = names[0] if names else None
+        return HostIdentity(
+            input=input,
+            addresses=addresses,
+            names=list(names),
+            primary_ip=primary_ip,
+            primary_name=primary_name,
+            unique_key=unique_key,
+        )
+
+
+class HostAddressManager:
+    """In-memory resolver that performs DNS-only lookups, enforces policy, and caches results."""
+
+    def __init__(self, policy: Optional[ResolutionPolicy] = None) -> None:
+        self._policy = policy if policy is not None else ResolutionPolicy()
+        self._cache: dict[str, HostIdentity] = {}
+
+    @property
+    def policy(self) -> ResolutionPolicy:
+        return self._policy
+
+    def get_identity(self, target: str) -> HostIdentity:
+        """Resolve and normalize a hostname or IP under the current policy."""
+        if target in self._cache:
+            return self._cache[target]
+
+        target = target.strip()
+        # If target is IP literal
+        try:
+            literal_ip = ipaddress.ip_address(target)
+        except ValueError:
+            literal_ip = None
+
+        if literal_ip is not None:
+            # Use the literal IP only; names via PTR if available
+            candidate_ips: set[str] = {str(literal_ip)}
+            names_set: set[str] = set(self._reverse_dns_names(literal_ip))
+            ips = self._policy.filter_addresses(candidate_ips)
+            if self._policy.require_hostname and not names_set:
+                logger.debug('Reject %s: no PTR hostname found and policy requires hostname', target)
+                raise ResolutionPolicyViolationError('Policy requires a hostname for the input IP address (no PTR record found).')
+            if not ips:
+                raise ResolutionPolicyViolationError('Input IP address was rejected by policy')
+            identity = HostIdentity.from_policy(target, self._policy, ips, sorted(names_set))
+            self._cache[target] = identity
+            return identity
+
+        # Target is hostname: if it's a valid FQDN, use DNS path; otherwise treat as local alias (e.g., localhost)
+        try:
+            fqdn = self._policy.validate_hostname(target)
+        except ResolutionPolicyViolationError:
+            fqdn = None
+        if fqdn is None:
+            # Non-FQDN (e.g., localhost). Seed with system resolver only.
+            candidate_ips: set[str] = set(
+                NetworkManager.resolve_hostname_to_ips(
+                    target,
+                    only_ipv4=not self._policy.allow_ipv6,
+                    exclude_loopback=False,
+                )
+            )
+            # Collect names by PTR of candidate IPs and include original token
+            names_set: set[str] = {target}
+            for ip_text in list(candidate_ips):
+                try:
+                    ip_obj = ipaddress.ip_address(ip_text)
+                except ValueError:
+                    continue
+                names_set.update(self._reverse_dns_names(ip_obj))
+            ips = self._policy.filter_addresses(candidate_ips)
+            if not ips:
+                raise ResolutionPolicyViolationError('All resolved addresses were rejected by policy.')
+            identity = HostIdentity.from_policy(target, self._policy, ips, sorted(names_set))
+            self._cache[target] = identity
+            return identity
+
+        # FQDN path: forward DNS, then PTR of accepted IPs; no further expansion
+        addrs, _ = self._resolve_dns(fqdn)
+        if not addrs:
+            raise ResolutionError(f'Could not resolve {fqdn} to any IP addresses.')
+        ips = self._policy.filter_addresses([str(ip) for ip in addrs])
+        names_set: set[str] = {fqdn}
+        ptr_match = False
+        for ip in ips:
+            ptrs = self._reverse_dns_names(ip)
+            if fqdn in ptrs:
+                ptr_match = True
+            names_set.update(ptrs)
+        if not ptr_match:
+            raise ResolutionError(f'{fqdn} failed the DNS round-trip check — forward and reverse records do not match.')
+        if not ips:
+            raise ResolutionPolicyViolationError('All resolved addresses were rejected by policy.')
+        identity = HostIdentity.from_policy(fqdn, self._policy, ips, sorted(names_set))
+        self._cache[target] = identity
+        return identity
+
+    def get_local_identity(self) -> HostIdentity:
+        """Return normalized identity of the current host."""
+        name = socket.getfqdn().strip().lower()
+        candidates: list[str] = []
+        if _is_fqdn(name):
+            candidates.append(name)
+        try:
+            local_ips = NetworkManager.get_current_node_ips(
+                ignore_loopback=False,
+                only_ipv4=not self._policy.allow_ipv6,
+            )
+        except CMAPIBasicError:
+            logger.exception('Failed to get local IP addresses for identity resolution')
+            local_ips = []
+        candidates.extend(local_ips)
+        seen: set[str] = set()
+        for candidate in candidates:
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            try:
+                return self.get_identity(candidate)
+            except CMAPIBasicError:
+                logger.exception('Local identity candidate failed resolution: %s', candidate)
+                continue
+        raise ResolutionPolicyViolationError('Could not determine any acceptable local IP addresses under current policy.')
+
+    def _resolve_dns(self, hostname: str) -> tuple[list[IPAddress], list[str]]:
+        """Resolve the given hostname using DNS and return (addresses, names)."""
+        resolver = dns.resolver.Resolver(configure=True)
+
+        # IPv4
+        a_records: list[IPAddress] = []
+        try:
+            for a_rdata in resolver.resolve(hostname, 'A', raise_on_no_answer=False):
+                a_records.append(ipaddress.ip_address(a_rdata.to_text()))
+        except Exception:
+            logger.exception('A lookup failed for %s', hostname)
+
+        # IPv6
+        aaaa_records: list[IPAddress] = []
+        if self._policy.allow_ipv6:
+            try:
+                for aaaa_rdata in resolver.resolve(hostname, 'AAAA', raise_on_no_answer=False):
+                    aaaa_records.append(ipaddress.ip_address(aaaa_rdata.to_text()))
+            except Exception:
+                logger.exception('AAAA lookup failed for %s', hostname)
+
+        names = [hostname]
+        return a_records + aaaa_records, names
+
+    def _reverse_dns_names(self, ip: IPAddress) -> list[str]:
+        """Fetch PTR names for an IP via DNS."""
+        try:
+            reverse_name = dns.reversename.from_address(str(ip))
+            answer = dns.resolver.resolve(reverse_name, 'PTR', raise_on_no_answer=False)
+            names: list[str] = []
+            for ptr_rdata in answer:
+                fqdn_name = str(ptr_rdata.target).rstrip('.').lower()
+                if _is_fqdn(fqdn_name):
+                    names.append(fqdn_name)
+            return names
+        except Exception:
+            logger.exception('PTR lookup failed for %s', ip)
+            return []
+
+    def _contains_private(self, addrs: list[str]) -> bool:
+        """Return True if any resolvable address string is a private IP."""
+        for addr in addrs:
+            try:
+                if ipaddress.ip_address(addr).is_private:
+                    return True
+            except ValueError:
+                continue
+        return False
+
+
+def _is_fqdn(name: str) -> bool:
+    """Return True if the string is a valid FQDN (lower-cased, no trailing dot).
+
+    Rules for labels (per common DNS practice):
+    - Each label is 1..63 characters.
+    - Only ASCII letters, digits, and hyphen are allowed (LDH rule).
+    - A label cannot start or end with a hyphen.
+    - The name must contain at least one dot separating labels.
+    """
+    if not name:
+        return False
+    if name.endswith('.'):
+        return False
+    if '.' not in name:
+        return False
+    labels = name.split('.')
+    for label in labels:
+        if not label or len(label) > 63:
+            return False
+        for ch in label:
+            if not (ch.isalnum() or ch == '-'):
+                return False
+        if label[0] == '-' or label[-1] == '-':
+            return False
+    return True

--- a/cmapi/cmapi_server/managers/host_identity.py
+++ b/cmapi/cmapi_server/managers/host_identity.py
@@ -1,7 +1,6 @@
 import hashlib
 import ipaddress
 import logging
-import socket
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -26,18 +25,16 @@ def get_host_address_manager() -> 'HostAddressManager':
 
 @dataclass(frozen=True)
 class ResolutionPolicy:
-    """Rules controlling how hosts are resolved, what is/isn't allowed (like IPv6)."""
+    """Class to represent our requirements for the addresses, how are they resolved,
+      what must be filtered out, how addresses are ordered, etc.
+
+    It's nice to separate these concerns from the resolving itself.
+    Also maybe in the future we'll make it configurable by users.
+    """
 
     allow_private_ips: bool = True
     allow_ipv6: bool = False
     require_hostname: bool = False
-
-    def validate_hostname(self, name: str) -> str:
-        """Validate and normalize a hostname to FQDN."""
-        normalized = name.strip().lower()
-        if not _is_fqdn(normalized):
-            raise ResolutionPolicyViolationError(f'The name {name} is not a fully qualified domain name.')
-        return normalized
 
     def filter_addresses(self, addrs: Iterable[str]) -> list[IPAddress]:
         """Filter out IP addresses that don't match the policy."""
@@ -47,9 +44,8 @@ class ResolutionPolicy:
             list(addrs), self.allow_private_ips, self.allow_ipv6
         )
         for addr in addrs:
-            try:
-                ip = ipaddress.ip_address(addr)
-            except ValueError:
+            ip = ip_or_none(addr)
+            if ip is None:
                 logger.debug('Skip %s: not a valid IP literal', addr)
                 continue
 
@@ -83,7 +79,7 @@ class ResolutionPolicy:
         return ips
 
     def order_addresses(self, ips: Sequence[IPAddress]) -> list[IPAddress]:
-        """Deterministic ordering: global first, then IPv4 before IPv6, then sort by numeric value."""
+        """Order IPs deterministically to choose the primary IP."""
         def key(ip: IPAddress) -> tuple[int, int, int, int, int, int, int, int]:
             is_global = 0 if ip.is_global else 1
             is_ipv4 = 0 if isinstance(ip, ipaddress.IPv4Address) else 1
@@ -101,7 +97,7 @@ class HostIdentity:
     input: str
     # The first, most important IP addr and host name (ordering is done by policy)
     primary_ip: str
-    primary_name: Optional[str]
+    primary_name: Optional[str]  # Name can be missing (but policy can make it required)
     ips: list[str]  # All IP addrs
     names: list[str]  # All host names (only those that are visible to other hosts)
     unique_key: str  # unique id of this host, will be used later for aliases
@@ -109,35 +105,35 @@ class HostIdentity:
 
     @staticmethod
     def from_policy(input: str, policy: ResolutionPolicy, ips: Sequence[IPAddress], names: Sequence[str]) -> 'HostIdentity':
-        """Construct a HostIdentity from filtered addresses and names using policy ordering and hashing rules."""
+        """Construct a HostIdentity from filtered addresses and names using policy ordering."""
         if not ips:
-            raise ResolutionPolicyViolationError('All resolved addresses were rejected by policy (loopback / link-local / multicast).')
-        ordered = policy.order_addresses(ips)
-        addresses = [str(ip) for ip in ordered]
+            raise ResolutionPolicyViolationError('All resolved addresses were rejected by policy.')
 
+        ordered_ips = policy.order_addresses(ips)
         # Calculate host unique key from its addresses (we prefer globals as more stable ones)
-        globals_sorted = [str(ip) for ip in ordered if ip.is_global]
-        privates_sorted = [str(ip) for ip in ordered if ip.is_private]
-        basis = globals_sorted if globals_sorted else privates_sorted
+        globals_ordered = [ip for ip in ordered_ips if ip.is_global]
+        privates_ordered = [ip for ip in ordered_ips if ip.is_private]
+        to_hash = globals_ordered if globals_ordered else privates_ordered
         hasher = hashlib.sha256()
-        for address_text in basis:
-            hasher.update(address_text.encode('utf-8'))
+        for ip in to_hash:
+            hasher.update(str(ip).encode('utf-8'))
         unique_key = hasher.hexdigest()
 
-        primary_ip = addresses[0]
-        primary_name = names[0] if names else None
         return HostIdentity(
             input=input,
-            ips=addresses,
+            ips=[str(ip) for ip in ordered_ips],
             names=list(names),
-            primary_ip=primary_ip,
-            primary_name=primary_name,
+            primary_ip=str(ordered_ips[0]),
+            primary_name=names[0] if names else None,
             unique_key=unique_key,
         )
 
     @property
     def effective_hostname(self) -> str:
-        """Hostname or primary IP if hostname is not set"""
+        """Hostname or primary IP if hostname is not set
+
+        If policy requires host to have a hostname and it doesn't, we won't even get here
+        """
         return self.primary_name or self.primary_ip
 
     def __repr__(self) -> str:
@@ -161,115 +157,45 @@ class HostIdentity:
 
 
 class HostAddressManager:
-    """In-memory resolver that performs DNS-only lookups, enforces policy, and caches results."""
+    """Calculates HostIdentity from passed hostname or IP address."""
 
     def __init__(self, policy: Optional[ResolutionPolicy] = None) -> None:
         self._policy = policy if policy is not None else ResolutionPolicy()
         self._cache: dict[str, HostIdentity] = {}
 
-    @property
-    def policy(self) -> ResolutionPolicy:
-        return self._policy
-
     def get_identity(self, target: str) -> HostIdentity:
-        """Resolve and normalize a hostname or IP under the current policy."""
+        """Resolve and normalize a hostname or IP."""
         if target in self._cache:
             return self._cache[target]
 
         target = target.strip()
-        # If target is IP literal
-        try:
-            literal_ip = ipaddress.ip_address(target)
-        except ValueError:
-            literal_ip = None
 
-        if literal_ip is not None:
-            # Use the literal IP only; names via PTR if available
-            candidate_ips: set[str] = {str(literal_ip)}
-            names_set: set[str] = set(self._reverse_dns_names(literal_ip))
-            ips = self._policy.filter_addresses(candidate_ips)
-            if self._policy.require_hostname and not names_set:
-                logger.debug('Reject %s: no PTR hostname found and policy requires hostname', target)
-                raise ResolutionPolicyViolationError('Policy requires a hostname for the input IP address (no PTR record found).')
-            if not ips:
-                raise ResolutionPolicyViolationError('Input IP address was rejected by policy')
-            identity = HostIdentity.from_policy(target, self._policy, ips, sorted(names_set))
-            self._cache[target] = identity
-            return identity
+        ip = ip_or_none(target)
+        if ip is not None:
+            identity = self._get_identity_from_ip(ip, target)
+        else:
+            identity = self._get_identity_from_hostname(target)
 
-        # Target is hostname: if it's a valid FQDN, use DNS path; otherwise treat as local alias (e.g., localhost)
-        try:
-            fqdn = self._policy.validate_hostname(target)
-        except ResolutionPolicyViolationError:
-            fqdn = None
-        if fqdn is None:
-            # Non-FQDN (e.g., localhost). Seed with system resolver only.
-            candidate_ips: set[str] = set(
-                NetworkManager.resolve_hostname_to_ips(
-                    target,
-                    only_ipv4=not self._policy.allow_ipv6,
-                    exclude_loopback=False,
-                )
-            )
-            # Collect names by PTR of candidate IPs and include original token
-            names_set: set[str] = {target}
-            for ip_text in list(candidate_ips):
-                try:
-                    ip_obj = ipaddress.ip_address(ip_text)
-                except ValueError:
-                    continue
-                names_set.update(self._reverse_dns_names(ip_obj))
-            ips = self._policy.filter_addresses(candidate_ips)
-            if not ips:
-                raise ResolutionPolicyViolationError('All resolved addresses were rejected by policy.')
-            identity = HostIdentity.from_policy(target, self._policy, ips, sorted(names_set))
-            self._cache[target] = identity
-            return identity
-
-        # FQDN path: forward DNS, then PTR of accepted IPs; no further expansion
-        addrs, _ = self._resolve_dns(fqdn)
-        if not addrs:
-            raise ResolutionError(f'Could not resolve {fqdn} to any IP addresses.')
-        ips = self._policy.filter_addresses([str(ip) for ip in addrs])
-        names_set: set[str] = {fqdn}
-        ptr_match = False
-        for ip in ips:
-            ptrs = self._reverse_dns_names(ip)
-            if fqdn in ptrs:
-                ptr_match = True
-            names_set.update(ptrs)
-        if not ptr_match:
-            raise ResolutionError(f'{fqdn} failed the DNS round-trip check — forward and reverse records do not match.')
-        if not ips:
-            raise ResolutionPolicyViolationError('All resolved addresses were rejected by policy.')
-        identity = HostIdentity.from_policy(fqdn, self._policy, ips, sorted(names_set))
         self._cache[target] = identity
         return identity
 
     def get_local_identity(self) -> HostIdentity:
-        """Return normalized identity of the current host."""
-        name = socket.getfqdn().strip().lower()
-        candidates: list[str] = []
-        if _is_fqdn(name):
-            candidates.append(name)
+        """Calculate HostIdentity for the current host."""
         try:
             local_ips = NetworkManager.get_current_node_ips(
                 ignore_loopback=False,
                 only_ipv4=not self._policy.allow_ipv6,
             )
-        except CMAPIBasicError:
-            logger.exception('Failed to get local IP addresses for identity resolution')
-            local_ips = []
-        candidates.extend(local_ips)
-        seen: set[str] = set()
-        for candidate in candidates:
-            if candidate in seen:
-                continue
-            seen.add(candidate)
+        except:
+            logger.exception('Failed to get local IP addresses')
+            raise
+
+        # Use the first IP that resolves into a normal identity that is not rejected by policy
+        for ip_text in set(local_ips):
             try:
-                return self.get_identity(candidate)
+                return self.get_identity(ip_text)
             except CMAPIBasicError:
-                logger.exception('Local identity candidate failed resolution: %s', candidate)
+                logger.exception('Local identity candidate %s failed resolution', ip_text)
                 continue
         raise ResolutionPolicyViolationError('Could not determine any acceptable local IP addresses under current policy.')
 
@@ -285,67 +211,149 @@ class HostAddressManager:
             return identity, False
 
         for ip_text in identity.ips:
-            try:
-                ip_obj = ipaddress.ip_address(ip_text)
-            except ValueError:
+            ip = ip_or_none(ip_text)
+            if ip is None:
+                logger.error('Invalid IP address: %s', ip_text)
                 continue
+
             try:
-                reverse_names = self._reverse_dns_names(ip_obj)
+                reverse_names = self._get_names_of_ip(ip)
             except Exception:
+                logger.exception('Failed to get reverse names for %s', ip)
                 continue
+
             if normalized in reverse_names:
-                logger.debug('Roundtrip check passed for %s: %s', hostname, ip_obj)
+                logger.debug('Roundtrip check passed for %s: %s', hostname, ip)
                 return identity, True
 
         logger.warning('Roundtrip check failed for %s', hostname)
         return identity, False
 
-    def _resolve_dns(self, hostname: str) -> tuple[list[IPAddress], list[str]]:
-        """Resolve the given hostname using DNS and return (addresses, names)."""
+    @property
+    def policy(self) -> ResolutionPolicy:
+        return self._policy
+
+    def _get_identity_from_ip(self, ip: IPAddress, original_input: str) -> HostIdentity:
+        if not self._policy.filter_addresses([str(ip)]):
+            raise ResolutionPolicyViolationError('Input IP address was rejected by policy')
+
+        names: list[str] = self._get_names_of_ip(ip)
+        if self._policy.require_hostname and not names:
+            logger.warning('Reject %s: no names found for this IP and policy requires hostname', original_input)
+            raise ResolutionPolicyViolationError('Policy requires a hostname for the input IP address (no PTR record found).')
+
+        return HostIdentity.from_policy(original_input, self._policy, [ip], sorted(names))
+
+    def _get_identity_from_hostname(self, hostname: str) -> HostIdentity:
+        normalized = hostname.strip().lower()
+        if not _is_fqdn(normalized):
+            return self._get_identity_from_non_fqdn(hostname)
+        return self._get_identity_from_fqdn(normalized)
+
+    def _get_identity_from_fqdn(self, fqdn: str) -> HostIdentity:
+        # Get IPs from hostname (via DNS), filter them, then get names from each IP
+        addrs = self._resolve_dns(fqdn)
+        if not addrs:
+            raise ResolutionError(f'Could not resolve {fqdn} to any IP addresses.')
+        filtered_ips = self._policy.filter_addresses([str(ip) for ip in addrs])
+
+        # Resolve each IP back to names and check if there is any that resolved back to passed fqdn
+        names: set[str] = {fqdn}
+        roundtrip_found = False
+        for ip in filtered_ips:
+            names_of_ip = self._get_names_of_ip(ip)
+            if fqdn in names_of_ip:
+                roundtrip_found = True
+            names.update(names_of_ip)
+
+        if not roundtrip_found:
+            logger.warning(
+                'FQDN %s failed DNS forward/reverse round-trip; IPs: %s',
+                fqdn,
+                [str(ip) for ip in filtered_ips],
+            )
+            raise ResolutionError(f'{fqdn} failed the DNS round-trip check — forward and reverse records do not match.')
+
+        if not filtered_ips:
+            raise ResolutionPolicyViolationError('All resolved addresses were rejected by policy.')
+
+        return HostIdentity.from_policy(fqdn, self._policy, filtered_ips, sorted(names))
+
+    def _get_identity_from_non_fqdn(self, hostname: str) -> HostIdentity:
+        # Like FQDN version, but we know that nothing will resolve back to passed hostname
+        candidate_ips: set[str] = set(
+            NetworkManager.resolve_hostname_to_ips(
+                hostname,
+                only_ipv4=not self._policy.allow_ipv6,
+                exclude_loopback=False,
+            )
+        )
+
+        ips = self._policy.filter_addresses(candidate_ips)
+        if not ips:
+            raise ResolutionPolicyViolationError('All resolved addresses were rejected by policy.')
+
+        # Collect names of IPs
+        names: set[str] = set()
+        for ip_text in list(candidate_ips):
+            ip = ip_or_none(ip_text)
+            if ip is None:
+                logger.error('Invalid IP address: %s', ip_text)
+                continue
+            names.update(self._get_names_of_ip(ip))
+
+        if self._policy.require_hostname and not names:
+            logger.error(
+                'Non-FQDN name %s does not resolve to any valid hostname; candidate IPs: %s',
+                hostname,
+                sorted(candidate_ips),
+            )
+            raise ResolutionPolicyViolationError('Policy requires a hostname for the input host, but DNS did not return any FQDN names.')
+
+        return HostIdentity.from_policy(hostname, self._policy, ips, sorted(names))
+
+    def _resolve_dns(self, hostname: str) -> list[IPAddress]:
+        """Resolve the given hostname using DNS and return addresses."""
         ipv4_texts: list[str] = []
         ipv6_texts: list[str] = []
         try:
             ipv4_texts = self._dns_resolve_ipv4(hostname)
         except dns.resolver.NoAnswer:
-            logger.debug('IPv4 lookup returned no records for %s', hostname)
+            logger.warning('IPv4 lookup returned no records for %s', hostname)
             ipv4_texts = []
         except Exception:
             logger.exception('IPv4 lookup unexpected failure for %s', hostname)
             raise
+
         if self._policy.allow_ipv6:
             try:
                 ipv6_texts = self._dns_resolve_ipv6(hostname)
             except dns.resolver.NoAnswer:
-                logger.debug('IPv6 lookup returned no records for %s', hostname)
+                logger.warning('IPv6 lookup returned no records for %s', hostname)
                 ipv6_texts = []
             except Exception:
                 logger.exception('IPv6 lookup unexpected failure for %s', hostname)
                 raise
 
         addrs: list[IPAddress] = []
-        for t in ipv4_texts:
-            try:
-                addrs.append(ipaddress.ip_address(t))
-            except ValueError:
+        for ip_text in ipv4_texts + ipv6_texts:
+            ip = ip_or_none(ip_text)
+            if ip is None:
+                logger.error('DNS returned invalid IP address %s for host name %s, skipping', ip_text, hostname)
                 continue
-        for t in ipv6_texts:
-            try:
-                addrs.append(ipaddress.ip_address(t))
-            except ValueError:
-                continue
+            addrs.append(ip)
 
-        names = [hostname]
-        return addrs, names
+        return addrs
 
-    def _reverse_dns_names(self, ip: IPAddress) -> list[str]:
+    def _get_names_of_ip(self, ip: IPAddress) -> list[str]:
         """Fetch PTR names for an IP via DNS."""
         try:
             return self._dns_reverse(str(ip))
         except dns.resolver.NoAnswer:
-            logger.debug('PTR lookup returned no records for %s', ip)
+            logger.warning('ip-to-name lookup returned no records for %s', ip)
             return []
         except Exception:
-            logger.exception('PTR lookup unexpected failure for %s', ip)
+            logger.exception('ip-to-name lookup unexpected failure for %s', ip)
             raise
 
     # DNS abstraction methods for easier mocking
@@ -385,13 +393,21 @@ class HostAddressManager:
     def _contains_private(self, addrs: list[str]) -> bool:
         """Return True if any resolvable address string is a private IP."""
         for addr in addrs:
-            try:
-                if ipaddress.ip_address(addr).is_private:
-                    return True
-            except ValueError:
+            ip = ip_or_none(addr)
+            if ip is None:
                 continue
+            if ip.is_private:
+                return True
         return False
 
+def ip_or_none(val: str) -> Optional[IPAddress]:
+    try:
+        return ipaddress.ip_address(val)
+    except ValueError:
+        return None
+
+def is_ip_address(val: str) -> bool:
+    return ip_or_none(val) is not None
 
 def _is_fqdn(name: str) -> bool:
     """Return True if the string is a valid FQDN (lower-cased, no trailing dot).

--- a/cmapi/cmapi_server/managers/network.py
+++ b/cmapi/cmapi_server/managers/network.py
@@ -3,9 +3,8 @@ import fcntl
 import logging
 import socket
 import struct
-from dataclasses import dataclass
 from ipaddress import ip_address
-from typing import List, Optional, cast
+from typing import Optional
 
 from cmapi_server.exceptions import CMAPIBasicError
 
@@ -277,44 +276,3 @@ class NetworkManager:
                 raise CMAPIBasicError(f'No IPs found for {hostname!r}')
             ip = ip_list[0]
         return ip, hostname
-
-    @classmethod
-    def validate_hostname_fwd_rev(cls, hostname: str) -> None:
-        """Validate forward and reverse DNS for a hostname.
-
-        Checks that hostname resolves to one or more usable IPs and that at
-        least one of those IPs reverse-resolves back to the provided hostname
-        (either an exact match or an FQDN starting with the hostname are accepted).
-
-        :raises CMAPIBasicError: if validation fails
-        """
-        exclude_loopback = not cls.is_only_loopback_hostname(hostname)
-        ips = cls.resolve_hostname_to_ips(
-            hostname,
-            only_ipv4=True,
-            exclude_loopback=exclude_loopback,
-        )
-
-        if not ips:
-            raise CMAPIBasicError(
-                f"Hostname {hostname!r} did not resolve to any usable IPs. "
-                "Please fix DNS or add the host by IP."
-            )
-
-        wanted = hostname.rstrip('.').lower()
-        for ip in ips:
-            rev_names = cls.get_hostnames_by_ip(ip)
-            for rev in rev_names:
-                rev_norm = rev.rstrip('.').lower()
-                # Accept exact match ("db1" == "db1") or FQDN starting with the short hostname
-                # e.g. user provided "db1" and PTR returns "db1.example.com"
-                if rev_norm == wanted or rev_norm.startswith(wanted + '.'):
-                    return
-
-        raise CMAPIBasicError(
-            'Forward/reverse DNS check failed: '
-            f"hostname {hostname!r} resolved to {ips}, but none of these IPs "
-            f"reverse-resolve back to {hostname!r}. Consider adding the host by IP, "
-            'or fix DNS so that at least one IP has a PTR/record mapping back to '
-            'the provided hostname.'
-        )

--- a/cmapi/cmapi_server/managers/network.py
+++ b/cmapi/cmapi_server/managers/network.py
@@ -249,30 +249,3 @@ class NetworkManager:
             if not ip_address(ip).is_loopback:
                 return False
         return True
-
-    @classmethod
-    def resolve_ip_and_hostname(cls, input_str: str) -> tuple[str, Optional[str]]:
-        """Resolve input string to an (IP, hostname) pair.
-
-        :param input_str: Input which may be an IP address or a hostname
-        :type input_str: str
-        :return: A tuple containing (ip, hostname)
-        :rtype: tuple[str, str]
-        :raises CMAPIBasicError: if hostname resolution yields no IPs
-        """
-        ip: str = ''
-        hostname: Optional[str] = None
-
-        if cls.is_ip(input_str):
-            ip = input_str
-            hostname = cls.get_hostname(input_str)
-        else:
-            hostname = input_str
-            ip_list = cls.resolve_hostname_to_ips(
-                input_str,
-                exclude_loopback=not cls.is_only_loopback_hostname(input_str)
-            )
-            if not ip_list:
-                raise CMAPIBasicError(f'No IPs found for {hostname!r}')
-            ip = ip_list[0]
-        return ip, hostname

--- a/cmapi/cmapi_server/managers/resolving_sources.py
+++ b/cmapi/cmapi_server/managers/resolving_sources.py
@@ -1,35 +1,47 @@
 import ipaddress
 import logging
+from enum import Enum
 from functools import cache
-from typing import Union
+from typing import Dict, List, Set, Type, Union
 
 import dns.resolver
 import dns.reversename
+
+from cmapi_server.managers.network import NetworkManager
 
 IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 
 logger = logging.getLogger(__name__)
 
 
+class ResolvingSourceName(str, Enum):
+    DNS = 'dns'
+    OS = 'os'
+
+
 class ResolvingSource:
     """Base class for name/IP resolution sources"""
 
-    def resolve(self, hostname: str) -> list[IPAddress]:
+    name: ResolvingSourceName
+
+    def resolve(self, hostname: str) -> List[IPAddress]:
         """Forward lookup: hostname -> list of IPAddress objects."""
         raise NotImplementedError
 
-    def reverse(self, ip: IPAddress) -> list[str]:
+    def reverse(self, ip: IPAddress) -> List[str]:
         """Reverse lookup: IPAddress -> list of normalized hostnames."""
         raise NotImplementedError
 
 
 class DNSResolvingSource(ResolvingSource):
-    """DNS-based resolving source"""
+    """Use only DNS for resolution"""
 
-    def resolve(self, hostname: str) -> list[IPAddress]:
+    name = ResolvingSourceName.DNS
+
+    def resolve(self, hostname: str) -> List[IPAddress]:
         resolver = dns.resolver.Resolver(configure=True)
-        results: list[IPAddress] = []
-        seen: set[str] = set()
+        results: List[IPAddress] = []
+        seen: Set[str] = set()
 
         # A records
         try:
@@ -68,7 +80,7 @@ class DNSResolvingSource(ResolvingSource):
 
         return results
 
-    def reverse(self, ip: IPAddress) -> list[str]:
+    def reverse(self, ip: IPAddress) -> List[str]:
         ip_text = str(ip)
         reverse_name = dns.reversename.from_address(ip_text)
         try:
@@ -76,7 +88,7 @@ class DNSResolvingSource(ResolvingSource):
         except dns.resolver.NoAnswer:
             return []
 
-        names: list[str] = []
+        names: List[str] = []
         for ptr_rdata in answer:
             try:
                 name = str(ptr_rdata.target).rstrip('.').lower()
@@ -87,8 +99,44 @@ class DNSResolvingSource(ResolvingSource):
         return names
 
 
+class OSResolvingSource(ResolvingSource):
+    """Uses all the sources defined in /etc/nsswitch.conf for resolving"""
+
+    name = ResolvingSourceName.OS
+
+    def resolve(self, hostname: str) -> List[IPAddress]:
+        ip_texts = NetworkManager.resolve_hostname_to_ips(
+            hostname,
+            only_ipv4=False,
+            exclude_loopback=False,
+        )
+
+        results: List[IPAddress] = []
+        seen: set[str] = set()
+        for ip_text in ip_texts:
+            if ip_text in seen:
+                continue
+            try:
+                ip = ipaddress.ip_address(ip_text)
+            except ValueError:
+                logger.error('OS resolver returned invalid IP address %s for host name %s, skipping', ip_text, hostname)
+                continue
+            seen.add(ip_text)
+            results.append(ip)
+        return results
+
+    def reverse(self, ip: IPAddress) -> List[str]:
+        return NetworkManager.get_hostnames_by_ip(str(ip))
+
+
+_RESOLVER_REGISTRY: Dict[ResolvingSourceName, Type[ResolvingSource]] = {
+    cls.name: cls for cls in (DNSResolvingSource, OSResolvingSource)
+}
+
+
 @cache
-def get_resolving_source(name: str) -> ResolvingSource:
-    if name == 'dns':
-        return DNSResolvingSource()
-    raise ValueError(f'Unknown resolving source: {name}')
+def get_resolving_source(name: ResolvingSourceName) -> ResolvingSource:
+    cls = _RESOLVER_REGISTRY.get(name)
+    if cls is None:
+        raise ValueError(f'Unknown resolving source: {name}')
+    return cls()

--- a/cmapi/cmapi_server/managers/resolving_sources.py
+++ b/cmapi/cmapi_server/managers/resolving_sources.py
@@ -1,0 +1,94 @@
+import ipaddress
+import logging
+from functools import cache
+from typing import Union
+
+import dns.resolver
+import dns.reversename
+
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+logger = logging.getLogger(__name__)
+
+
+class ResolvingSource:
+    """Base class for name/IP resolution sources"""
+
+    def resolve(self, hostname: str) -> list[IPAddress]:
+        """Forward lookup: hostname -> list of IPAddress objects."""
+        raise NotImplementedError
+
+    def reverse(self, ip: IPAddress) -> list[str]:
+        """Reverse lookup: IPAddress -> list of normalized hostnames."""
+        raise NotImplementedError
+
+
+class DNSResolvingSource(ResolvingSource):
+    """DNS-based resolving source"""
+
+    def resolve(self, hostname: str) -> list[IPAddress]:
+        resolver = dns.resolver.Resolver(configure=True)
+        results: list[IPAddress] = []
+        seen: set[str] = set()
+
+        # A records
+        try:
+            answer = resolver.resolve(hostname, 'A', raise_on_no_answer=False)
+            for rdata in answer:
+                try:
+                    ip_text = rdata.to_text()
+                    if ip_text in seen:
+                        continue
+                    ip = ipaddress.ip_address(ip_text)
+                except Exception:
+                    continue
+                seen.add(ip_text)
+                results.append(ip)
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
+            pass
+
+        # AAAA records
+        try:
+            answer = resolver.resolve(hostname, 'AAAA', raise_on_no_answer=False)
+            for rdata in answer:
+                try:
+                    ip_text = rdata.to_text()
+                    if ip_text in seen:
+                        continue
+                    ip = ipaddress.ip_address(ip_text)
+                except Exception:
+                    continue
+                seen.add(ip_text)
+                results.append(ip)
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
+            pass
+
+        if not results:
+            logger.warning('DNS lookups (A/AAAA) did not return any addresses for %s', hostname)
+
+        return results
+
+    def reverse(self, ip: IPAddress) -> list[str]:
+        ip_text = str(ip)
+        reverse_name = dns.reversename.from_address(ip_text)
+        try:
+            answer = dns.resolver.resolve(reverse_name, 'PTR', raise_on_no_answer=False)
+        except dns.resolver.NoAnswer:
+            return []
+
+        names: list[str] = []
+        for ptr_rdata in answer:
+            try:
+                name = str(ptr_rdata.target).rstrip('.').lower()
+            except Exception:
+                continue
+            if name:
+                names.append(name)
+        return names
+
+
+@cache
+def get_resolving_source(name: str) -> ResolvingSource:
+    if name == 'dns':
+        return DNSResolvingSource()
+    raise ValueError(f'Unknown resolving source: {name}')

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -192,7 +192,8 @@ def remove_node(
     try:
         active_nodes = helpers.get_active_nodes(input_config_filename)
 
-        ip4, _ = NetworkManager.resolve_ip_and_hostname(node)
+        host_identity = get_host_address_manager().get_identity(node)
+        ip4 = host_identity.primary_ip
 
         if len(active_nodes) > 1:
             pm_num = _remove_node_from_PMS(c_root, ip4)
@@ -297,7 +298,11 @@ def add_dbroot(input_config_filename = None, output_config_filename = None, host
     else:
         c_root = node_config.get_current_config_root(config_filename = input_config_filename)
 
-    ip4, _ = NetworkManager.resolve_ip_and_hostname(host) if host else (None, None)
+    if host:
+        host_identity = get_host_address_manager().get_identity(host)
+        ip4 = host_identity.primary_ip
+    else:
+        ip4 = None
     try:
         ret = _add_dbroot(c_root, ip4)
     except Exception as e:
@@ -395,11 +400,9 @@ def _add_active_node(root, node):
     we replace it with the IP address.
     '''
 
-    ip4, hostname = NetworkManager.resolve_ip_and_hostname(node)
-    # If reverse lookup failed, hostname may be None. Use the IP as a
-    # fallback so removal by hostname also works consistently.
-    if hostname is None:
-        hostname = ip4
+    host_identity = get_host_address_manager().get_identity(node)
+    ip4 = host_identity.primary_ip
+    hostname = host_identity.effective_hostname
 
     # Remove both hostname and IP form before adding IP to avoid checking if
     #   some of them is already there. Then we add by IP
@@ -432,11 +435,9 @@ def _remove_node(root, node):
     remove node from DesiredNodes, InactiveNodes, ActiveNodes
     '''
     # Remove both hostname and IPv4 forms
-    ip4, hostname = NetworkManager.resolve_ip_and_hostname(node)
-    # If reverse lookup failed, normalize hostname to ip so we always try
-    # removing both variants from lists.
-    if hostname is None:
-        hostname = ip4
+    host_identity = get_host_address_manager().get_identity(node)
+    ip4 = host_identity.primary_ip
+    hostname = host_identity.effective_hostname
     for lst in (
         root.find("./DesiredNodes"),
         root.find("./InactiveNodes"),
@@ -449,9 +450,9 @@ def _remove_node(root, node):
 # This moves a node from ActiveNodes to InactiveNodes
 def _deactivate_node(root, node):
     """Move node from ActiveNodes to InactiveNodes. Store as IPv4."""
-    ip4, hostname = NetworkManager.resolve_ip_and_hostname(node)
-    if hostname is None:
-        hostname = ip4
+    host_identity = get_host_address_manager().get_identity(node)
+    ip4 = host_identity.primary_ip
+    hostname = host_identity.effective_hostname
 
     active_nodes = root.find("./ActiveNodes")
     __remove_helper(active_nodes, hostname)
@@ -1048,7 +1049,9 @@ def _add_Module_entries(root, node: str) -> None:
     # XXXPAT: No guarantee these are the values used in the rest of the system.
     # TODO: what should we do with complicated network configs where node has
     #       several ips and\or several hostnames
-    ip4, hostname = NetworkManager.resolve_ip_and_hostname(node)
+    host_identity = get_host_address_manager().get_identity(node)
+    ip4 = host_identity.primary_ip
+    hostname = host_identity.primary_name
     if hostname is None:
         logging.warning(f'Could not resolve hostname for {node}, using IP address as hostname')
         hostname = ip4
@@ -1101,7 +1104,8 @@ def _add_WES(root, pm_num, node):
     `node` may be a hostname or an IP; we normalize to IPv4 to avoid
     mismatches when comparing against ModuleIPAddr entries.
     """
-    ip4, _hostname = NetworkManager.resolve_ip_and_hostname(node)
+    host_identity = get_host_address_manager().get_identity(node)
+    ip4 = host_identity.primary_ip
     wes_node = etree.SubElement(root, f"pm{pm_num}_WriteEngineServer")
     etree.SubElement(wes_node, "IPAddr").text = ip4
     etree.SubElement(wes_node, "Port").text = "8630"
@@ -1219,7 +1223,7 @@ def _replace_localhost(root: etree.Element, node: str) -> bool:
         return False
 
     host_identity = get_host_address_manager().get_identity(node)
-    ipaddr, hostname = host_identity.primary_ip, host_identity.primary_name
+    ipaddr, hostname = host_identity.primary_ip, host_identity.effective_hostname
     logging.info(
         f'add_node(): replacing 127.0.0.1/localhost with {ipaddr}/{hostname} '
         f'as this node\'s name. Be sure {hostname} resolves to {ipaddr} on '

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -7,15 +7,12 @@ import datetime
 import logging
 import os
 import shutil
-import socket
 import subprocess
 import time
 from typing import Optional
 
 import requests
 from lxml import etree
-from mcs_node_control.models.node_config import NodeConfig
-from tracing.traced_session import get_traced_session
 
 from cmapi_server import helpers
 from cmapi_server.constants import (
@@ -26,10 +23,12 @@ from cmapi_server.constants import (
     LOCALHOSTS,
     MCS_DATA_PATH,
 )
+from cmapi_server.exceptions import CMAPIBasicError
 from cmapi_server.managers.application import AppStatefulConfig
-from cmapi_server.managers.network import NetworkManager
 from cmapi_server.managers.host_identity import get_host_address_manager
-
+from cmapi_server.managers.network import NetworkManager
+from mcs_node_control.models.node_config import NodeConfig
+from tracing.traced_session import get_traced_session
 
 PMS_NODE_PORT = '8620'
 EXEMGR_NODE_PORT = '8601'
@@ -103,13 +102,22 @@ def add_node(
 
     logging.info('Adding node %s', node)
 
-    host_identity = get_host_address_manager().get_identity(node)
+    addr_mgr = get_host_address_manager()
+    host_identity = addr_mgr.get_identity(node)
     logging.debug('Resolved %s to %s', node, host_identity)
 
     # If a hostname (not IP) is provided, ensure fwd/rev DNS consistency.
     # Skip validation for localhost aliases to preserve legacy single-node flows.
     if not NetworkManager.is_ip(node) and not NetworkManager.is_only_loopback_hostname(node):
-        NetworkManager.validate_hostname_fwd_rev(node)
+        _, ok = addr_mgr.check_hostname_rev_lookup(node)
+        if not ok:
+            raise CMAPIBasicError(
+                f'''Forward/reverse DNS check failed:
+                hostname {node!r} resolved to {host_identity.ips}, but none of these IPs
+                reverse-resolve back to {node!r}. Consider adding the host by IP,
+                or fix DNS so that at least one IP has a PTR/record mapping back to
+                the provided hostname.'''
+            )
 
     try:
         if not _replace_localhost(c_root, node):

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -105,7 +105,6 @@ def add_node(
 
     host_identity = get_host_address_manager().get_identity(node)
     logging.debug('Resolved %s to %s', node, host_identity)
-    # TODO use host identity instead of node
 
     # If a hostname (not IP) is provided, ensure fwd/rev DNS consistency.
     # Skip validation for localhost aliases to preserve legacy single-node flows.
@@ -114,7 +113,7 @@ def add_node(
 
     try:
         if not _replace_localhost(c_root, node):
-            ip4, _ = NetworkManager.resolve_ip_and_hostname(node)
+            ip4 = host_identity.primary_ip
             pm_num = _add_node_to_PMS(c_root, ip4)
 
             if not read_replica:
@@ -1211,16 +1210,8 @@ def _replace_localhost(root: etree.Element, node: str) -> bool:
         )
         return False
 
-    # TODO use NetworkManager here
-    # getaddrinfo returns list of 5-tuples (..., sockaddr)
-    # use sockaddr to retrieve ip, sockaddr = (address, port) for AF_INET
-    ipaddr = socket.getaddrinfo(node, 8640, family=socket.AF_INET)[0][-1][0]
-    # signifies that node is an IP addr already
-    if ipaddr == node:
-        # use the primary hostname if given an ip addr
-        hostname = socket.gethostbyaddr(ipaddr)[0]
-    else:
-        hostname = node   # use whatever name they gave us
+    host_identity = get_host_address_manager().get_identity(node)
+    ipaddr, hostname = host_identity.primary_ip, host_identity.primary_name
     logging.info(
         f'add_node(): replacing 127.0.0.1/localhost with {ipaddr}/{hostname} '
         f'as this node\'s name. Be sure {hostname} resolves to {ipaddr} on '
@@ -1241,11 +1232,11 @@ def _replace_localhost(root: etree.Element, node: str) -> bool:
 
         if 'ModuleIPAddr' in n.tag:
             n.text = ipaddr
-            logging.info(f"Replaced %s (was %s) with IP %s", path, old_val, ipaddr)
+            logging.info("Replaced %s (was %s) with IP %s", path, old_val, ipaddr)
             continue
         if 'ModuleHostName' in n.tag:
             n.text = hostname
-            logging.info(f"Replaced %s (was %s) with hostname %s", path, old_val, hostname)
+            logging.info("Replaced %s (was %s) with hostname %s", path, old_val, hostname)
             continue
 
         # Generic fields: replace localhost IPs with ipaddr, hostnames with hostname
@@ -1254,15 +1245,15 @@ def _replace_localhost(root: etree.Element, node: str) -> bool:
             new_val = ipaddr if is_local_ip else hostname
             if is_local_ip:
                 new_val = ipaddr
-                logging.info(f"Replaced %s (was %s) with IP %s", path, old_val, new_val)
+                logging.info("Replaced %s (was %s) with IP %s", path, old_val, new_val)
             else:
                 new_val = hostname
-                logging.info(f"Replaced %s (was %s) with hostname %s", path, old_val, new_val)
+                logging.info("Replaced %s (was %s) with hostname %s", path, old_val, new_val)
             n.text = new_val
 
     old_controller = controller_host.text
     controller_host.text = hostname # keep controllernode as fqdn
-    logging.info(f"Replaced %s (was %s) with hostname %s", './DBRM_Controller/IPAddr', old_controller, hostname)
+    logging.info("Replaced %s (was %s) with hostname %s", './DBRM_Controller/IPAddr', old_controller, hostname)
 
     return True
 

--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -28,6 +28,7 @@ from cmapi_server.constants import (
 )
 from cmapi_server.managers.application import AppStatefulConfig
 from cmapi_server.managers.network import NetworkManager
+from cmapi_server.managers.host_identity import get_host_address_manager
 
 
 PMS_NODE_PORT = '8620'
@@ -101,6 +102,11 @@ def add_node(
     c_root = node_config.get_current_config_root(input_config_filename)
 
     logging.info('Adding node %s', node)
+
+    host_identity = get_host_address_manager().get_identity(node)
+    logging.debug('Resolved %s to %s', node, host_identity)
+    # TODO use host identity instead of node
+
     # If a hostname (not IP) is provided, ensure fwd/rev DNS consistency.
     # Skip validation for localhost aliases to preserve legacy single-node flows.
     if not NetworkManager.is_ip(node) and not NetworkManager.is_only_loopback_hostname(node):

--- a/cmapi/cmapi_server/test/mock_resolution.py
+++ b/cmapi/cmapi_server/test/mock_resolution.py
@@ -73,6 +73,79 @@ class MockResolutionBuilder:
         self._default_hostname = hostname
         return self
 
+    def build(self):
+
+        @contextmanager
+        def _ctx():
+            patches = [
+                # Patch socket-level resolvers (NetworkManager uses these under the hood)
+                patch('socket.getaddrinfo', side_effect=self._fake_getaddrinfo),
+                patch('socket.gethostbyname', side_effect=self._fake_gethostbyname),
+                patch('socket.gethostbyaddr', side_effect=self._fake_gethostbyaddr),
+                # Patch local identity to be synthetic; avoid real system calls
+                patch('socket.gethostname', return_value=CUR_HOST_HOSTNAME),
+                patch('socket.getfqdn', return_value=CUR_HOST_HOSTNAME),
+                # Patch NetworkManager local IP discovery (it uses psutil or system libs,
+                #   proper mocking would be too complex)
+                patch('cmapi_server.managers.network.NetworkManager.get_current_node_ips', return_value=[CUR_HOST_IP, DEFAULT_LOCALHOST_IP]),
+                # Patch HostAddressManager DNS abstraction methods
+                patch('cmapi_server.managers.host_identity.HostAddressManager._dns_resolve_ipv4',
+                      side_effect=self._fake_dns_resolve_ipv4),
+                patch('cmapi_server.managers.host_identity.HostAddressManager._dns_resolve_ipv6',
+                      side_effect=self._fake_dns_resolve_ipv6),
+                patch('cmapi_server.managers.host_identity.HostAddressManager._dns_reverse',
+                      side_effect=self._fake_dns_reverse),
+            ]
+            with ExitStack() as stack:
+                for p in patches:
+                    stack.enter_context(p)
+                yield
+
+        return _ctx()
+
+    def _fake_getaddrinfo(self, host, port, family=socket.AF_UNSPEC, type=0, proto=0, flags=0):
+        # Only handle AF_INET calls; otherwise, simulate failure
+        if family not in (socket.AF_UNSPEC, socket.AF_INET):
+            raise socket.gaierror
+        # For localhost, return loopback first and include CUR_HOST_IP as secondary
+        if host == DEFAULT_LOCALHOST_HOSTNAME:
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, '', (DEFAULT_LOCALHOST_IP, port)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, '', (CUR_HOST_IP, port)),
+            ]
+        ip, _ = self._resolve_forward(host)
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', (ip, port))]
+
+    def _fake_gethostbyname(self, name: str) -> str:
+        ip, _ = self._resolve_forward(name)
+        return ip
+
+    def _fake_gethostbyaddr(self, addr: str):
+        # If no reverse record was set, simulate reverse lookup failure
+        if addr not in self._reverse:
+            raise socket.herror
+        primary, aliases = self._reverse[addr]
+        return (primary, aliases, [addr])
+
+    # HostIdentityManager DNS abstraction mocks
+    def _fake_dns_resolve_ipv4(self, hostname: str) -> List[str]:
+        # Return mapped IPv4 for provided hostname, or empty list if unknown
+        ip = self._forward.get(hostname)
+        return [ip] if ip else []
+
+    def _fake_dns_resolve_ipv6(self, hostname: str) -> List[str]:
+        # Keep IPv6 disabled by default in tests for determinism
+        return []
+
+    def _fake_dns_reverse(self, ip_text: str) -> List[str]:
+        # Return PTR names (primary + aliases) from reverse map, lowercase
+        rec = self._reverse.get(ip_text)
+        if not rec:
+            return []
+        primary, aliases = rec
+        names = [primary, *aliases]
+        return [n.rstrip('.').lower() for n in names if n]
+
     def _resolve_forward(self, host: str) -> Tuple[str, str]:
         """Resolve hostname or IP to (ip, hostname) using mappings/defaults."""
         # If input looks like an IP, return it with reverse or default hostname
@@ -100,50 +173,6 @@ class MockResolutionBuilder:
 
         # As a last resort, echo back (host, host)
         return host, host
-
-    def build(self):
-
-        def _fake_getaddrinfo(host, port, family=socket.AF_UNSPEC, type=0, proto=0, flags=0):
-            # Only handle AF_INET calls; otherwise, simulate failure
-            if family not in (socket.AF_UNSPEC, socket.AF_INET):
-                raise socket.gaierror
-            # For localhost, return loopback first and include CUR_HOST_IP as secondary
-            if host == DEFAULT_LOCALHOST_HOSTNAME:
-                return [
-                    (socket.AF_INET, socket.SOCK_STREAM, 6, '', (DEFAULT_LOCALHOST_IP, port)),
-                    (socket.AF_INET, socket.SOCK_STREAM, 6, '', (CUR_HOST_IP, port)),
-                ]
-            ip, _ = self._resolve_forward(host)
-            return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', (ip, port))]
-
-        def _fake_gethostbyname(name: str) -> str:
-            ip, _ = self._resolve_forward(name)
-            return ip
-
-        def _fake_gethostbyaddr(addr: str):
-            # If no reverse record was set, simulate reverse lookup failure
-            if addr not in self._reverse:
-                raise socket.herror
-            primary, aliases = self._reverse[addr]
-            return (primary, aliases, [addr])
-
-        @contextmanager
-        def _ctx():
-            patches = [
-                # Patch socket-level resolvers (NetworkManager uses these under the hood)
-                patch('socket.getaddrinfo', side_effect=_fake_getaddrinfo),
-                patch('socket.gethostbyname', side_effect=_fake_gethostbyname),
-                patch('socket.gethostbyaddr', side_effect=_fake_gethostbyaddr),
-                # Patch local identity to be synthetic; avoid real system calls
-                patch('socket.gethostname', return_value=CUR_HOST_HOSTNAME),
-                patch('socket.getfqdn', return_value=CUR_HOST_HOSTNAME),
-            ]
-            with ExitStack() as stack:
-                for p in patches:
-                    stack.enter_context(p)
-                yield
-
-        return _ctx()
 
 
 def simple_resolution_mock(hostname: str, ip: str):

--- a/cmapi/cmapi_server/test/mock_resolution.py
+++ b/cmapi/cmapi_server/test/mock_resolution.py
@@ -88,12 +88,10 @@ class MockResolutionBuilder:
                 # Patch NetworkManager local IP discovery (it uses psutil or system libs,
                 #   proper mocking would be too complex)
                 patch('cmapi_server.managers.network.NetworkManager.get_current_node_ips', return_value=[CUR_HOST_IP, DEFAULT_LOCALHOST_IP]),
-                # Patch HostAddressManager DNS abstraction methods
-                patch('cmapi_server.managers.host_identity.HostAddressManager._dns_resolve_ipv4',
-                      side_effect=self._fake_dns_resolve_ipv4),
-                patch('cmapi_server.managers.host_identity.HostAddressManager._dns_resolve_ipv6',
-                      side_effect=self._fake_dns_resolve_ipv6),
-                patch('cmapi_server.managers.host_identity.HostAddressManager._dns_reverse',
+                # Patch DNS resolving source used by HostAddressManager
+                patch('cmapi_server.managers.resolving_sources.DNSResolvingSource.resolve',
+                      side_effect=self._fake_dns_resolve),
+                patch('cmapi_server.managers.resolving_sources.DNSResolvingSource.reverse',
                       side_effect=self._fake_dns_reverse),
             ]
             with ExitStack() as stack:
@@ -127,17 +125,19 @@ class MockResolutionBuilder:
         primary, aliases = self._reverse[addr]
         return (primary, aliases, [addr])
 
-    # HostIdentityManager DNS abstraction mocks
-    def _fake_dns_resolve_ipv4(self, hostname: str) -> List[str]:
+    def _fake_dns_resolve(self, hostname: str) -> List[str]:
+        """Fake DNS A/AAAA resolution used by DNSResolvingSource.resolve.
+
+        We only care about returning IP strings that match our forward mapping.
+        IPv6 is kept disabled by default in tests for determinism.
+        """
         # Return mapped IPv4 for provided hostname, or empty list if unknown
         ip = self._forward.get(hostname)
         return [ip] if ip else []
 
-    def _fake_dns_resolve_ipv6(self, hostname: str) -> List[str]:
-        # Keep IPv6 disabled by default in tests for determinism
-        return []
-
-    def _fake_dns_reverse(self, ip_text: str) -> List[str]:
+    def _fake_dns_reverse(self, ip_obj) -> List[str]:
+        """Fake DNS PTR resolution used by DNSResolvingSource.reverse."""
+        ip_text = str(ip_obj)
         # Return PTR names (primary + aliases) from reverse map, lowercase
         rec = self._reverse.get(ip_text)
         if not rec:

--- a/cmapi/cmapi_server/test/mock_resolution.py
+++ b/cmapi/cmapi_server/test/mock_resolution.py
@@ -28,7 +28,7 @@ class MockResolutionBuilder:
     def __init__(self):
         # Forward: hostname -> ip
         self._forward: Dict[str, str] = {}
-        # Reverse: ip -> (primary_hostname, alias_list)
+        # Reverse: ip -> (primary_name, alias_list)
         self._reverse: Dict[str, Tuple[str, List[str]]] = {}
         # Defaults used when no explicit mapping is provided
         self._default_ip: Optional[str] = None

--- a/cmapi/cmapi_server/test/test_cluster.py
+++ b/cmapi/cmapi_server/test/test_cluster.py
@@ -3,6 +3,7 @@ import os
 import socket
 import subprocess
 from shutil import copyfile
+from unittest.mock import patch
 
 import requests
 
@@ -24,6 +25,12 @@ class BaseClusterTestCase(BaseServerTestCase):
     @classmethod
     def setUpClass(cls) -> None:
         copyfile(MCS_CONFIG_FILEPATH, COPY_MCS_CONFIG_FILEPATH)
+        # Disable real DNS lookups for rev lookup checks, this isn't focus of these tests
+        cls._rev_check_patcher = patch(
+            'cmapi_server.managers.host_identity.HostAddressManager.check_hostname_rev_lookup',
+            new=lambda manager, hostname: (manager.get_identity(hostname), True),
+        )
+        cls._rev_check_patcher.start()
         return super().setUpClass()
 
     @classmethod
@@ -32,6 +39,7 @@ class BaseClusterTestCase(BaseServerTestCase):
         os.remove(os.path.abspath(COPY_MCS_CONFIG_FILEPATH))
         MCSProcessManager.stop_node(is_primary=True, use_sudo=False)
         MCSProcessManager.start_node(is_primary=True, use_sudo=False)
+        cls._rev_check_patcher.stop()
         return super().tearDownClass()
 
     def setUp(self) -> None:

--- a/cmapi/cmapi_server/test/test_failover_agent.py
+++ b/cmapi/cmapi_server/test/test_failover_agent.py
@@ -1,13 +1,10 @@
 import logging
 
-from mcs_node_control.models.node_config import NodeConfig
-
 from cmapi_server.failover_agent import FailoverAgent
-from cmapi_server.managers.network import NetworkManager
 from cmapi_server.node_manipulation import add_node, remove_node
-from cmapi_server.test.mock_resolution import simple_resolution_mock, make_local_resolution_builder
+from cmapi_server.test.mock_resolution import make_local_resolution_builder
 from cmapi_server.test.unittest_global import BaseNodeManipTestCase, tmp_mcs_config_filename
-
+from mcs_node_control.models.node_config import NodeConfig
 
 logging.basicConfig(level='DEBUG')
 

--- a/cmapi/mcs_node_control/models/node_config.py
+++ b/cmapi/mcs_node_control/models/node_config.py
@@ -19,6 +19,7 @@ from cmapi_server.constants import (
     DEFAULT_SM_CONF_PATH,
     MCS_MODULE_FILE_PATH,
 )
+from cmapi_server.managers.host_identity import get_host_address_manager
 
 # from cmapi_server.managers.process import MCSProcessManager
 from mcs_node_control.models.misc import get_dbroots_list, read_module_id
@@ -433,8 +434,16 @@ class NodeConfig:
             root = self.get_current_config_root()
 
         primary_address = self.get_dbrm_conn_info(root)['IPAddr']
-        is_primary = primary_address in self.get_network_addresses_and_names()
-        module_logger.debug('is_primary: %s, primary_address: %s', is_primary, primary_address)
+
+        local_identity = get_host_address_manager().get_local_identity()
+        candidates = set(local_identity.ips)
+        candidates.update(local_identity.names)
+
+        is_primary = primary_address in candidates
+        module_logger.debug(
+            'is_primary: %s, primary_address: %s, local_identity: %s',
+            is_primary, primary_address, local_identity,
+        )
         return is_primary
 
     def is_single_node(self,

--- a/cmapi/mcs_node_control/models/node_config.py
+++ b/cmapi/mcs_node_control/models/node_config.py
@@ -433,7 +433,9 @@ class NodeConfig:
             root = self.get_current_config_root()
 
         primary_address = self.get_dbrm_conn_info(root)['IPAddr']
-        return primary_address in self.get_network_addresses_and_names()
+        is_primary = primary_address in self.get_network_addresses_and_names()
+        module_logger.debug('is_primary: %s, primary_address: %s', is_primary, primary_address)
+        return is_primary
 
     def is_single_node(self,
                        root=None):

--- a/cmapi/mcs_node_control/models/node_config.py
+++ b/cmapi/mcs_node_control/models/node_config.py
@@ -4,12 +4,12 @@ import logging
 import pwd
 import re
 import socket
+from collections.abc import Iterator
 from contextlib import contextmanager
 from os import chown, mkdir, replace
 from pathlib import Path
 from shutil import copyfile
 from typing import Optional
-from collections.abc import Iterator
 from xml.dom import minidom  # to pick up pretty printing functionality
 
 from lxml import etree
@@ -17,6 +17,7 @@ from lxml import etree
 from cmapi_server.constants import (
     DEFAULT_MCS_CONF_PATH,
     DEFAULT_SM_CONF_PATH,
+    LOCALHOSTS,
     MCS_MODULE_FILE_PATH,
 )
 from cmapi_server.managers.host_identity import get_host_address_manager
@@ -438,6 +439,10 @@ class NodeConfig:
         local_identity = get_host_address_manager().get_local_identity()
         candidates = set(local_identity.ips)
         candidates.update(local_identity.names)
+
+        # HostIdentity ignores loopback/non-DNS-visible names, so add them explicitly
+        if self.is_single_node(root):
+            candidates.update(LOCALHOSTS)
 
         is_primary = primary_address in candidates
         module_logger.debug(

--- a/cmapi/pyproject.toml
+++ b/cmapi/pyproject.toml
@@ -1,6 +1,15 @@
 [tool.ruff]
 line-length = 100
 target-version = "py39"
+# Exclude cache and temporary directories
+exclude = [
+    "__pycache__",
+]
+
+[tool.ruff.format]
+quote-style = "single"
+
+[tool.ruff.lint]
 # Enable common rule sets
 select = [
     "E",  # pycodestyle errors
@@ -11,16 +20,7 @@ select = [
     "N",  # pep8-naming: naming conventions
     "Q",  # flake8-quotes: enforce quote style
 ]
-
 ignore = []
-
-# Exclude cache and temporary directories
-exclude = [
-    "__pycache__",
-]
-
-[tool.ruff.format]
-quote-style = "single"
 
 [tool.ruff.lint.isort]
 known-first-party = ["cmapi_server", "failover", "mcs_node_control", "tracing"]

--- a/cmapi/requirements.in
+++ b/cmapi/requirements.in
@@ -21,3 +21,4 @@ sentry-sdk==2.34.1
 # Invariant checks
 mr_kot==0.9.2
 mr_kot_fs_validators==0.2.0
+dnspython==2.7.0

--- a/cmapi/requirements.txt
+++ b/cmapi/requirements.txt
@@ -4,23 +4,6 @@
 #
 #    dev_tools/piptools.sh compile-all
 #
-aiohttp==3.11.16
-awscli==1.38.28
-CherryPy==18.10.0
-cryptography==43.0.3
-distro==1.9.0
-furl==2.1.4
-gsutil==5.33
-lxml==5.3.2
-psutil==7.0.0
-pyotp==2.9.0
-requests==2.32.3
-# required for CherryPy RoutesDispatcher,
-# but CherryPy itself has no such a dependency
-Routes==2.5.1
-typer==0.15.2
-
-# indirect dependencies
 aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.11.16
@@ -74,6 +57,8 @@ cryptography==43.0.3
     #   -r requirements.in
     #   pyopenssl
 distro==1.9.0
+    # via -r requirements.in
+dnspython==2.7.0
     # via -r requirements.in
 docutils==0.16
     # via awscli

--- a/cmapi/tracing/trace_tool.py
+++ b/cmapi/tracing/trace_tool.py
@@ -98,7 +98,6 @@ def _record_incoming_json_preview(req) -> dict[str, Any]:
 
     parsed_json = getattr(req, 'json', None)
     if parsed_json is None:
-        logger.debug('request.json is not available')
         return attrs
     normalized = json.dumps(parsed_json, ensure_ascii=False, sort_keys=True)
     if len(normalized) > _PREVIEW_MAX_CHARS:


### PR DESCRIPTION
Вводим новую сущность HostIdentity, она содержит IP адреса и проверенные имена хоста, если они есть. Идея в том, что мы один раз для каждого хоста вычисляем эти адреса, каждый из них должен быть виден с других хостов (поэтому каждое имя мы проверяем в dns). То есть мы скипаем всякие локальные, link-local адреса, а еще выбрасываем алиасы, прописанные где-либо кроме dns (то есть например всякие настройки systemd, которые у нас всплывали на debian, перестают давать нам неправильные имена)

Чтобы не перегружать HostIdentity, настройки резолвинга вынесены в отдельный класс полиси. Там же упорядочивание адресов (как нам упорядочивать адреса, чтобы понять какой адрес первичный и самый главный?)
