### PR TITLE
ci testing improvements

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -716,16 +716,15 @@ local AllPipelines =
     for triggeringEvent in events
     for server in servers[current_branch]
   ] +
-  // last argument is to ignore mtr and regression failures
-  // [
-  //   Pipeline(b, platform, triggeringEvent, a, server, flag, "", ["regression", "mtr"])
-  //   for a in ["amd64"]
-  //   for b in std.objectFields(platforms)
-  //   for platform in ["ubuntu:24.04"]
-  //   for flag in ["ASan", "UBSan"]
-  //   for triggeringEvent in events
-  //   for server in servers[current_branch]
-  // ] +
+  [
+    Pipeline(b, platform, triggeringEvent, a, server, flag, "")
+    for a in ["amd64"]
+    for b in std.objectFields(platforms)
+    for platform in ["ubuntu:24.04"]
+    for flag in ["ASan", "UBSan"]
+    for triggeringEvent in events
+    for server in servers[current_branch]
+  ] +
 
   [];
 

--- a/build/bootstrap_mcs.sh
+++ b/build/bootstrap_mcs.sh
@@ -695,7 +695,7 @@ fix_config_files() {
         if grep -q ASAN $MDB_SERVICE_FILE; then
             warn "MDB Server has ASAN options in $MDB_SERVICE_FILE, check it's compatibility"
         else
-            echo Environment="'ASAN_OPTIONS=abort_on_error=$SANITIZERS_ABORT_ON_ERROR:disable_coredump=0,print_stats=false,detect_odr_violation=0,check_initialization_order=0,detect_stack_use_after_return=1,atexit=false,log_path=${REPORT_PATH}/asan.mariadb'" >>$MDB_SERVICE_FILE
+            echo Environment="'ASAN_OPTIONS=abort_on_error=$SANITIZERS_ABORT_ON_ERROR:disable_coredump=0,print_stats=false,detect_odr_violation=0,check_initialization_order=0,detect_stack_use_after_return=0,atexit=false,log_path=${REPORT_PATH}/asan.mariadb'" >>$MDB_SERVICE_FILE
             message "ASAN options were added to $MDB_SERVICE_FILE"
         fi
     fi

--- a/build/monitor_memory.sh
+++ b/build/monitor_memory.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Monitor memory usage for regression test
+# Usage: monitor_memory.sh <test_name>
+
+TEST_NAME="${1:?Test name required}"
+LOG_FILE="/regression-results/memory-monitor-${TEST_NAME}"
+
+INTERVAL=5
+PREV_MEM_FILE="/tmp/mem_snapshot_${TEST_NAME}.txt"
+GROWTH_THRESHOLD_MB=200
+
+# Get process list sorted by memory
+ps_by_memory() {
+  ps aux --sort=-rss 2>/dev/null || ps aux | sort -k4 -rn
+}
+
+printf "\n=== Memory Monitor Started for test: %s at %s ===\n\n" "${TEST_NAME}" "$(date)" >> "$LOG_FILE"
+
+while true; do
+    
+    {
+        echo "========================================"
+        echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
+        echo "========================================"
+        printf "\n--- System Memory ---\n"
+        free -h
+        
+        printf "\n--- Top 10 Processes by memory ---\n"
+        PS_OUTPUT=$(ps_by_memory)
+        CURRENT_SNAPSHOT=$(echo "$PS_OUTPUT" | awk 'NR>1 {printf "%s %s %d\n", $2, $11, $6}' | head -n 20)
+        echo "$PS_OUTPUT" | head -n 11
+        
+        if [[ -f "$PREV_MEM_FILE" ]]; then
+            printf "\n--- Memory Growth (since last check) ---\n"
+            
+            # Compare snapshots and show processes with significant growth
+            while read -r PID CMD CURR_RSS; do
+                
+                # Find previous RSS for this PID
+                PREV_RSS=$(grep "^$PID " "$PREV_MEM_FILE" 2>/dev/null | awk '{print $3}')
+                
+                if [[ -n "$PREV_RSS" ]]; then
+                    DELTA_MB=$(((CURR_RSS - PREV_RSS) / 1024))
+                    ABS_DELTA=$((DELTA_MB < 0 ? -DELTA_MB : DELTA_MB))
+                    
+                    if [[ $ABS_DELTA -gt 10 ]]; then
+                        printf "  PID %-7s %-20s %+6d MB" "$PID" "$CMD" "$DELTA_MB"
+                        [[ $DELTA_MB -gt $GROWTH_THRESHOLD_MB ]] && printf " [!] ALERT\n" || printf "\n"
+                    fi
+                fi
+            done <<< "$CURRENT_SNAPSHOT"
+        fi
+        
+        # Save current snapshot for next iteration
+        echo "$CURRENT_SNAPSHOT" > "$PREV_MEM_FILE"
+        echo
+    } >> "$LOG_FILE"
+    
+    sleep "$INTERVAL"
+done

--- a/build/monitor_memory.sh
+++ b/build/monitor_memory.sh
@@ -24,6 +24,11 @@ while true; do
         echo "========================================"
         printf "\n--- System Memory ---\n"
         free -h
+
+        if [[ -f "/tmp/current_query.txt" ]]; then
+            CURRENT_QUERY=$(cat /tmp/current_query.txt)
+            printf "\n--- Current Query ---\n%s\n" "$CURRENT_QUERY"
+        fi
         
         printf "\n--- Top 10 Processes by memory ---\n"
         PS_OUTPUT=$(ps_by_memory)

--- a/build/prepare_test_container.sh
+++ b/build/prepare_test_container.sh
@@ -64,7 +64,10 @@ start_container() {
     elif [[ "$CONTAINER_NAME" == *upgrade* ]]; then
         docker_run_args+=(--env UCF_FORCE_CONFNEW=1 --volume /sys/fs/cgroup:/sys/fs/cgroup:ro)
     elif [[ "$CONTAINER_NAME" == *regression* ]]; then
-        docker_run_args+=(--shm-size=500m --memory 15g)
+        # Mount volume to write memory logs outside of container
+        REGRESSION_RESULTS_DIR="${SCRIPT_LOCATION}/regression-results"
+        mkdir -p "$REGRESSION_RESULTS_DIR"
+        docker_run_args+=(--shm-size=500m --memory 15g --volume "${REGRESSION_RESULTS_DIR}:/regression-results")
     else
         error "Unknown container type: $CONTAINER_NAME"
         exit 1

--- a/build/prepare_test_container.sh
+++ b/build/prepare_test_container.sh
@@ -147,18 +147,24 @@ prepare_container() {
 
     #Install columnstore in container
     message "Installing columnstore..."
-    SERVER_VERSION=$(grep -E 'MYSQL_VERSION_(MAJOR|MINOR)' $MDB_SOURCE_PATH/VERSION | cut -d'=' -f2 | paste -sd. -)
-    message "Server version of build is $SERVER_VERSION"
+    
+    # Try to detect server version from VERSION file (CI) or PACKAGES_URL (local)
+    if [[ -f "$MDB_SOURCE_PATH/VERSION" ]]; then
+        SERVER_VERSION=$(grep -E 'MYSQL_VERSION_(MAJOR|MINOR)' $MDB_SOURCE_PATH/VERSION | cut -d'=' -f2 | paste -sd. -)
+    else
+        # Extract from PACKAGES_URL: e.g., /10.6-enterprise/ -> 10.6
+        SERVER_VERSION=$(echo "$PACKAGES_URL" | sed -n 's|.*/\([0-9]\+\.[0-9]\+\)-enterprise\(/.*\)\?|\1|p')
+    fi
+    message "Server version of build is: ${SERVER_VERSION:-unknown}"
 
     if [[ "$RESULT" == *rocky* ]]; then
         execInnerDockerWithRetry "$CONTAINER_NAME" 'yum install -y MariaDB-columnstore-engine MariaDB-test'
     else
-
         execInnerDockerWithRetry "$CONTAINER_NAME" 'apt update -y && apt install -y mariadb-plugin-columnstore mariadb-test mariadb-test-data mariadb-plugin-columnstore-dbgsym mariadb-test-dbgsym'
-        if [[ $SERVER_VERSION == '10.6' ]]; then
-            execInnerDockerWithRetry "$CONTAINER_NAME" 'apt install -y mariadb-client-10.6-dbgsym mariadb-client-core-10.6-dbgsym mariadb-server-10.6-dbgsym mariadb-server-core-10.6-dbgsym'
-        else
-            execInnerDockerWithRetry "$CONTAINER_NAME" 'apt install -y mariadb-client-dbgsym mariadb-client-core-dbgsym mariadb-server-dbgsym mariadb-server-core-dbgsym'
+        
+        # Try to install server debug symbols (may not be available)
+        if [[ -n "$SERVER_VERSION" && $SERVER_VERSION == '10.6' ]]; then
+            execInnerDocker "$CONTAINER_NAME" 'apt install -y mariadb-client-10.6-dbgsym mariadb-client-core-10.6-dbgsym mariadb-server-10.6-dbgsym mariadb-server-core-10.6-dbgsym' || warn "Debug symbols not available (not critical)"
         fi
     fi
 

--- a/build/prepare_test_container.sh
+++ b/build/prepare_test_container.sh
@@ -117,6 +117,8 @@ prepare_container() {
 
     # Prepare core dump directory inside container
     execInnerDocker "$CONTAINER_NAME" 'mkdir -p core && chmod 777 core'
+    # Prepare ASAN logs directory
+    execInnerDocker "$CONTAINER_NAME" 'mkdir -p /tmp/asan && chmod 777 /tmp/asan'
     docker cp "$COLUMNSTORE_SOURCE_PATH"/core_dumps/. "$CONTAINER_NAME":/
     docker cp "$COLUMNSTORE_SOURCE_PATH"/build/utils.sh "$CONTAINER_NAME":/
     docker cp "$COLUMNSTORE_SOURCE_PATH"/setup-repo.sh "$CONTAINER_NAME":/

--- a/build/report_test_stage.sh
+++ b/build/report_test_stage.sh
@@ -101,6 +101,11 @@ fi
 execInnerDocker "$CONTAINER_NAME" "/logs.sh ${STAGE}"
 execInnerDocker "$CONTAINER_NAME" "/core_dump_check.sh core /core/ ${STAGE}"
 
+# Check for sanitizer reports
+if ! execInnerDocker "$CONTAINER_NAME" "/check_sanitizer_reports.sh core ${STAGE}"; then
+    SANITIZER_FAILED=1
+fi
+
 docker cp "${CONTAINER_NAME}:/core/" "/drone/src/${RESULT}/"
 docker cp "${CONTAINER_NAME}:/unit_logs/" "/drone/src/${RESULT}/"
 
@@ -108,4 +113,9 @@ execInnerDocker "$CONTAINER_NAME" "/core_dump_drop.sh core"
 echo "Saved artifacts:"
 ls -R "/drone/src/${RESULT}/"
 echo "Done reporting ${STAGE}"
+
+# Exit with error if sanitizer issues found
+if [[ "${SANITIZER_FAILED:-0}" -eq 1 ]]; then
+    exit 1
+fi
 

--- a/build/report_test_stage.sh
+++ b/build/report_test_stage.sh
@@ -84,9 +84,12 @@ elif [[ "${CONTAINER_NAME}" == *regression* ]]; then
     echo
     docker cp "${CONTAINER_NAME}:/mariadb-columnstore-regression-test/mysql/queries/nightly/alltest/reg-logs/" "/drone/src/${RESULT}/" || echo "missing regression logs"
     docker cp "${CONTAINER_NAME}:/mariadb-columnstore-regression-test/mysql/queries/nightly/alltest/testErrorLogs.tgz" "/drone/src/${RESULT}/" || echo "missing testErrorLogs.tgz"
-
+    
+    # Copy memory-monitor logs into alltest for archive
+    execInnerDocker "$CONTAINER_NAME" 'cp /regression-results/memory-monitor-* /mariadb-columnstore-regression-test/mysql/queries/nightly/alltest/ 2>/dev/null' || echo "no memory-monitor logs"
+    
     execInnerDocker "$CONTAINER_NAME" 'tar czf regressionQueries.tgz /mariadb-columnstore-regression-test/mysql/queries/'
-    execInnerDocker "$CONTAINER_NAME" 'cd /mariadb-columnstore-regression-test/mysql/queries/nightly/alltest && tar czf testErrorLogs2.tgz *.log /var/log/mariadb/columnstore' || echo "failed to grab regression results"
+    execInnerDocker "$CONTAINER_NAME" 'cd /mariadb-columnstore-regression-test/mysql/queries/nightly/alltest && tar czf testErrorLogs2.tgz *.log memory-monitor-* /var/log/mariadb/columnstore 2>/dev/null' || echo "failed to grab regression results"
     docker cp "${CONTAINER_NAME}:/mariadb-columnstore-regression-test/mysql/queries/nightly/alltest/testErrorLogs2.tgz" "/drone/src/${RESULT}/" || echo "missing testErrorLogs2.tgz"
     docker cp "${CONTAINER_NAME}:regressionQueries.tgz" "/drone/src/${RESULT}/" || echo "missing regressionQueries.tgz"
 

--- a/build/run_regression.sh
+++ b/build/run_regression.sh
@@ -8,11 +8,11 @@ source "$SCRIPT_LOCATION"/utils.sh
 optparse.define short=c long=container-name     desc="Name of the Docker container where regression tests will run" variable=CONTAINER_NAME
 optparse.define short=b long=regression-branch  desc="Branch from regression tests repo"                            variable=REGRESSION_BRANCH
 optparse.define short=d long=distro             desc="Linux distro for which regression is executed"                variable=DISTRO
-optparse.define short=t long=regression-timeout desc="Timeout for the regression test run"                          variable=REGRESSION_TIMEOUT
+optparse.define short=t long=regression-timeout desc="Timeout for the regression test run"                          variable=REGRESSION_TIMEOUT default=2h
 optparse.define short=n long=test-name          desc="Name of regression test to execute"                           variable=TEST_NAME
 source "$(optparse.build)"
 
-for flag in CONTAINER_NAME REGRESSION_BRANCH DISTRO REGRESSION_TIMEOUT TEST_NAME; do
+for flag in CONTAINER_NAME REGRESSION_BRANCH DISTRO TEST_NAME; do
   if [[ -z "${!flag}" ]]; then
     error "Missing required flag: -${flag:0:1} / --${flag,,}"
     exit 1
@@ -41,13 +41,33 @@ prepare_regression() {
     CONFIG_PATH_PREFIX="/etc/mysql/mariadb.conf.d/50-"
   fi
 
-  git clone --recurse-submodules --branch "${REGRESSION_BRANCH}" --depth 1 https://github.com/mariadb-corporation/mariadb-columnstore-regression-test
+  # Clone regression test repo (requires GitHub token)
+  REPO_URL="https://github.com/mariadb-corporation/mariadb-columnstore-regression-test"
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    REPO_URL="https://${GITHUB_TOKEN}@github.com/mariadb-corporation/mariadb-columnstore-regression-test"
+  fi
+
+  rm -rf mariadb-columnstore-regression-test
+  git clone --recurse-submodules --branch "${REGRESSION_BRANCH}" --depth 1 "${REPO_URL}"
   cd mariadb-columnstore-regression-test
   git rev-parse --abbrev-ref HEAD && git rev-parse HEAD
   cd ..
 
   docker cp mariadb-columnstore-regression-test "${CONTAINER_NAME}:/"
-  docker cp "/mdb/${BUILD_DIR}/storage/columnstore/columnstore/storage-manager" "${CONTAINER_NAME}:/"
+
+  # Copy memory monitoring script
+  docker cp "${SCRIPT_LOCATION}/monitor_memory.sh" "${CONTAINER_NAME}:/"
+  execInnerDocker "${CONTAINER_NAME}" "chmod +x /monitor_memory.sh"
+
+  # Copy storage-manager (try CI path first, fallback to local)
+  SM_PATH="/mdb/${BUILD_DIR}/storage/columnstore/columnstore/storage-manager"
+  [[ ! -d "$SM_PATH" ]] && SM_PATH="${SCRIPT_LOCATION}/../storage-manager"
+  
+  if [[ -d "$SM_PATH" ]]; then
+    docker cp "$SM_PATH" "${CONTAINER_NAME}:/"
+  else
+    warn "storage-manager not found, some tests may fail"
+  fi
 
   #copy test data for regression test suite
   execInnerDocker "${CONTAINER_NAME}" 'bash -c "wget -qO- https://cspkg.s3.amazonaws.com/testData.tar.lz4 | lz4 -dc - | tar xf - -C mariadb-columnstore-regression-test/"'
@@ -62,18 +82,29 @@ prepare_regression() {
   execInnerDocker "${CONTAINER_NAME}" "systemctl start mariadb"
   execInnerDocker "${CONTAINER_NAME}" "systemctl restart mariadb-columnstore"
   execInnerDocker "${CONTAINER_NAME}" "g++ /mariadb-columnstore-regression-test/mysql/queries/queryTester.cpp -O2 -o /mariadb-columnstore-regression-test/mysql/queries/queryTester"
+  execInnerDocker "${CONTAINER_NAME}" "mkdir -p /mariadb-columnstore-regression-test/mysql/queries/nightly/alltest"
 
   message "Regression preparation complete"
 }
 
 run_test() {
-  message "Running test: ${TEST_NAME:-<none>}"
+  local test_dir="/mariadb-columnstore-regression-test/mysql/queries/nightly/alltest"
+  
+  message "Running test: ${TEST_NAME}"
 
-  execInnerDocker "${CONTAINER_NAME}" "sleep 4800 && bash /save_stack.sh /mariadb-columnstore-regression-test/mysql/queries/nightly/alltest/reg-logs/ &"
+  execInnerDockerNoTTY "${CONTAINER_NAME}" "nohup /monitor_memory.sh \"${TEST_NAME%.sh}\" >/dev/null 2>&1 &"
+
+  sleep 1
+  if ! execInnerDocker "${CONTAINER_NAME}" "ps aux | grep -q '[m]onitor_memory.sh'"; then
+    warn "Memory monitor failed to start for test: ${TEST_NAME}"
+  fi
+
+  execInnerDocker "${CONTAINER_NAME}" "sleep 4800 && bash /save_stack.sh ${test_dir}/reg-logs/ &"
 
   execInnerDockerNoTTY "${CONTAINER_NAME}" \
-    "export PRESERVE_LOGS=true && cd /mariadb-columnstore-regression-test/mysql/queries/nightly/alltest && \
-     timeout -k 1m -s SIGKILL --preserve-status ${REGRESSION_TIMEOUT} ./go.sh --sm_unit_test_dir=/storage-manager --tests=${TEST_NAME} \
+    "export PRESERVE_LOGS=true && cd ${test_dir} && \
+     timeout -k 1m -s SIGKILL --preserve-status ${REGRESSION_TIMEOUT} \
+     ./go.sh --sm_unit_test_dir=/storage-manager --tests=${TEST_NAME} \
        || ./regression_logs.sh ${TEST_NAME}"
 }
 

--- a/build/run_regression_locally.sh
+++ b/build/run_regression_locally.sh
@@ -89,10 +89,8 @@ for test in "${TESTS[@]}"; do
         --regression-timeout "$REGRESSION_TIMEOUT" || true
 done
 
-# Copy test results from container to host
-RESULTS_DIR="./regression-results"
-rm -rf "$RESULTS_DIR"
-mkdir -p "$RESULTS_DIR"
+RESULTS_DIR="${SCRIPT_LOCATION}/regression-results"
+
 docker cp "$CONTAINER_NAME":/mariadb-columnstore-regression-test/mysql/queries/nightly/alltest/. "$RESULTS_DIR/" 2>/dev/null || true
 
 echo ""

--- a/build/run_regression_locally.sh
+++ b/build/run_regression_locally.sh
@@ -42,8 +42,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Strip _ASan/_UBSan suffix for Docker image (keep it for RESULT_PATH)
+CLEAN_PLATFORM=$(echo "$PLATFORM" | sed -E 's/_(ASan|UBSan)//i')
 # Apply image naming logic from jsonnet: "detravi/" + std.strReplace(platform, "/", "-")
-DOCKER_IMAGE="detravi/${PLATFORM}"
+DOCKER_IMAGE="detravi/${CLEAN_PLATFORM}"
 
 # Checks
 [[ "$EUID" -ne 0 ]] && echo "Run with sudo" && exit 1

--- a/build/run_regression_locally.sh
+++ b/build/run_regression_locally.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Run ColumnStore regression tests locally on pre-built packages from S3
+#
+# Usage:
+#   # Minimal (ubuntu:24.04, test000.sh)
+#   ./run_regression_locally.sh \
+#     -u https://cspkg.s3.amazonaws.com/stable-23.10/pull_request/2463/10.6-enterprise \
+#     -t ghp_xxxxxxxxxxxxxxxxxxxx
+#
+#   ./run_regression_locally.sh \
+#     -u https://cspkg.s3.amazonaws.com/stable-23.10/cron/2506/10.6-enterprise \
+#     -t ghp_xxxxxxxxxxxxxxxxxxxx \
+#     -n all \
+#     -p ubuntu:24.04 \
+#     -b stable-23.10
+#
+# Output:
+#   ./regression-results/ - Test logs and memory monitor log
+
+set -e
+
+SCRIPT_LOCATION=$(dirname "$0")
+source "$SCRIPT_LOCATION"/utils.sh
+
+echo "Arguments received: $@"
+
+optparse.define short=u long=packages-url      desc="S3 URL with pre-built packages"         variable=PACKAGES_URL
+optparse.define short=t long=github-token      desc="GitHub token to pull from regression tests repo"         variable=GITHUB_TOKEN
+optparse.define short=p long=platform          desc="Docker platform"                         variable=PLATFORM          default="ubuntu:24.04"
+optparse.define short=b long=regression-branch desc="Regression repo branch"                  variable=REGRESSION_BRANCH default="stable-23.10"
+optparse.define short=n long=test-name         desc="Test name to execute (or 'all')"        variable=TEST_NAME         default="test000.sh"
+source $(optparse.build)
+
+# Internal variables
+CONTAINER_NAME="regression_local_$$"
+REGRESSION_TIMEOUT="2h"
+RESULT_PATH="${PLATFORM//:/}"  # ubuntu:24.04 → ubuntu24.04 (no underscore)
+
+# Cleanup on exit
+cleanup() {
+    [[ -n "${CONTAINER_NAME:-}" ]] && docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Apply image naming logic from jsonnet: "detravi/" + std.strReplace(platform, "/", "-")
+DOCKER_IMAGE="detravi/${PLATFORM}"
+
+# Checks
+[[ "$EUID" -ne 0 ]] && echo "Run with sudo" && exit 1
+! command -v docker &>/dev/null && echo "Docker not installed" && exit 1
+
+# Check required parameters
+for flag in PACKAGES_URL GITHUB_TOKEN; do
+  if [[ -z "${!flag}" ]]; then
+    error "Missing required flag: --${flag,,}"
+    [[ "$flag" == "GITHUB_TOKEN" ]] && echo "Create token at: https://github.com/settings/tokens (needs 'repo' scope)"
+    exit 1
+  fi
+done
+
+export GITHUB_TOKEN
+
+echo "Platform: $PLATFORM → Docker image: $DOCKER_IMAGE"
+echo "Packages: $PACKAGES_URL"
+
+# Prepare container
+echo "→ Preparing container..."
+bash "$SCRIPT_LOCATION/prepare_test_container.sh" \
+    --container-name "$CONTAINER_NAME" \
+    --docker-image "$DOCKER_IMAGE" \
+    --result-path "$RESULT_PATH" \
+    --packages-url "$PACKAGES_URL" \
+    --do-setup true || exit 1
+
+# Run tests
+if [[ "$TEST_NAME" == "all" ]]; then
+    TESTS=("test000.sh" "test001.sh")
+else
+    TESTS=("$TEST_NAME")
+fi
+
+for test in "${TESTS[@]}"; do
+    echo "→ Running test: $test"
+    bash "$SCRIPT_LOCATION/run_regression.sh" \
+        --container-name "$CONTAINER_NAME" \
+        --test-name "$test" \
+        --distro "$PLATFORM" \
+        --regression-branch "$REGRESSION_BRANCH" \
+        --regression-timeout "$REGRESSION_TIMEOUT" || true
+done
+
+# Copy test results from container to host
+RESULTS_DIR="./regression-results"
+rm -rf "$RESULTS_DIR"
+mkdir -p "$RESULTS_DIR"
+docker cp "$CONTAINER_NAME":/mariadb-columnstore-regression-test/mysql/queries/nightly/alltest/. "$RESULTS_DIR/" 2>/dev/null || true
+
+echo ""
+echo "=========================================="
+echo "Regression tests completed"
+echo "=========================================="
+echo "Results: $RESULTS_DIR/"
+echo ""
+ls -lh "$RESULTS_DIR"/ | grep -E "(memory-monitor|\.log)" || echo "No logs found"
+

--- a/core_dumps/check_sanitizer_reports.sh
+++ b/core_dumps/check_sanitizer_reports.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR_NAME=$1
+
+echo "Checking for sanitizer reports in /$DIR_NAME/"
+
+FOUND_ISSUES=0
+
+# Check for ASAN reports
+shopt -s nullglob
+for f in /"$DIR_NAME"/asan.* /"$DIR_NAME"/asan_*; do
+    if [[ -f "$f" ]]; then
+        FOUND_ISSUES=1
+        echo ""
+        echo "=========================================="
+        echo "⚠️  ASAN report found: $(basename "$f")"
+        echo "=========================================="
+        cat "$f"
+        echo ""
+    fi
+done
+
+# Check for UBSAN reports
+for f in /"$DIR_NAME"/ubsan.* /"$DIR_NAME"/ubsan_*; do
+    if [[ -f "$f" ]]; then
+        FOUND_ISSUES=1
+        echo ""
+        echo "=========================================="
+        echo "⚠️  UBSAN report found: $(basename "$f")"
+        echo "=========================================="
+        cat "$f"
+        echo ""
+    fi
+done
+
+
+if [[ $FOUND_ISSUES -eq 1 ]]; then
+    exit 1
+fi
+
+echo "✅ No sanitizer reports found"
+exit 0

--- a/oam/install_scripts/CMakeLists.txt
+++ b/oam/install_scripts/CMakeLists.txt
@@ -31,7 +31,7 @@ if(WITH_COLUMNSTORE_ASAN)
     endif()
 
     set(ASAN_OPTIONS
-        abort_on_error=${ABORT_ON_ERROR}:disable_coredump=0:print_stats=0:detect_odr_violation=0:check_initialization_order=1:detect_stack_use_after_return=1:atexit=0
+        abort_on_error=${ABORT_ON_ERROR}:disable_coredump=0:print_stats=0:detect_odr_violation=0:check_initialization_order=1:detect_stack_use_after_return=0:atexit=0
     )
     set(ALLOC_CONFIG ASAN_OPTIONS=${ASAN_OPTIONS})
 


### PR DESCRIPTION
1. Sanitizer Report Checking
Scans for ASAN/UBSAN reports after all test stages (regression, MTR, smoke, etc.). *log step after tests will fail if sanitizer reports found. Reports' content is printed in drone.

2. Script for easy local execution of regression tests 
build/run_regression_locally.sh

3. Ram consumption monitoring for regression tests
Each regression test gets a separate memory monitor log (memory-monitor-{test_name}.log) which contains output of ps ordered by ram usage. Logs every 5 seconds, alerts on >200MB growth in 5 seconds.

4. Disabled asan's detect_stack_use_after_return option, as it broke regression run when runner was being killed in CI assumingly due to huge overhead

