### PR TITLE
Fix memory leak in buildPredicateItem() for IN_FUNC handling

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -1369,22 +1369,24 @@ bool buildPredicateItem(Item_func* ifp, gp_walk_info* gwip)
   else if (ifp->functype() == Item_func::IN_FUNC)
   {
     idbassert(gwip->rcWorkStack.size() >= 2);
-    ReturnedColumn* rhs = gwip->rcWorkStack.top();
+    std::unique_ptr<ReturnedColumn> rhs(gwip->rcWorkStack.top());
     gwip->rcWorkStack.pop();
-    ReturnedColumn* lhs = gwip->rcWorkStack.top();
+    std::unique_ptr<ReturnedColumn> lhs(gwip->rcWorkStack.top());
     gwip->rcWorkStack.pop();
 
     // @bug3038
-    RowColumn* rrhs = dynamic_cast<RowColumn*>(rhs);
-    RowColumn* rlhs = dynamic_cast<RowColumn*>(lhs);
+    RowColumn* rrhs = dynamic_cast<RowColumn*>(rhs.get());
+    RowColumn* rlhs = dynamic_cast<RowColumn*>(lhs.get());
 
     if (rrhs && rlhs)
     {
+      rhs.release();  // buildRowColumnFilter takes ownership
+      lhs.release();
       return buildRowColumnFilter(gwip, rrhs, rlhs, ifp);
     }
 
-    ConstantColumn* crhs = dynamic_cast<ConstantColumn*>(rhs);
-    ConstantColumn* clhs = dynamic_cast<ConstantColumn*>(lhs);
+    ConstantColumn* crhs = dynamic_cast<ConstantColumn*>(rhs.get());
+    ConstantColumn* clhs = dynamic_cast<ConstantColumn*>(lhs.get());
 
     if (!crhs || !clhs)
     {
@@ -1411,11 +1413,10 @@ bool buildPredicateItem(Item_func* ifp, gp_walk_info* gwip)
     sop.reset(new PredicateOperator(eqop));
     SRCP scsp = gwip->scsp;
     idbassert(scsp.get() != nullptr);
-    // sop->setOpType(gwip->scsp->resultType(), rhs->resultType());
     sop->setOpType(scsp->resultType(), rhs->resultType());
     ConstantFilter* cf = 0;
 
-    cf = new ConstantFilter(sop, scsp->clone(), lhs);
+    cf = new ConstantFilter(sop, scsp->clone(), lhs.release());
     sop.reset(new LogicOperator(cmbop));
     cf->op(sop);
     sop.reset(new PredicateOperator(eqop));
@@ -1424,15 +1425,18 @@ bool buildPredicateItem(Item_func* ifp, gp_walk_info* gwip)
 
     while (!gwip->rcWorkStack.empty())
     {
-      lhs = gwip->rcWorkStack.top();
+      std::unique_ptr<ReturnedColumn> val(gwip->rcWorkStack.top());
 
-      if (dynamic_cast<ConstantColumn*>(lhs) == 0)
+      if (dynamic_cast<ConstantColumn*>(val.get()) == 0)
+      {
+        val.release();  // put back - not ours to delete
         break;
+      }
 
       gwip->rcWorkStack.pop();
       sop.reset(new PredicateOperator(eqop));
-      sop->setOpType(scsp->resultType(), lhs->resultType());
-      cf->pushFilter(new SimpleFilter(sop, scsp->clone(), lhs->clone(), gwip->timeZone));
+      sop->setOpType(scsp->resultType(), val->resultType());
+      cf->pushFilter(new SimpleFilter(sop, scsp->clone(), val->clone(), gwip->timeZone));
     }
 
     if (!gwip->rcWorkStack.empty())


### PR DESCRIPTION
ConstantColumn objects popped from rcWorkStack were only used for
cloning but never freed, causing memory leaks detected by ASAN.
 
Refactored to use std::unique_ptr<ReturnedColumn> for RAII-style
memory management:
- rhs and lhs are now wrapped in unique_ptr upon extraction from stack
- For buildRowColumnFilter path: release() transfers ownership
- For ConstantFilter: lhs.release() transfers ownership to constructor
- rhs is automatically deleted after clone() via unique_ptr destructor
- Loop values wrapped in unique_ptr and auto-deleted after cloning
 
This follows the same RAII pattern already used in buildRowColumnFilter().


```
==10105==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 3264 byte(s) in 3 object(s) allocated from:
    #0 0x7782e93f1548 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x7782dd2521a2 in cal_impl_if::newConstantColumnNotNullUsingValNativeNoTz(Item*, cal_impl_if::gp_walk_info&) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_helpers.cpp:136
    #2 0x7782dd252594 in cal_impl_if::buildConstantColumnNotNullUsingValNative(Item*, cal_impl_if::gp_walk_info&) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_helpers.cpp:100
    #3 0x7782dd2ea34e in cal_impl_if::buildReturnedColumnBody(Item*, cal_impl_if::gp_walk_info&, bool&, bool, execplan::IDBQueryType) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:2829
    #4 0x7782dd2eb27e in cal_impl_if::buildReturnedColumn(Item*, cal_impl_if::gp_walk_info&, bool&, bool, execplan::IDBQueryType) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:2995
    #5 0x7782dd26da5c in cal_impl_if::gp_walk(Item const*, void*) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_walks.cpp:158
    #6 0x612e1a7afb66 in Item_func::traverse_cond(void (*)(Item const*, void*), void*, Item::traverse_order) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/sql/item_func.cc:478
    #7 0x7782dd31cb73 in cal_impl_if::processWhere(st_select_lex&, cal_impl_if::gp_walk_info&, boost::shared_ptr<execplan::CalpontSelectExecutionPlan>&, std::vector<Item*, std::allocator<Item*> > const&) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:6071
    #8 0x7782dd327ecd in cal_impl_if::getSelectPlan(cal_impl_if::gp_walk_info&, st_select_lex&, boost::shared_ptr<execplan::CalpontSelectExecutionPlan>&, bool, bool, bool, std::vector<Item*, std::allocator<Item*> > const&) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:7229
    #9 0x7782dd32cef2 in cal_impl_if::cs_get_select_plan(ha_columnstore_select_handler*, THD*, boost::shared_ptr<execplan::CalpontSelectExecutionPlan>&, cal_impl_if::gp_walk_info&, bool) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:7595
    #10 0x7782dd132361 in ha_mcs_impl_pushdown_init(mcs_handler_info*, TABLE*, bool) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_impl.cpp:4212
    #11 0x7782dd0ced58 in create_columnstore_select_handler_(THD*, st_select_lex*, st_select_lex_unit*) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_pushdown.cpp:836
    #12 0x612e19df060d in find_select_handler_inner /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/sql/sql_select.cc:5116
    #13 0x612e19f1569f in mysql_select(THD*, TABLE_LIST*, List<Item>&, Item*, unsigned int, st_order*, st_order*, Item*, st_order*, unsigned long long, select_result*, st_select_lex_unit*, st_select_lex*) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/sql/sql_select.cc:5267
    #14 0x612e19f173d8 in handle_select(THD*, LEX*, select_result*, unsigned long) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/sql/sql_select.cc:575
    #15 0x612e19d45904 in mysql_execute_command(THD*, bool) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/sql/sql_parse.cc:4842
    #16 0x612e19d47a81 in mysql_parse(THD*, char*, unsigned int, Parser_state*) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/sql/sql_parse.cc:8229
    #17 0x612e19d4bd75 in dispatch_command(enum_server_command, THD*, char*, unsigned int, bool) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/sql/sql_parse.cc:1915
    #18 0x612e19d51fb0 in do_command(THD*, bool) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/sql/sql_parse.cc:1428
    #19 0x612e1a1a804c in do_handle_one_connection(CONNECT*, bool) /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/sql/sql_connect.cc:1386
    #20 0x612e1a1a8874 in handle_one_connection /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/sql/sql_connect.cc:1298
    #21 0x612e1ae8bd45 in pfs_spawn_thread /usr/src/mariadb-10.6-1:10.6.25.21+maria~ubu2404/storage/perfschema/pfs.cc:2201
    #22 0x7782e9351a41 in asan_thread_start ../../../../src/libsanitizer/asan/asan_interceptors.cpp:234
    #23 0x7782e85f4aa3 in start_thread nptl/pthread_create.c:447
```