### PR TITLE
MCOL-6204: new crashtrace [develop-23.02]

### DIFF
--- a/versioning/BRM/slavenode.cpp
+++ b/versioning/BRM/slavenode.cpp
@@ -88,14 +88,16 @@ void stop(int sig)
   if (!die)
   {
     die = true;
-    comm->stop();
+    if (comm)
+      comm->stop();
     monitorThreads.interrupt_all();
   }
 }
 
 void reset(int sig)
 {
-  comm->reset();
+  if (comm)
+    comm->reset();
 }
 
 void ServiceWorkerNode::setupChildSignalHandlers()


### PR DESCRIPTION
Problem: The workernode process crashes when a signal (SIGINT, SIGTERM, or SIGHUP) arrives during startup, specifically while the `SlaveComm` object is being constructed.

Root Cause: In `ServiceWorkerNode::Child()` signal handlers are registered before the comm object is constructed:

