### PR TITLE
Post-incident fixes

### DIFF
--- a/cmapi/cmapi_server/cmapi_logger.conf
+++ b/cmapi/cmapi_server/cmapi_logger.conf
@@ -47,6 +47,17 @@
             "formatter": "default",
             "filename": "/var/log/mariadb/columnstore/cmapi_server.log",
             "mode": "a",
+            "maxBytes": 10048576,
+            "backupCount": 10,
+            "encoding": "utf8"
+        },
+        "shared_storage_file": {
+            "level": "DEBUG",
+            "class": "logging.handlers.RotatingFileHandler",
+            "filters": ["trace_params_filter"],
+            "formatter": "default",
+            "filename": "/var/log/mariadb/columnstore/shared_storage_monitor.log",
+            "mode": "a",
             "maxBytes": 1048576,
             "backupCount": 10,
             "encoding": "utf8"
@@ -99,6 +110,11 @@
         },
         "json_trace": {
             "handlers": ["json_trace"],
+            "level": "DEBUG",
+            "propagate": false
+        },
+        "shared_storage_monitor": {
+            "handlers": ["shared_storage_file"],
             "level": "DEBUG",
             "propagate": false
         }

--- a/cmapi/cmapi_server/controllers/endpoints.py
+++ b/cmapi/cmapi_server/controllers/endpoints.py
@@ -1954,6 +1954,7 @@ class NodeController:
     def check_shared_file(self, file_path, check_sum):
         func_name = 'check_shared_file'
         log_begin(module_logger, func_name)
