### PR TITLE
MCOL-6251: QA fixes

### DIFF
--- a/dbcon/execplan/simplecolumn.cpp
+++ b/dbcon/execplan/simplecolumn.cpp
@@ -107,7 +107,7 @@ void getSimpleColsExtended(execplan::ParseTree* n, void* obj)
   Filter* f = dynamic_cast<Filter*>(tn);
   FunctionColumn* fc = dynamic_cast<FunctionColumn*>(tn);
   SimpleColumn* sc = dynamic_cast<SimpleColumn*>(tn);
-  
+
   // Skip subquery filters - they contain sub-CSEPs that should be processed separately by RBO
   // Walking into them would incorrectly collect subquery columns for outer query processing
   SelectFilter* sf = dynamic_cast<SelectFilter*>(tn);
@@ -122,7 +122,8 @@ void getSimpleColsExtended(execplan::ParseTree* n, void* obj)
       for (const auto& col : sf->cols())
       {
         col->setSimpleColumnListExtended();
-        list->insert(list->end(), col->simpleColumnListExtended().begin(), col->simpleColumnListExtended().end());
+        list->insert(list->end(), col->simpleColumnListExtended().begin(),
+                     col->simpleColumnListExtended().end());
       }
     }
     // SimpleScalarFilter also has cols() - the outer query column being compared with subquery result
@@ -131,7 +132,8 @@ void getSimpleColsExtended(execplan::ParseTree* n, void* obj)
       for (const auto& col : ssf->cols())
       {
         col->setSimpleColumnListExtended();
-        list->insert(list->end(), col->simpleColumnListExtended().begin(), col->simpleColumnListExtended().end());
+        list->insert(list->end(), col->simpleColumnListExtended().begin(),
+                     col->simpleColumnListExtended().end());
       }
     }
     // ExistsFilter has no outer columns to collect (it's just EXISTS (subquery))
@@ -162,31 +164,31 @@ void getSimpleColsExtended(execplan::ParseTree* n, void* obj)
     f->setSimpleColumnListExtended();
     list->insert(list->end(), f->simpleColumnListExtended().begin(), f->simpleColumnListExtended().end());
   }
-//  else //if (lo) // XXX: should it be default case?
-//  {
-//    if (n->left())
-//    {
-//      n->left()->walk(getSimpleColsExtended, obj);
-//    }
-//    if (n->right())
-//    {
-//      n->right()->walk(getSimpleColsExtended, obj);
-//    }
-//  }
-//  else
-//  {
-//	  idblog("collecting simple columns from " << tn->toString());
-//	  idblog("  type " << typeid(*tn).name());
-//	  //n->walk(getSimpleColsExtended, obj);
-//  }
-    if (n->left())
-    {
-      n->left()->walk(getSimpleColsExtended, obj);
-    }
-    if (n->right())
-    {
-      n->right()->walk(getSimpleColsExtended, obj);
-    }
+  //  else //if (lo) // XXX: should it be default case?
+  //  {
+  //    if (n->left())
+  //    {
+  //      n->left()->walk(getSimpleColsExtended, obj);
+  //    }
+  //    if (n->right())
+  //    {
+  //      n->right()->walk(getSimpleColsExtended, obj);
+  //    }
+  //  }
+  //  else
+  //  {
+  //	  idblog("collecting simple columns from " << tn->toString());
+  //	  idblog("  type " << typeid(*tn).name());
+  //	  //n->walk(getSimpleColsExtended, obj);
+  //  }
+  if (n->left())
+  {
+    n->left()->walk(getSimpleColsExtended, obj);
+  }
+  if (n->right())
+  {
+    n->right()->walk(getSimpleColsExtended, obj);
+  }
 }
 
 ParseTree* replaceRefCol(ParseTree*& n, CalpontSelectExecutionPlan::ReturnedColumnList& derivedColList)
@@ -406,10 +408,9 @@ const string SimpleColumn::toString(bool compact) const
   output << "Column: " << data();
   datatypes::Charset cs(fResultType.charsetNumber);
   output << endl
-         << "Info: " << schemaName() << "." << tableName()
-         << "(" << tableAlias() << ")"
-          << "."  << columnName()
-         << " (Type: " << colDataTypeToString(fResultType.colDataType) << ", OID: " << oid() << ")";
+         << "Info: " << schemaName() << "." << tableName() << "(" << tableAlias() << ")"
+         << "." << columnName() << " (Type: " << colDataTypeToString(fResultType.colDataType)
+         << ", OID: " << oid() << ")";
 
   return output.str();
 }

--- a/dbcon/execplan/simplecolumn.cpp
+++ b/dbcon/execplan/simplecolumn.cpp
@@ -115,7 +115,7 @@ void getSimpleColsExtended(execplan::ParseTree* n, void* obj)
   SimpleScalarFilter* ssf = dynamic_cast<SimpleScalarFilter*>(tn);
   if (sf || ef || ssf)
   {
-    // For subquery filters, only collect the outer query columns (cols() for SelectFilter)
+    // For subquery filters, only collect the outer query columns (cols())
     // Do NOT descend into sub->filters() - that will be handled when RBO processes the subquery
     if (sf)
     {
@@ -125,7 +125,16 @@ void getSimpleColsExtended(execplan::ParseTree* n, void* obj)
         list->insert(list->end(), col->simpleColumnListExtended().begin(), col->simpleColumnListExtended().end());
       }
     }
-    // For ExistsFilter and SimpleScalarFilter, there are no outer columns to collect
+    // SimpleScalarFilter also has cols() - the outer query column being compared with subquery result
+    if (ssf)
+    {
+      for (const auto& col : ssf->cols())
+      {
+        col->setSimpleColumnListExtended();
+        list->insert(list->end(), col->simpleColumnListExtended().begin(), col->simpleColumnListExtended().end());
+      }
+    }
+    // ExistsFilter has no outer columns to collect (it's just EXISTS (subquery))
     return;
   }
 

--- a/dbcon/execplan/simplecolumn.cpp
+++ b/dbcon/execplan/simplecolumn.cpp
@@ -49,6 +49,8 @@ using namespace joblist;
 #include "simplecolumn.h"
 #include "simplefilter.h"
 #include "selectfilter.h"
+#include "existsfilter.h"
+#include "simplescalarfilter.h"
 #include "outerjoinonfilter.h"
 #include "aggregatecolumn.h"
 #include "constantfilter.h"
