### PR TITLE
Added explicit After=network-online into mcs-loadbrm service

### DIFF
--- a/oam/install_scripts/mcs-loadbrm.service.in
+++ b/oam/install_scripts/mcs-loadbrm.service.in
@@ -1,7 +1,8 @@
 [Unit]
 Description=loadbrm
 PartOf=mcs-workernode@1.service mcs-workernode@2.service
-After=network.target mcs-storagemanager.service
+After=network.target network-online.target mcs-storagemanager.service
+Wants=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Just to ensure that network addresses are already allocated when loadbrm tries to calculate them