### PR TITLE
set GMT timezone in the setup test

### DIFF
--- a/mysql-test/columnstore/setup/regression_env_setup.test
+++ b/mysql-test/columnstore/setup/regression_env_setup.test
@@ -10,6 +10,7 @@
 --source ../include/detect_maxscale.inc
 #
 --disable_warnings
+SET time_zone='+00:00';
 DROP DATABASE IF EXISTS tpch1m;
 DROP DATABASE IF EXISTS tpch1;
 DROP DATABASE IF EXISTS ssb1;


### PR DESCRIPTION
A number of tests fail if the default time zone is not GMT in the test environment.