### PR TITLE
fix(query-acceleator): Fixes SUGSEGV in MCOL-6238

### DIFF
--- a/dbcon/execplan/constantfilter.cpp
+++ b/dbcon/execplan/constantfilter.cpp
@@ -347,6 +347,11 @@ void ConstantFilter::setSimpleColumnListExtended()
                                      fFilterList[i]->simpleColumnListExtended().begin(),
                                      fFilterList[i]->simpleColumnListExtended().end());
   }
+  fCol->setSimpleColumnListExtended();
+  fSimpleColumnListExtended.insert(fSimpleColumnListExtended.end(),
+                                   fCol->simpleColumnListExtended().begin(),
+                                   fCol->simpleColumnListExtended().end());
+
 }
 
 }  // namespace execplan


### PR DESCRIPTION
Now all SimpleColumns in ConstantFilter are updated during Query Accelerator processing.