### PR TITLE
feat(cmapi):MCOL-6178 improvements.

### DIFF
--- a/cmapi/cmapi_server/__main__.py
+++ b/cmapi/cmapi_server/__main__.py
@@ -26,7 +26,7 @@ from cmapi_server import helpers
 from cmapi_server.constants import CMAPI_CONF_PATH, DEFAULT_MCS_CONF_PATH
 from cmapi_server.controllers.dispatcher import dispatcher, jsonify_404, jsonify_error
 from cmapi_server.failover_agent import FailoverAgent
-from cmapi_server.invariant_checks import run_invariant_checks
+from cmapi_server.invariant_checks import init_invariant_checks_mode, run_invariant_checks
 from cmapi_server.managers.application import AppManager
 from cmapi_server.managers.certificate import CertificateManager
 from cmapi_server.managers.process import MCSProcessManager
@@ -155,9 +155,12 @@ if __name__ == '__main__':
     CertificateManager.create_self_signed_certificate_if_not_exist()
     CertificateManager.renew_certificate()
 
-    # Run checks, if some of them fail -- log and exit
-    diag = run_invariant_checks()
-    if diag:
+    # Read invariant checks mode once from config and cache it
+    init_invariant_checks_mode()
+
+    # Run checks, if some of them fail -- log and exit (unless warning mode)
+    diag, warn_only = run_invariant_checks()
+    if diag and not warn_only:
         logging.error('Invariant checks failed, exiting')
         sys.exit(1)
 

