### PR TITLE
Revert "fix(cmapi): MCOL-6091 CMAPI gives DMLProc only 10 seconds for a greceful stop"

### DIFF
--- a/cmapi/cmapi_server/constants.py
+++ b/cmapi/cmapi_server/constants.py
@@ -116,10 +116,7 @@ MCS_BACKUP_MANAGER_SH = os.path.join(MCS_INSTALL_BIN, 'mcs_backup_manager.sh')
 CMAPI_PORT = 8640  #TODO: use it in all places
 CURRENT_NODE_CMAPI_URL = f'https://localhost:{CMAPI_PORT}'
 REQUEST_TIMEOUT: float = 30.0
-
-DMLPROC_SHUTDOWN_TIMEOUT: float = 300.0  # 5 minutes, should be less then LONG_REQUEST_TIMEOUT
-LONG_REQUEST_TIMEOUT: float = 400.0  # should be less than TRANSACTION_TIMEOUT
-TRANSACTION_TIMEOUT: float = 600.0  # 10 minutes
+TRANSACTION_TIMEOUT: float = 300.0  # 5 minutes
 
 # API version
 _version = '0.4.0'

--- a/cmapi/cmapi_server/controllers/endpoints.py
+++ b/cmapi/cmapi_server/controllers/endpoints.py
@@ -17,18 +17,10 @@ from mcs_node_control.models.dbrm import set_cluster_mode
 from mcs_node_control.models.node_config import NodeConfig
 from mcs_node_control.models.node_status import NodeStatus
 from cmapi_server.constants import (
-    CMAPI_PACKAGE_NAME,
-    CMAPI_PORT,
-    DEFAULT_MCS_CONF_PATH,
-    DMLPROC_SHUTDOWN_TIMEOUT,
-    EM_PATH_SUFFIX,
-    MCS_BRM_CURRENT_PATH,
-    MCS_EM_PATH,
-    MDB_CS_PACKAGE_NAME,
-    MDB_SERVER_PACKAGE_NAME,
-    REQUEST_TIMEOUT,
-    S3_BRM_CURRENT_PATH,
-    SECRET_KEY,
+    CMAPI_PACKAGE_NAME, CMAPI_PORT, DEFAULT_MCS_CONF_PATH,
+    DEFAULT_SM_CONF_PATH, EM_PATH_SUFFIX, MCS_BRM_CURRENT_PATH, MCS_EM_PATH,
+    MDB_CS_PACKAGE_NAME, MDB_SERVER_PACKAGE_NAME, REQUEST_TIMEOUT,
+    S3_BRM_CURRENT_PATH, SECRET_KEY,
 )
 from cmapi_server.controllers.api_clients import NodeControllerClient
 from cmapi_server import helpers
@@ -736,7 +728,7 @@ class ShutdownController:
         req = cherrypy.request
         use_sudo = get_use_sudo(req.app.config)
         request_body = cherrypy.request.json
