### PR TITLE
fix(ASAN): MCOL-5604 - fix ASAN diagnostics

### DIFF
--- a/writeengine/shared/we_blockop.cpp
+++ b/writeengine/shared/we_blockop.cpp
@@ -87,10 +87,6 @@ const uint8_t* BlockOp::getEmptyRowValue(const CalpontSystemCatalog::ColDataType
                                          const int width) const
 {
   auto attrs = datatypes::SystemCatalog::TypeAttributesStd(width, 0, -1);
-  // Bulk operation runtime should have m_typeHandler nullptr calling this
-  // Non-bulk operations runtime branch
-  if (m_typeHandler)
-    return m_typeHandler->getEmptyValueForType(attrs);
 
   // Bulk operation branch
   auto* typeHandler = datatypes::TypeHandler::find(colDataType, attrs);


### PR DESCRIPTION
This simple patch removes use of type handler of column operations which can be incorrect.