--- a/cmapi/cmapi_server/cmapi_logger.conf
+++ b/cmapi/cmapi_server/cmapi_logger.conf
@@ -6,6 +6,9 @@
         },
         "trace_params_filter": {
             "()": "cmapi_server.logging_management.TraceParamsFilter"
+        },
+        "shared_storage_access_filter": {
+            "()": "cmapi_server.logging_management.SharedStorageAccessFilter"
         }
     },
     "formatters": {
@@ -86,6 +89,7 @@
     "loggers": {
         "cherrypy.access": {
             "handlers": ["console", "file"],
+            "filters": ["shared_storage_access_filter"],
             "level": "INFO",
             "propagate": false
         },

--- a/cmapi/cmapi_server/controllers/endpoints.py
+++ b/cmapi/cmapi_server/controllers/endpoints.py
@@ -492,7 +492,7 @@ class ConfigController:
                 if diag and not warn_only:
                     raise_422_error(
                         module_logger, func_name,
-                        f'Invariant checks failed. Details:\n{diag.strip()}',
+                        f'Invariant checks failed. Details:\n{diag.strip() if diag else ""}',
                         exc_info=False
                     )
 

--- a/cmapi/cmapi_server/controllers/endpoints.py
+++ b/cmapi/cmapi_server/controllers/endpoints.py
@@ -488,8 +488,8 @@ class ConfigController:
                     sm_config_string=sm_config
                 )
 
-                diag = run_invariant_checks()
-                if diag:
+                diag, warn_only = run_invariant_checks()
+                if diag and not warn_only:
                     raise_422_error(
                         module_logger, func_name,
                         f'Invariant checks failed. Details:\n{diag.strip()}',

--- a/cmapi/cmapi_server/invariant_checks.py
+++ b/cmapi/cmapi_server/invariant_checks.py
@@ -12,16 +12,30 @@ from mcs_node_control.models.node_config import NodeConfig
 logger = logging.getLogger(__name__)
 
 
+# Supported modes for the 'invariant_checks' config option:
+#   enforce  – run checks and fail on problems (default)
+#   warning  – run checks but only log warnings, never fail
+#   disabled – skip checks entirely
+# Boolean values (true/false) are also accepted:
+#   true  -> enforce
+#   false -> disabled
+_BOOL_TO_MODE = {'true': 'enforce', '1': 'enforce', 'yes': 'enforce',
+                 'false': 'disabled', '0': 'disabled', 'no': 'disabled'}
+VALID_MODES = ('enforce', 'warning', 'disabled')
+
+_cache = {'mode': 'enforce'}
+
+
 def resolve_symlinks_in_path(base_path: str, subdirs: List[str]) -> List[str]:
     """Build required directories list, resolving symlinks at each level.
 
-    If base_path or any intermediate directory is a symlink, resolve it
-    before appending subsequent path components. This ensures we check
+    If *base_path* or any intermediate directory is a symlink, resolve it
+    before appending subsequent path components.  This ensures we check
     the actual target directories rather than potentially broken paths.
 
-    :param base_path: The root path (e.g., MCS_DATA_PATH).
-    :param subdirs: List of subdirectory components to append sequentially.
-    :return: List of resolved directory paths to check.
+    :param base_path: The root path (e.g., ``MCS_DATA_PATH``).
+    :param subdirs: Subdirectory components to append sequentially.
+    :returns: Resolved directory paths to check.
     """
     result: List[str] = []
     current: str = base_path
@@ -45,28 +59,68 @@ def resolve_symlinks_in_path(base_path: str, subdirs: List[str]) -> List[str]:
     return result
 
 
-def is_invariant_checks_enabled() -> bool:
-    """Check if invariant checks are enabled in CMAPI config.
+def init_invariant_checks_mode() -> None:
+    """Read the invariant-checks mode from CMAPI config and cache it.
 
-    :return: True if invariant checks are enabled (default), False otherwise.
+    Must be called once at application startup.  Subsequent calls to
+    :func:`get_invariant_checks_mode` return the cached value without
+    re-reading the config file.
+
+    Reads ``[application] invariant_checks`` from the CMAPI config file.
+    Accepted values: ``enforce`` (default), ``warning``, ``disabled``.
+    Boolean literals (``true``/``false``) are accepted for backward
+    compatibility and mapped to ``enforce``/``disabled``.
     """
     cfg_parser = helpers.get_config_parser(CMAPI_CONF_PATH)
-    return cfg_parser.getboolean('application', 'invariant_checks', fallback=True)
+    raw = cfg_parser.get(
+        'application', 'invariant_checks', fallback='enforce',
+    ).strip().lower()
+    mode = _BOOL_TO_MODE.get(raw, raw)
+    if mode not in VALID_MODES:
+        logger.warning(
+            'Unknown invariant_checks value %r in config, '
+            'falling back to "enforce".',
+            raw,
+        )
+        mode = 'enforce'
+    _cache['mode'] = mode
+    logger.info('Invariant checks mode: %s', mode)
 
 
-def run_invariant_checks() -> Optional[str]:
-    """Run invariant checks, log results, and return a formatted string with problems, if any.
+def get_invariant_checks_mode() -> str:
+    """Return the cached invariant-checks mode.
 
-    If invariant checks are disabled in CMAPI config file (invariant_checks = false),
-    this function returns None without running any checks.
-
-    :return: Formatted string with problems if checks fail, None otherwise.
+    :returns: One of ``'enforce'``, ``'warning'``, or ``'disabled'``.
+    :rtype: str
     """
-    if not is_invariant_checks_enabled():
-        logger.info('Invariant checks are turned OFF in CMAPI config file.')
-        return None
+    return _cache['mode']
 
-    logger.info('Starting invariant checks')
+
+def run_invariant_checks() -> Tuple[Optional[str], bool]:
+    """Run invariant checks and return diagnostics together with the mode.
+
+    Behaviour depends on the cached ``invariant_checks`` mode
+    (see :func:`init_invariant_checks_mode`):
+
+    * ``enforce`` (default) – run checks; return diagnostics on failure.
+    * ``warning`` – run checks; return diagnostics on failure but signal
+      that callers should only log a warning, not abort.
+    * ``disabled`` – skip checks entirely.
+
+    :returns: ``(diag, warn_only)`` where *diag* is a formatted string
+        with problems (or ``None`` when checks pass / are disabled) and
+        *warn_only* is ``True`` when the caller should log a warning
+        instead of raising / exiting.
+    :rtype: tuple[str | None, bool]
+    """
+    mode = get_invariant_checks_mode()
+
+    if mode == 'disabled':
+        logger.info('Invariant checks are disabled in CMAPI config file.')
+        return None, False
+
+    warn_only = mode == 'warning'
+    logger.info('Starting invariant checks (mode=%s)', mode)
     runner = Runner()
     result = runner.run()
     problems = result.problems()
@@ -87,11 +141,16 @@ def run_invariant_checks() -> Optional[str]:
         {k.value: v for k, v in result.counts.items() if v != 0}
     )
     if result.overall in (Status.FAIL, Status.ERROR):
-        logger.error('Invariant checks failed')
-        return diag
+        if warn_only:
+            logger.warning(
+                'Invariant checks failed (warning mode, not aborting)',
+            )
+        else:
+            logger.error('Invariant checks failed')
+        return diag, warn_only
     else:
         logger.info('Invariant checks passed')
-        return None
+        return None, warn_only
 
 
 ### Facts

--- a/cmapi/cmapi_server/invariant_checks.py
+++ b/cmapi/cmapi_server/invariant_checks.py
@@ -19,8 +19,8 @@ logger = logging.getLogger(__name__)
 # Boolean values (true/false) are also accepted:
 #   true  -> enforce
 #   false -> disabled
-_BOOL_TO_MODE = {'true': 'enforce', '1': 'enforce', 'yes': 'enforce',
-                 'false': 'disabled', '0': 'disabled', 'no': 'disabled'}
+_BOOL_TO_MODE = {'true': 'enforce', '1': 'enforce', 'yes': 'enforce', 'on': 'enforce',
+                 'false': 'disabled', '0': 'disabled', 'no': 'disabled', 'off': 'disabled'}
 VALID_MODES = ('enforce', 'warning', 'disabled')
 
 _cache = {'mode': 'enforce'}
@@ -141,12 +141,11 @@ def run_invariant_checks() -> Tuple[Optional[str], bool]:
         {k.value: v for k, v in result.counts.items() if v != 0}
     )
     if result.overall in (Status.FAIL, Status.ERROR):
