### PR TITLE
MCOL-6309 boost system dependency isn't available

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -1,5 +1,5 @@
 # Single source of truth for Boost components we need
-set(BOOST_COMPONENTS chrono filesystem program_options regex system thread)
+set(BOOST_COMPONENTS chrono filesystem program_options regex thread)
 
 find_package(Boost 1.88.0 COMPONENTS ${BOOST_COMPONENTS})
 

--- a/storage-manager/CMakeLists.txt
+++ b/storage-manager/CMakeLists.txt
@@ -71,7 +71,6 @@ target_compile_definitions(storagemanager PUBLIC BOOST_NO_CXX11_SCOPED_ENUMS)
 columnstore_link(
     storagemanager
     boost_chrono
-    boost_system
     boost_thread
     boost_filesystem
     boost_regex

--- a/tools/rebuildEM/CMakeLists.txt
+++ b/tools/rebuildEM/CMakeLists.txt
@@ -2,4 +2,4 @@ include_directories(${ENGINE_COMMON_INCLUDES})
 
 set(rebuildEM_SRCS main.cpp rebuildEM.cpp)
 columnstore_executable(mcsRebuildEM ${rebuildEM_SRCS})
-columnstore_link(mcsRebuildEM ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} boost_system boost_filesystem)
+columnstore_link(mcsRebuildEM ${ENGINE_LDFLAGS} ${ENGINE_WRITE_LIBS} boost_filesystem)

--- a/utils/idbdatafile/CMakeLists.txt
+++ b/utils/idbdatafile/CMakeLists.txt
@@ -14,4 +14,4 @@ set(idbdatafile_LIB_SRCS
 )
 
 columnstore_library(idbdatafile ${idbdatafile_LIB_SRCS})
-columnstore_link(idbdatafile PRIVATE ${NETSNMP_LIBRARIES} ${ENGINE_OAM_LIBS} boost_filesystem boost_system)
+columnstore_link(idbdatafile PRIVATE ${NETSNMP_LIBRARIES} ${ENGINE_OAM_LIBS} boost_filesystem)


### PR DESCRIPTION
Columnstore has a minimium version of 1.88.

Since version 1.69 boost-system has been a library stub, and all of its functionality is included
in boost header files.

The CMake boost is checking for the library that
is no longer required.

Since boost 1.90, that is included in Ubuntu 26.04, there is nolonger the stub library installed.

We remove the check since its no-longer required.