+        logger = logging.getLogger('shared_storage_monitor')
         ACCEPTED_PATHS = (
             '/var/lib/columnstore/data1/',
             '/var/lib/columnstore/storagemanager/metadata/data1/'
@@ -1963,27 +1964,27 @@ class NodeController:
 
         success = True
         file_path_obj = Path(file_path)
-        logging.debug(f'Checking shared file at {file_path} with md5 {check_sum}.')
+        logger.debug(f'Checking shared file at {file_path} with md5 {check_sum}.')
         if not file_path_obj.exists():
             success = False
-            logging.debug(f'Shared file {file_path} does not exist.')
+            logger.debug(f'Shared file {file_path} does not exist.')
         else:
             with file_path_obj.open(mode='rb') as file_to_check:
                 data = file_to_check.read()
                 calculated_md5 = hashlib.md5(data).hexdigest()
             if calculated_md5 != check_sum:
-                logging.debug(
+                logger.debug(
                     f'Shared file at {file_path} md5 {calculated_md5} does not match given md5 {check_sum}.'
                 )
                 success = False
         if success:
-            logging.debug(f'Shared file {file_path} md5 matches {check_sum}.')
+            logger.debug(f'Shared file {file_path} md5 matches {check_sum}.')
 
         response = {
             'timestamp': str(datetime.now()),
             'success': success
         }
-        logging.debug(f'{func_name} returns {str(response)}')
+        logger.debug(f'{func_name} returns {str(response)}')
         return response
 
     @cherrypy.tools.timeit()

--- a/cmapi/cmapi_server/handlers/cluster.py
+++ b/cmapi/cmapi_server/handlers/cluster.py
@@ -470,6 +470,7 @@ class ClusterHandler:
         :return: status result
         """
         tmp_file_path: str
+        logger = logging.getLogger('shared_storage_monitor')
         active_nodes = get_active_nodes()
         if skip_nodes:
             # Remove any nodes the caller asked us to skip (e.g., unstable HB)
@@ -495,11 +496,11 @@ class ClusterHandler:
             temp_file.flush()
             os.fsync(temp_file.fileno())
             tmp_file_path = temp_file.name
-            logging.debug(f'Temporary file to check shared storage created at: {tmp_file_path}')
+            logger.debug(f'Temporary file to check shared storage created at: {tmp_file_path}')
             tmp_file_md5 = hashlib.md5(file_data).hexdigest()
-            logging.debug(f'Temporary file md5: {tmp_file_md5}')
+            logger.debug(f'Temporary file md5: {tmp_file_md5}')
             for node in active_nodes:
-                logging.debug(f'Checking shared file on {node!r}.')
+                logger.debug(f'Checking shared file on {node!r}.')
                 client = NodeControllerClient(
                     request_timeout=REQUEST_TIMEOUT,
                     base_url=f'https://{node}:{CMAPI_PORT}'
@@ -510,7 +511,7 @@ class ClusterHandler:
                         node_response = client.check_shared_file(
                             file_path=tmp_file_path, check_sum=tmp_file_md5
                         )
-                        logging.debug(f'Finished checking file on {node!r}')
+                        logger.debug(f'Finished checking file on {node!r}')
                         all_responses[node] = node_response
                         break
                     except CMAPIBasicError as err:  # per-node failure must not abort the whole check
@@ -520,7 +521,7 @@ class ClusterHandler:
                         continue
                 else:
                     # Retries exhausted
-                    logging.warning(
+                    logger.warning(
                         f'Error checking shared file on {node!r}: {last_err_msg}',
                         exc_info=True
                     )
@@ -552,7 +553,7 @@ class ClusterHandler:
             'nodes_errors': {**nodes_errors}
         }
 
-        logging.debug(
+        logger.debug(
             'Successfully finished checking shared storage on all nodes.'
         )
         return response

--- a/cmapi/cmapi_server/managers/process.py
+++ b/cmapi/cmapi_server/managers/process.py
@@ -222,15 +222,21 @@ class MCSProcessManager:
         attempts = cls.CONTROLLER_MAX_RETRY
         success = False
         while attempts > 0:
+            start = time.monotonic()
             try:
                 with DBRM():
                     # check connection
                     success = True
             except (OSError, ConnectionRefusedError, RuntimeError):
+                elapsed = time.monotonic() - start
+                remaining = SOCK_TIMEOUT - elapsed
                 logging.info(
                     'Cannot establish connection to controllernode.'
-                    f'Controller node still not started. Waiting...{attempts}'
+                    f'Controller node still not started. {attempts} attempts left.'
                 )
+                if remaining > 0:
+                    logging.debug('Sleeping %.1f seconds', remaining)
+                    time.sleep(remaining)
             else:
                 break
             attempts -= 1

--- a/cmapi/cmapi_server/managers/process.py
+++ b/cmapi/cmapi_server/managers/process.py
@@ -193,6 +193,7 @@ class MCSProcessManager:
                         f'{workernodes[name]["Port"]} not started yet.'
                     )
                 else:
+                    logging.debug(f'Workernode {workernodes[name]["IPAddr"]}:{workernodes[name]["Port"]} started.')
                     # delete started workernode from workernodes dict
                     del workernodes[name]
                 finally:
@@ -248,6 +249,7 @@ class MCSProcessManager:
                     logging.debug('Sleeping %.1f seconds', remaining)
                     time.sleep(remaining)
             else:
+                logging.debug('Controllernode is reachable')
                 break
             attempts -= 1
 

--- a/cmapi/cmapi_server/managers/process.py
+++ b/cmapi/cmapi_server/managers/process.py
@@ -172,7 +172,8 @@ class MCSProcessManager:
         attempts = cls.CONTROLLER_MAX_RETRY
         while attempts > 0 and len(workernodes) > 0:
             logging.debug(f'Waiting for "{list(workernodes)}"....{attempts}')
-            # creating a separated list with workernode names
+            start = time.monotonic()
+            # creating a separate list with workernode names
             # for safe deleting items from source dict
             for name in list(workernodes):
                 try:
@@ -187,7 +188,7 @@ class MCSProcessManager:
                         )
                     )
                 except (ConnectionRefusedError, socket.timeout):
-                    logging.debug(
+                    logging.info(
                         f'"{name}" {workernodes[name]["IPAddr"]}:'
                         f'{workernodes[name]["Port"]} not started yet.'
                     )
@@ -196,6 +197,15 @@ class MCSProcessManager:
                     del workernodes[name]
                 finally:
                     sock.close()
+
+            if workernodes:
+                # We get here only if some workernodes were not accessible during this attempt
+                elapsed = time.monotonic() - start
+                remaining = SOCK_TIMEOUT - elapsed
+                if remaining > 0:
+                    logging.debug('Sleeping %.1f seconds', remaining)
+                    time.sleep(remaining)
+
             attempts -= 1
 
         if workernodes:

--- a/cmapi/tracing/trace_tool.py
+++ b/cmapi/tracing/trace_tool.py
@@ -98,7 +98,6 @@ def _record_incoming_json_preview(req) -> dict[str, Any]:
 
     parsed_json = getattr(req, 'json', None)
     if parsed_json is None:
-        logger.debug('request.json is not available')
         return attrs
     normalized = json.dumps(parsed_json, ensure_ascii=False, sort_keys=True)
     if len(normalized) > _PREVIEW_MAX_CHARS:

--- a/cmapi/tracing/traceparent_backend.py
+++ b/cmapi/tracing/traceparent_backend.py
@@ -1,64 +1,48 @@
 import logging
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import cherrypy
+
 from mcs_node_control.models.node_config import NodeConfig
 from tracing.tracer import TracerBackend, TraceSpan
 from tracing.utils import swallow_exceptions
 
-logger = logging.getLogger("tracer")
-json_logger = logging.getLogger("json_trace")
+logger = logging.getLogger('tracer')
+json_logger = logging.getLogger('json_trace')
 
 
 class TraceparentBackend(TracerBackend):
     """Default backend that logs span lifecycle and mirrors events/status."""
     def __init__(self):
         my_addresses = list(NodeConfig().get_network_addresses())
-        logger.info("My addresses: %s", my_addresses)
-        json_logger.info("my_addresses", extra={"my_addresses": my_addresses})
+        logger.info('My addresses: %s', my_addresses)
+        json_logger.info('my_addresses', extra={'my_addresses': my_addresses})
 
     @swallow_exceptions
     def on_span_start(self, span: TraceSpan) -> None:
-        logger.info(
-            "span_begin name='%s' kind=%s tid=%s sid=%s%s",
-            span.name, span.kind, span.trace_id, span.span_id,
-            f' psid={span.parent_span_id}' if span.parent_span_id else '',
-        )
-        json_logger.info("span_begin", extra=span.to_flat_dict())
+        json_logger.info('span_begin', extra=span.to_flat_dict())
 
     @swallow_exceptions
     def on_span_end(self, span: TraceSpan, exc: Optional[BaseException]) -> None:
         end_ns = time.time_ns()
         duration_ms = (end_ns - span.start_ns) / 1_000_000
-        span.set_attribute("duration_ms", duration_ms)
-        span.set_attribute("end_ns", end_ns)
+        span.set_attribute('duration_ms', duration_ms)
+        span.set_attribute('end_ns', end_ns)
 
         # Try to set status code if not already set
-        if span.kind == "SERVER" and "http.status_code" not in span.attributes:
+        if span.kind == 'SERVER' and 'http.status_code' not in span.attributes:
             try:
                 status_str = str(cherrypy.response.status)
                 code = int(status_str.split()[0])
-                span.set_attribute("http.status_code", code)
+                span.set_attribute('http.status_code', code)
             except Exception:
                 pass
 
-        logger.info(
-            "span_end name='%s' kind=%s tid=%s sid=%s%s duration_ms=%.3f",
-            span.name, span.kind, span.trace_id, span.span_id,
-            f' psid={span.parent_span_id}' if span.parent_span_id else '',
-            duration_ms,
-        )
-        json_logger.info("span_end", extra=span.to_flat_dict())
+        json_logger.info('span_end', extra=span.to_flat_dict())
 
     @swallow_exceptions
-    def on_span_event(self, span: TraceSpan, name: str, attrs: Dict[str, Any]) -> None:
-        logger.info(
-            "span_event name='%s' tid=%s sid=%s%s attrs=%s",
-            name, span.trace_id, span.span_id,
-            f' psid={span.parent_span_id}' if span.parent_span_id else '',
-            attrs,
-        )
-        json_logger.info("span_event", extra=span.to_flat_dict())
+    def on_span_event(self, span: TraceSpan, name: str, attrs: dict[str, Any]) -> None:
+        json_logger.info('span_event', extra=span.to_flat_dict())
 
 

--- a/oam/install_scripts/mcs-loadbrm.py.in
+++ b/oam/install_scripts/mcs-loadbrm.py.in
@@ -134,9 +134,15 @@ def is_primary_fallback(current_hostname):
     logging.debug(
         'Current DBRM_Controller/IPAddr is {}'.format(current_hostname)
     )
-    hostnames = set()
+    ip_addrs = []
     for _, nic_name in socket.if_nameindex():
         ip_addr = get_ip_address_by_nic(nic_name)
+        if ip_addr:
+            ip_addrs.append(ip_addr)
+    logging.debug('Found ip addresses {}.'.format(ip_addrs))
+
+    hostnames = set()
+    for ip_addr in ip_addrs:
         if ip_addr:
             hostnames_3tuple = socket.gethostbyaddr(ip_addr)
             hostnames.update([hostnames_3tuple[0], *hostnames_3tuple[1]])


### PR DESCRIPTION
### Moved shared storage logs into a separate file
Shared storage monitor produces lots of logs, so much that they overwrite all 10 backups in several hours. So here we move them to a separate log file so that main cmapi_server logs are preserved.

### Tracer span begin\end logging is removed from human-readable log

### Added more explicit sleeps when waiting for controllernode
There were implicit timeouts (5 seconds) while waiting on the socket, but if something else happened (like OSError), there was no sleep and attempts were exceeded very fast