-        timeout = request_body.get('timeout', DMLPROC_SHUTDOWN_TIMEOUT)
+        timeout = request_body.get('timeout', 0)
         node_config = NodeConfig()
         try:
             MCSProcessManager.stop_node(
@@ -905,7 +897,7 @@ class ClusterController:
 
         request = cherrypy.request
         request_body = request.json
-        timeout = request_body.get('timeout', DMLPROC_SHUTDOWN_TIMEOUT)
+        timeout = request_body.get('timeout', None)
         force = request_body.get('force', False)
         config = request_body.get('config', DEFAULT_MCS_CONF_PATH)
         in_transaction = request_body.get('in_transaction', False)
@@ -915,7 +907,7 @@ class ClusterController:
                 with TransactionManager():
                     response = ClusterHandler.shutdown(config, timeout)
             else:
-                response = ClusterHandler.shutdown(config, timeout)
+                response = ClusterHandler.shutdown(config)
         except CMAPIBasicError as err:
             raise_422_error(module_logger, func_name, err.message)
 
@@ -1605,7 +1597,7 @@ class NodeProcessController():
 
         request = cherrypy.request
         request_body = request.json
-        timeout = request_body.get('timeout', DMLPROC_SHUTDOWN_TIMEOUT)
+        timeout = request_body.get('timeout', 10)
         force = request_body.get('force', False)
 
         if force:

--- a/cmapi/cmapi_server/handlers/cluster.py
+++ b/cmapi/cmapi_server/handlers/cluster.py
@@ -16,11 +16,7 @@ from mcs_node_control.models.node_config import NodeConfig
 from tracing.traced_session import get_traced_session
 
 from cmapi_server.constants import (
-    CMAPI_CONF_PATH,
-    CMAPI_PORT,
-    DEFAULT_MCS_CONF_PATH,
-    DMLPROC_SHUTDOWN_TIMEOUT,
-    REQUEST_TIMEOUT,
+    CMAPI_CONF_PATH, CMAPI_PORT, DEFAULT_MCS_CONF_PATH, REQUEST_TIMEOUT,
 )
 from cmapi_server.exceptions import CMAPIBasicError, exc_to_cmapi_error
 from cmapi_server.controllers.api_clients import NodeControllerClient
@@ -48,7 +44,7 @@ class ClusterAction(Enum):
 
 
 def toggle_cluster_state(
-        action: ClusterAction, config: str, timeout: int = DMLPROC_SHUTDOWN_TIMEOUT) -> dict:
+        action: ClusterAction, config: str) -> dict:
     """Toggle the state of the cluster (start or stop).
 
     :param action: The cluster action to perform.
@@ -68,7 +64,7 @@ def toggle_cluster_state(
 
     switch_node_maintenance(maintainance_flag)
     update_revision_and_manager()
-    broadcast_new_config(config, distribute_secrets=True, timeout=timeout)
+    broadcast_new_config(config, distribute_secrets=True)
 
 
 class ClusterHandler:
@@ -165,7 +161,7 @@ class ClusterHandler:
 
     @staticmethod
     def shutdown(
-        config: str = DEFAULT_MCS_CONF_PATH, timeout: int = DMLPROC_SHUTDOWN_TIMEOUT,
+        config: str = DEFAULT_MCS_CONF_PATH, timeout: Optional[int] = None
     ) -> dict:
         """Method to stop the MCS Cluster.
 
@@ -173,7 +169,7 @@ class ClusterHandler:
                        defaults to DEFAULT_MCS_CONF_PATH
         :type config: str, optional
         :param timeout: timeout in seconds to gracefully stop DMLProc,
-                        defaults to DMLPROC_SHUTDOWN_TIMEOUT
+                        defaults to None
         :type timeout: Optional[int], optional
         :raises CMAPIBasicError: if no nodes in the cluster
         :return: start timestamp
@@ -184,7 +180,7 @@ class ClusterHandler:
             'Cluster shutdown command called. Shutting down the cluster.'
         )
         operation_start_time = str(datetime.now())
-        toggle_cluster_state(ClusterAction.STOP, config, timeout=timeout)
+        toggle_cluster_state(ClusterAction.STOP, config)
         logger.debug('Successfully finished shutting down the cluster.')
         return {'timestamp': operation_start_time}
 

--- a/cmapi/cmapi_server/helpers.py
+++ b/cmapi/cmapi_server/helpers.py
@@ -28,15 +28,8 @@ from cmapi_server.exceptions import CMAPIBasicError
 requests.packages.urllib3.disable_warnings()  # pylint: disable=no-member
 
 from cmapi_server.constants import (
-    CMAPI_CONF_PATH,
-    CMAPI_DEFAULT_CONF_PATH,
-    DEFAULT_MCS_CONF_PATH,
-    DEFAULT_SM_CONF_PATH,
-    DMLPROC_SHUTDOWN_TIMEOUT,
-    LOCALHOSTS,
-    LONG_REQUEST_TIMEOUT,
-    TRANSACTION_TIMEOUT,
-    _version
+    CMAPI_CONF_PATH, CMAPI_DEFAULT_CONF_PATH, DEFAULT_MCS_CONF_PATH,
+    DEFAULT_SM_CONF_PATH, LOCALHOSTS, _version
 )
 from cmapi_server.handlers.cej import CEJPasswordHandler
 from cmapi_server.managers.process import MCSProcessManager