+        msg = f'Invariant checks failed. Details:\n{diag.strip() if diag else ""}'
         if warn_only:
-            logger.warning(
-                'Invariant checks failed (warning mode, not aborting)',
-            )
+            logger.warning('%s (warning mode, not aborting)', msg)
         else:
-            logger.error('Invariant checks failed')
+            logger.error(msg)
         return diag, warn_only
     else:
         logger.info('Invariant checks passed')

--- a/cmapi/cmapi_server/logging_management.py
+++ b/cmapi/cmapi_server/logging_management.py
@@ -35,6 +35,74 @@ class TraceParamsFilter(logging.Filter):
             record.trace_params = ""
         return True
 
+class SharedStorageAccessFilter(logging.Filter):
+    """Redirect shared-storage check access logs to a separate log file.
+
+    When attached to the ``cherrypy.access`` logger this filter intercepts
+    log records whose message matches shared-storage-related endpoint paths
+    (``check-shared-storage``, ``check-shared-file``) and forwards them to
+    the file handler used by the ``shared_storage_monitor`` logger.
+
+    Matched records are suppressed from the normal access-log handler chain
+    so they do not clutter ``cmapi_server.log``.  The dedicated handler is
+    resolved lazily on the first matching record and cached for the
+    lifetime of the filter instance.
+
+    :param name: Standard :class:`logging.Filter` *name* argument.
+    :type name: str
+    """
+
+    _ENDPOINTS = ('check-shared-storage', 'check-shared-file')
+
+    def __init__(self, name=''):
+        """Initialise the filter.
+
+        :param name: Logger-name prefix used by the base class filter.
+        :type name: str
+        """
+        super().__init__(name)
+        self._handler = None
+
+    def filter(self, record):
+        """Decide whether *record* should reach the default handlers.
+
+        If the formatted message contains a shared-storage endpoint path
+        the record is emitted directly to the shared-storage log file and
+        suppressed from the regular handler chain (returns ``False``).
+
+        :param record: The log record to evaluate.
+        :type record: logging.LogRecord
+        :returns: ``True`` to keep the record in the normal flow;
+            ``False`` to suppress it.
+        :rtype: bool
+        """
+        msg = record.getMessage()
+        if not any(ep in msg for ep in self._ENDPOINTS):
+            return True
+        handler = self._resolve_handler()
+        if handler is not None:
+            handler.handle(record)
+        return False
+
+    def _resolve_handler(self):
+        """Lazily resolve the shared-storage file handler.
+
+        The handler is obtained from the ``shared_storage_monitor`` logger
+        on first call and cached for subsequent invocations.
+
+        :returns: The file handler, or ``None`` if it cannot be found.
+        :rtype: logging.Handler or None
+        """
+        if self._handler is not None:
+            return self._handler
+        ss_logger = logging.getLogger('shared_storage_monitor')
+        for h in ss_logger.handlers:
+            if hasattr(h, 'baseFilename'):
+                self._handler = h
+                return h
+        return None
+
+
 def custom_cherrypy_error(
         self, msg='', context='', severity=logging.INFO, traceback=False
     ):

--- a/cmapi/cmapi_server/logging_management.py
+++ b/cmapi/cmapi_server/logging_management.py
@@ -80,8 +80,9 @@ class SharedStorageAccessFilter(logging.Filter):
         if not any(ep in msg for ep in self._ENDPOINTS):
             return True
         handler = self._resolve_handler()
-        if handler is not None:
-            handler.handle(record)
+        if handler is None:
+            return True
+        handler.handle(record)
         return False
 
     def _resolve_handler(self):


### PR DESCRIPTION
- clean up main logs file.
    - move some periodic access log  messages from main cmapi server log file to shared storage logs
- Invariant checks now could be configured.
    - add configuration value for invariant checks
    - load configuration on CMAPI startup
    - add warning only mode