### PR TITLE
chore(ci): fix MTR logs path for MariaDB 11.4+

### DIFF
--- a/build/report_test_stage.sh
+++ b/build/report_test_stage.sh
@@ -41,12 +41,21 @@ fi
 
 select_pkg_format ${RESULT}
 
+# Detect MTR path - try mariadb path first (11.4+), fallback to mysql path
 if [[ "$PKG_FORMAT" == "rpm" ]]; then
     SYSTEMD_PATH="/usr/lib/systemd/systemd"
-    MTR_PATH="/usr/share/mysql-test"
+    if execInnerDocker "${CONTAINER_NAME}" "test -d /usr/share/mariadb-test" 2>/dev/null; then
+        MTR_PATH="/usr/share/mariadb-test"
+    else
+        MTR_PATH="/usr/share/mysql-test"
+    fi
 else
     SYSTEMD_PATH="systemd"
-    MTR_PATH="/usr/share/mysql/mysql-test"
+    if execInnerDocker "${CONTAINER_NAME}" "test -d /usr/share/mariadb/mariadb-test" 2>/dev/null; then
+        MTR_PATH="/usr/share/mariadb/mariadb-test"
+    else
+        MTR_PATH="/usr/share/mysql/mysql-test"
+    fi
 fi
 
 echo "Reporting test stage: ${STAGE} executed in ${CONTAINER_NAME} container"


### PR DESCRIPTION
11.x server versions https://cspkg.s3.amazonaws.com/index.html?prefix=stable-23.10/cron/2907/11.8-enterprise/amd64/ubuntu24.04/ 
dont have mtr logs directory published because of the different paths


whereas runs with 10.x have it published: https://cspkg.s3.amazonaws.com/index.html?prefix=stable-23.10/cron/2907/10.6-enterprise/amd64/debian12/

MariaDB 11.4+ uses /usr/share/mariadb/mariadb-test instead of /usr/share/mysql/mysql-test. This fix detects the correct path