@@ -70,7 +63,7 @@ def start_transaction(
     remove_nodes: Optional[list] = None,
     optional_nodes: Optional[list] = None,
     txn_id: Optional[int] = None,
-    timeout: float = TRANSACTION_TIMEOUT
+    timeout: float = 300.0
 ):
     """Start internal CMAPI transaction.
 
@@ -94,7 +87,7 @@ def start_transaction(
     :param txn_id: id for transaction to start, defaults to None
     :type txn_id: Optional[int], optional
     :param timeout: time in seconds for cmapi transaction lock before it ends
-                    automatically, defaults to TRANSACTION_TIMEOUT
+                    automatically, defaults to 300
     :type timeout: float, optional
     :return: (success, txn_id, nodes)
     :rtype: tuple[bool, int, list[str]]
@@ -331,7 +324,8 @@ def broadcast_new_config(
                                defaults to DEFAULT_SM_CONF_PATH
     :param test_mode: for test purposes, defaults to False TODO: remove
     :param nodes: nodes list for config put, defaults to None
-    :param timeout: timeout passing to gracefully stop DMLProc process,
+    :param timeout: timeout passing to gracefully stop DMLProc TODO: for next
+                    releases. Could affect all logic of broadcacting new config
     :param distribute_secrets: flag to distribute secrets to nodes
     :param stateful_config_dict: stateful config update dict to distribute to nodes
     :raises CMAPIBasicError: If Broadcasting config to nodes failed with errors
@@ -347,7 +341,7 @@ def broadcast_new_config(
     headers = {'x-api-key': key}
     if stateful_config_dict:
         body = {
-            'timeout': DMLPROC_SHUTDOWN_TIMEOUT if timeout is None else timeout,
+            'timeout': 300,
             'stateful_config_dict': stateful_config_dict,
             'only_stateful_config': True,
         }
@@ -363,7 +357,7 @@ def broadcast_new_config(
         body = {
             'manager': root.find('./ClusterManager').text,
             'revision': root.find('./ConfigRevision').text,
-            'timeout': DMLPROC_SHUTDOWN_TIMEOUT if timeout is None else timeout,
+            'timeout': 300,
             'config': config_text,
             'mcs_config_filename': cs_config_filename,
             'sm_config_filename': sm_config_filename,
@@ -401,7 +395,7 @@ def broadcast_new_config(
         async with create_traced_async_session() as session:
             try:
                 async with session.put(
-                    url, headers=headers, json=body, ssl=False, timeout=LONG_REQUEST_TIMEOUT
+                    url, headers=headers, json=body, ssl=False, timeout=120
                 ) as response:
                     resp_json =  await response.json(encoding='utf-8')
                     response.raise_for_status()

--- a/cmapi/cmapi_server/managers/process.py
+++ b/cmapi/cmapi_server/managers/process.py
@@ -3,18 +3,11 @@ from __future__ import annotations
 import logging
 import os.path
 import socket
-import time
 from time import sleep
 
 import psutil
 
-from cmapi_server.constants import (
-    ALL_MCS_PROGS,
-    DMLPROC_SHUTDOWN_TIMEOUT,
-    MCS_INSTALL_BIN,
-    MCSProgs,
-    ProgInfo,
-)
+from cmapi_server.constants import ALL_MCS_PROGS, MCS_INSTALL_BIN, MCSProgs, ProgInfo
 from cmapi_server.exceptions import CMAPIBasicError
 from cmapi_server.process_dispatchers.base import BaseDispatcher
 from cmapi_server.process_dispatchers.container import ContainerDispatcher
@@ -245,49 +238,32 @@ class MCSProcessManager:
         return True
 
     @classmethod
-    def _wait_for_DMLProc_stop(cls, timeout: int = DMLPROC_SHUTDOWN_TIMEOUT) -> bool:
+    def _wait_for_DMLProc_stop(cls, timeout: int = 10) -> bool:
         """Waiting DMLProc process to stop.
 