@@ -98,20 +100,37 @@ void getSimpleCols(execplan::ParseTree* n, void* obj)
 
 void getSimpleColsExtended(execplan::ParseTree* n, void* obj)
 {
-	idblog("getting simple columns from ParseTree " << n->toString());
   TreeNode* tn = n->data();
-	idblog("getting simple columns from TreeNode " << tn->toString());
   vector<SimpleColumn*>* list = reinterpret_cast<vector<SimpleColumn*>*>(obj);
   ArithmeticColumn* ac = dynamic_cast<ArithmeticColumn*>(tn);
   AggregateColumn* agc = dynamic_cast<AggregateColumn*>(tn);
   Filter* f = dynamic_cast<Filter*>(tn);
   FunctionColumn* fc = dynamic_cast<FunctionColumn*>(tn);
   SimpleColumn* sc = dynamic_cast<SimpleColumn*>(tn);
-  //LogicOperator* lo = dynamic_cast<LogicOperator*>(tn);
+  
+  // Skip subquery filters - they contain sub-CSEPs that should be processed separately by RBO
+  // Walking into them would incorrectly collect subquery columns for outer query processing
+  SelectFilter* sf = dynamic_cast<SelectFilter*>(tn);
+  ExistsFilter* ef = dynamic_cast<ExistsFilter*>(tn);
+  SimpleScalarFilter* ssf = dynamic_cast<SimpleScalarFilter*>(tn);
+  if (sf || ef || ssf)
+  {
+    // For subquery filters, only collect the outer query columns (cols() for SelectFilter)
+    // Do NOT descend into sub->filters() - that will be handled when RBO processes the subquery
+    if (sf)
+    {
+      for (const auto& col : sf->cols())
+      {
+        col->setSimpleColumnListExtended();
+        list->insert(list->end(), col->simpleColumnListExtended().begin(), col->simpleColumnListExtended().end());
+      }
+    }
+    // For ExistsFilter and SimpleScalarFilter, there are no outer columns to collect
+    return;
+  }
 
   if (sc)
   {
-	  idblog("simple column bottom case");
     list->push_back(sc);
   }
   else if (fc)
@@ -131,7 +150,6 @@ void getSimpleColsExtended(execplan::ParseTree* n, void* obj)
   }
   else if (f)
   {
-	  idblog("any filter in getSimpleColsExtended()");
     f->setSimpleColumnListExtended();
     list->insert(list->end(), f->simpleColumnListExtended().begin(), f->simpleColumnListExtended().end());
   }

