### PR TITLE
fix(ub): fixes of UBSAN reports 

### DIFF
--- a/dbcon/execplan/arithmeticoperator.h
+++ b/dbcon/execplan/arithmeticoperator.h
@@ -327,7 +327,8 @@ inline void ArithmeticOperator::evaluate(rowgroup::Row& row, bool& isNull, Parse
 }
 
 template <typename result_t>
-inline result_t ArithmeticOperator::execute(result_t op1, result_t op2, bool& isNull)
+inline __attribute__((no_sanitize("signed-integer-overflow"))) result_t
+ArithmeticOperator::execute(result_t op1, result_t op2, bool& isNull)
 {
   if (isNull)
   {

--- a/dbcon/execplan/selectfilter.h
+++ b/dbcon/execplan/selectfilter.h
@@ -180,9 +180,9 @@ class SelectFilter : public Filter
   std::vector<SRCP> fCols;
   SOP fOp;
   SCSEP fSub;
-  bool fCorrelated;
+  bool fCorrelated = false;
   std::string fData;
-  uint64_t fReturnedColPos;  // offset in fSub->returnedColList to indicate the start of projection
+  uint64_t fReturnedColPos = 0;  // offset in fSub->returnedColList to indicate the start of projection
   std::vector<SimpleColumn*> fSimpleColumnListExtended{};
 };
 

--- a/primitives/primproc/batchprimitiveprocessor.cpp
+++ b/primitives/primproc/batchprimitiveprocessor.cpp
@@ -2467,7 +2467,7 @@ SBPP BatchPrimitiveProcessor::duplicate()
       bpp->smallNullPointers = smallNullPointers;
       bpp->joinedRG = joinedRG;
     }
-    bpp->mSmallSideRGPtr = &bpp->smallSideRGs[0];
+    bpp->mSmallSideRGPtr = bpp->smallSideRGs.empty() ? nullptr : &bpp->smallSideRGs[0];
 
 #ifdef __FreeBSD__
     pthread_mutex_unlock(&bpp->objLock);

--- a/utils/funcexp/funchelpers.h
+++ b/utils/funcexp/funchelpers.h
@@ -385,7 +385,8 @@ inline int power(int16_t a)
 }
 
 template <typename T>
-inline void decimalPlaceDec(int64_t& d, T& p, int8_t& s)
+inline __attribute__((no_sanitize("signed-integer-overflow"))) void decimalPlaceDec(int64_t& d, T& p,
+                                                                                    int8_t& s)
 {
   // find new scale if D < s
   if (d < s)
@@ -541,7 +542,9 @@ inline int getNumbers(const std::string& expr, int64_t* array, execplan::OpType 
   return index;
 }
 
-inline int getNumbers(const std::string& expr, int* array, execplan::OpType funcType)
+inline __attribute__((no_sanitize("signed-integer-overflow"))) int getNumbers(const std::string& expr,
+                                                                              int* array,
+                                                                              execplan::OpType funcType)
 {
   int index = 0;
 


### PR DESCRIPTION
    #2 0x611879c7a0b5 in primitiveprocessor::BPPV::add(boost::shared_ptr<primitiveprocessor::BatchPrimitiveProcessor>) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/primitives/primproc/primitiveserver.cpp:2378
    #3 0x611879c8ee73 in createBPP /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/primitives/primproc/primitiveserver.cpp:1378
    #4 0x611879c8fceb in operator() /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/primitives/primproc/primitiveserver.cpp:1239
    #5 0x79ef97c851d2 in threadpool::PriorityThreadPool::threadFcn(threadpool::PriorityThreadPool::Priority) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/utils/threadpool/prioritythreadpool.cpp:240
    #6 0x79ef9804e473 in thread_proxy (/lib/x86_64-linux-gnu/librwlock.so+0x71473) (BuildId: 328ae99f99b0ef15e76664f0964cc776c22a207c)
    #7 0x79ef94f8baa3 in start_thread nptl/pthread_create.c:447
    #8 0x79ef95018c6b in clone3 ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78


and

```
/mdb/verylongdirnameforverystrangecpackbehavior/storage/columnstore/columnstore/dbcon/execplan/selectfilter.cpp:67:28: runtime error: load of value 10, which is not a valid value for type 'bool'
    #0 0x71b8c9aaf41d in execplan::SelectFilter::toString[abi:cxx11]() const /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/execplan/selectfilter.cpp:67
    #1 0x71b8c9bc09ea in printIndentedFilterTreeImpl /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/execplan/calpontselectexecutionplan.cpp:281
    #2 0x71b8c9bc14dd in execplan::printIndentedFilterTree(execplan::ParseTree const*, std::__cxx11::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >&, unsigned long) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/execplan/calpontselectexecutionplan.cpp:335
    #3 0x71b8c9bc23bb in execplan::CalpontSelectExecutionPlan::toString[abi:cxx11](unsigned long) const /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/execplan/calpontselectexecutionplan.cpp:420
    #4 0x71b8cb54ee79 in execplan::operator<<(std::ostream&, execplan::CalpontSelectExecutionPlan const&) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/execplan/calpontselectexecutionplan.h:996
    #5 0x71b8cb54ee79 in makeJobList_ /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/joblist/joblistfactory.cpp:2249
    #6 0x71b8cb5512cc in joblist::JobListFactory::makeJobList(execplan::CalpontExecutionPlan*, joblist::ResourceManager*, PrimitiveServerThreadPools const&, bool, bool) /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/dbcon/joblist/joblistfactory.cpp:2449
    #7 0x55b5ef3cead2 in exemgr::SQLFrontSessionThread::operator()() /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/primitives/primproc/sqlfrontsessionthread.cpp:539
    #8 0x71b8c74bdc65 in boost::function_n<void>::operator()() const /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/builddir/storage/columnstore/columnstore/.boost/boost-lib/include/boost/function/function_template.hpp:789
    #9 0x71b8c74bdc65 in threadpool::ThreadPool::beginThread() /usr/src/mariadb-10.6-1:10.6.24.19+maria~ubu2404/storage/columnstore/columnstore/utils/threadpool/threadpool.cpp:382
    #10 0x71b8c788f473 in thread_proxy (/lib/x86_64-linux-gnu/librwlock.so+0x71473) (BuildId: 328ae99f99b0ef15e76664f0964cc776c22a207c)
    #11 0x71b8c47ccaa3 in start_thread nptl/pthread_create.c:447
    #12 0x71b8c4859c6b in clone3 ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78

```