-        :param timeout: timeout to wait in seconds, defaults to DMLPROC_SHUTDOWN_TIMEOUT
+        :param timeout: timeout to wait, defaults to 10
         :type timeout: int, optional
         :return: True on success
         :rtype: bool
         """
         logging.info(f'Waiting for DMLProc to stop in {timeout} seconds')
-        # Use a deadline-based loop with throttled logging to reduce noise.
-        deadline = time.monotonic() + max(1, int(timeout))
-        LOG_INTERVAL = 30  # seconds
-        next_log_in = 0  # log immediately on first iteration
-
-        while True:
-            remaining = int(deadline - time.monotonic())
-            if remaining <= 0:
-                break
-
+        dmlproc_stopped = False
+        while timeout > 0:
+            logging.info(
+                f'Waiting for DMLProc to stop. Seconds left {timeout}.'
+            )
             if not Process.check_process_alive('DMLProc'):
                 logging.info('DMLProc gracefully stopped by DBRM command.')
-                return True
-
-            # Throttle waiting logs to roughly once every LOG_INTERVAL seconds
-            if next_log_in <= 0:
-                sleep_for = min(10, remaining)
-                logging.info(
-                    (
-                        f'Waiting for DMLProc to stop. Seconds left ~{remaining}. '
-                        f'Sleeping {sleep_for} seconds before next check.'
-                    )
-                )
-                next_log_in = LOG_INTERVAL
-
-            sleep_for = min(10, remaining)
-            sleep(sleep_for)
-            next_log_in -= sleep_for
-
-        logging.error(
-            'DMLProc didn\'t stop gracefully by DBRM command within '
-            f'{timeout} seconds. Will be stopped directly.'
-        )
-        return False
+                dmlproc_stopped = True
+                break
+            sleep(1)
+            timeout -= 1
+        else:
+            logging.error(
+                f'DMLProc did not stopped gracefully by DBRM command within '
+                f'{timeout} seconds. Will be stopped directly.'
+            )
+        return dmlproc_stopped
 
     @classmethod
     def noop(cls, *args, **kwargs):
@@ -348,7 +324,7 @@ class MCSProcessManager:
 
     @classmethod
     def stop(
-        cls, name: str, is_primary: bool, use_sudo: bool, timeout: int = DMLPROC_SHUTDOWN_TIMEOUT
+        cls, name: str, is_primary: bool, use_sudo: bool, timeout: int = 10
     ) -> bool:
         """Stop mcs process.
 
@@ -479,7 +455,7 @@ class MCSProcessManager:
         cls,
         is_primary: bool,
         use_sudo: bool = True,
-        timeout: int = DMLPROC_SHUTDOWN_TIMEOUT,
+        timeout: int = 10,
     ):
         """Stop mcs node processes.
 
@@ -496,7 +472,7 @@ class MCSProcessManager:
         # undefined behaviour when primary gone and then recovers (failover
         # triggered 2 times).
         for prog_name in cls._get_sorted_progs(is_primary=True, reverse=True):
-            if not cls.stop(prog_name, is_primary, use_sudo, timeout=timeout):
+            if not cls.stop(prog_name, is_primary, use_sudo):
                 logging.error(f'Process "{prog_name}" not stopped properly.')
                 raise CMAPIBasicError(f'Error while stopping "{prog_name}"')
 

--- a/cmapi/cmapi_server/managers/upgrade/repo.py
+++ b/cmapi/cmapi_server/managers/upgrade/repo.py
@@ -154,6 +154,7 @@ class MariaDBESRepoManager:
         :raises CMAPIBasicError: no latest version matched with latest tested
         :raises CMAPIBasicError: if request error
         :return: latest MDB version matched with latest tested major
+        :rtype: str
         """
         try:
             # Download the keyring file
@@ -173,7 +174,7 @@ class MariaDBESRepoManager:
             )
             latest_version_num = sorted(latest_version_nums, reverse=True)[0]
             logging.debug(
-                'Succesfully got latest MDB version number: '
+                'Succesfully got latest MBD version number: '
                 f'{latest_version_num}'
             )
         except requests.RequestException as exc:

--- a/cmapi/mcs_cluster_tool/cluster_app.py
+++ b/cmapi/mcs_cluster_tool/cluster_app.py
@@ -159,7 +159,6 @@ def stop(
         #       could affect put_config (helpers.py broadcast_config) operation
         timeout = 0
 
-    #TODO: bypass timeout here
     resp = client.shutdown_cluster({'in_transaction': True})
     return {'timestamp': start_time}
 

--- a/cmapi/mcs_cluster_tool/tools_commands.py
+++ b/cmapi/mcs_cluster_tool/tools_commands.py
@@ -19,12 +19,8 @@ from rich.table import Table
 
 
 from cmapi_server.constants import (
-    CMAPI_CONF_PATH,
-    CMAPI_PORT,
-    MCS_DATA_PATH,
-    MCS_SECRETS_FILENAME,
-    REQUEST_TIMEOUT,
-    TRANSACTION_TIMEOUT,
+    MCS_DATA_PATH, MCS_SECRETS_FILENAME, REQUEST_TIMEOUT, TRANSACTION_TIMEOUT,
+    CMAPI_CONF_PATH, CMAPI_PORT,
 )
 from cmapi_server.controllers.api_clients import (
     AppControllerClient, ClusterControllerClient, NodeControllerClient


### PR DESCRIPTION
This reverts commit c5e3b847ab1afa3e565718d32bbdcf4dc441241a.

To avoid some strange behaviour after adding nodes in systemd installations. (select freezes on one random non primary node after adding nodes and start simple validation)