--- a/dbcon/execplan/simplefilter.cpp
+++ b/dbcon/execplan/simplefilter.cpp
@@ -836,7 +836,6 @@ void SimpleFilter::setSimpleColumnList()
 
 void SimpleFilter::setSimpleColumnListExtended()
 {
-	idblog("setting simple columns in simple filter: " << toString());
   SimpleColumn* lsc = dynamic_cast<SimpleColumn*>(fLhs);
   SimpleColumn* rsc = dynamic_cast<SimpleColumn*>(fRhs);
   fSimpleColumnListExtended.clear();

--- a/dbcon/joblist/subquerytransformer.cpp
+++ b/dbcon/joblist/subquerytransformer.cpp
@@ -19,7 +19,7 @@
 //  $Id: subquerytransformer.cpp 6406 2010-03-26 19:18:37Z xlou $
 
 #include <iostream>
-//#define NDEBUG
+// #define NDEBUG
 #include <cassert>
 using namespace std;
 
@@ -79,7 +79,7 @@ SubQueryTransformer::~SubQueryTransformer()
 SJSTEP& SubQueryTransformer::makeSubQueryStep(execplan::CalpontSelectExecutionPlan* csep,
                                               bool subInFromClause)
 {
-    // Setup job info, job list and error status relation.
+  // Setup job info, job list and error status relation.
   fSubJobInfo = new JobInfo(fOutJobInfo->rm);
   fSubJobInfo->sessionId = fOutJobInfo->sessionId;
   fSubJobInfo->txnId = fOutJobInfo->txnId;
@@ -118,9 +118,8 @@ SJSTEP& SubQueryTransformer::makeSubQueryStep(execplan::CalpontSelectExecutionPl
   fSubJobInfo->isDML = fOutJobInfo->isDML;
   fSubJobInfo->orderByThreads = csep->orderByThreads();
 
-
   // Update v-table's alias.
-  fVtable.name("$sub"+fVtable.name()+"/"+fVtable.alias());
+  fVtable.name("$sub" + fVtable.name() + "/" + fVtable.alias());
 
   if (fVtable.alias().empty())
   {
@@ -266,7 +265,8 @@ SJSTEP& SubQueryTransformer::makeSubQueryStep(execplan::CalpontSelectExecutionPl
       precision.push_back(ti.precision);
     }
 
-    fOutJobInfo->vtableColTypes[UniqId(fVtable.columnOid(i), fVtable.alias(), "", "", execplan::Partitions())] =
+    fOutJobInfo
+        ->vtableColTypes[UniqId(fVtable.columnOid(i), fVtable.alias(), "", "", execplan::Partitions())] =
         fVtable.columnType(i);
   }
 
@@ -301,13 +301,13 @@ void SubQueryTransformer::checkCorrelateInfo(TupleHashJoinStep* thjs, const JobI
 
 void SubQueryTransformer::updateCorrelateInfo()
 {
-	idblog("updateCorrelateInfo");
+  idblog("updateCorrelateInfo");
   // put vtable into the table list to resolve correlated filters
   // Temp fix for @bug3932 until outer join has no dependency on table order.
   // Insert at [1], not to mess with OUTER join and hint(INFINIDB_ORDERED -- bug2317).
-  fOutJobInfo->tableList.insert(
-      fOutJobInfo->tableList.begin() + 1,
-      makeTableKey(*fOutJobInfo, fVtable.tableOid(), fVtable.name(), fVtable.alias(), "", fVtable.view(), fVtable.partitions()));
+  fOutJobInfo->tableList.insert(fOutJobInfo->tableList.begin() + 1,
+                                makeTableKey(*fOutJobInfo, fVtable.tableOid(), fVtable.name(),
+                                             fVtable.alias(), "", fVtable.view(), fVtable.partitions()));
 
   // tables in outer level
   set<uint32_t> outTables;
@@ -423,7 +423,7 @@ void SubQueryTransformer::updateCorrelateInfo()
             sc->viewName(fVtable.view());
             sc->oid(fVtable.columnOid(k->second));
             sc->columnName(fVtable.columns()[k->second]->columnName());
-	    sc->partitions(fVtable.partitions());
+            sc->partitions(fVtable.partitions());
             const CalpontSystemCatalog::ColType& ct = fVtable.columnType(k->second);
             TupleInfo ti = setTupleInfo(ct, sc->oid(), *fOutJobInfo, fVtable.tableOid(), sc, fVtable.alias());
 
@@ -433,7 +433,7 @@ void SubQueryTransformer::updateCorrelateInfo()
             schemas[j] = sc->schemaName();
             columnKeys[j] = ti.key;
             tableKeys[j] = getTableKey(*fOutJobInfo, ti.key);
-	    partitions[j] = sc->partitions();
+            partitions[j] = sc->partitions();
           }
           else
           {
@@ -524,7 +524,8 @@ void SubQueryTransformer::updateCorrelateInfo()
 
       if (outTables.find(tid) == outTables.end())
       {
-        if (subMap.find(UniqId(j->oid(), j->alias(), j->schema(), j->view(), j->partitions(), 0)) != subMap.end())
+        if (subMap.find(UniqId(j->oid(), j->alias(), j->schema(), j->view(), j->partitions(), 0)) !=
+            subMap.end())
           // throw CorrelateFailExcept();
           throw IDBExcept(logging::ERR_NON_SUPPORT_SUB_QUERY_TYPE);
       }

--- a/dbcon/joblist/subquerytransformer.cpp
+++ b/dbcon/joblist/subquerytransformer.cpp
@@ -301,7 +301,7 @@ void SubQueryTransformer::checkCorrelateInfo(TupleHashJoinStep* thjs, const JobI
 
 void SubQueryTransformer::updateCorrelateInfo()
 {
-	idbloh("updateCorrelateInfo");
+	idblog("updateCorrelateInfo");
   // put vtable into the table list to resolve correlated filters
   // Temp fix for @bug3932 until outer join has no dependency on table order.
   // Insert at [1], not to mess with OUTER join and hint(INFINIDB_ORDERED -- bug2317).

--- a/dbcon/mysql/columnstore.cnf
+++ b/dbcon/mysql/columnstore.cnf
@@ -7,5 +7,5 @@ plugin-load-add=ha_columnstore.so
 
 collation_server = utf8_general_ci
 character_set_server = utf8
-
+columnstore_innodb_queries_use_mcs=on
 loose-columnstore_use_import_for_batchinsert = ON

--- a/dbcon/mysql/columnstore.cnf
+++ b/dbcon/mysql/columnstore.cnf
@@ -7,5 +7,5 @@ plugin-load-add=ha_columnstore.so
 
 collation_server = utf8_general_ci
 character_set_server = utf8
-columnstore_innodb_queries_use_mcs=on
+
 loose-columnstore_use_import_for_batchinsert = ON

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -7626,7 +7626,8 @@ int cs_get_select_plan(ha_columnstore_select_handler* handler, THD* thd, SCSEP& 
     store_applied_rules(ctx.serializeAppliedRules());
     if (csep->traceOn())
     {
-      cerr << "csepWasOptimized=" << csepWasOptimized << " appliedRules=" << ctx.serializeAppliedRules() << endl;
+      cerr << "csepWasOptimized=" << csepWasOptimized << " appliedRules=" << ctx.serializeAppliedRules()
+           << endl;
     }
     if (csep->traceOn() && csepWasOptimized)
     {

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -7435,6 +7435,7 @@ int getSelectPlan(gp_walk_info& gwi, SELECT_LEX& select_lex, SCSEP& csep, bool i
   csep->derivedTableList(gwi.derivedTbList);
   csep->selectSubList(selectSubList);
   csep->subSelectList(gwi.subselectList);
+  idblog("getSelectPlan: subselectList.size()=" << gwi.subselectList.size());
   return 0;
 }
 
@@ -7617,11 +7618,16 @@ int cs_get_select_plan(ha_columnstore_select_handler* handler, THD* thd, SCSEP& 
     // TODO RBO can crash or fail leaving CSEP in an invalid state, so there must be a valid CSEP copy
     // TBD There is a tradeoff b/w copy per rule and copy per optimizer run.
     bool csepWasOptimized = optimizer::optimizeCSEP(*csep, ctx, get_unstable_optimizer(&ctx.getThd()));
+    idblog("csepWasOptimized=" << csepWasOptimized << " appliedRules=" << ctx.serializeAppliedRules());
     idblog("optimized CSEP: " << csep->toString());
 
     // Store optimized plan and applied rules
     store_query_plan(csep, PlanType::Optimized);
     store_applied_rules(ctx.serializeAppliedRules());
+    if (csep->traceOn())
+    {
+      cerr << "csepWasOptimized=" << csepWasOptimized << " appliedRules=" << ctx.serializeAppliedRules() << endl;
+    }
     if (csep->traceOn() && csepWasOptimized)
     {
       cerr << "---------------- cs_get_select_plan optimized EXECUTION PLAN ----------------" << endl;

--- a/dbcon/rbo/rbo_apply_parallel_ces.cpp
+++ b/dbcon/rbo/rbo_apply_parallel_ces.cpp
@@ -468,7 +468,7 @@ void updateScToUseRewrittenDerived(execplan::SimpleColumn* sc, const std::string
   sc->tableName(newTableAlias);
   sc->tableAlias(newTableAlias);
   sc->derivedTable(newTableAlias);
-  sc->data("``.`" + newTableAlias + "`.`" + sc->columnName() + "`" );
+  sc->data("``.`" + newTableAlias + "`.`" + sc->columnName() + "`");
 
   sc->colPosition(colPosition);
   sc->isColumnStore(true);
@@ -507,7 +507,7 @@ void tryToUpdateScToUseRewrittenDerived(
   auto singleTable = sc->singleTable();
   if (!singleTable)
     return;
-  
+
   auto tableAliasToSCPositionsIt = tableAliasToSCPositionsMap.find(*singleTable);
 
   if (tableAliasToSCPositionsIt != tableAliasToSCPositionsMap.end())
@@ -544,7 +544,6 @@ void updateSCsUsingIteration(optimizer::TableAliasToNewAliasAndSCPositionsMap& t
 void updateSCsUsingWalkers(optimizer::TableAliasToNewAliasAndSCPositionsMap& tableAliasToSCPositionsMap,
                            execplan::ParseTree* pt)
 {
-
   std::vector<execplan::SimpleColumn*> simpleColumns;
   pt->walk(execplan::getSimpleColsExtended, &simpleColumns);
   for (auto* sc : simpleColumns)
@@ -576,16 +575,16 @@ SCsAndTheirProjectionPositions findPositionsForExtraSCs(
 bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBOptimizerContext& ctx)
 {
   auto tables = csep.tableList();
-  
+
   execplan::CalpontSelectExecutionPlan::TableList newTableList;
   // TODO support CSEPs with derived tables
   execplan::CalpontSelectExecutionPlan::SelectList newDerivedTableList;
   bool ruleMustBeApplied = false;
-  
+
   // Get reference to accumulated map from outer queries - used for updating correlated columns
   // that reference tables from outer query
   optimizer::TableAliasToNewAliasAndSCPositionsMap& accumulatedMap = ctx.getAccumulatedTableAliasMap();
-  
+
   // Local map for THIS CSEP's tables - subquery creates its OWN derived tables
   // We insert local tables here AND into accumulatedMap
   // Column updates will modify entries in accumulatedMap (which includes local tables)
@@ -596,7 +595,7 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
   std::vector<execplan::CalpontSystemCatalog::TableAliasName> localTables;
   // Local map for THIS CSEP's tables only - separate from accumulated map
   optimizer::TableAliasToNewAliasAndSCPositionsMap localTableMap;
-  
+
   for (auto& table : tables)
   {
     cal_impl_if::SchemaAndTableName schemaAndTableName = {table.schema, table.table};
@@ -618,7 +617,7 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
       newTableList.push_back(table);
     }
   }
-  
+
   // Create a WORKING map for this CSEP's column updates
   // Start with local tables, then add outer query tables (local takes priority)
   // This ensures:
@@ -626,13 +625,13 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
   // 2. Correlated columns from outer query use outer query's derived tables
   // 3. We don't modify accumulatedMap (which would affect outer query)
   optimizer::TableAliasToNewAliasAndSCPositionsMap workingMap = localTableMap;
-  
+
   // Add outer query mappings for correlated columns (only if not already in local map)
   for (auto& [k, v] : accumulatedMap)
   {
     workingMap.insert({k, v});  // insert() won't overwrite existing local entries
   }
-  
+
   // Use workingMap for all column updates in this CSEP
   optimizer::TableAliasToNewAliasAndSCPositionsMap& tableAliasToSCPositionsMap = workingMap;
 
@@ -691,13 +690,13 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
         auto* sf = dynamic_cast<execplan::SelectFilter*>(n->data());
         if (!ef && !ssf && !sf)
           return;
-        
+
         auto* mapPtr = static_cast<optimizer::TableAliasToNewAliasAndSCPositionsMap*>(obj);
         auto& map = *mapPtr;
-        
+
         // Get the subquery
         auto sub = ef ? ef->sub() : (ssf ? ssf->sub() : sf->sub());
-        
+
         // Build a set of subquery's own table aliases to distinguish outer query columns
         std::set<std::string> subqueryTableAliases;
         if (sub)
@@ -707,7 +706,7 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
             subqueryTableAliases.insert(t.alias);
           }
         }
-        
+
         // Helper to check if a column belongs to outer query (not subquery's own tables)
         auto isOuterQueryColumn = [&subqueryTableAliases](execplan::SimpleColumn* sc) -> bool
         {
@@ -718,7 +717,7 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
           // Column is from outer query if it's NOT in subquery's table list
           return subqueryTableAliases.count(alias) == 0;
         };
-        
+
         // For ExistsFilter (used for NOT IN), correlated outer query columns are in sub->filters()
         // We need to rewrite ONLY outer query columns, not subquery's own columns
         if (ef && sub)
@@ -736,7 +735,7 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
             }
           }
         }
-        
+
         // For SelectFilter, update the outer query columns being compared
         if (sf)
         {
@@ -779,7 +778,7 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
     // Replace table list with new table list populated with union units
     csep.tableList(newTableList);
     csep.returnedCols(newReturnedColumns);
-    
+
     // Update accumulatedMap with this CSEP's local tables for subqueries to use
     // This must happen AFTER column updates so subqueries see the correct mappings
     for (auto& table : localTables)

--- a/dbcon/rbo/rbo_apply_parallel_ces.cpp
+++ b/dbcon/rbo/rbo_apply_parallel_ces.cpp
@@ -36,6 +36,7 @@
 #include "simplefilter.h"
 #include "existsfilter.h"
 #include "outerjoinonfilter.h"
+#include "selectfilter.h"
 #include "simplescalarfilter.h"
 
 namespace optimizer
@@ -213,8 +214,6 @@ bool parallelCESFilter(execplan::CalpontSelectExecutionPlan& csep, optimizer::RB
   // Filter out tables that were re-written.
   bool someFT = someAreForeignTables(csep);
   bool someFTSI = someForeignTablesHasStatisticsAndMbIndex(csep, ctx);
-  idblog("csep some FT " << (someFT ? "yes" : "no") << ", some FTSI " << (someFTSI ? "yes" : "no"));
-  idblog("csep: " << csep.toString());
   return someFT && someFTSI;
 }
 
@@ -504,12 +503,14 @@ execplan::SimpleColumn* cloneSCForDerivedProjection(execplan::SimpleColumn* sc)
 void tryToUpdateScToUseRewrittenDerived(
     execplan::SimpleColumn* sc, optimizer::TableAliasToNewAliasAndSCPositionsMap& tableAliasToSCPositionsMap)
 {
-  auto tableAliasToSCPositionsIt = tableAliasToSCPositionsMap.find(*sc->singleTable());
-  idblog("  sc: " << sc->toString());
+  auto singleTable = sc->singleTable();
+  if (!singleTable)
+    return;
+  
+  auto tableAliasToSCPositionsIt = tableAliasToSCPositionsMap.find(*singleTable);
 
   if (tableAliasToSCPositionsIt != tableAliasToSCPositionsMap.end())
   {
-	  idblog("  in table map!");
     auto& [newTableAlias, SCToPosCounterMap, currentColPositionCursorValue] =
         tableAliasToSCPositionsIt->second;
 
@@ -523,7 +524,6 @@ void tryToUpdateScToUseRewrittenDerived(
       ++currentColPositionCursorValue;
     }
     updateScToUseRewrittenDerived(sc, newTableAlias, colPosition, std::nullopt);
-    idblog("  updated sc: " << sc->toString());
   }
 }
 
@@ -575,22 +575,39 @@ SCsAndTheirProjectionPositions findPositionsForExtraSCs(
 bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBOptimizerContext& ctx)
 {
   auto tables = csep.tableList();
+  
   execplan::CalpontSelectExecutionPlan::TableList newTableList;
   // TODO support CSEPs with derived tables
   execplan::CalpontSelectExecutionPlan::SelectList newDerivedTableList;
   bool ruleMustBeApplied = false;
-  optimizer::TableAliasToNewAliasAndSCPositionsMap tableAliasToSCPositionsMap;
+  
+  // Get reference to accumulated map from outer queries - used for updating correlated columns
+  // that reference tables from outer query
+  optimizer::TableAliasToNewAliasAndSCPositionsMap& accumulatedMap = ctx.getAccumulatedTableAliasMap();
+  
+  // Local map for THIS CSEP's tables - subquery creates its OWN derived tables
+  // We insert local tables here AND into accumulatedMap
+  // Column updates will modify entries in accumulatedMap (which includes local tables)
+  // Then we copy back local table entries for derived table creation
 
   // 1st pass over tables to create derived tables placeholders to collect
-  // SCs to be updated
+  // SCs to be updated - each CSEP creates its OWN derived tables
+  std::vector<execplan::CalpontSystemCatalog::TableAliasName> localTables;
+  // Local map for THIS CSEP's tables only - separate from accumulated map
+  optimizer::TableAliasToNewAliasAndSCPositionsMap localTableMap;
+  
   for (auto& table : tables)
   {
     cal_impl_if::SchemaAndTableName schemaAndTableName = {table.schema, table.table};
     auto anyColumnStatistics = ctx.getGwi().findStatisticsForATable(schemaAndTableName);
     if (!table.isColumnstore() && anyColumnStatistics)
     {
+      // Create NEW derived table for THIS CSEP's table
+      // Each CSEP (including subqueries) creates its OWN derived tables
       std::string tableAlias = getRewrittenSubTableAlias(table, ctx);
-      tableAliasToSCPositionsMap.insert({table, {tableAlias, {}, 0}});
+      // Add to LOCAL map - this CSEP's own derived tables
+      localTableMap.insert({table, {tableAlias, {}, 0}});
+      localTables.push_back(table);
       execplan::CalpontSystemCatalog::TableAliasName tn = execplan::make_aliasview("", "", tableAlias, "");
       newTableList.push_back(tn);
       ruleMustBeApplied = true;
@@ -600,6 +617,18 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
       newTableList.push_back(table);
     }
   }
+  
+  // Merge local map into accumulated map for column updates
+  // Local tables take priority over outer query tables (for this CSEP's columns)
+  for (auto& [k, v] : localTableMap)
+  {
+    accumulatedMap.insert_or_assign(k, v);
+  }
+  
+  // Use accumulatedMap for all column updates - this includes:
+  // - Local tables (this CSEP's derived tables) 
+  // - Outer query tables (for correlated columns in subqueries)
+  optimizer::TableAliasToNewAliasAndSCPositionsMap& tableAliasToSCPositionsMap = accumulatedMap;
 
   // 2nd pass over RCs to update RCs with derived table SCs in projection
   execplan::CalpontSelectExecutionPlan::ReturnedColumnList newReturnedColumns;
@@ -632,19 +661,14 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
     auto filters = csep.filters();
     if (filters)
     {
-	    idblog("filters " << filters->toString());
       updateSCsUsingWalkers(tableAliasToSCPositionsMap, filters);
-      idblog("filters updated: " << filters->toString());
     }
 
     // 6th pass over filters to use derived table SCs in filters
     auto having = csep.having();
     if (having)
     {
-	    idblog("processing HAVING");
-	    idblog("HAVING: " << having->toString());
       updateSCsUsingWalkers(tableAliasToSCPositionsMap, having);
-	    idblog("updated HAVING: " << having->toString());
     }
 
     // 6.5 pass: update correlated columns inside EXISTS subqueries
@@ -653,36 +677,32 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
     {
       if (!root)
         return;
-      // Walker to process ExistsFilter nodes
+      // Walker to process ExistsFilter, SimpleScalarFilter, and SelectFilter nodes
       auto walker = [](const execplan::ParseTree* n, void* obj)
       {
         auto* ef = dynamic_cast<execplan::ExistsFilter*>(n->data());
         auto* ssf = dynamic_cast<execplan::SimpleScalarFilter*>(n->data());
-        if (!ef && !ssf)
+        auto* sf = dynamic_cast<execplan::SelectFilter*>(n->data());
+        if (!ef && !ssf && !sf)
           return;
+        
         auto* mapPtr = static_cast<optimizer::TableAliasToNewAliasAndSCPositionsMap*>(obj);
         auto& map = *mapPtr;
-        auto sub = ef ? ef->sub() : ssf->sub();
-        if (sub)
+        
+        // NOTE: We do NOT process sub->filters() or sub->having() here.
+        // The subquery will be processed by RBO separately and will create its OWN derived tables.
+        // Processing subquery filters here would incorrectly rewrite subquery columns to outer query's
+        // derived tables instead of the subquery's own derived tables.
+        // 
+        // We only update SelectFilter.cols() - the outer query columns being compared with subquery result.
+        
+        // For SelectFilter, update the outer query columns being compared
+        if (sf)
         {
-          if (auto subFilters = sub->filters())
+          for (const auto& col : sf->cols())
           {
-		  idblog("rewriting filter " << subFilters->toString());
-            std::vector<execplan::SimpleColumn*> subSCs;
-            subFilters->walk(execplan::getSimpleColsExtended, &subSCs);
-	    idblog("  " << subSCs.size() << " simple columns collected");
-            for (auto* sc : subSCs)
-            {
-		    idblog("  rewriting simple column " << sc->toString());
-              if (sc)
-                tryToUpdateScToUseRewrittenDerived(sc, map);
-            }
-          }
-          if (auto subHaving = sub->having())
-          {
-            std::vector<execplan::SimpleColumn*> subSCs;
-            subHaving->walk(execplan::getSimpleColsExtended, &subSCs);
-            for (auto* sc : subSCs)
+            col->setSimpleColumnListExtended();
+            for (auto* sc : col->simpleColumnListExtended())
             {
               if (sc)
                 tryToUpdateScToUseRewrittenDerived(sc, map);
@@ -694,34 +714,21 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
     };
 
     if (filters)
-    {
-	    idblog("before updated exists correlated FILTERS: " << filters->toString());
       updateExistsCorrelated(filters);
-	    idblog("updated exists correlated FILTERS: " << filters->toString());
-    }
     if (having)
-    {
       updateExistsCorrelated(having);
-	    idblog("updated exists correlated HAVING: " << having->toString());
-    }
 
-    // 7th pass over tables to create derived CSEP with the collected SCs
-    for (auto& table : tables)
+    // 7th pass over LOCAL tables to create derived CSEP with the collected SCs
+    // Create derived tables only for LOCAL tables (this CSEP's own tables)
+    for (auto& table : localTables)
     {
-      cal_impl_if::SchemaAndTableName schemaAndTableName = {table.schema, table.table};
-      if (!table.isColumnstore())
+      // Get the mapping from accumulatedMap (where column updates happened)
+      auto tableIt = tableAliasToSCPositionsMap.find(table);
+      if (tableIt != tableAliasToSCPositionsMap.end())
       {
-        auto produceDerivedTableIt = tableAliasToSCPositionsMap.find(table);
-        if (produceDerivedTableIt != tableAliasToSCPositionsMap.end())
-        {
-          auto& [newTableAlias, SCToPosCounterMap, unused] = produceDerivedTableIt->second;
-          auto derivedSCEP = createDerivedTableFromTable(csep, table, newTableAlias, ctx, SCToPosCounterMap);
-          newDerivedTableList.push_back(std::move(derivedSCEP));
-        }
-      }
-      else
-      {
-        newTableList.push_back(table);
+        auto& [newTableAlias, SCToPosCounterMap, unused] = tableIt->second;
+        auto derivedSCEP = createDerivedTableFromTable(csep, table, newTableAlias, ctx, SCToPosCounterMap);
+        newDerivedTableList.push_back(std::move(derivedSCEP));
       }
     }
 
@@ -729,14 +736,6 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
     // Replace table list with new table list populated with union units
     csep.tableList(newTableList);
     csep.returnedCols(newReturnedColumns);
-    if (csep.having())
-    {
-	    idblog("final HAVING: " << csep.having()->toString());
-    }
-    else
-    {
-	    idblog("no having");
-    }
   }
   return ruleMustBeApplied;
 }

--- a/dbcon/rbo/rbo_apply_parallel_ces.cpp
+++ b/dbcon/rbo/rbo_apply_parallel_ces.cpp
@@ -21,6 +21,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <set>
 #include <vector>
 
 #include "rulebased_optimizer.h"
@@ -694,12 +695,47 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
         auto* mapPtr = static_cast<optimizer::TableAliasToNewAliasAndSCPositionsMap*>(obj);
         auto& map = *mapPtr;
         
-        // NOTE: We do NOT process sub->filters() or sub->having() here.
-        // The subquery will be processed by RBO separately and will create its OWN derived tables.
-        // Processing subquery filters here would incorrectly rewrite subquery columns to outer query's
-        // derived tables instead of the subquery's own derived tables.
-        // 
-        // We only update SelectFilter.cols() - the outer query columns being compared with subquery result.
+        // Get the subquery
+        auto sub = ef ? ef->sub() : (ssf ? ssf->sub() : sf->sub());
+        
+        // Build a set of subquery's own table aliases to distinguish outer query columns
+        std::set<std::string> subqueryTableAliases;
+        if (sub)
+        {
+          for (auto& t : sub->tableList())
+          {
+            subqueryTableAliases.insert(t.alias);
+          }
+        }
+        
+        // Helper to check if a column belongs to outer query (not subquery's own tables)
+        auto isOuterQueryColumn = [&subqueryTableAliases](execplan::SimpleColumn* sc) -> bool
+        {
+          const std::string& alias = sc->tableAlias();
+          // Skip already rewritten columns
+          if (alias.find("$added_sub_") != std::string::npos)
+            return false;
+          // Column is from outer query if it's NOT in subquery's table list
+          return subqueryTableAliases.count(alias) == 0;
+        };
+        
+        // For ExistsFilter (used for NOT IN), correlated outer query columns are in sub->filters()
+        // We need to rewrite ONLY outer query columns, not subquery's own columns
+        if (ef && sub)
+        {
+          if (auto subFilters = sub->filters())
+          {
+            std::vector<execplan::SimpleColumn*> subSCs;
+            subFilters->walk(execplan::getSimpleColsExtended, &subSCs);
+            for (auto* sc : subSCs)
+            {
+              if (sc && isOuterQueryColumn(sc))
+              {
+                tryToUpdateScToUseRewrittenDerived(sc, map);
+              }
+            }
+          }
+        }
         
         // For SelectFilter, update the outer query columns being compared
         if (sf)
@@ -710,7 +746,9 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
             for (auto* sc : col->simpleColumnListExtended())
             {
               if (sc)
+              {
                 tryToUpdateScToUseRewrittenDerived(sc, map);
+              }
             }
           }
         }

--- a/dbcon/rbo/rbo_apply_parallel_ces.cpp
+++ b/dbcon/rbo/rbo_apply_parallel_ces.cpp
@@ -618,17 +618,22 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
     }
   }
   
-  // Merge local map into accumulated map for column updates
-  // Local tables take priority over outer query tables (for this CSEP's columns)
-  for (auto& [k, v] : localTableMap)
+  // Create a WORKING map for this CSEP's column updates
+  // Start with local tables, then add outer query tables (local takes priority)
+  // This ensures:
+  // 1. Local tables use THIS CSEP's derived tables
+  // 2. Correlated columns from outer query use outer query's derived tables
+  // 3. We don't modify accumulatedMap (which would affect outer query)
+  optimizer::TableAliasToNewAliasAndSCPositionsMap workingMap = localTableMap;
+  
+  // Add outer query mappings for correlated columns (only if not already in local map)
+  for (auto& [k, v] : accumulatedMap)
   {
-    accumulatedMap.insert_or_assign(k, v);
+    workingMap.insert({k, v});  // insert() won't overwrite existing local entries
   }
   
-  // Use accumulatedMap for all column updates - this includes:
-  // - Local tables (this CSEP's derived tables) 
-  // - Outer query tables (for correlated columns in subqueries)
-  optimizer::TableAliasToNewAliasAndSCPositionsMap& tableAliasToSCPositionsMap = accumulatedMap;
+  // Use workingMap for all column updates in this CSEP
+  optimizer::TableAliasToNewAliasAndSCPositionsMap& tableAliasToSCPositionsMap = workingMap;
 
   // 2nd pass over RCs to update RCs with derived table SCs in projection
   execplan::CalpontSelectExecutionPlan::ReturnedColumnList newReturnedColumns;
@@ -736,6 +741,17 @@ bool applyParallelCES(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBO
     // Replace table list with new table list populated with union units
     csep.tableList(newTableList);
     csep.returnedCols(newReturnedColumns);
+    
+    // Update accumulatedMap with this CSEP's local tables for subqueries to use
+    // This must happen AFTER column updates so subqueries see the correct mappings
+    for (auto& table : localTables)
+    {
+      auto tableIt = workingMap.find(table);
+      if (tableIt != workingMap.end())
+      {
+        accumulatedMap.insert_or_assign(table, tableIt->second);
+      }
+    }
   }
   return ruleMustBeApplied;
 }

--- a/dbcon/rbo/rbo_apply_parallel_ces.h
+++ b/dbcon/rbo/rbo_apply_parallel_ces.h
@@ -29,47 +29,10 @@
 
 namespace optimizer
 {
-struct TableAliasLessThan
-{
-  bool operator()(const execplan::CalpontSystemCatalog::TableAliasName& lhs,
-                  const execplan::CalpontSystemCatalog::TableAliasName& rhs) const
-  {
-    if (lhs.schema < rhs.schema)
-    {
-      return true;
-    }
-    else if (lhs.schema == rhs.schema)
-    {
-      if (lhs.table < rhs.table)
-      {
-        return true;
-      }
-      else if (lhs.table == rhs.table)
-      {
-        if (lhs.alias < rhs.alias)
-        {
-          return true;
-        }
-      }
-    }
-
-    return false;
-  }
-};
-
-struct SimpleColumnLessThan
-{
-  bool operator()(const execplan::SimpleColumn* lhs, const execplan::SimpleColumn* rhs) const
-  {
-    return lhs->columnName() < rhs->columnName();
-  }
-};
+// TableAliasLessThan, SimpleColumnLessThan, SCToPosCounterMap, and TableAliasToNewAliasAndSCPositionsMap
+// are now defined in rulebased_optimizer.h
 
 using NewTableAliasAndColumnPosCounter = std::pair<std::string, size_t>;
-using SCToPosCounterMap = std::map<execplan::SimpleColumn*, size_t, SimpleColumnLessThan>;
-using TableAliasToNewAliasAndSCPositionsMap =
-    std::map<execplan::CalpontSystemCatalog::TableAliasName,
-             std::tuple<std::string, SCToPosCounterMap, size_t>, TableAliasLessThan>;
 
 // Helper functions in details namespace
 namespace details

--- a/dbcon/rbo/rulebased_optimizer.cpp
+++ b/dbcon/rbo/rulebased_optimizer.cpp
@@ -115,10 +115,12 @@ bool Rule::apply(execplan::CalpontSelectExecutionPlan& root, optimizer::RBOptimi
   bool changedThisRound = false;
   bool hasBeenApplied = false;
 
+  idblog("Rule::apply START rule=" << name);
   do
   {
     changedThisRound = walk(root, ctx);
     hasBeenApplied |= changedThisRound;
+    idblog("Rule::apply round complete: changedThisRound=" << changedThisRound << " hasBeenApplied=" << hasBeenApplied);
     if (ctx.logRulesEnabled() && changedThisRound)
     {
       std::cout << "MCS RBO: " << name << " has been applied this round." << std::endl;
@@ -130,6 +132,7 @@ bool Rule::apply(execplan::CalpontSelectExecutionPlan& root, optimizer::RBOptimi
     }
   } while (changedThisRound && !applyOnlyOnce);
 
+  idblog("Rule::apply END rule=" << name << " hasBeenApplied=" << hasBeenApplied);
   return hasBeenApplied;
 }
 
@@ -143,8 +146,13 @@ bool Rule::walk(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBOptimiz
 
   while (!planStack.empty())
   {
+    idblog("Rule::walk loop iteration, planStack.size=" << planStack.size());
     execplan::CalpontSelectExecutionPlan* current = planStack.top();
     planStack.pop();
+    
+    idblog("Rule::walk processing CSEP subType=" << current->subType() 
+           << " unionVec.size=" << current->unionVec().size()
+           << " subSelectList.size=" << current->subSelectList().size());
 
     // Walk nested UNION UNITS
     for (auto& unionUnit : current->unionVec())
@@ -152,6 +160,7 @@ bool Rule::walk(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBOptimiz
       auto* unionUnitPtr = dynamic_cast<execplan::CalpontSelectExecutionPlan*>(unionUnit.get());
       if (unionUnitPtr)
       {
+        idblog("  pushing unionUnit subType=" << unionUnitPtr->subType());
         planStack.push(unionUnitPtr);
       }
     }
@@ -162,6 +171,7 @@ bool Rule::walk(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBOptimiz
       auto* subselectPtr = dynamic_cast<execplan::CalpontSelectExecutionPlan*>(subselect.get());
       if (subselectPtr)
       {
+        idblog("  pushing subselect subType=" << subselectPtr->subType());
         planStack.push(subselectPtr);
       }
     }
@@ -170,11 +180,31 @@ bool Rule::walk(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBOptimiz
 
     if (mayApply(*current, ctx))
     {
-      rewrite |= applyRule(*current, ctx);
-      ctx.incrementUniqueId();
+      idblog("  mayApply=true, calling applyRule");
+      try
+      {
+        rewrite |= applyRule(*current, ctx);
+        ctx.incrementUniqueId();
+        idblog("  applyRule completed, planStack.size=" << planStack.size());
+      }
+      catch (const std::exception& e)
+      {
+        idblog("  STD EXCEPTION in applyRule: " << e.what());
+        throw;
+      }
+      catch (...)
+      {
+        idblog("  UNKNOWN EXCEPTION in applyRule");
+        throw;
+      }
+    }
+    else
+    {
+      idblog("  mayApply=false, skipping applyRule");
     }
   }
 
+  idblog("Rule::walk END, rewrite=" << rewrite << " planStack.empty=" << planStack.empty());
   return rewrite;
 }
 

--- a/dbcon/rbo/rulebased_optimizer.cpp
+++ b/dbcon/rbo/rulebased_optimizer.cpp
@@ -46,7 +46,7 @@ std::string getRewrittenSubTableAlias(const execplan::CalpontSystemCatalog::Tabl
   }
   else
   {
-    return table.alias;  
+    return table.alias;
   }
 #endif
 }
@@ -97,14 +97,14 @@ bool optimizeCSEP(execplan::CalpontSelectExecutionPlan& root, optimizer::RBOptim
     optimizer::Rule parallelCES{"parallel_ces", optimizer::parallelCESFilter, optimizer::applyParallelCES};
     rules.push_back(parallelCES);
 
-//    optimizer::Rule rewriteDistinct{"rewrite_distinct", optimizer::rewriteDistinctFilter,
-//                                    optimizer::applyRewriteDistinct};
-//    rules.push_back(rewriteDistinct);
+    //    optimizer::Rule rewriteDistinct{"rewrite_distinct", optimizer::rewriteDistinctFilter,
+    //                                    optimizer::applyRewriteDistinct};
+    //    rules.push_back(rewriteDistinct);
   }
 
-//  optimizer::Rule predicatePushdown{"predicate_pushdown", optimizer::predicatePushdownFilter,
-//                                    optimizer::applyPredicatePushdown};
-//  rules.push_back(predicatePushdown);
+  //  optimizer::Rule predicatePushdown{"predicate_pushdown", optimizer::predicatePushdownFilter,
+  //                                    optimizer::applyPredicatePushdown};
+  //  rules.push_back(predicatePushdown);
 
   return optimizeCSEPWithRules(root, rules, ctx);
 }
@@ -120,7 +120,8 @@ bool Rule::apply(execplan::CalpontSelectExecutionPlan& root, optimizer::RBOptimi
   {
     changedThisRound = walk(root, ctx);
     hasBeenApplied |= changedThisRound;
-    idblog("Rule::apply round complete: changedThisRound=" << changedThisRound << " hasBeenApplied=" << hasBeenApplied);
+    idblog("Rule::apply round complete: changedThisRound=" << changedThisRound
+                                                           << " hasBeenApplied=" << hasBeenApplied);
     if (ctx.logRulesEnabled() && changedThisRound)
     {
       std::cout << "MCS RBO: " << name << " has been applied this round." << std::endl;
@@ -149,9 +150,9 @@ bool Rule::walk(execplan::CalpontSelectExecutionPlan& csep, optimizer::RBOptimiz
     idblog("Rule::walk loop iteration, planStack.size=" << planStack.size());
     execplan::CalpontSelectExecutionPlan* current = planStack.top();
     planStack.pop();
-    
-    idblog("Rule::walk processing CSEP subType=" << current->subType() 
-           << " unionVec.size=" << current->unionVec().size()
+
+    idblog("Rule::walk processing CSEP subType="
+           << current->subType() << " unionVec.size=" << current->unionVec().size()
            << " subSelectList.size=" << current->subSelectList().size());
 
     // Walk nested UNION UNITS

--- a/dbcon/rbo/rulebased_optimizer.h
+++ b/dbcon/rbo/rulebased_optimizer.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#include <map>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #define PREFER_MY_CONFIG_H
@@ -28,9 +30,57 @@
 
 #include "execplan/calpontselectexecutionplan.h"
 #include "execplan/calpontsystemcatalog.h"
+#include "execplan/simplecolumn.h"
 
 namespace optimizer
 {
+
+// Forward declarations for table alias mapping types
+// Compares by schema, table, AND alias - for exact table matching
+struct TableAliasLessThan
+{
+  bool operator()(const execplan::CalpontSystemCatalog::TableAliasName& lhs,
+                  const execplan::CalpontSystemCatalog::TableAliasName& rhs) const
+  {
+    if (lhs.schema < rhs.schema)
+      return true;
+    if (lhs.schema == rhs.schema)
+    {
+      if (lhs.table < rhs.table)
+        return true;
+      if (lhs.table == rhs.table)
+        return lhs.alias < rhs.alias;
+    }
+    return false;
+  }
+};
+
+// Compares by schema and table ONLY (ignores alias) - for finding same base table across queries
+struct TableSchemaTableLessThan
+{
+  bool operator()(const execplan::CalpontSystemCatalog::TableAliasName& lhs,
+                  const execplan::CalpontSystemCatalog::TableAliasName& rhs) const
+  {
+    if (lhs.schema < rhs.schema)
+      return true;
+    if (lhs.schema == rhs.schema)
+      return lhs.table < rhs.table;
+    return false;
+  }
+};
+
+struct SimpleColumnLessThan
+{
+  bool operator()(const execplan::SimpleColumn* lhs, const execplan::SimpleColumn* rhs) const
+  {
+    return lhs->columnName() < rhs->columnName();
+  }
+};
+
+using SCToPosCounterMap = std::map<execplan::SimpleColumn*, size_t, SimpleColumnLessThan>;
+using TableAliasToNewAliasAndSCPositionsMap =
+    std::map<execplan::CalpontSystemCatalog::TableAliasName,
+             std::tuple<std::string, SCToPosCounterMap, size_t>, TableAliasLessThan>;
 
 class RBOptimizerContext
 {
@@ -96,6 +146,17 @@ class RBOptimizerContext
     return out;
   }
 
+  // Accumulated table alias mapping for parallel CES rule
+  // This allows subqueries to see outer query's rewritten table aliases
+  TableAliasToNewAliasAndSCPositionsMap& getAccumulatedTableAliasMap()
+  {
+    return accumulatedTableAliasMap_;
+  }
+  const TableAliasToNewAliasAndSCPositionsMap& getAccumulatedTableAliasMap() const
+  {
+    return accumulatedTableAliasMap_;
+  }
+
  private:
   // gwi lifetime should be longer than optimizer context.
   // In plugin runtime this is always true.
@@ -106,6 +167,8 @@ class RBOptimizerContext
   uint cesOptimizationParallelFactor_;
   // Names of rules that were actually applied in order
   std::vector<std::string> appliedRules_;
+  // Accumulated table alias mapping for parallel CES - allows subqueries to see outer query's mappings
+  TableAliasToNewAliasAndSCPositionsMap accumulatedTableAliasMap_;
 };
 
 struct Rule

--- a/mysql-test/columnstore/future/query_accelerator.test
+++ b/mysql-test/columnstore/future/query_accelerator.test
@@ -42,7 +42,6 @@ SELECT  "QUERY 1";
 # check Query Accelerator for q1 (simple aggregation)
 SELECT mcs_get_plan('rules') LIKE '%parallel_ces%' AS qa_q1_applied;
 
---source ../include/disable_rbo_parallel_ces.inc
 SELECT  "QUERY 2";
     SELECT
         s_acctbal,
@@ -72,7 +71,6 @@ SELECT  "QUERY 2";
       )
     ORDER BY s_acctbal DESC, n_name, s_name, p_partkey
     LIMIT 100;
---source ../include/enable_rbo_parallel_ces.inc
 
 SELECT  "QUERY 3";
     SELECT
@@ -230,7 +228,6 @@ SELECT  "QUERY 10";
     LIMIT 20;
 
 SELECT  "QUERY 11";
---source ../include/disable_rbo_parallel_ces.inc
     SELECT
         ps_partkey,
         SUM(ps_supplycost * ps_availqty) AS value
@@ -310,7 +307,6 @@ SELECT  "QUERY 15";
       )
     ORDER BY s_suppkey;
 
---source ../include/disable_rbo_parallel_ces.inc
 SELECT  "QUERY 16";
     SELECT
         p_brand,
@@ -329,7 +325,6 @@ SELECT  "QUERY 16";
       )
     GROUP BY p_brand, p_type, p_size
     ORDER BY supplier_cnt DESC, p_brand, p_type, p_size;
---source ../include/enable_rbo_parallel_ces.inc
 
 SELECT  "QUERY 17";
     SELECT
@@ -344,7 +339,6 @@ SELECT  "QUERY 17";
         WHERE l_partkey = p_partkey
       );
 
---source ../include/disable_rbo_parallel_ces.inc
 SELECT  "QUERY 18";
     SELECT
         c_name,
@@ -364,7 +358,6 @@ SELECT  "QUERY 18";
     GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
     ORDER BY o_totalprice DESC, o_orderdate, o_orderkey
     LIMIT 100;
---source ../include/enable_rbo_parallel_ces.inc
 
 SELECT  "QUERY 19";
     SELECT


### PR DESCRIPTION
## Исправленные проблемы для TPC-H запросов с подзапросами

Функция [applyParallelCES](cci:1://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/rbo/rbo_apply_parallel_ces.cpp:575:0-814:1) переписывает foreign-таблицы в derived tables для параллельного выполнения. При этом все [SimpleColumn](cci:1://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/simplecolumn.cpp:224:0-230:1), ссылающиеся на эти таблицы, должны быть обновлены для использования новых алиасов derived tables. Проблема была в том, что:

1. **Для Q2/Q11**: Коррелированные столбцы внешнего запроса внутри подзапросов не обновлялись корректно
2. **Для Q16**: `NOT IN` подзапрос представлен как [ExistsFilter](cci:2://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/existsfilter.h:41:0-142:1), и коррелированные столбцы находятся в `sub->filters()`, а не в `cols()`

---

### Исправление 1: [simplecolumn.cpp](cci:7://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/simplecolumn.cpp:0:0-0:0) — функция [getSimpleColsExtended()](cci:1://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/simplecolumn.cpp:98:0-178:1)

**Проблема**: Функция [getSimpleColsExtended()](cci:1://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/simplecolumn.cpp:98:0-178:1) рекурсивно собирала [SimpleColumn](cci:1://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/simplecolumn.cpp:224:0-230:1) из всех фильтров, включая фильтры подзапросов (`SelectFilter`, [ExistsFilter](cci:2://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/existsfilter.h:41:0-142:1), `SimpleScalarFilter`). Это приводило к преждевременному переписыванию столбцов подзапроса алиасами внешнего запроса.

**Решение**: Добавлена проверка на типы фильтров подзапросов — функция теперь:
- **Не заходит** внутрь `SelectFilter`, [ExistsFilter](cci:2://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/existsfilter.h:41:0-142:1), `SimpleScalarFilter`
- Собирает только `cols()` для `SelectFilter` и `SimpleScalarFilter` (столбцы внешнего запроса, сравниваемые с результатом подзапроса)

```cpp
// Skip subquery filters - they contain sub-CSEPs that should be processed separately by RBO
SelectFilter* sf = dynamic_cast<SelectFilter*>(tn);
ExistsFilter* ef = dynamic_cast<ExistsFilter*>(tn);
SimpleScalarFilter* ssf = dynamic_cast<SimpleScalarFilter*>(tn);
if (sf || ef || ssf)
{
  // For subquery filters, only collect the outer query columns (cols())
  if (sf)
  {
    for (const auto& col : sf->cols())
    {
      col->setSimpleColumnListExtended();
      list->insert(list->end(), col->simpleColumnListExtended().begin(),
                   col->simpleColumnListExtended().end());
    }
  }
  if (ssf)
  {
    for (const auto& col : ssf->cols())
    {
      col->setSimpleColumnListExtended();
      list->insert(list->end(), col->simpleColumnListExtended().begin(),
                   col->simpleColumnListExtended().end());
    }
  }
  return;  // Do NOT descend into sub->filters()
}
```

---

### Исправление 2: [rbo_apply_parallel_ces.cpp](cci:7://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/rbo/rbo_apply_parallel_ces.cpp:0:0-0:0) — работа с `accumulatedMap`

**Проблема**: `accumulatedMap` использовался напрямую для обновления столбцов. Когда подзапрос имел таблицу с тем же именем, что и внешний запрос, `insert()` не перезаписывал существующую запись, и столбцы подзапроса ошибочно ссылались на derived table внешнего запроса.

**Решение**: Введена **локальная рабочая копия** `workingMap`:

```cpp
// Create a WORKING map for this CSEP's column updates
// Start with local tables, then add outer query tables (local takes priority)
optimizer::TableAliasToNewAliasAndSCPositionsMap workingMap = localTableMap;

// Add outer query mappings for correlated columns (only if not already in local map)
for (auto& [k, v] : accumulatedMap)
{
  workingMap.insert({k, v});  // insert() won't overwrite existing local entries
}

// Use workingMap for all column updates in this CSEP
optimizer::TableAliasToNewAliasAndSCPositionsMap& tableAliasToSCPositionsMap = workingMap;
```

Это гарантирует, что локальные таблицы текущего CSEP имеют приоритет над таблицами внешнего запроса.

---

### Исправление 3: [rbo_apply_parallel_ces.cpp](cci:7://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/rbo/rbo_apply_parallel_ces.cpp:0:0-0:0) — обработка [ExistsFilter](cci:2://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/existsfilter.h:41:0-142:1)

**Проблема**: Для Q16 (`NOT IN` подзапрос) коррелированный столбец `ps_suppkey` находился внутри [ExistsFilter->sub()->filters()](cci:1://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/existsfilter.h:62:2-65:3), но существующий код не обрабатывал [ExistsFilter](cci:2://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/existsfilter.h:41:0-142:1) корректно.

**Решение**: Расширена функция `updateExistsCorrelated`:

1. Добавлена обработка [ExistsFilter](cci:2://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/existsfilter.h:41:0-142:1) — извлекаются столбцы из `sub->filters()`
2. Используется `std::set<std::string>` для определения таблиц подзапроса
3. Переписываются **только** столбцы внешнего запроса (не в `subqueryTableAliases`)

```cpp
// Build a set of subquery's own table aliases to distinguish outer query columns
std::set<std::string> subqueryTableAliases;
if (sub)
{
  for (auto& t : sub->tableList())
  {
    subqueryTableAliases.insert(t.alias);
  }
}

// Helper to check if a column belongs to outer query (not subquery's own tables)
auto isOuterQueryColumn = [&subqueryTableAliases](execplan::SimpleColumn* sc) -> bool
{
  const std::string& alias = sc->tableAlias();
  // Skip already rewritten columns
  if (alias.find("$added_sub_") != std::string::npos)
    return false;
  // Column is from outer query if it's NOT in subquery's table list
  return subqueryTableAliases.count(alias) == 0;
};

// For ExistsFilter (used for NOT IN), correlated outer query columns are in sub->filters()
if (ef && sub)
{
  if (auto subFilters = sub->filters())
  {
    std::vector<execplan::SimpleColumn*> subSCs;
    subFilters->walk(execplan::getSimpleColsExtended, &subSCs);
    for (auto* sc : subSCs)
    {
      if (sc && isOuterQueryColumn(sc))
      {
        tryToUpdateScToUseRewrittenDerived(sc, map);
      }
    }
  }
}
```

---

