### PR TITLE
feat(queryacc): MCOL-6298 - Query Accelerator convenience

### DIFF
--- a/dbcon/mysql/columnstore.cnf
+++ b/dbcon/mysql/columnstore.cnf
@@ -9,3 +9,5 @@ collation_server = utf8_general_ci
 character_set_server = utf8
 
 loose-columnstore_use_import_for_batchinsert = ON
+columnstore_innodb_queries_use_mcs = OFF
+

--- a/dbcon/mysql/install_mcs_mysql.sh.in
+++ b/dbcon/mysql/install_mcs_mysql.sh.in
@@ -123,6 +123,49 @@ CREATE TABLE IF NOT EXISTS infinidb_querystats.priority
 ) DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 insert ignore into infinidb_querystats.priority values ('High', 100),('Medium', 66), ('Low', 33);
+
+CREATE DATABASE IF NOT EXISTS queryacc;
+
+DELIMITER $$
+CREATE OR REPLACE FUNCTION queryacc.enable_queryacc() RETURNS TEXT NOT DETERMINISTIC
+BEGIN
+  DECLARE old_settings TEXT;
+  SET old_settings = @@optimizer_switch;
+  SET @@columnstore_unstable_optimizer='on';
+  SET @@optimizer_switch='index_merge=off,index_merge_union=off,index_merge_sort_union=off,index_merge_intersection=off,index_merge_sort_intersection=off,index_condition_pushdown=off,derived_merge=off,derived_with_keys=off,firstmatch=off,loosescan=off,materialization=on,in_to_exists=off,semijoin=off,partial_match_rowid_merge=off,partial_match_table_scan=off,subquery_cache=off,mrr=off,mrr_cost_based=off,mrr_sort_keys=off,outer_join_with_cache=off,semijoin_with_cache=off,join_cache_incremental=off,join_cache_hashed=off,join_cache_bka=off,optimize_join_buffer_size=off,table_elimination=off,extended_keys=off,exists_to_in=off,orderby_uses_equalities=off,condition_pushdown_for_derived=on,split_materialized=off,condition_pushdown_for_subquery=off,rowid_filter=off,condition_pushdown_from_having=on,not_null_range_scan=off,hash_join_cardinality=off,cset_narrowing=off,sargable_casefold=off';
+  SET @@columnstore_query_accel_parallel_factor=5;
+  RETURN old_settings;
+END;
+$$
+DELIMITER ;
+
+DELIMITER $$
+CREATE OR REPLACE PROCEDURE queryacc.disable_queryacc(IN old_settings TEXT)
+BEGIN
+  SET @@optimizer_switch = old_settings;
+  SET @@columnstore_unstable_optimizer='off';
+END;
+$$
+DELIMITER ;
+
+DELIMITER $$
+CREATE OR REPLACE PROCEDURE queryacc.with_queryacc(IN query TEXT)
+BEGIN
+  DECLARE old_settings TEXT;
+  SET old_settings = enable_queryacc();
+  BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+      CALL disable_queryacc(old_settings);
+      RESIGNAL;
+    END;
+    EXECUTE IMMEDIATE query;
+  END;
+  CALL disable_queryacc(old_settings);
+END;
+$$
+DELIMITER ;
+
 EOD
 
 $MDB <@ENGINE_SUPPORTDIR@/calsetuserpriority.sql 2>/dev/null


### PR DESCRIPTION
This patch adds flag to enable query accelerator by default and adds three stored procedures to enable query accelerator, disable query accelerator and execute just single query with query accelerator enabled.

Here's how to use:

  SET old_settings = enable_queryacc();
  SELECT ... FROM ...;
  CALL disable_queryacc(old_settings);