### PR TITLE
MDEV-9826 Fix columnstore call to hash_sort signatures changed in the…

### DIFF
--- a/utils/common/collation.h
+++ b/utils/common/collation.h
@@ -116,7 +116,12 @@ class MariaDBHasher
   }
   MariaDBHasher& add(CHARSET_INFO* cs, const char* str, size_t length)
   {
+#ifdef MY_HASH_ADD_MARIADB
+    my_hasher_st hasher= my_hasher_mysql5x();
+    cs->hash_sort(&hasher, (const uchar*)str, length);
+#else
     cs->hash_sort((const uchar*)str, length, &mPart1, &mPart2);
+#endif
     return *this;
   }
   MariaDBHasher& add(CHARSET_INFO* cs, const utils::ConstString& str)


### PR DESCRIPTION
… server

The signature changed in MDEV-9826

See the mariadb-server repo bb-main-mdev-9826-v4 e093a2b3640b84ca02c3dd7692cdcc09826e23ab for the companion server commit