### PR TITLE
fix(packaging) add ignores for rpm builds of cmapi

### DIFF
--- a/cmapi/CMakeLists.txt
+++ b/cmapi/CMakeLists.txt
@@ -126,7 +126,6 @@ install(
 )
 install(FILES mcs_cluster_tool/mcs.1 DESTINATION ${MAN_DIR})
 
-
 option(RPM "Build an RPM" OFF)
 if(RPM)
     set(CPACK_GENERATOR "RPM")
@@ -164,7 +163,27 @@ if(RPM)
     set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/postinst)
     set(CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/prerm)
     set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION ${ETC_DIR} ${SHARE_DIR})
-    set(CPACK_RPM_USER_FILELIST "%config(noreplace) ${CMAPI_CONF_FILEPATH}")
+
+
+    # Define %ignore as a comment so RPM doesn't claim ownership of shared directories
+    set(CPACK_RPM_SPEC_MORE_DEFINE
+        "${CPACK_RPM_SPEC_MORE_DEFINE}
+%define ignore \#
+"
+    )
+
+    set(ignored
+        "%ignore /usr/share/man"
+        "%ignore /usr/share/man/man1"
+        "%ignore /usr/lib/systemd"
+        "%ignore /usr/lib/systemd/system"
+    )
+
+    # Combine your config file and your ignores into the same USER_FILELIST
+    set(CPACK_RPM_USER_FILELIST
+        "%config(noreplace) ${CMAPI_CONF_FILEPATH}"
+        ${ignored}
+    )
 
     set(CPACK_RPM_PACKAGE_OBSOLETES "mariadb-columnstore-cmapi")
     set(CPACK_RPM_PACKAGE_REQUIRES "curl")


### PR DESCRIPTION
before

```
rpm -ql ./MariaDB-columnstore-cmapi-25.10.2-1.el9.x86_64.rpm | grep systemd
/etc/columnstore/systemd.env
/usr/lib/systemd
/usr/lib/systemd/system
/usr/lib/systemd/system/cmapi_updater.service
/usr/lib/systemd/system/mariadb-columnstore-cmapi.service
/usr/share/columnstore/cmapi/cmapi_server/process_dispatchers/systemd.py
```

after
```
rpm -ql ./MariaDB-columnstore-cmapi-25.10.2-1.el9.x86_64.rpm | grep systemd                                                                            
/etc/columnstore/systemd.env
/usr/lib/systemd/system/cmapi_updater.service
/usr/lib/systemd/system/mariadb-columnstore-cmapi.service
/usr/share/columnstore/cmapi/cmapi_server/process_dispatchers/systemd.py
```

this change should help with install conflicts like this
```
Error: Transaction test error:
  file /usr/share/man from install of MariaDB-columnstore-cmapi-25.10.2-1.el8.aarch64 conflicts with file from package filesystem-3.8-6.el8.aarch64
  file /usr/share/man/man1 from install of MariaDB-columnstore-cmapi-25.10.2-1.el8.aarch64 conflicts with file from package filesystem-3.8-6.el8.aarch64
  file /usr/lib/systemd from install of MariaDB-columnstore-cmapi-25.10.2-1.el8.aarch64 conflicts with file from package systemd-239-82.el8_10.8.aarch64
  file /usr/lib/systemd/system from install of MariaDB-columnstore-cmapi-25.10.2-1.el8.aarch64 conflicts with file from package systemd-239-82.el8_10.8.aarch64
  file /usr/lib/systemd/system from install of MariaDB-columnstore-cmapi-25.10.2-1.el8.aarch64 conflicts with file from package plymouth-0.9.4-12.20200615git1e36e30.el8_10.aarch64
  ```