### PR TITLE
fix(rbo): fix some cornercases in wrapping columns

### DIFF
--- a/dbcon/rbo/rbo_apply_rewrite_distinct.cpp
+++ b/dbcon/rbo/rbo_apply_rewrite_distinct.cpp
@@ -47,7 +47,16 @@ execplan::SRCP cloneAsSimpleColumn(const execplan::SRCP& rc, const std::string& 
 
   // fill TreeNode data
   rcCloned->derivedTable(tableAlias);
-  rcCloned->derivedRefCol(rc.get());
+  if (auto* rcRef = rc->derivedRefCol())
+  {
+    rcCloned->derivedRefCol(rcRef);
+    rcRef->incRefCount();
+  }
+  else
+  {
+    rcCloned->derivedRefCol(rc.get());
+    rc->incRefCount();
+  }
   rcCloned->resultType(rc->resultType());
   rcCloned->operationType(rc->operationType());
   rcCloned->colPosition(colPos);
@@ -68,7 +77,6 @@ execplan::SRCP cloneAsSimpleColumn(const execplan::SRCP& rc, const std::string& 
   {
     rcCloned->timeZone(rcwc->timeZone());
   }
-  rc->incRefCount();
 
   auto colName = getSimpleColumnAlias(*rc, colPos);
   rcCloned->columnName(colName);

--- a/dbcon/rbo/rbo_groupby_wrap_columns.cpp
+++ b/dbcon/rbo/rbo_groupby_wrap_columns.cpp
@@ -185,20 +185,24 @@ bool needWrap(execplan::TreeNode* tn, ColumnWrapperContext& lctx)
     return false;
   }
 
-  // In this case sorting direction is not significant, so set it to the default value
+  // In this case sorting direction & joinInfo is not significant, so set it to the default value
   // for columns comparison (actual for ORDER BY columns)
+  // Old values are not restored after exceptions, as the entire query will be aborted in this case
   bool asc = rc->asc();
+  auto joinInfo = rc->joinInfo();
   rc->asc(true);
+  rc->joinInfo(0);
   bool ret = true;
   for (const auto& gbCol : *lctx.gbCols)
   {
-    if (*rc == *gbCol)
+    if (*rc == *gbCol && rc->derivedRefCol() == gbCol->derivedRefCol())
     {
       ret = false;
       break;
     }
   }
   rc->asc(asc);
+  rc->joinInfo(joinInfo);
   return ret;
 }
 


### PR DESCRIPTION
* ignore joinInfo while comparing columns
* treat columns as equal only if their derivedColRef()s are the same
* do not create derivedColRef() chains in rewriteDistinct
