### PR TITLE
fix(cpimport): MCOL-6243 - cpimport fails at fields longer than 1M

### DIFF
--- a/mysql-test/columnstore/bugfixes/MCOL-6243-long-text-cpimport-fail.result
+++ b/mysql-test/columnstore/bugfixes/MCOL-6243-long-text-cpimport-fail.result
@@ -1,0 +1,12 @@
+DROP DATABASE IF EXISTS MCOL_6243;
+CREATE DATABASE MCOL_6243;
+USE MCOL_6243;
+CREATE TABLE t1 (
+short_id varchar(36)
+, long_content longtext
+)  ENGINE=Columnstore DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+LOAD DATA LOCAL INFILE 'DATADIR/mcol_6243_input.csv' INTO TABLE t1 CHARACTER SET UTF8MB4 FIELDS TERMINATED BY ';' OPTIONALLY ENCLOSED BY '"' ESCAPED BY '\\' (short_id, long_content);;
+SELECT short_id, length(long_content) FROM t1;
+short_id	length(long_content)
+short id	1200000
+DROP DATABASE MCOL_6243;

--- a/mysql-test/columnstore/bugfixes/MCOL-6243-long-text-cpimport-fail.test
+++ b/mysql-test/columnstore/bugfixes/MCOL-6243-long-text-cpimport-fail.test
@@ -1,0 +1,26 @@
+# Checks that long text values longer than 1MB (old cpimport buffer size)
+# get loaded by cpimport.
+
+--disable_warnings
+DROP DATABASE IF EXISTS MCOL_6243;
+--enable_warnings
+CREATE DATABASE MCOL_6243;
+USE MCOL_6243;
+
+CREATE TABLE t1 (
+      short_id varchar(36)
+    , long_content longtext
+)  ENGINE=Columnstore DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+let $DATADIR=`SELECT @@datadir`;
+--exec rm -f $DATADIR/mcol_6243_input.csv
+--exec printf "short id;" > $DATADIR/mcol_6243_input.csv
+# this line produces 100,000 repetitions of the "long content" string, totaling 1,200,000 bytes.
+--system bash -c "printf 'long content%.0s' {1..100000}" >> $DATADIR/mcol_6243_input.csv
+--replace_result $DATADIR DATADIR
+--eval LOAD DATA LOCAL INFILE '$DATADIR/mcol_6243_input.csv' INTO TABLE t1 CHARACTER SET UTF8MB4 FIELDS TERMINATED BY ';' OPTIONALLY ENCLOSED BY '"' ESCAPED BY '\\\\' (short_id, long_content);
+--exec rm -f $DATADIR/mcol_6243_input.csv
+
+SELECT short_id, length(long_content) FROM t1;
+
+DROP DATABASE MCOL_6243;

