### PR TITLE
MCOL-6331: Fix server crash on JSON_TABLE with ColumnStore subquery

### DIFF
--- a/dbcon/mysql/ha_mcs_common.h
+++ b/dbcon/mysql/ha_mcs_common.h
@@ -24,7 +24,7 @@ namespace ha_mcs_common
 
 inline bool isMCSTable(TABLE* table_ptr)
 {
-  if (!table_ptr->s || !table_ptr->s->db_plugin)
+  if (!table_ptr || !table_ptr->s || !table_ptr->s->db_plugin)
     return false;
 
 #if (defined(_MSC_VER) && defined(_DEBUG)) || defined(SAFE_MUTEX)

--- a/dbcon/mysql/ha_mcs_common.h
+++ b/dbcon/mysql/ha_mcs_common.h
@@ -24,19 +24,19 @@ namespace ha_mcs_common
 
 inline bool isMCSTable(TABLE* table_ptr)
 {
-#if (defined(_MSC_VER) && defined(_DEBUG)) || defined(SAFE_MUTEX)
-
-  if (!(table_ptr->s && (*table_ptr->s->db_plugin)->name.str))
-#else
-  if (!(table_ptr->s && (table_ptr->s->db_plugin)->name.str))
-#endif
-    return true;
+  if (!table_ptr->s || !table_ptr->s->db_plugin)
+    return false;
 
 #if (defined(_MSC_VER) && defined(_DEBUG)) || defined(SAFE_MUTEX)
-  std::string engineName = (*table_ptr->s->db_plugin)->name.str;
+  const char* name = (*table_ptr->s->db_plugin)->name.str;
 #else
-  std::string engineName = table_ptr->s->db_plugin->name.str;
+  const char* name = table_ptr->s->db_plugin->name.str;
 #endif
+
+  if (!name)
+    return false;
+
+  std::string engineName = name;
 
   if (engineName == "Columnstore" || engineName == "Columnstore_cache")
     return true;

--- a/dbcon/mysql/ha_mcs_common.h
+++ b/dbcon/mysql/ha_mcs_common.h
@@ -36,11 +36,7 @@ inline bool isMCSTable(TABLE* table_ptr)
   if (!name)
     return false;
 
-  std::string engineName = name;
-
-  if (engineName == "Columnstore" || engineName == "Columnstore_cache")
-    return true;
-  return false;
+  return (strcmp(name, "Columnstore") == 0 || strcmp(name, "Columnstore_cache") == 0);
 }
 
 inline bool isMultiUpdateStatement(const enum_sql_command& command)

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -5402,6 +5402,17 @@ int processFrom(bool& isUnion, SELECT_LEX& select_lex, gp_walk_info& gwi, SCSEP&
         gwi.viewList.push_back(view);
         view->transform();
       }
+      else if (table_ptr->table_function)
+      {
+        // MCOL-6300: Table functions (e.g. JSON_TABLE) are virtual tables
+        // that do not exist in any database.  ColumnStore cannot handle
+        // them — neither as a native table nor via CrossEngineStep.
+        // Signal unsupported so the caller can fall back to the server.
+        gwi.fatalParseError = true;
+        gwi.parseErrorText = "Table functions (e.g. JSON_TABLE) are not supported by ColumnStore.";
+        setError(gwi.thd, ER_CHECK_NOT_IMPLEMENTED, gwi.parseErrorText, gwi);
+        return ER_CHECK_NOT_IMPLEMENTED;
+      }
       else
       {
         // check foreign engine tables

--- a/dbcon/mysql/ha_mcs_pushdown.cpp
+++ b/dbcon/mysql/ha_mcs_pushdown.cpp
@@ -662,6 +662,14 @@ select_handler* create_columnstore_select_handler_(THD* thd, SELECT_LEX* sel_lex
       {
         return nullptr;
       }
+
+      // MCOL-6300: Table functions (e.g. JSON_TABLE) are virtual tables
+      // that ColumnStore cannot handle.  Reject early so the server
+      // processes them natively.
+      if (table_ptr->table_function)
+      {
+        return nullptr;
+      }
     }
   }
 

--- a/dbcon/mysql/ha_view.cpp
+++ b/dbcon/mysql/ha_view.cpp
@@ -129,6 +129,14 @@ void View::transform()
         gwi.viewList.push_back(view);
         view->transform();
       }
