### PR TITLE
fix(clustermanagement): Simplify how we calculate which nodes are read replicas 

### DIFF
--- a/cmapi/cmapi_server/node_manipulation.py
+++ b/cmapi/cmapi_server/node_manipulation.py
@@ -10,7 +10,7 @@ import shutil
 import socket
 import subprocess
 import time
-from typing import Optional
+from typing import Dict, Optional
 
 import requests
 from lxml import etree
@@ -125,7 +125,7 @@ def add_node(
                     _rebalance_dbroots(c_root)
                     _move_primary_node(c_root)
 
-            if NodeConfig().get_read_replicas(c_root):
+            if NodeConfig().get_read_replicas_pm_nums(c_root):
                 update_dbroots_of_read_replicas(c_root)
     except Exception:
         logging.error(
@@ -182,9 +182,11 @@ def remove_node(
         ip4, _ = NetworkManager.resolve_ip_and_hostname(node)
 
         if len(active_nodes) > 1:
-            pm_num = _remove_node_from_PMS(c_root, ip4)
+            pm_num = get_pm_num_by_addr(c_root, ip4)
+            read_replicas_pms = node_config.get_read_replicas_pm_nums(c_root)
+            is_read_replica = pm_num in read_replicas_pms
 
-            is_read_replica = ip4 in node_config.get_read_replicas(c_root)
+            _remove_node_from_PMS(c_root, ip4)
             if not is_read_replica:
                 _remove_WES(c_root, pm_num)
 
@@ -202,7 +204,7 @@ def remove_node(
                 _rebalance_dbroots(c_root)
                 _move_primary_node(c_root)
 
-            if NodeConfig().get_read_replicas(c_root):
+            if node_config.get_read_replicas_pm_nums(c_root):
                 update_dbroots_of_read_replicas(c_root)
         else:
             # TODO:
@@ -1265,7 +1267,7 @@ class NodeNotFoundException(Exception):
     pass
 
 
-def get_pm_module_num_to_addr_map(root: etree.Element) -> dict[int, str]:
+def get_pm_module_num_to_addr_map(root: etree.Element) -> Dict[int, str]:
     """Get a mapping of PM module numbers to their IP addresses"""
     module_num_to_addr = {}
     smc_node = root.find("./SystemModuleConfig")
@@ -1276,28 +1278,25 @@ def get_pm_module_num_to_addr_map(root: etree.Element) -> dict[int, str]:
     return module_num_to_addr
 
 
+def get_pm_num_by_addr(root: etree.Element, addr: str) -> int:
+    """Get the PM module number by IP address"""
+    pm_num_to_addr = get_pm_module_num_to_addr_map(root)
+    for pm_num, pm_addr in pm_num_to_addr.items():
+        if pm_addr == addr:
+            return pm_num
+    logging.warning('PM with IP %s not found in config', addr)
+    return None
+
+
 def update_dbroots_of_read_replicas(root: etree.Element) -> None:
     """Read replicas do not have their own dbroots, but they must have all the
     dbroots of the other nodes. Sets the list of dbroots of each read replica to
     the list of all dbroots in the cluster.
     """
     nc = NodeConfig()
-    pm_num_to_addr = get_pm_module_num_to_addr_map(root)
-    for read_replica in nc.get_read_replicas(root):
-        # Get PM num by IP address
-        this_ip_pm_num = None
-        for pm_num, pm_addr in pm_num_to_addr.items():
-            if pm_addr == read_replica:
-                this_ip_pm_num = pm_num
-                break
-
-        if this_ip_pm_num is not None:
-            # Add dbroots of other nodes to this read replica
-            add_dbroots_of_other_nodes(root, this_ip_pm_num)
-        else:  # This should not happen
-            err_msg = f"Could not find PM number for read replica {read_replica}"
-            logging.error(err_msg)
-            raise NodeNotFoundException(err_msg)
+    for read_replica_pm_num in nc.get_read_replicas_pm_nums(root):
+        # Add dbroots of other nodes to this read replica
+        add_dbroots_of_other_nodes(root, read_replica_pm_num)
 
 
 def add_dbroots_of_other_nodes(root: etree.Element, module_num: int) -> None:

--- a/cmapi/cmapi_server/test/test_node_manip.py
+++ b/cmapi/cmapi_server/test/test_node_manip.py
@@ -129,11 +129,6 @@ class NodeManipTester(BaseNodeManipTestCase):
             nc = NodeConfig()
             root = nc.get_current_config_root(self.tmp_files[1])
 
-            # Check that get_read_replicas infers the read replica correctly
-            read_replicas = nc.get_read_replicas(root)
-            self.assertEqual(len(read_replicas), 1)
-            self.assertEqual(read_replicas[0], self.REMOTE_IP)
-
             # Check if PMS was added
             pms_node_ipaddr = root.find('./PMS2/IPAddr')
             self.assertEqual(pms_node_ipaddr.text, self.REMOTE_IP)
@@ -141,6 +136,11 @@ class NodeManipTester(BaseNodeManipTestCase):
             # Check that WriteEngineServer was not added
             wes_node = root.find('./pm2_WriteEngineServer')
             self.assertIsNone(wes_node)
+
+            # Check that get_read_replicas_pm_nums infers the read replica correctly
+            read_replicas_pm_nums = nc.get_read_replicas_pm_nums(root)
+            self.assertEqual(len(read_replicas_pm_nums), 1)
+            self.assertEqual(read_replicas_pm_nums[0], 2)
 
             mock_rebalance_dbroots.assert_not_called()
             mock_move_primary_node.assert_not_called()
@@ -160,8 +160,8 @@ class NodeManipTester(BaseNodeManipTestCase):
 
             nc = NodeConfig()
             root = nc.get_current_config_root(self.tmp_files[2])
-            read_replicas = nc.get_read_replicas(root)
-            self.assertEqual(len(read_replicas), 0)
+            read_replicas_pm_nums = nc.get_read_replicas_pm_nums(root)
+            self.assertEqual(len(read_replicas_pm_nums), 0)
 
             for section_path in ['InactiveNodes', 'DesiredNodes', 'ActiveNodes']:
                 section = root.find(section_path)

--- a/cmapi/mcs_node_control/models/node_config.py
+++ b/cmapi/mcs_node_control/models/node_config.py
@@ -586,33 +586,28 @@ has dbroot {subel.text}')
 
         return dbroots
 
-    def get_read_replicas(self, root=None) -> list[str]:
-        """Collects IP addresses of read replicas.
+    def get_read_replicas_pm_nums(self, root=None) -> list[int]:
+        """Collects PM numbers of read replicas.
 
         A read replica is any PM that does not have a corresponding WriteEngineServer.
         """
         root = root or self.get_current_config_root()
 
-        # Collect all PM IP addresses
-        smc_node = root.find("./SystemModuleConfig")
-        mod_count = int(smc_node.find("./ModuleCount3").text)
-        pm_addrs = set()
-        for i in range(1, mod_count + 1):
-            ip_node = smc_node.find(f"./ModuleIPAddr{i}-1-3")
-            if ip_node is not None and ip_node.text:
-                pm_addrs.add(ip_node.text)
+        smc_node = root.find('./SystemModuleConfig')
+        mod_count = int(smc_node.find('./ModuleCount3').text)
 
-        # Collect all WriteEngineServer IP addresses
-        wes_addrs = set()
+        read_replica_pm_nums: list[int] = []
         for i in range(1, mod_count + 1):
-            wes = root.find(f"./pm{i}_WriteEngineServer")
-            if wes is not None:
-                ip = wes.findtext("./IPAddr")
-                if ip:
-                    wes_addrs.add(ip)
+            mod_ip_node = smc_node.find(f'./ModuleIPAddr{i}-1-3')
+            if mod_ip_node is None or mod_ip_node.text is None:
+                module_logger.warning('Module %d IP addr is not filled', i)
+                continue
 
-        # Find PMs without a WriteEngineServer
-        return list(sorted(pm_addrs - wes_addrs))
+            wes = root.find(f'./pm{i}_WriteEngineServer')
+            if wes is None or wes.findtext('./IPAddr') is None:
+                read_replica_pm_nums.append(i)
+
+        return read_replica_pm_nums
 
     def am_i_read_replica(self, root=None) -> bool:
         """Checks if this node is configured as a read replica.
@@ -622,8 +617,5 @@ has dbroot {subel.text}')
         root = root or self.get_current_config_root()
 
         pm_num = self.get_current_pm_num(root)
-        pm_ip = self.get_module_net_address(root, module_id=pm_num)
-
-        # Check if our PM's IP is in the list of read replicas
-        read_replicas = set(self.get_read_replicas(root))
-        return pm_ip in read_replicas
+        read_replicas_pms = self.get_read_replicas_pm_nums(root)
+        return pm_num in read_replicas_pms


### PR DESCRIPTION
 Вычисление, какие ноды являются рид-репликами, можно сильно упростить. РР это просто ПМ, у которого не прописан write engine server. Раньше код сверял множества адресов, но это ненужное переусложнение, которое может приводить к ошибкам, достаточно просто вычислить номера ПМов, у которых нет соответствующей секции WES.
Функция переименована для ясности, это даёт большую часть диффа.