--- a/writeengine/bulk/we_bulkloadbuffer.cpp
+++ b/writeengine/bulk/we_bulkloadbuffer.cpp
@@ -2160,86 +2160,106 @@ int BulkLoadBuffer::fillFromFile(const BulkLoadBuffer& overFlowBufIn, FILE* hand
   copyOverflow(overFlowBufIn);
   size_t readSize = 0;
 
-  // Copy the overflow data from the last buffer, that did not get written
-  if (fOverflowSize != 0)
+  bool success = false;
+  do
   {
-    memcpy(fData, fOverflowBuf, fOverflowSize);
-
-    if (fOverflowBuf != nullptr)
+    success = false;
+    // Copy the overflow data from the last buffer, that did not get written
+    if (fOverflowSize != 0)
     {
-      delete[] fOverflowBuf;
-      fOverflowBuf = nullptr;
-    }
-  }
+      memcpy(fData, fOverflowBuf, fOverflowSize);
 
-  readSize = fread(fData + fOverflowSize, 1, fBufferSize - fOverflowSize, handle);
-
-  if (ferror(handle))
-  {
-    return ERR_FILE_READ_IMPORT;
-  }
-
-  bool bEndOfData = false;
-
-  if (feof(handle))
-    bEndOfData = true;
-
-  if (bEndOfData &&                           // @bug 3516: Add '\n' if missing from last record
-      (fImportDataMode == IMPORT_DATA_TEXT))  // Only applies to ascii mode
-  {
-    if ((fOverflowSize > 0) | (readSize > 0))
-    {
-      if (fData[fOverflowSize + readSize - 1] != '\n')
+      if (fOverflowBuf != nullptr)
       {
-        // Should be safe to add byte to fData w/o risk of overflowing,
-        // since we hit EOF.  That should mean fread() did not read all
-        // the bytes we requested, meaning we have room to add a byte.
-        fData[fOverflowSize + readSize] = '\n';
-        readSize++;
+        delete[] fOverflowBuf;
+        fOverflowBuf = nullptr;
       }
     }
-  }
 
-  // Lazy allocation of fToken memory as needed
-  if (fTokens == 0)
-  {
-    resizeTokenArray();
-  }
+    readSize = fread(fData + fOverflowSize, 1, fBufferSize - fOverflowSize, handle);
 
-  if ((readSize > 0) || (fOverflowSize > 0))
-  {
-    if (fOverflowBuf != NULL)
+    if (ferror(handle))
     {
-      delete[] fOverflowBuf;
-      fOverflowBuf = NULL;
+      return ERR_FILE_READ_IMPORT;
     }
 
-    fReadSize = readSize + fOverflowSize;
-    fStartRow = correctTotalRows;
-    fStartRowForLogging = totalReadRows;
+    bool bEndOfData = false;
 
-    if (fImportDataMode == IMPORT_DATA_TEXT)
+    if (feof(handle))
+      bEndOfData = true;
+
+    if (bEndOfData &&                           // @bug 3516: Add '\n' if missing from last record
+        (fImportDataMode == IMPORT_DATA_TEXT))  // Only applies to ascii mode
     {
-      tokenize(columnsInfo, allowedErrCntThisCall, skipRows);
+      if ((fOverflowSize > 0) || (readSize > 0))
+      {
+        if (fData[fOverflowSize + readSize - 1] != '\n')
+        {
+          // Should be safe to add byte to fData w/o risk of overflowing,
+          // since we hit EOF.  That should mean fread() did not read all
+          // the bytes we requested, meaning we have room to add a byte.
+          fData[fOverflowSize + readSize] = '\n';
+          readSize++;
+        }
+      }
+    }
+
+    // Lazy allocation of fToken memory as needed
+    if (fTokens == 0)
+    {
+      resizeTokenArray();
+    }
+
+    if ((readSize > 0) || (fOverflowSize > 0))
+    {
+      if (fOverflowBuf != NULL)
+      {
+        delete[] fOverflowBuf;
+        fOverflowBuf = NULL;
+      }
+
+      fReadSize = readSize + fOverflowSize;
+      fStartRow = correctTotalRows;
+      fStartRowForLogging = totalReadRows;
+
+      if (fImportDataMode == IMPORT_DATA_TEXT)
+      {
+        tokenize(columnsInfo, allowedErrCntThisCall, skipRows);
+      }
+      else
+      {
+        int rc = tokenizeBinary(columnsInfo, allowedErrCntThisCall, bEndOfData);
+
+        if (rc != NO_ERROR)
+  	return rc;
+      }
+
+      // Old logic: If we read a full buffer without hitting any new lines, then
+      //            terminate import because row size is greater than read buffer size.
+      if ((fTotalReadRowsForLog == 0) && (fReadSize == fBufferSize))
+      {
+        // new logic: increase fBufferSize and reallocate fData; rerun parsing as the data in the overflow.
+        size_t doubled = size_t(fBufferSize) * 2;
+        fLog->logMsg( "doubling buffer size", MSGLVL_INFO1 );
+	if (doubled >= 1UL <<31)
+	{
+	  return ERR_BULK_ROW_FILL_BUFFER; // row exceeds 2GiB.
+	}
+        fBufferSize = doubled;
+	delete[] fData;
+	fData = new char[fBufferSize];
+	continue;
+      }
+
+      totalReadRows += fTotalReadRowsForLog;
+      correctTotalRows += fTotalReadRows;
+      success = true;
     }
     else
     {
-      int rc = tokenizeBinary(columnsInfo, allowedErrCntThisCall, bEndOfData);
-
-      if (rc != NO_ERROR)
-        return rc;
+      success = true;
     }
-
-    // If we read a full buffer without hitting any new lines, then
-    // terminate import because row size is greater than read buffer size.
-    if ((fTotalReadRowsForLog == 0) && (fReadSize == fBufferSize))
-    {
-      return ERR_BULK_ROW_FILL_BUFFER;
-    }
-
-    totalReadRows += fTotalReadRowsForLog;
-    correctTotalRows += fTotalReadRows;
-  }
+  } while (!success);
 
   return NO_ERROR;
 }

