### PR TITLE
MCOL-5983: Add COMPARE_BITMASK primitive filter for bitwise AND pattern optimization

### DIFF
--- a/dbcon/joblist/jlf_execplantojoblist.cpp
+++ b/dbcon/joblist/jlf_execplantojoblist.cpp
@@ -29,6 +29,7 @@
 #include <map>
 #include <climits>
 #include <cmath>
+#include "mcs_datatype.h"
 using namespace std;
 
 #include <boost/shared_ptr.hpp>
@@ -1913,20 +1914,34 @@ const JobStepVector doSimpleFilter(SimpleFilter* sf, JobInfo& jobInfo)
     if (jsv.empty())
       throw runtime_error("Unhandled SimpleFilter");
   }
-  // Handle bitmask pattern: (col & mask) = mask
+  // Handle bitmask pattern: (col & mask) = mask or mask = (col & mask)
   // This allows bitwise AND filters to be pushed down as primitive filters
-  else if (lhsType == FUNCTIONCOLUMN && opeq == *sop)
+  else if ((lhsType == FUNCTIONCOLUMN || rhsType == FUNCTIONCOLUMN) && opeq == *sop)
   {
-    const FunctionColumn* fc = static_cast<const FunctionColumn*>(lhs);
-    const ConstantColumn* cc = dynamic_cast<const ConstantColumn*>(rhs);
+    // Normalize: fc is the FunctionColumn, cc is the ConstantColumn on the other side
+    const FunctionColumn* fc = dynamic_cast<const FunctionColumn*>(lhsType == FUNCTIONCOLUMN ? lhs : rhs);
+    const ConstantColumn* cc = dynamic_cast<const ConstantColumn*>(lhsType == FUNCTIONCOLUMN ? rhs : lhs);
     bool handled = false;
 
     // Check if this is a bitwise AND function with a SimpleColumn and ConstantColumn
-    if (cc && fc->functionName() == "&" && fc->functionParms().size() == 2)
+    // Supports: (col & mask) = mask, (mask & col) = mask, mask = (col & mask), mask = (mask & col)
+    if (cc && fc && fc->functionName() == "&" && fc->functionParms().size() == 2)
     {
       const auto& parms = fc->functionParms();
-      const SimpleColumn* sc = dynamic_cast<const SimpleColumn*>(parms[0]->data());
-      const ConstantColumn* maskCC = dynamic_cast<const ConstantColumn*>(parms[1]->data());
+
+      // Extract SimpleColumn and ConstantColumn from either argument order
+      auto extractBitmaskArgs = [](const funcexp::FunctionParm& p)
+          -> std::pair<const SimpleColumn*, const ConstantColumn*> {
+        if (auto sc = dynamic_cast<const SimpleColumn*>(p[0]->data()))
+          if (auto cc = dynamic_cast<const ConstantColumn*>(p[1]->data()))
+            return {sc, cc};
+        if (auto sc = dynamic_cast<const SimpleColumn*>(p[1]->data()))
+          if (auto cc = dynamic_cast<const ConstantColumn*>(p[0]->data()))
+            return {sc, cc};
+        return {nullptr, nullptr};
+      };
+
+      auto [sc, maskCC] = extractBitmaskArgs(parms);
 
       if (sc && maskCC && !sc->schemaName().empty() && sc->isColumnStore())
       {
@@ -1945,14 +1960,7 @@ const JobStepVector doSimpleFilter(SimpleFilter* sf, JobInfo& jobInfo)
           }
 
           // Only for integer types
-          if (ct.colDataType == CalpontSystemCatalog::BIGINT ||
-              ct.colDataType == CalpontSystemCatalog::UBIGINT ||
-              ct.colDataType == CalpontSystemCatalog::INT ||
-              ct.colDataType == CalpontSystemCatalog::UINT ||
-              ct.colDataType == CalpontSystemCatalog::SMALLINT ||
-              ct.colDataType == CalpontSystemCatalog::USMALLINT ||
-              ct.colDataType == CalpontSystemCatalog::TINYINT ||
-              ct.colDataType == CalpontSystemCatalog::UTINYINT)
+          if (datatypes::isInteger(ct.colDataType))
           {
             string alias(extractTableAlias(sc));
             string view(sc->viewName());
@@ -3431,8 +3439,21 @@ namespace joblist
 
       // Reorder AND filters: process cheaper filters first
       // This helps when combining expensive filters (LIKE '%...%') with cheap filters (bitmask)
-      // Heuristic: LIKE on TEXT/BLOB is expensive, numeric filters are cheap
-      auto estimateCost = [](const ParseTree* pt) -> int {
+      // Heuristic: LIKE on TEXT/BLOB is expensive, bitmask primitive filters are cheap
+
+      // Check if FunctionColumn is a bitmask pattern: (col & const) or (const & col)
+      auto isBitmaskPattern = [](const FunctionColumn* fc) -> bool {
+        if (!fc || fc->functionName() != "&" || fc->functionParms().size() != 2)
+          return false;
+        const auto& p = fc->functionParms();
+        bool hasSimpleCol = dynamic_cast<const SimpleColumn*>(p[0]->data()) ||
+                            dynamic_cast<const SimpleColumn*>(p[1]->data());
+        bool hasConst = dynamic_cast<const ConstantColumn*>(p[0]->data()) ||
+                        dynamic_cast<const ConstantColumn*>(p[1]->data());
+        return hasSimpleCol && hasConst;
+      };
+
+      auto estimateCost = [&isBitmaskPattern](const ParseTree* pt) -> int {
         if (!pt || !pt->data())
           return 0;
         TreeNode* data = pt->data();
@@ -3443,14 +3464,12 @@ namespace joblist
           // LIKE is expensive
           if (op && (op->op() == OP_LIKE || op->op() == OP_NOTLIKE))
             return 1000;
-          // Check if LHS is a bitmask function (col & mask) = mask
-          const FunctionColumn* fc = dynamic_cast<const FunctionColumn*>(sf->lhs());
-          if (fc && fc->functionName() == "&")
-            return 10;  // Bitmask is cheap
+          // Check for bitmask pattern: (col & mask) = mask (pushdown to primitive filter)
+          const FunctionColumn* fcLhs = dynamic_cast<const FunctionColumn*>(sf->lhs());
+          const FunctionColumn* fcRhs = dynamic_cast<const FunctionColumn*>(sf->rhs());
+          if (isBitmaskPattern(fcLhs) || isBitmaskPattern(fcRhs))
+            return 10;  // Bitmask primitive filter is cheap
         }
-        const FunctionColumn* fc = dynamic_cast<const FunctionColumn*>(data);
-        if (fc && fc->functionName() == "&")
-          return 10;  // Bitmask is cheap
         return 100;  // Default cost
       };
 

--- a/dbcon/joblist/jlf_execplantojoblist.cpp
+++ b/dbcon/joblist/jlf_execplantojoblist.cpp
@@ -1913,6 +1913,91 @@ const JobStepVector doSimpleFilter(SimpleFilter* sf, JobInfo& jobInfo)
     if (jsv.empty())
       throw runtime_error("Unhandled SimpleFilter");
   }
+  // Handle bitmask pattern: (col & mask) = mask
+  // This allows bitwise AND filters to be pushed down as primitive filters
+  else if (lhsType == FUNCTIONCOLUMN && opeq == *sop)
+  {
+    const FunctionColumn* fc = static_cast<const FunctionColumn*>(lhs);
+    const ConstantColumn* cc = dynamic_cast<const ConstantColumn*>(rhs);
+    bool handled = false;
+
+    // Check if this is a bitwise AND function with a SimpleColumn and ConstantColumn
+    if (cc && fc->functionName() == "&" && fc->functionParms().size() == 2)
+    {
+      const auto& parms = fc->functionParms();
+      const SimpleColumn* sc = dynamic_cast<const SimpleColumn*>(parms[0]->data());
+      const ConstantColumn* maskCC = dynamic_cast<const ConstantColumn*>(parms[1]->data());
+
+      if (sc && maskCC && !sc->schemaName().empty() && sc->isColumnStore())
+      {
+        std::string maskStr = maskCC->constval().safeString("");
+        std::string rhsStr = cc->constval().safeString("");
+
+        if (maskStr == rhsStr)
+        {
+          CalpontSystemCatalog::OID tbl_oid = tableOid(sc, jobInfo.csc);
+          CalpontSystemCatalog::ColType ct = sc->colType();
+
+          if (!sc->schemaName().empty() && sc->isColumnStore())
+          {
+            ct = jobInfo.csc->colType(sc->oid());
+            ct.charsetNumber = sc->colType().charsetNumber;
+          }
+
+          // Only for integer types
+          if (ct.colDataType == CalpontSystemCatalog::BIGINT ||
+              ct.colDataType == CalpontSystemCatalog::UBIGINT ||
+              ct.colDataType == CalpontSystemCatalog::INT ||
+              ct.colDataType == CalpontSystemCatalog::UINT ||
+              ct.colDataType == CalpontSystemCatalog::SMALLINT ||
+              ct.colDataType == CalpontSystemCatalog::USMALLINT ||
+              ct.colDataType == CalpontSystemCatalog::TINYINT ||
+              ct.colDataType == CalpontSystemCatalog::UTINYINT)
+          {
+            string alias(extractTableAlias(sc));
+            string view(sc->viewName());
+
+            pColStep* pcs = new pColStep(sc->oid(), tbl_oid, ct, jobInfo);
+            pcs->alias(alias);
+            pcs->view(view);
+            pcs->name(sc->columnName());
+            pcs->schema(sc->schemaName());
+            pcs->cardinality(sf->cardinality());
+
+            int64_t maskValue = 0;
+            try
+            {
+              // Use stoull for unsigned values, then cast to int64_t
+              // This handles values > INT64_MAX correctly
+              maskValue = static_cast<int64_t>(std::stoull(maskStr));
+            }
+            catch (...)
+            {
+              delete pcs;
+              jsv = doExpressionFilter(sf, jobInfo);
+              return jsv;
+            }
+
+            pcs->addFilter(COMPARE_BITMASK, maskValue, 0);
+
+            SJSTEP sjstep;
+            sjstep.reset(pcs);
+            jsv.push_back(sjstep);
+
+            pcs->addFilter(sf);
+
+            TupleInfo ti(setTupleInfo(ct, sc->oid(), jobInfo, tbl_oid, sc, alias));
+            pcs->tupleId(ti.key);
+
+            handled = true;
+          }
+        }
+      }
+    }
+
+    if (!handled)
+      jsv = doExpressionFilter(sf, jobInfo);
+  }
   else if (lhsType == ARITHMETICCOLUMN || rhsType == ARITHMETICCOLUMN || lhsType == FUNCTIONCOLUMN ||
            rhsType == FUNCTIONCOLUMN)
   {
@@ -3344,11 +3429,48 @@ namespace joblist
     {
       /*doAND(jsv, jobInfo)*/;
 
-      if (n->left())
-        walkTree(n->left(), jobInfo);
+      // Reorder AND filters: process cheaper filters first
+      // This helps when combining expensive filters (LIKE '%...%') with cheap filters (bitmask)
+      // Heuristic: LIKE on TEXT/BLOB is expensive, numeric filters are cheap
+      auto estimateCost = [](const ParseTree* pt) -> int {
+        if (!pt || !pt->data())
+          return 0;
+        TreeNode* data = pt->data();
+        const SimpleFilter* sf = dynamic_cast<const SimpleFilter*>(data);
+        if (sf)
+        {
+          const SOP& op = sf->op();
+          // LIKE is expensive
+          if (op && (op->op() == OP_LIKE || op->op() == OP_NOTLIKE))
+            return 1000;
+          // Check if LHS is a bitmask function (col & mask) = mask
+          const FunctionColumn* fc = dynamic_cast<const FunctionColumn*>(sf->lhs());
+          if (fc && fc->functionName() == "&")
+            return 10;  // Bitmask is cheap
+        }
+        const FunctionColumn* fc = dynamic_cast<const FunctionColumn*>(data);
+        if (fc && fc->functionName() == "&")
+          return 10;  // Bitmask is cheap
+        return 100;  // Default cost
+      };
 
-      if (n->right())
-        walkTree(n->right(), jobInfo);
+      int leftCost = estimateCost(n->left());
+      int rightCost = estimateCost(n->right());
+
+      if (leftCost <= rightCost)
+      {
+        if (n->left())
+          walkTree(n->left(), jobInfo);
+        if (n->right())
+          walkTree(n->right(), jobInfo);
+      }
+      else
+      {
+        if (n->right())
+          walkTree(n->right(), jobInfo);
+        if (n->left())
+          walkTree(n->left(), jobInfo);
+      }
     }
     else if (*op == opOR || *op == opor)
     {

--- a/dbcon/joblist/primitivemsg.h
+++ b/dbcon/joblist/primitivemsg.h
@@ -55,6 +55,10 @@ const int8_t COMPARE_NGE = (COMPARE_GE | COMPARE_NOT);  // 0x0e
 const int8_t COMPARE_LIKE = 0x10;
 const int8_t COMPARE_NLIKE = (COMPARE_LIKE | COMPARE_NOT);  // 0x18
 
+// Bitmask comparison: (value & mask) = mask
+// Used for Bloom filter style queries where we check if all bits in mask are set
+const int8_t COMPARE_BITMASK = 0x20;
+
 namespace primitives
 {
 using RIDType = uint16_t;

--- a/primitives/linux-port/column.cpp
+++ b/primitives/linux-port/column.cpp
@@ -169,6 +169,13 @@ inline bool colCompare_(const T& val1, const T& val2, uint8_t COP)
 
     case COMPARE_NULLEQ: return val1 == val2;
 
+    case COMPARE_BITMASK:
+      // Bitmask comparison only valid for integral types
+      if constexpr (std::is_integral_v<T>)
+        return (val1 & val2) == val2;
+      else
+        return false;
+
     default: logIt(34, COP, "colCompare_"); return false;  // throw an exception here?
   }
 }
@@ -206,6 +213,13 @@ inline bool colCompare_(const T& val1, const T& val2, uint8_t COP, uint8_t rf)
     case COMPARE_GT: return val1 > val2 || (val1 == val2 && (rf & 0x80));
 
     case COMPARE_NULLEQ: return val1 == val2 && rf == 0;
+
+    case COMPARE_BITMASK:
+      // Bitmask comparison only valid for integral types
+      if constexpr (std::is_integral_v<T>)
+        return (val1 & val2) == val2;
+      else
+        return false;
 
     default: logIt(34, COP, "colCompare_"); return false;  // throw an exception here?
   }
@@ -1560,6 +1574,11 @@ void vectorizedFiltering_(NewColRequestHeader* in, ColResultHeader* out, const T
         case (COMPARE_LT): filterMask = simdProcessor.cmpLt(l, filterArgsVectors[j]); break;
         case (COMPARE_NE): filterMask = simdProcessor.cmpNe(l, filterArgsVectors[j]); break;
         case (COMPARE_NIL): filterMask = falseMask; break;
+        case (COMPARE_BITMASK):
+          // Bitmask: (value & mask) == mask
+          // Using SIMD: AND then compare equal
+          filterMask = simdProcessor.cmpEq(simdProcessor.bwAnd(l, filterArgsVectors[j]), filterArgsVectors[j]);
+          break;
 
         default:
           idbassert(false);


### PR DESCRIPTION
This PR adds support for pushing down bitwise AND filter patterns (col & mask) = mask as primitive filters, enabling significant performance improvements for Bloom filter-based queries.

Background
Bloom filters are commonly used in specialized databases (e.g., chemical/molecular databases) to accelerate substring searches. A typical query pattern is:

```
SELECT * FROM molecules 
WHERE smiles LIKE '%C(=O)C(O)%' 
  AND (signature & @bloom_mask) = @bloom_mask;
```
Previously, the bitwise AND expression was evaluated in FE1 (Function Expression Group 1) after all primitive filters, negating the benefit of the Bloom filter pre-filtering.

Pattern Recognition: `doSimpleFilter()` detects `FunctionColumn("&") = ConstantColumn` where both mask arguments match 
- Filter Creation: Creates a `pColStep` with `COMPARE_BITMASK` operator instead of falling back to `ExpressionFilter`
- SIMD Execution: The primitive processor uses `bwAnd() + cmpEq()` SIMD intrinsics for vectorized filtering
- Filter Reordering: `walkTree()` uses cost-based heuristics to execute cheap bitmask filters before expensive LIKE filters