### PR TITLE
Fix MTR suite symlink for MariaDB 11.4+

### DIFF
--- a/build/prepare_test_container.sh
+++ b/build/prepare_test_container.sh
@@ -34,15 +34,29 @@ fi
 
 select_pkg_format ${RESULT}
 
+# Detect server version from VERSION file (CI) or PACKAGES_URL (local)
+if [[ -f "$MDB_SOURCE_PATH/VERSION" ]]; then
+    SERVER_VERSION=$(grep -E 'MYSQL_VERSION_(MAJOR|MINOR)' $MDB_SOURCE_PATH/VERSION | cut -d'=' -f2 | paste -sd. -)
+else
+    # Extract from PACKAGES_URL: e.g., /10.6-enterprise/ -> 10.6
+    SERVER_VERSION=$(echo "$PACKAGES_URL" | sed -n 's|.*/\([0-9]\+\.[0-9]\+\)-enterprise\(/.*\)\?|\1|p')
+fi
+message "Server version of build is: ${SERVER_VERSION:-unknown}"
+
+SERVERNAME="mysql"
+if [[ "${SERVER_VERSION%%.*}" -ge 11 ]]; then
+    SERVERNAME="mariadb"
+fi
+
 start_container() {
     message Starting $DOCKER_IMAGE
     if [[ $PKG_FORMAT == "rpm" ]]; then
         SYSTEMD_PATH="/usr/lib/systemd/systemd"
-        MTR_PATH="/usr/share/mysql-test"
+        MTR_PATH="/usr/share/${SERVERNAME}-test"
     else
         # Debian/Ubuntu based
         SYSTEMD_PATH="/lib/systemd/systemd"
-        MTR_PATH="/usr/share/mysql/mysql-test"
+        MTR_PATH="/usr/share/${SERVERNAME}/${SERVERNAME}-test"
     fi
 
     docker_run_args=(
@@ -163,15 +177,6 @@ prepare_container() {
     if [[ "$DO_INSTALL" == "true" ]]; then
         #Install columnstore in container
         message "Installing columnstore..."
-    
-        # Try to detect server version from VERSION file (CI) or PACKAGES_URL (local)
-        if [[ -f "$MDB_SOURCE_PATH/VERSION" ]]; then
-            SERVER_VERSION=$(grep -E 'MYSQL_VERSION_(MAJOR|MINOR)' $MDB_SOURCE_PATH/VERSION | cut -d'=' -f2 | paste -sd. -)
-        else
-            # Extract from PACKAGES_URL: e.g., /10.6-enterprise/ -> 10.6
-            SERVER_VERSION=$(echo "$PACKAGES_URL" | sed -n 's|.*/\([0-9]\+\.[0-9]\+\)-enterprise\(/.*\)\?|\1|p')
-        fi
-        message "Server version of build is: ${SERVER_VERSION:-unknown}"
         if [[ "$RESULT" == *rocky* ]]; then
             execInnerDockerWithRetry "$CONTAINER_NAME" 'yum install -y MariaDB-columnstore-engine MariaDB-test'
         else

--- a/tests/scripts/run_mtr.sh
+++ b/tests/scripts/run_mtr.sh
@@ -65,6 +65,13 @@ if [[ ! -d ${INSTALLED_MTR_PATH}/suite/columnstore ]]; then
     ln -s ${COLUMNSTORE_MTR_SOURCE} ${INSTALLED_MTR_PATH}/suite
 fi
 
+# MTR may resolve suite paths via mysql-test instead of mariadb-test
+MTR_MYSQL_TEST_SUITE="/usr/share/${SERVERNAME}/mysql-test/suite"
+if [[ -d "/usr/share/${SERVERNAME}/mysql-test" && ! -d "${MTR_MYSQL_TEST_SUITE}/columnstore" ]]; then
+    message " ・ Adding symlink for columnstore tests to ${MTR_MYSQL_TEST_SUITE}/columnstore from ${COLUMNSTORE_MTR_SOURCE}"
+    ln -s ${COLUMNSTORE_MTR_SOURCE} ${MTR_MYSQL_TEST_SUITE}
+fi
+
 if [[ ! -d '/data/qa/source/dbt3/' || ! -d '/data/qa/source/ssb/' ]]; then
     message ' ・ Downloading and extracting test data for full MTR to /data'
     bash -c "wget -qO- https://cspkg.s3.amazonaws.com/mtr-test-data.tar.lz4 | lz4 -dc - | tar xf - -C /"

--- a/tests/scripts/run_mtr.sh
+++ b/tests/scripts/run_mtr.sh
@@ -60,16 +60,16 @@ add_mtr_warn_functions() {
 
 cd ${INSTALLED_MTR_PATH}
 
-if [[ ! -d ${INSTALLED_MTR_PATH}/suite/columnstore ]]; then
+if [[ ! -d "${INSTALLED_MTR_PATH}/suite/columnstore" ]]; then
     message " ・ Adding symlink for columnstore tests to ${INSTALLED_MTR_PATH}/suite/columnstore from ${COLUMNSTORE_MTR_SOURCE}"
-    ln -s ${COLUMNSTORE_MTR_SOURCE} ${INSTALLED_MTR_PATH}/suite
+    ln -s "${COLUMNSTORE_MTR_SOURCE}" "${INSTALLED_MTR_PATH}/suite"
 fi
 
 # MTR may resolve suite paths via mysql-test instead of mariadb-test
-MTR_MYSQL_TEST_SUITE="/usr/share/${SERVERNAME}/mysql-test/suite"
-if [[ -d "/usr/share/${SERVERNAME}/mysql-test" && ! -d "${MTR_MYSQL_TEST_SUITE}/columnstore" ]]; then
-    message " ・ Adding symlink for columnstore tests to ${MTR_MYSQL_TEST_SUITE}/columnstore from ${COLUMNSTORE_MTR_SOURCE}"
-    ln -s ${COLUMNSTORE_MTR_SOURCE} ${MTR_MYSQL_TEST_SUITE}
+MTR_MYSQL_TEST_BASE="/usr/share/${SERVERNAME}/mysql-test"
+if [[ -d "${MTR_MYSQL_TEST_BASE}" && ! -d "${MTR_MYSQL_TEST_BASE}/suite/columnstore" ]]; then
+    message " ・ Adding symlink for columnstore tests to ${MTR_MYSQL_TEST_BASE}/suite/columnstore from ${COLUMNSTORE_MTR_SOURCE}"
+    ln -s "${COLUMNSTORE_MTR_SOURCE}" "${MTR_MYSQL_TEST_BASE}/suite"
 fi
 
 if [[ ! -d '/data/qa/source/dbt3/' || ! -d '/data/qa/source/ssb/' ]]; then


### PR DESCRIPTION
On MariaDB 11.4+ the installed MTR paths changed from `mysql` to `mariadb` naming, causing suite resolution failures.

### Changes

**`tests/scripts/run_mtr.sh`** (local MTR runner):
- Add symlink in `mysql-test/suite/` path where MTR actually searches on some 11.4 installations
- Add proper quoting to `ln -s` calls

**`build/prepare_test_container.sh`** (CI):
- Move server version detection before `start_container()` so `MTR_PATH` can be version-aware
- Replace hardcoded `/usr/share/mysql-test` and `/usr/share/mysql/mysql-test` with `${SERVERNAME}`-based paths matching `build/run_mtr.sh` logic
- Remove duplicate version detection from `prepare_container()`

Backward compatible: on 10.x `SERVERNAME=mysql` produces the same old paths.