### PR TITLE
MDEV-39030: fix(ha_columnstore.so): failing to load due to undefined symbol from rpl_master_info_file.h

### DIFF
--- a/dbcon/mysql/idb_mysql.h
+++ b/dbcon/mysql/idb_mysql.h
@@ -32,6 +32,22 @@
 
 #undef LOG_INFO
 
+/*
+  Prevent rpl_master_info_file.h (transitively included via sql_lex.h) from
+  being fully parsed. Its inline static VALUE_MAP (std::unordered_map with
+  Info_file::Mem_fn) creates a complex template instantiation that produces
+  an unresolvable symbol when ha_columnstore.so is loaded by the server.
+  ColumnStore does not use any replication info file types, so a forward
+  declaration of Master_info_file (needed by LEX_MASTER_INFO in sql_lex.h)
+  is sufficient.
+*/
+#ifndef RPL_MASTER_INFO_FILE_H
+#define RPL_MASTER_INFO_FILE_H
+struct Master_info_file;
+enum struct enum_master_use_gtid {};
+enum struct trilean {};
+#endif
+
 #ifdef _DEBUG
 #ifndef SAFE_MUTEX
 #define SAFE_MUTEX


### PR DESCRIPTION
The MDEV-37530 refactor introduced rpl_master_info_file.h with an inline static std::unordered_map (VALUE_MAP) using Info_file::Mem_fn. This header is transitively included by sql_lex.h, which ColumnStore pulls in via idb_mysql.h. The complex template instantiation creates a symbol that ha_columnstore.so cannot resolve at dlopen() time:

  undefined symbol: _ZNSt10_HashtableISt17basic_string_viewIcSt11char_traitsIcEE...

Guard RPL_MASTER_INFO_FILE_H in idb_mysql.h before server headers are included, providing only a forward declaration of Master_info_file (sufficient for LEX_MASTER_INFO::mi_functor in sql_lex.h). This matches the header's own pre-C++17 fallback stubs.

Also fix the isleap() macro to match the server's my_time.h definition, which correctly uses bitwise AND and excludes year 0.