### PR TITLE
fix(startup): make DMLProc wait for controllernode

### DIFF
--- a/cmapi/cmapi_server/managers/process.py
+++ b/cmapi/cmapi_server/managers/process.py
@@ -226,24 +226,30 @@ class MCSProcessManager:
         :return: True on success
         :rtype: bool
         """
-        logging.debug(
-            'Waiting for controllernode to come up before starting '
-            'ddlproc/dmlproc on non-primary nodes.'
+        logging.info(
+            f'_wait_for_controllernode: starting with max_retry={cls.CONTROLLER_MAX_RETRY}, '
+            f'sock_timeout={SOCK_TIMEOUT}s'
         )
+        overall_start = time.monotonic()
         attempts = cls.CONTROLLER_MAX_RETRY
         success = False
         while attempts > 0:
             start = time.monotonic()
             try:
-                with DBRM():
-                    # check connection
+                with DBRM() as dbrm:
+                    elapsed = time.monotonic() - start
+                    logging.info(
+                        f'_wait_for_controllernode: connected to '
+                        f'{dbrm.dbrm_socket._host}:{dbrm.dbrm_socket._port} '
+                        f'in {elapsed:.2f}s'
+                    )
                     success = True
-            except (OSError, ConnectionRefusedError, RuntimeError):
+            except (OSError, ConnectionRefusedError, RuntimeError) as e:
                 elapsed = time.monotonic() - start
                 remaining = SOCK_TIMEOUT - elapsed
                 logging.info(
-                    'Cannot establish connection to controllernode.'
-                    f'Controller node still not started. {attempts} attempts left.'
+                    f'_wait_for_controllernode: attempt {cls.CONTROLLER_MAX_RETRY - attempts + 1}/{cls.CONTROLLER_MAX_RETRY} '
+                    f'failed: {type(e).__name__}: {e}. Elapsed: {elapsed:.2f}s.'
                 )
                 if remaining > 0:
                     logging.debug('Sleeping %.1f seconds', remaining)
@@ -253,14 +259,15 @@ class MCSProcessManager:
                 break
             attempts -= 1
 
+        overall_elapsed = time.monotonic() - overall_start
         if not success:
             logging.error(
-                'Controllernode is not reachable after '
-                f'{cls.CONTROLLER_MAX_RETRY} attempts to connect with '
-                f'{SOCK_TIMEOUT} seconds timeout.'
+                f'_wait_for_controllernode: FAILED after {overall_elapsed:.2f}s '
+                f'({cls.CONTROLLER_MAX_RETRY} attempts with {SOCK_TIMEOUT}s timeout). '
                 'Starting mcs-dmlproc/mcs-ddlproc anyway.'
             )
             return False
+        logging.info(f'_wait_for_controllernode: SUCCESS in {overall_elapsed:.2f}s')
         return True
 
     @classmethod

--- a/cmapi/mcs_node_control/models/dbrm.py
+++ b/cmapi/mcs_node_control/models/dbrm.py
@@ -45,6 +45,11 @@ class DBRM:
             )
         dbrm_host = master_conn_info['IPAddr'] or DEFAULT_HOST
         dbrm_port = int(master_conn_info['Port']) or DEFAULT_PORT
+        module_logger.info(
+            f'DBRM.connect: connecting to {dbrm_host}:{dbrm_port} '
+            f'(from config: IPAddr={master_conn_info.get("IPAddr")}, '
+            f'Port={master_conn_info.get("Port")})'
+        )
         self.dbrm_socket.connect(dbrm_host, dbrm_port)
 
     def close(self):

--- a/cmapi/mcs_node_control/models/dbrm_socket.py
+++ b/cmapi/mcs_node_control/models/dbrm_socket.py
@@ -84,17 +84,27 @@ class DBRMSocketHandler():
 
         :raises RuntimeError: [description]
         """
+        logging.info(
+            f'_detect_protocol: starting protocol detection '
+            f'(current long_strings={DBRMSocketHandler.long_strings})'
+        )
         success = False
         # check at first old protocol because 5.x.x version got an issue if
         # we try to send new format packages.
         for long_strings in (False, True):
             DBRMSocketHandler.long_strings = long_strings
+            logging.info(f'_detect_protocol: trying long_strings={long_strings}')
             self.send('readonly')
             try:
                 _ = self.receive()
                 success = True
+                logging.info(f'_detect_protocol: success with long_strings={long_strings}')
                 break
-            except (socket.timeout, TimeoutError):
+            except (socket.timeout, TimeoutError) as e:
+                logging.warning(
+                    f'_detect_protocol: timeout with long_strings={long_strings}: '
+                    f'{type(e).__name__}: {e}'
+                )
                 # wrong packet sended could cause errors on the mcs engine side
                 self._recreate_socket()
                 continue
@@ -205,7 +215,19 @@ class DBRMSocketHandler():
         self._host = host
         self._port = port
         self._socket.settimeout(SOCK_TIMEOUT)
-        self._socket.connect((host, port))
+        logging.info(
+            f'DBRMSocketHandler.connect: attempting connection to {host}:{port} '
+            f'with timeout={SOCK_TIMEOUT}s'
+        )
+        try:
+            self._socket.connect((host, port))
+            logging.info(f'DBRMSocketHandler.connect: connected successfully to {host}:{port}')
+        except Exception as e:
+            logging.error(
+                f'DBRMSocketHandler.connect: failed to connect to {host}:{port}: '
+                f'{type(e).__name__}: {e}'
+            )
+            raise
 
     def close(self):
         """Closing the socket.
@@ -226,6 +248,10 @@ class DBRMSocketHandler():
         :type command_value: int, optional
         """
         if DBRMSocketHandler.long_strings is None:
+            logging.info(
+                f'DBRMSocketHandler.send: long_strings is None, '
+                f'calling _detect_protocol()'
+            )
             self._detect_protocol()
         msg_bytes = self._make_msg(command_name, command_value)
         self._send(msg_bytes)


### PR DESCRIPTION
Under ASAN builds, the test_add_node_and_shutdown test fails because mcs-dmlproc service times out during startup (15 minutes TimeoutStartSec).

The root cause is higly likely that _wait_for_controllernode() in cmapi only verified that a TCP connection could be established to controllernode, but did not verify that controllernode was actually ready to handle requests. Under ASAN, controllernode may accept connections while still initializing internally. When DMLProc starts and sends its first DBRM request, it blocks indefinitely waiting for a response from a not-yet-ready controllernode.

Modified _wait_for_controllernode() to not only establish a connection but also send a test command (get_system_state()) and wait for a response. This ensures controllernode is fully initialized and ready to handle requests before DMLProc/DDLProc are started.