### PR TITLE
Fix MTR suite symlink: create mysql-test/suite dir if missing

### DIFF
--- a/tests/scripts/run_mtr.sh
+++ b/tests/scripts/run_mtr.sh
@@ -62,14 +62,16 @@ cd ${INSTALLED_MTR_PATH}
 
 if [[ ! -d "${INSTALLED_MTR_PATH}/suite/columnstore" ]]; then
     message " ・ Adding symlink for columnstore tests to ${INSTALLED_MTR_PATH}/suite/columnstore from ${COLUMNSTORE_MTR_SOURCE}"
-    ln -s "${COLUMNSTORE_MTR_SOURCE}" "${INSTALLED_MTR_PATH}/suite"
+    ln -sfn "${COLUMNSTORE_MTR_SOURCE}" "${INSTALLED_MTR_PATH}/suite"
 fi
 
-# MTR may resolve suite paths via mysql-test instead of mariadb-test
-MTR_MYSQL_TEST_BASE="/usr/share/${SERVERNAME}/mysql-test"
-if [[ -d "${MTR_MYSQL_TEST_BASE}" && ! -d "${MTR_MYSQL_TEST_BASE}/suite/columnstore" ]]; then
-    message " ・ Adding symlink for columnstore tests to ${MTR_MYSQL_TEST_BASE}/suite/columnstore from ${COLUMNSTORE_MTR_SOURCE}"
-    ln -s "${COLUMNSTORE_MTR_SOURCE}" "${MTR_MYSQL_TEST_BASE}/suite"
+# MTR's mtr_cases.pm searches for suites in mysql-test/suite/ relative to
+# the parent of the test directory, even when running from mariadb-test/.
+MTR_MYSQL_TEST_SUITE="$(dirname "${INSTALLED_MTR_PATH%/}")/mysql-test/suite"
+if [[ ! -d "${MTR_MYSQL_TEST_SUITE}/columnstore" ]]; then
+    mkdir -p "${MTR_MYSQL_TEST_SUITE}"
+    message " ・ Adding symlink for columnstore tests to ${MTR_MYSQL_TEST_SUITE}/columnstore from ${COLUMNSTORE_MTR_SOURCE}"
+    ln -sfn "${COLUMNSTORE_MTR_SOURCE}" "${MTR_MYSQL_TEST_SUITE}"
 fi
 
 if [[ ! -d '/data/qa/source/dbt3/' || ! -d '/data/qa/source/ssb/' ]]; then


### PR DESCRIPTION
Follow-up to #3926. The previous fix checked if `mysql-test/` exists before creating the symlink, but on source builds only `mariadb-test/` exists — the `-d` guard silently skipped.

### Root cause

MTR's `mtr_cases.pm` (package version) searches for suites **only** in `mysql-test/suite/` relative to the parent of the test directory:
```perl
my @dirs = my_find_dir(dirname($::glob_mysql_test_dir),
                       ["mysql-test/suite", @plugin_suitedirs],
                       $suitename, ...);
```

On source builds, the test dir is `mariadb-test/` and `mysql-test/` doesn't exist at all.

### Fix

- Replace `-d` guard with `mkdir -p` to create the directory if missing
- Compute path dynamically via `dirname INSTALLED_MTR_PATH` instead of hardcoding

### Tested

- Reproduced in Docker (Ubuntu 24.04 + MariaDB 11.4 packages)
- Verified symlink creation, suite resolution, idempotency, and 10.x compatibility