### PR TITLE
Ignore error message in the mcs65_crossengine_order_by test

### DIFF
--- a/mysql-test/columnstore/basic/r/mcs65_crossengine_order_by.result
+++ b/mysql-test/columnstore/basic/r/mcs65_crossengine_order_by.result
@@ -63,7 +63,6 @@ t1_int	t1_char	t2_int	t2_char
 3	fffff	3	iii
 5	a	5	hhh
 SELECT * FROM t1, t2 WHERE t1.t1_int = t2.t2_int ORDER BY -1;
-ERROR 42S22: Unknown column '???' in 'ORDER BY'
 SELECT * FROM t1, t2 WHERE t1.t1_int = t2.t2_int ORDER BY 0;
 ERROR 42S22: Unknown column '0' in 'ORDER BY'
 SELECT * FROM t1, t2 WHERE t1.t1_int = t2.t2_int ORDER BY 5;

--- a/mysql-test/columnstore/basic/t/mcs65_crossengine_order_by.test
+++ b/mysql-test/columnstore/basic/t/mcs65_crossengine_order_by.test
@@ -50,8 +50,10 @@ SELECT * FROM t1, t2 WHERE t1.t1_int = t2.t2_int ORDER BY t2.t2_int, t1.t1_int, 
 SELECT * FROM t1, t2 WHERE t1.t1_int = t2.t2_int ORDER BY t2.t2_int DESC, t1.t1_int DESC, t2.t2_char DESC;
 SELECT * FROM t1, t2 WHERE t1.t1_int = t2.t2_int ORDER BY t2.t2_char ASC, t2.t2_int, t1.t1_int;
 SELECT * FROM t1, t2 WHERE t1.t1_int = t2.t2_int ORDER BY t2.t2_char DESC, t2.t2_int DESC, t1.t1_int DESC;
+--disable_result_log
 --error ER_BAD_FIELD_ERROR
 SELECT * FROM t1, t2 WHERE t1.t1_int = t2.t2_int ORDER BY -1;
+--enable_result_log
 --error ER_BAD_FIELD_ERROR
 SELECT * FROM t1, t2 WHERE t1.t1_int = t2.t2_int ORDER BY 0;
 --error ER_BAD_FIELD_ERROR


### PR DESCRIPTION
MTR works in a strange way if both --error and --replace_rexex refer to the one SQL statement. So, the easiest fix is --disable_result_log