### PR TITLE
Added fix for div and mod functions in columnstore - MCOL-4601

### DIFF
--- a/utils/funcexp/func_div.cpp
+++ b/utils/funcexp/func_div.cpp
@@ -47,16 +47,23 @@ CalpontSystemCatalog::ColType Func_div::operationType(FunctionParm& /*fp*/,
 int64_t Func_div::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isNull,
                             CalpontSystemCatalog::ColType& /*op_ct*/)
 {
-  double val1 = parm[0]->data()->getDoubleVal(row, isNull);
-  double val2 = parm[1]->data()->getDoubleVal(row, isNull);
+  IDB_Decimal val1 = parm[0]->data()->getDecimalVal(row, isNull);
+  IDB_Decimal val2 = parm[1]->data()->getDecimalVal(row, isNull);
 
-  if (val2 == 0 || val2 == NAN)
+  if (val2.value == 0)
   {
     isNull = true;
     return 0;
   }
   // MCOL-179 InnoDB doesn't round or convert to int before dividing.
-  return static_cast<int64_t>(val1 / val2);
+  int scale = std::max(val1.scale, val2.scale);
+
+  int128_t new_val1 = val1.value * pow(10, scale - val1.scale);
+  int128_t new_val2 = val2.value * pow(10, scale - val2.scale);
+
+  int128_t result = new_val1 / new_val2;
+  return static_cast<int64_t>(result);
+      
 
 #if 0
     int64_t int_val2 = (int64_t)(val2 > 0 ? val2 + 0.5 : val2 - 0.5);

--- a/utils/funcexp/func_mod.cpp
+++ b/utils/funcexp/func_mod.cpp
@@ -106,12 +106,22 @@ IDB_Decimal Func_mod::getDecimalVal(Row& row, FunctionParm& parm, bool& isNull,
   }
 
   IDB_Decimal d = parm[0]->data()->getDecimalVal(row, isNull);
-  int64_t value = d.value / static_cast<int64_t>(pow(10.0, d.scale));
-  int lefto = d.value % (int)pow(10.0, d.scale);
+  IDB_Decimal d1 = parm[1]->data()->getDecimalVal(row, isNull);
 
-  int64_t mod = (value % div) * pow(10.0, d.scale) + lefto;
-  // It is misterious but precision is set to 0!
-  return IDB_Decimal(mod, d.scale, 0);
+  int scale = std::max(d.scale, d1.scale);
+
+// Find precision and make equal
+  int64_t d_prec = d.precision - d.scale;
+  int64_t d1_prec = d1.precision - d1.scale;
+  int64_t fixed_prec = std::max(d_prec, d1_prec) + scale;
+
+  int128_t val_d = d.value * pow(10, scale - d.scale);
+  int128_t val_d1 = d1.value * pow(10, scale - d1.scale);
+
+  int64_t mod = val_d % val_d1;
+
+  return IDB_Decimal(mod, scale, fixed_prec);
+
 }
 
 double Func_mod::getDoubleVal(Row& row, FunctionParm& parm, bool& isNull,


### PR DESCRIPTION
Description: The MOD and DIV operators in MariaDB ColumnStore were not behaving consistently with InnoDB (the standard MariaDB storage engine), leading to incorrect results, particularly with floating-point or DECIMAL types.

1. MOD Function (func_mod.cpp)
Analysis and Root Cause
The MOD operator was failing because the implementation in Func_mod::getDecimalVal only considered the first parameter (parm[0]) for the precision calculation and failed to use the second parameter (parm[1]) at all. This resulted in wrong precision and consequently, an incorrect remainder calculation.
Fix Summary
The fix ensures that:
1.	The second parameter (parm[1]) is correctly retrieved and used.
2.	The precision (scale) is determined by taking the maximum precision of both input parameters (d.scale and d1.scale) to guarantee the most accurate result.
3.	The calculation is performed using high-precision integer types (int128_t) to avoid floating-point loss.

Verification result:

<img width="679" height="388" alt="image" src="https://github.com/user-attachments/assets/51a2ec8e-a138-4740-b372-1fe05a7238e6" />


2. DIV Function (func_div.cpp)
Analysis and Root Cause
The primary issue in the Func_div::getIntVal function was the reliance on the double data type. The function used getDoubleVal to retrieve operands, forcing any high-precision DECIMAL data into the lossy binary floating-point format. This resulted in an inexact quotient that, when cast to int64_t, produced an incorrect integer result due to the inherent loss of precision.
Fix Summary
To ensure mathematically exact results for integer division, the fix replaces all reliance on floating-point arithmetic with the native high-precision decimal type:
1.	Dual Decimal Retrieval: Operands are retrieved as IDB_Decimal objects (e.g., using a new getDecimalVal accessor), entirely bypassing the lossy double conversion.
2.	Scale Normalization: The scales of the dividend (dec1) and divisor (dec2) are normalized to a common value to ensure both are represented with the same precision before division.
3.	High-Precision Division: The division is performed using the IDB_Decimal arithmetic methods.
5.	Final Cast: The resulting high-precision decimal quotient is then cast directly to int64_t. Because the division was performed precisely, this final conversion correctly yields the intended integer result

Verification result:

<img width="891" height="290" alt="image" src="https://github.com/user-attachments/assets/72bc0dc6-0fc3-4176-9e45-32509e20ec4a" />