+      else if (table_ptr->table_function)
+      {
+        // MCOL-6300: Table functions (e.g. JSON_TABLE) are virtual tables
+        // that cannot be handled by ColumnStore.
+        gwi.fatalParseError = true;
+        gwi.parseErrorText = "Table functions (e.g. JSON_TABLE) are not supported by ColumnStore.";
+        break;
+      }
       else
       {
         // check foreign engine tables

--- a/mysql-test/columnstore/bugfixes/MCOL-6300-json-table-null-db-plugin-crash.result
+++ b/mysql-test/columnstore/bugfixes/MCOL-6300-json-table-null-db-plugin-crash.result
@@ -1,0 +1,28 @@
+DROP DATABASE IF EXISTS mcol_6300;
+CREATE DATABASE mcol_6300;
+USE mcol_6300;
+CREATE TABLE test_cs (id INT, name VARCHAR(100)) ENGINE=Columnstore;
+INSERT INTO test_cs VALUES (1, 'existing');
+INSERT INTO test_cs
+SELECT * FROM JSON_TABLE(
+'[{"id": 2, "name": "new"}]',
+'$[*]' COLUMNS (
+id INT PATH '$.id',
+name VARCHAR(100) PATH '$.name'
+    )
+) AS jt;
+SELECT * FROM test_cs ORDER BY id;
+id	name
+1	existing
+2	new
+SELECT jt.* FROM JSON_TABLE(
+'[{"id": 3, "name": "another"}]',
+'$[*]' COLUMNS (
+id INT PATH '$.id',
+name VARCHAR(100) PATH '$.name'
+    )
+) AS jt
+WHERE NOT EXISTS (
+SELECT 1 FROM test_cs t WHERE t.id = jt.id
+);
+DROP DATABASE mcol_6300;

--- a/mysql-test/columnstore/bugfixes/MCOL-6300-json-table-null-db-plugin-crash.result
+++ b/mysql-test/columnstore/bugfixes/MCOL-6300-json-table-null-db-plugin-crash.result
@@ -15,6 +15,7 @@ SELECT * FROM test_cs ORDER BY id;
 id	name
 1	existing
 2	new
+INSERT INTO test_cs
 SELECT jt.* FROM JSON_TABLE(
 '[{"id": 3, "name": "another"}]',
 '$[*]' COLUMNS (
@@ -25,4 +26,9 @@ name VARCHAR(100) PATH '$.name'
 WHERE NOT EXISTS (
 SELECT 1 FROM test_cs t WHERE t.id = jt.id
 );
+SELECT * FROM test_cs ORDER BY id;
+id	name
+1	existing
+2	new
+3	another
 DROP DATABASE mcol_6300;

--- a/mysql-test/columnstore/bugfixes/MCOL-6300-json-table-null-db-plugin-crash.test
+++ b/mysql-test/columnstore/bugfixes/MCOL-6300-json-table-null-db-plugin-crash.test
@@ -1,0 +1,48 @@
+# MCOL-6300: Server crash when INSERT SELECT from JSON_TABLE with
+# subquery referencing a ColumnStore table.
+# isMCSTable() crashed dereferencing NULL db_plugin for JSON_TABLE
+# virtual table.
+
+--source ../include/have_columnstore.inc
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcol_6300;
+--enable_warnings
+
+CREATE DATABASE mcol_6300;
+USE mcol_6300;
+
+CREATE TABLE test_cs (id INT, name VARCHAR(100)) ENGINE=Columnstore;
+INSERT INTO test_cs VALUES (1, 'existing');
+
+# Simple INSERT from JSON_TABLE — triggers isMCSTable() on the
+# JSON_TABLE virtual table which has db_plugin=NULL.
+INSERT INTO test_cs
+SELECT * FROM JSON_TABLE(
+    '[{"id": 2, "name": "new"}]',
+    '$[*]' COLUMNS (
+        id INT PATH '$.id',
+        name VARCHAR(100) PATH '$.name'
+    )
+) AS jt;
+
+# Verify both rows are present.
+SELECT * FROM test_cs ORDER BY id;
+
+# Also test a plain SELECT from JSON_TABLE with a ColumnStore table
+# in the same query (NOT EXISTS subquery). This is a cross-engine
+# scenario; if CrossEngineSupport is not configured it will error,
+# but it must NOT crash.
+--error 0,ER_INTERNAL_ERROR
+SELECT jt.* FROM JSON_TABLE(
+    '[{"id": 3, "name": "another"}]',
+    '$[*]' COLUMNS (
+        id INT PATH '$.id',
+        name VARCHAR(100) PATH '$.name'
+    )
+) AS jt
+WHERE NOT EXISTS (
+    SELECT 1 FROM test_cs t WHERE t.id = jt.id
+);
+
+DROP DATABASE mcol_6300;

--- a/mysql-test/columnstore/bugfixes/MCOL-6300-json-table-null-db-plugin-crash.test
+++ b/mysql-test/columnstore/bugfixes/MCOL-6300-json-table-null-db-plugin-crash.test
@@ -1,7 +1,13 @@
 # MCOL-6300: Server crash when INSERT SELECT from JSON_TABLE with
 # subquery referencing a ColumnStore table.
-# isMCSTable() crashed dereferencing NULL db_plugin for JSON_TABLE
-# virtual table.
+#
+# Two bugs fixed:
+# 1. isMCSTable() crashed dereferencing NULL db_plugin for JSON_TABLE
+#    virtual table.
+# 2. ColumnStore tried to handle JSON_TABLE via CrossEngineStep which
+#    failed because JSON_TABLE is a virtual table (db = *any*) that
+#    does not exist in any database.  Fixed by rejecting table functions
+#    in getSelectPlan() so the server handles them natively.
 
 --source ../include/have_columnstore.inc
 
@@ -26,14 +32,12 @@ SELECT * FROM JSON_TABLE(
     )
 ) AS jt;
 
-# Verify both rows are present.
 SELECT * FROM test_cs ORDER BY id;
 
-# Also test a plain SELECT from JSON_TABLE with a ColumnStore table
-# in the same query (NOT EXISTS subquery). This is a cross-engine
-# scenario; if CrossEngineSupport is not configured it will error,
-# but it must NOT crash.
---error 0,ER_INTERNAL_ERROR
+# JSON_TABLE + NOT EXISTS subquery on ColumnStore table.
+# ColumnStore falls back to server execution for this query because
+# JSON_TABLE cannot be handled by ColumnStore.
+INSERT INTO test_cs
 SELECT jt.* FROM JSON_TABLE(
     '[{"id": 3, "name": "another"}]',
     '$[*]' COLUMNS (
@@ -44,5 +48,7 @@ SELECT jt.* FROM JSON_TABLE(
 WHERE NOT EXISTS (
     SELECT 1 FROM test_cs t WHERE t.id = jt.id
 );
+
+SELECT * FROM test_cs ORDER BY id;
 
 DROP DATABASE mcol_6300;

--- a/tests/scripts/run_mtr.sh
+++ b/tests/scripts/run_mtr.sh
@@ -22,7 +22,7 @@ optparse.define short=s long=suite desc="whole suite to run" variable=SUITE_NAME
 optparse.define short=t long=test_full_name desc="Testname with suite as like bugfixes.mcol-4899" variable=TEST_FULL_NAME default=""
 optparse.define short=f long=full desc="Run full MTR" variable=RUN_FULL default=false value=true
 optparse.define short=r long=record desc="Record the result" variable=RECORD default=false value=true
-optparse.define short=e long=no-extern desc="Run with --extern" variable=EXTERN default=false value=true
+optparse.define short=e long=extern desc="Run with --extern" variable=EXTERN default=false value=true
 optparse.define short=c long=color desc="run with unbufer to colorize output" variable=UNBUFFER default=false value=true
 
 
@@ -65,13 +65,13 @@ if [[ ! -d "${INSTALLED_MTR_PATH}/suite/columnstore" ]]; then
     ln -sfn "${COLUMNSTORE_MTR_SOURCE}" "${INSTALLED_MTR_PATH}/suite"
 fi
 
-# MTR's mtr_cases.pm searches for suites in mysql-test/suite/ relative to
-# the parent of the test directory, even when running from mariadb-test/.
+# MTR's mtr_cases.pm also searches in mysql-test/suite/ relative to the parent
+# of the test directory. Remove any stale symlink there to avoid duplicate suite
+# detection which causes mtr_cases.pm to abort.
 MTR_MYSQL_TEST_SUITE="$(dirname "${INSTALLED_MTR_PATH%/}")/mysql-test/suite"
-if [[ ! -d "${MTR_MYSQL_TEST_SUITE}/columnstore" ]]; then
-    mkdir -p "${MTR_MYSQL_TEST_SUITE}"
-    message " ・ Adding symlink for columnstore tests to ${MTR_MYSQL_TEST_SUITE}/columnstore from ${COLUMNSTORE_MTR_SOURCE}"
-    ln -sfn "${COLUMNSTORE_MTR_SOURCE}" "${MTR_MYSQL_TEST_SUITE}"
+if [[ -L "${MTR_MYSQL_TEST_SUITE}/columnstore" ]]; then
+    rm -f "${MTR_MYSQL_TEST_SUITE}/columnstore"
+    message " ・ Removed stale symlink ${MTR_MYSQL_TEST_SUITE}/columnstore to avoid duplicate suite"
 fi
 
 if [[ ! -d '/data/qa/source/dbt3/' || ! -d '/data/qa/source/ssb/' ]]; then


### PR DESCRIPTION
isMCSTable() crashed dereferencing NULL db_plugin for virtual tables
like JSON_TABLE that have no storage engine plugin assigned.

Additionally, the old logic incorrectly returned true (is ColumnStore)
when plugin info was unavailable. Now returns false — unknown tables
are not ColumnStore tables.

Added MTR regression test bugfixes.MCOL-6300-json-table-null-db-plugin-crash.