### PR TITLE
MCOL-6204: Fix workernode crash when signal arrives during startup

### DIFF
--- a/versioning/BRM/slavenode.cpp
+++ b/versioning/BRM/slavenode.cpp
@@ -89,14 +89,16 @@ void stop(int /*sig*/)
   if (!die)
   {
     die = true;
-    comm->stop();
+    if (comm)
+      comm->stop();
     monitorThreads.interrupt_all();
   }
 }
 
 void reset(int /*sig*/)
 {
-  comm->reset();
+  if (comm)
+    comm->reset();
 }
 
 void ServiceWorkerNode::setupChildSignalHandlers()


### PR DESCRIPTION
The workernode process could crash if a signal (SIGINT, SIGTERM, SIGHUP) was received during initialization. Signal handlers were registered before the SlaveComm object was constructed, causing a null pointer dereference when the handler tried to call comm->stop() or comm->reset().

The SlaveComm constructor can take significant time because it initializes MasterSegmentTable which acquires RWLocks on shared memory. If a signal arrived during this window, the process would crash.

Added null checks for the comm pointer in both stop() and reset() signal handlers to prevent the crash.