### PR TITLE
MCOL-5983: Fix bitmask comparison optimization when using user-defined variables as the mask value.

### DIFF
--- a/dbcon/joblist/jlf_execplantojoblist.cpp
+++ b/dbcon/joblist/jlf_execplantojoblist.cpp
@@ -1950,7 +1950,6 @@ const JobStepVector doSimpleFilter(SimpleFilter* sf, JobInfo& jobInfo)
 
         if (maskStr == rhsStr)
         {
-          CalpontSystemCatalog::OID tbl_oid = tableOid(sc, jobInfo.csc);
           CalpontSystemCatalog::ColType ct = sc->colType();
 
           if (!sc->schemaName().empty() && sc->isColumnStore())
@@ -1962,6 +1961,18 @@ const JobStepVector doSimpleFilter(SimpleFilter* sf, JobInfo& jobInfo)
           // Only for integer types
           if (datatypes::isInteger(ct.colDataType))
           {
+            int64_t maskValue = 0;
+            try
+            {
+              maskValue = static_cast<int64_t>(std::stoull(maskStr));
+            }
+            catch (...)
+            {
+              jsv = doExpressionFilter(sf, jobInfo);
+              return jsv;
+            }
+
+            CalpontSystemCatalog::OID tbl_oid = tableOid(sc, jobInfo.csc);
             string alias(extractTableAlias(sc));
             string view(sc->viewName());
 
@@ -1971,20 +1982,6 @@ const JobStepVector doSimpleFilter(SimpleFilter* sf, JobInfo& jobInfo)
             pcs->name(sc->columnName());
             pcs->schema(sc->schemaName());
             pcs->cardinality(sf->cardinality());
-
-            int64_t maskValue = 0;
-            try
-            {
-              // Use stoull for unsigned values, then cast to int64_t
-              // This handles values > INT64_MAX correctly
-              maskValue = static_cast<int64_t>(std::stoull(maskStr));
-            }
-            catch (...)
-            {
-              delete pcs;
-              jsv = doExpressionFilter(sf, jobInfo);
-              return jsv;
-            }
 
             pcs->addFilter(COMPARE_BITMASK, maskValue, 0);
 

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -2835,12 +2835,13 @@ ReturnedColumn* buildReturnedColumnBody(Item* item, gp_walk_info& gwi, bool& non
     }
     case Item::FUNC_ITEM:
     {
+      Item_func* ifp = (Item_func*)item;
+
       if (item->const_item())
       {
         rc = buildConstantColumnMaybeNullUsingValStr(item, gwi);
         break;
       }
-      Item_func* ifp = (Item_func*)item;
       string func_name = ifp->func_name();
 
       // try to evaluate const F&E. only for select clause

--- a/dbcon/mysql/ha_mcs_execplan_helpers.cpp
+++ b/dbcon/mysql/ha_mcs_execplan_helpers.cpp
@@ -87,9 +87,42 @@ execplan::ConstantColumn* buildConstantColumnMaybeNullFromValStr(const Item* ite
 // Create a ConstantColumn by calling val_str().
 // Supports both NULL and NOT NULL values.
 // Sets the time zone according to gwi.
+// Special handling for user variables that store numeric values as binary.
 
 execplan::ConstantColumn* buildConstantColumnMaybeNullUsingValStr(Item* item, gp_walk_info& gwi)
 {
+  // User variables with numeric values (e.g., SET @v = 0x15) are stored as binary strings.
+  // val_str() returns raw binary data, which breaks atoll() in ConstantColumn constructor.
+  // For binary charset, interpret the string as a little-endian integer.
+  if (item->type() == Item::FUNC_ITEM)
+  {
+    Item_func* ifp = static_cast<Item_func*>(item);
+    if (ifp->functype() == Item_func::GUSERVAR_FUNC)
+    {
+      Item_func_get_user_var* udf = static_cast<Item_func_get_user_var*>(ifp);
+      String buf;
+      String* str = udf->val_str(&buf);
+
+      if (udf->null_value)
+        return new execplan::ConstantColumnNull();
+
+      // Check if this is a binary string (numeric value stored as binary)
+      if (str && str->length() > 0 && str->length() <= 8 &&
+          str->charset() == &my_charset_bin)
+      {
+        // Interpret binary string as little-endian integer
+        uint64_t val = 0;
+        const unsigned char* p = (const unsigned char*)str->ptr();
+        for (size_t i = 0; i < str->length(); i++)
+          val |= ((uint64_t)p[i]) << (i * 8);
+
+        execplan::ConstantColumn* cc = new execplan::ConstantColumn((int64_t)val);
+        cc->timeZone(gwi.timeZone);
+        return cc;
+      }
+    }
+  }
+
   return buildConstantColumnMaybeNullFromValStr(item, ValStrStdString(item), gwi);
 }
 

--- a/dbcon/mysql/ha_mcs_execplan_helpers.h
+++ b/dbcon/mysql/ha_mcs_execplan_helpers.h
@@ -46,7 +46,7 @@ class ValStrStdString : public std::string
     return mIsNull;
   }
 };
-  
+
 bool nonConstFunc(Item_func* ifp);
 // Note: This function might be unused currently but is kept for future compatibility.
 execplan::ConstantColumn* buildConstantColumnMaybeNullFromValStr(const Item* item, const ValStrStdString& valStr,

--- a/dbcon/mysql/ha_mcs_execplan_walks.cpp
+++ b/dbcon/mysql/ha_mcs_execplan_walks.cpp
@@ -252,7 +252,7 @@ void gp_walk(const Item* item, void* arg)
       Item* ncitem = const_cast<Item*>(item);
       Item_func* ifp = static_cast<Item_func*>(ncitem);
       std::string funcName = ifp->func_name();
-      
+
       if (!gwip->condPush)
       {
         if (!ifp->fixed())
@@ -357,9 +357,8 @@ void gp_walk(const Item* item, void* arg)
                 logging::IDBErrorInfo::instance()->errorMsg(logging::ERR_DATATYPE_NOT_SUPPORT, funcName);
           return;
         }
-        ValStrStdString valStr(ifp);
 
-        execplan::ConstantColumn* cc = buildConstantColumnMaybeNullFromValStr(ifp, valStr, *gwip);
+        execplan::ConstantColumn* cc = buildConstantColumnMaybeNullUsingValStr(ifp, *gwip);
 
         for (uint32_t i = 0; i < ifp->argument_count() && !gwip->rcWorkStack.empty(); i++)
         {
@@ -369,19 +368,10 @@ void gp_walk(const Item* item, void* arg)
 
         // bug 3137. If filter constant like 1=0, put it to ptWorkStack
         // MariaDB bug 750. Breaks if compare is an argument to a function.
-        //				if ((int32_t)gwip->rcWorkStack.size() <=
-        //(gwip->rcBookMarkStack.empty()
-        //?
-        // 0
-        //: gwip->rcBookMarkStack.top())
-        //				&& isPredicateFunction(ifp, gwip))
         if (isPredicateFunction(ifp, gwip))
           gwip->ptWorkStack.push(new execplan::ParseTree(cc));
         else
           gwip->rcWorkStack.push(cc);
-
-        if (!valStr.isNull())
-          IDEBUG(cerr << "Const F&E " << item->full_name() << " evaluate: " << valStr << endl);
 
         break;
       }

--- a/mysql-test/columnstore/bugfixes/MCOL-5983-bitmask-primitive-filter.result
+++ b/mysql-test/columnstore/bugfixes/MCOL-5983-bitmask-primitive-filter.result
@@ -1,0 +1,69 @@
+DROP DATABASE IF EXISTS mcol_5983;
+CREATE DATABASE mcol_5983;
+USE mcol_5983;
+CREATE TABLE t1 (
+id INT,
+sig BIGINT UNSIGNED,
+data VARCHAR(100)
+) ENGINE=columnstore;
+INSERT INTO t1 VALUES 
+(1, 0x3F, 'all bits 0-5 set'),
+(2, 0x15, 'bits 0,2,4 set'),
+(3, 0x2A, 'bits 1,3,5 set'),
+(4, 0x0F, 'bits 0-3 set'),
+(5, 0x00, 'no bits set');
+SELECT id, HEX(sig), data FROM t1 WHERE (sig & 0x15) = 0x15 ORDER BY id;
+id	HEX(sig)	data
+1	3F	all bits 0-5 set
+2	15	bits 0,2,4 set
+SELECT id, HEX(sig), data FROM t1 
+WHERE (sig & 0x0F) = 0x0F AND data LIKE '%bits%' 
+ORDER BY id;
+id	HEX(sig)	data
+1	3F	all bits 0-5 set
+4	F	bits 0-3 set
+CREATE FUNCTION bloom64(s TEXT) RETURNS BIGINT UNSIGNED
+DETERMINISTIC SQL SECURITY INVOKER
+BEGIN
+DECLARE i   INT DEFAULT 1;
+DECLARE n   INT DEFAULT CHAR_LENGTH(s);
+DECLARE sig BIGINT UNSIGNED DEFAULT 0;
+DECLARE crc INT UNSIGNED;
+WHILE i <= n - 2 DO
+SET crc = CRC32(SUBSTRING(s, i, 3));
+SET sig = sig
+| (CAST(1 AS UNSIGNED) << ( crc         & 63))
+| (CAST(1 AS UNSIGNED) << ((crc >> 13) & 63))
+| (CAST(1 AS UNSIGNED) << ((crc >> 26) & 63));
+SET i = i + 1;
+END WHILE;
+RETURN sig;
+END//
+CREATE TABLE molecole (
+smiles TEXT NOT NULL,
+sig BIGINT UNSIGNED NOT NULL
+) ENGINE=columnstore;
+INSERT INTO molecole (smiles, sig) VALUES
+('CCO', bloom64('CCO')),
+('c1ccccc1', bloom64('c1ccccc1')),
+('CC(=O)OC1=CC=CC=C1C(=O)O', bloom64('CC(=O)OC1=CC=CC=C1C(=O)O')),
+('CCC(=O)O[C@]1(C[C@H]2[C@H]3[C@@H]1[C@]4(C(=O)C(O)=C(C4=O)O)O[C@@H]3C[C@H]2O)C', 
+bloom64('CCC(=O)O[C@]1(C[C@H]2[C@H]3[C@@H]1[C@]4(C(=O)C(O)=C(C4=O)O)O[C@@H]3C[C@H]2O)C'));
+INSERT INTO molecole SELECT * FROM molecole;
+INSERT INTO molecole SELECT * FROM molecole;
+SET @mask := bloom64('C(=O)');
+SELECT COUNT(*) AS with_literal FROM molecole 
+WHERE smiles LIKE '%C(=O)%' AND (sig & bloom64('C(=O)')) = bloom64('C(=O)');
+with_literal
+8
+SELECT COUNT(*) AS with_variable FROM molecole 
+WHERE smiles LIKE '%C(=O)%' AND (sig & @mask) = @mask;
+with_variable
+8
+DROP FUNCTION bloom64;
+SET @mask = 0x15;
+SELECT id, HEX(sig), data FROM t1 WHERE (sig & @mask) = @mask ORDER BY id;
+id	HEX(sig)	data
+1	3F	all bits 0-5 set
+2	15	bits 0,2,4 set
+DROP DATABASE mcol_5983;

--- a/mysql-test/columnstore/bugfixes/MCOL-5983-bitmask-primitive-filter.test
+++ b/mysql-test/columnstore/bugfixes/MCOL-5983-bitmask-primitive-filter.test
@@ -1,0 +1,99 @@
+#
+# MCOL-5983 Bit-wise operations slower than expected
+# Test verifies that (col & mask) = mask pattern works correctly
+# BUG: User variables don't work with COMPARE_BITMASK primitive filter
+#
+
+--source ../include/have_columnstore.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol_5983;
+--enable_warnings
+
+CREATE DATABASE mcol_5983;
+USE mcol_5983;
+
+# Basic test table
+CREATE TABLE t1 (
+  id INT,
+  sig BIGINT UNSIGNED,
+  data VARCHAR(100)
+) ENGINE=columnstore;
+
+INSERT INTO t1 VALUES 
+  (1, 0x3F, 'all bits 0-5 set'),
+  (2, 0x15, 'bits 0,2,4 set'),
+  (3, 0x2A, 'bits 1,3,5 set'),
+  (4, 0x0F, 'bits 0-3 set'),
+  (5, 0x00, 'no bits set');
+
+# Test 1: Basic bitmask with literal - should work
+# Mask 0x15 = bits 0,2,4. Should match id=1,2 only
+SELECT id, HEX(sig), data FROM t1 WHERE (sig & 0x15) = 0x15 ORDER BY id;
+
+# Test 2: Bitmask combined with LIKE (the original performance problem)
+SELECT id, HEX(sig), data FROM t1 
+WHERE (sig & 0x0F) = 0x0F AND data LIKE '%bits%' 
+ORDER BY id;
+
+# Test 3: Exact scenario from MCOL-5983 ticket with bloom64() function
+
+--delimiter //
+CREATE FUNCTION bloom64(s TEXT) RETURNS BIGINT UNSIGNED
+DETERMINISTIC SQL SECURITY INVOKER
+BEGIN
+  DECLARE i   INT DEFAULT 1;
+  DECLARE n   INT DEFAULT CHAR_LENGTH(s);
+  DECLARE sig BIGINT UNSIGNED DEFAULT 0;
+  DECLARE crc INT UNSIGNED;
+
+  WHILE i <= n - 2 DO
+    SET crc = CRC32(SUBSTRING(s, i, 3));
+    SET sig = sig
+              | (CAST(1 AS UNSIGNED) << ( crc         & 63))
+              | (CAST(1 AS UNSIGNED) << ((crc >> 13) & 63))
+              | (CAST(1 AS UNSIGNED) << ((crc >> 26) & 63));
+    SET i = i + 1;
+  END WHILE;
+
+  RETURN sig;
+END//
+--delimiter ;
+
+CREATE TABLE molecole (
+  smiles TEXT NOT NULL,
+  sig BIGINT UNSIGNED NOT NULL
+) ENGINE=columnstore;
+
+INSERT INTO molecole (smiles, sig) VALUES
+  ('CCO', bloom64('CCO')),
+  ('c1ccccc1', bloom64('c1ccccc1')),
+  ('CC(=O)OC1=CC=CC=C1C(=O)O', bloom64('CC(=O)OC1=CC=CC=C1C(=O)O')),
+  ('CCC(=O)O[C@]1(C[C@H]2[C@H]3[C@@H]1[C@]4(C(=O)C(O)=C(C4=O)O)O[C@@H]3C[C@H]2O)C', 
+   bloom64('CCC(=O)O[C@]1(C[C@H]2[C@H]3[C@@H]1[C@]4(C(=O)C(O)=C(C4=O)O)O[C@@H]3C[C@H]2O)C'));
+
+INSERT INTO molecole SELECT * FROM molecole;
+INSERT INTO molecole SELECT * FROM molecole;
+
+# Bloom filter query pattern from ticket:
+# SET @mask := bloom64('substring'); WHERE smiles LIKE '%substring%' AND (sig & @mask) = @mask
+
+SET @mask := bloom64('C(=O)');
+
+# With literal - works correctly
+SELECT COUNT(*) AS with_literal FROM molecole 
+WHERE smiles LIKE '%C(=O)%' AND (sig & bloom64('C(=O)')) = bloom64('C(=O)');
+
+# With variable - BUG (returns wrong count)
+SELECT COUNT(*) AS with_variable FROM molecole 
+WHERE smiles LIKE '%C(=O)%' AND (sig & @mask) = @mask;
+
+DROP FUNCTION bloom64;
+
+# Test 4: User variable - BUG! Returns all rows instead of filtered
+# Expected: same as Test 1 (id=1,2)
+# Actual: returns ALL rows (mask becomes 0)
+SET @mask = 0x15;
+SELECT id, HEX(sig), data FROM t1 WHERE (sig & @mask) = @mask ORDER BY id;
+
+DROP DATABASE mcol_5983;


### PR DESCRIPTION
Queries using user variables in bitmask comparisons returned incorrect results:

```sql
SET @mask = 0x15;
SELECT * FROM t WHERE (sig & @mask) = @mask;  -- Returns ALL rows instead of filtered
```

While the same query with a literal worked correctly:

```sql
SELECT * FROM t WHERE (sig & 0x15) = 0x15;  -- Works correctly
```

### Root Cause

MariaDB stores hex user variables (e.g., `SET @mask = 0x15`) as binary strings with `charset=binary`. When [val_str()](cci:1://file:///home/ubuntu/proj/MariaDBEnterprise/sql/item_func.h:4184:2-4201:3) is called, it returns raw binary bytes (`\x15`) instead of a text representation (`"21"`).

The [ConstantColumn](cci:1://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/execplan/constantcolumn.cpp:124:0-136:1) constructor parses this string using `atoll()`, which returns 0 for binary input, causing the mask value to be incorrectly set to 0.

### Solution

In [buildConstantColumnMaybeNullUsingValStr()](cci:1://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_helpers.h:56:0-56:97), detect user variables with binary charset and interpret the string as a little-endian integer:

```cpp
if (str && str->length() > 0 && str->length() <= 8 &&
    str->charset() == &my_charset_bin)
{
  // Interpret binary string as little-endian integer
  uint64_t val = 0;
  const unsigned char* p = (const unsigned char*)str->ptr();
  for (size_t i = 0; i < str->length(); i++)
    val |= ((uint64_t)p[i]) << (i * 8);
  ...
}
```

Using [charset() == &my_charset_bin](cci:1://file:///home/ubuntu/proj/MariaDBEnterprise/sql/item_func.h:3949:2-3949:53) is a reliable way to detect binary data, as opposed to scanning for non-printable characters.

### Changes

- **[dbcon/mysql/ha_mcs_execplan_helpers.cpp](cci:7://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_helpers.cpp:0:0-0:0)**: Detect binary charset user variables and convert to integer
- **[dbcon/mysql/ha_mcs_execplan_walks.cpp](cci:7://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_walks.cpp:0:0-0:0)**: Use [buildConstantColumnMaybeNullUsingValStr()](cci:1://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan_helpers.h:56:0-56:97) which handles binary user variables
- **[dbcon/joblist/jlf_execplantojoblist.cpp](cci:7://file:///home/ubuntu/proj/MariaDBEnterprise/storage/columnstore/columnstore/dbcon/joblist/jlf_execplantojoblist.cpp:0:0-0:0)**: Minor refactor — parse mask value before creating `pColStep`

### Testing

```sql
CREATE TABLE t (id INT, sig BIGINT UNSIGNED) ENGINE=columnstore;
INSERT INTO t VALUES (1, 0x3F), (2, 0x15), (3, 0x2A), (4, 0x07), (5, 0x00);

-- Both queries now return the same result: id=1,2
SELECT * FROM t WHERE (sig & 0x15) = 0x15;

SET @mask = 0x15;
SELECT * FROM t WHERE (sig & @mask) = @mask;

-- String variables still work normally
SET @str = 'hello';
SELECT @str;  -- Returns 'hello'
```