### PR TITLE
chore(ci): update Rust version

### DIFF
--- a/build/prepare_test_container.sh
+++ b/build/prepare_test_container.sh
@@ -144,7 +144,7 @@ prepare_container() {
         execInnerDockerWithRetry "$CONTAINER_NAME" 'apt update -y && apt install -y elfutils expect findutils iproute2 g++ gawk gdb hostname lz4 patch procps rsyslog sudo tar wget'
     fi
 
-    execInnerDockerWithRetry "$CONTAINER_NAME" 'wget -qO- https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.85.0'
+    execInnerDockerWithRetry "$CONTAINER_NAME" 'wget -qO- https://sh.rustup.rs | sh -s -- -y --default-toolchain stable'
     execInnerDockerWithRetry "$CONTAINER_NAME" 'source /root/.cargo/env && cargo install tpchgen-cli && ln -sf /root/.cargo/bin/tpchgen-cli /usr/local/bin/tpchgen-cli'
 
     # Configure core dump naming pattern


### PR DESCRIPTION
tpchgen-cli has a set of deps with unfixed versions

And after the deps update it fails to compile with rust 1.85

```
error[E0658]: `let` expressions in this position are unstable
  --> /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/comfy-table-7.2.2/src/utils/arrangement/disabled.rs:21:12
   |
21 |         if let Some(max_width) = constraint::max(table, &column.constraint, visible_columns)
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

error[E0658]: `let` expressions in this position are unstable
   --> /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/comfy-table-7.2.2/src/utils/formatting/content_format.rs:101:12
    |
101 |         if let Some(lines) = row.max_height
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

   Compiling seq-macro v0.3.6
   Compiling jiff v0.2.18
   Compiling lexical-parse-float v1.0.6
   Compiling clap_builder v4.5.54
``` 