--- a/writeengine/splitter/we_filereadthread.cpp
+++ b/writeengine/splitter/we_filereadthread.cpp
@@ -93,8 +93,6 @@ WEFileReadThread::WEFileReadThread(WESDHandler& aSdh)
     fBuffSize = fSdh.getReadBufSize();
   }
 
-  fBuff = new char[fBuffSize];
-
   const WECmdArgs& args = fSdh.fRef.fCmdArgs;
   initS3Connection(args);
 }
@@ -118,7 +116,6 @@ WEFileReadThread::~WEFileReadThread()
   }
 
   fpThread = 0;
-  delete[] fBuff;
   // cout << "WEFileReadThread destructor called" << endl;
 
   if (doS3Import)
@@ -363,11 +360,27 @@ void WEFileReadThread::feedData()
   }
 }
 
+// helper to copy line from input file to the stringstream.
+// not very performant, yet.
+static void copyLine(std::vector<char>& out, std::istream& is)
+{
+  out.clear();
+  while (is.good() && !is.eof())
+  {
+    char c = is.get();
+    out.push_back(c);
+    if (c == '\n')
+    {
+      break;
+    }
+  }
+}
 //------------------------------------------------------------------------------
 // Read input data as ASCII text
 //------------------------------------------------------------------------------
 unsigned int WEFileReadThread::readDataFile(messageqcpp::SBS& Sbs)
 {
+  fBuff.reserve(fBuffSize * 2);	
   boost::mutex::scoped_lock aLock(fFileMutex);
 
   // For now we are going to send KEEPALIVES
@@ -378,7 +391,6 @@ unsigned int WEFileReadThread::readDataFile(messageqcpp::SBS& Sbs)
     // char aBuff[1024*1024];			// TODO May have to change it later
     // char*pStart = aBuff;
     unsigned int aIdx = 0;
-    int aLen = 0;
     *Sbs << static_cast<ByteStream::byte>(WE_CLT_SRV_DATA);
 
     while (!fInFile.eof() && aIdx < getBatchQty())
@@ -386,14 +398,13 @@ unsigned int WEFileReadThread::readDataFile(messageqcpp::SBS& Sbs)
       if (fSkipRows > 0)
       {
         fSkipRows--;
-        fInFile.getline(fBuff, fBuffSize - 1);
+	copyLine(fBuff, fInFile);
         if (fSdh.getDebugLvl() > 3)
         {
-          aLen = fInFile.gcount();
-          if (aLen > 0 && aLen < fBuffSize - 2)
+          if (fBuff.size() > 0)
           {
-            fBuff[aLen - 1] = 0;
-            cout << "Skip header row (" << fSkipRows<< " to go): " << fBuff << endl;
+	    std::string s(fBuff.data(), fBuff.size());
+            cout << "Skip header row (" << fSkipRows<< " to go): " << s << endl;
           }
         }
         continue;
@@ -401,36 +412,32 @@ unsigned int WEFileReadThread::readDataFile(messageqcpp::SBS& Sbs)
 
       if (fEnclEsc)
       {
+	cout << "getting next row" << endl;
         // pStart = aBuff;
-        aLen = getNextRow(fInFile, fBuff, fBuffSize - 1);
+        getNextRow(fInFile, fBuff);
       }
       else
       {
-        fInFile.getline(fBuff, fBuffSize - 1);
-        aLen = fInFile.gcount();
+	      cout << "copying line" << endl;
+        copyLine(fBuff, fInFile);
       }
 
-      ////aLen chars incl \n, Therefore aLen-1; '<<' oper won't go past it
-      // cout << "Data Length " << aLen <<endl;
-      if ((aLen < (fBuffSize - 2)) && (aLen > 0))
+      if (fBuff.size())
       {
-        fBuff[aLen - 1] = '\n';
-        fBuff[aLen] = 0;
+        if (fBuff[fBuff.size() - 1] != '\n')
+          fBuff.push_back('\n');
 
         if (fSdh.getDebugLvl() > 3)
-          cout << "Data Read " << fBuff << endl;
+	{
+	  std::string s(fBuff.data(), fBuff.size());
+          cout << "Data Read " << s << endl;
+	}
 
-        (*Sbs).append(reinterpret_cast<ByteStream::byte*>(fBuff), aLen);
+        (*Sbs).append(reinterpret_cast<ByteStream::byte*>(fBuff.data()), fBuff.size());
         aIdx++;
 
         if (fSdh.getDebugLvl() > 2)
           cout << "File data line = " << aIdx << endl;
-      }
-      else if (aLen >= fBuffSize - 2)  // Didn't hit delim; BIG ROW
-      {
-        cout << "Bad Row data " << endl;
-        cout << fBuff << endl;
-        throw runtime_error("Data Row too BIG to handle!!");
       }
 
       // for debug
@@ -458,12 +465,13 @@ unsigned int WEFileReadThread::readBinaryDataFile(messageqcpp::SBS& Sbs, unsigne
 
     while ((!fInFile.eof()) && (aIdx < getBatchQty()))
     {
-      fInFile.read(fBuff, recLen);
+      fBuff.resize(recLen);
+      fInFile.read(fBuff.data(), recLen);
       aLen = fInFile.gcount();
 
       if (aLen > 0)
       {
-        (*Sbs).append(reinterpret_cast<ByteStream::byte*>(fBuff), aLen);
+        (*Sbs).append(reinterpret_cast<ByteStream::byte*>(fBuff.data()), aLen);
         aIdx++;
 
         if (fSdh.getDebugLvl() > 2)
@@ -585,14 +593,14 @@ void WEFileReadThread::openInFile()
 
 //------------------------------------------------------------------------------
 
-int WEFileReadThread::getNextRow(istream& ifs, char* pBuf, int MaxLen)
+int WEFileReadThread::getNextRow(istream& ifs, std::vector<char>& buf)
 {
+  buf.resize(0); // keep allocated capacity.
   // const char ENCL ='\"';		//TODO for time being
   // const char ESC = '\0';		//TODO for time being
   const char ENCL = fEncl;
   const char ESC = fEsc;
   bool aTrailEsc = false;
-  char* pEnd = pBuf;
   int aCh = ifs.get();
 
   while (ifs.good())
@@ -600,7 +608,7 @@ int WEFileReadThread::getNextRow(istream& ifs, char* pBuf, int MaxLen)
     if (aCh == ENCL)
     {
       // we got the first enclosedBy char.
-      *pEnd++ = aCh;
+      buf.push_back(aCh);
       aCh = ifs.get();
 
       // cout << "aCh 1 = " << aCh << endl;
@@ -608,38 +616,38 @@ int WEFileReadThread::getNextRow(istream& ifs, char* pBuf, int MaxLen)
       {
         if (aCh == ESC)  // check spl cond ESC inside ENCL of '\n' here
         {
-          *pEnd++ = aCh;
+          buf.push_back(aCh);
           aCh = ifs.get();
-          *pEnd++ = aCh;
+          buf.push_back(aCh);
           aCh = ifs.get();  // get the next char for while loop
                             // cout << "aCh 2 = " << aCh << endl;
         }                   // case ESC
         else
         {
-          *pEnd++ = aCh;
+          buf.push_back(aCh);
           aCh = ifs.get();
           // cout << "aCh 3 = " << aCh << endl;
         }
       }
 
-      *pEnd++ = aCh;     // ENCL char got
+      buf.push_back(aCh);     // ENCL char got
       aTrailEsc = true;  //@BUG 4641
     }                    // case ENCL
     else if (aCh == ESC)
     {
-      *pEnd++ = aCh;
+      buf.push_back(aCh);
       aCh = ifs.get();
-      *pEnd++ = aCh;
+      buf.push_back(aCh);
       // cout << "aCh 4 = " << aCh << endl;
     }  // case ESC
     else
     {
-      *pEnd++ = aCh;
+      buf.push_back(aCh);
       // cout << "aCh 5 = " << aCh << endl;
     }
 
     // cout << "pBuf1 " << pBuf << endl;
-    if ((aCh == '\n') || ((pEnd - pBuf) == MaxLen))
+    if (aCh == '\n')
       break;  // we got a full row
 
     aCh = ifs.get();
@@ -655,14 +663,14 @@ int WEFileReadThread::getNextRow(istream& ifs, char* pBuf, int MaxLen)
       }
       else
       {
-        *pEnd++ = aCh;
+        buf.push_back(aCh);
         aCh = ifs.get();
       }
     }
 
   }  // end of while loop
 
-  return pEnd - pBuf;
+  return buf.size();
 }
 
 void WEFileReadThread::initS3Connection(const WECmdArgs& args)

--- a/writeengine/splitter/we_filereadthread.cpp
+++ b/writeengine/splitter/we_filereadthread.cpp
@@ -364,10 +364,14 @@ void WEFileReadThread::feedData()
 // not very performant, yet.
 static void copyLine(std::vector<char>& out, std::istream& is)
 {
-  out.clear();
+  out.resize(0);
   while (is.good() && !is.eof())
   {
-    char c = is.get();
+    int c = is.get();
+    if (c < 0)
+    {
+	    break; // unfortunately, eof() is insufficient.
+    }
     out.push_back(c);
     if (c == '\n')
     {
@@ -380,7 +384,7 @@ static void copyLine(std::vector<char>& out, std::istream& is)
 //------------------------------------------------------------------------------
 unsigned int WEFileReadThread::readDataFile(messageqcpp::SBS& Sbs)
 {
-  fBuff.reserve(fBuffSize * 2);	
+  fBuff.reserve(fBuffSize * 2);
   boost::mutex::scoped_lock aLock(fFileMutex);
 
   // For now we are going to send KEEPALIVES
@@ -412,13 +416,11 @@ unsigned int WEFileReadThread::readDataFile(messageqcpp::SBS& Sbs)
 
       if (fEnclEsc)
       {
-	cout << "getting next row" << endl;
         // pStart = aBuff;
         getNextRow(fInFile, fBuff);
       }
       else
       {
-	      cout << "copying line" << endl;
         copyLine(fBuff, fInFile);
       }
 

--- a/writeengine/splitter/we_filereadthread.h
+++ b/writeengine/splitter/we_filereadthread.h
@@ -70,7 +70,7 @@ class WEFileReadThread
   unsigned int readBinaryDataFile(messageqcpp::SBS& Sbs, unsigned int recLen);
   void openInFile();
 
-  int getNextRow(std::istream& ifs, char* pBuf, int MaxLen);
+  int getNextRow(std::istream& ifs, std::vector<char>& buf);
 
   boost::thread* getFpThread() const
   {
@@ -155,7 +155,7 @@ class WEFileReadThread
   char fEsc;        // Esc char
   char fDelim;      // Column Delimit char
   size_t fSkipRows; // Header rows to skip
-  char* fBuff;      // main data buffer
+  std::vector<char> fBuff;      // main data buffer
   int fBuffSize;
 
   /* To support mode 1 imports from objects on S3 */


### PR DESCRIPTION
This patch makes cpimport buffers resizeable, thus cpimport's command-line buffer size argument is nothing but a hint now.