### PR TITLE
MCOL-6333: CPACK_RPM_BUILDREQUIRES to include selinux dependency

### DIFF
--- a/cmake/selinux_policy.cmake
+++ b/cmake/selinux_policy.cmake
@@ -23,9 +23,9 @@ if(NOT _is_rhel_like
     return()
 endif()
 
-# Add RPM BuildRequires for the engine component only on matching systems Use the common appender macro to handle comma
-# separation
-columnstore_append_for_cpack(CPACK_RPM_columnstore-engine_PACKAGE_BUILDREQUIRES "selinux-policy-devel")
+# Use the common appender macro to handle comma separation.
+# As a SRPM directive, it is global rather than for the component
+columnstore_append_for_cpack(CPACK_RPM_BUILDREQUIRES "selinux-policy-devel")
 
 # Paths
 set(SELINUX_SRC_DIR "${CMAKE_CURRENT_LIST_DIR}/../build/security")


### PR DESCRIPTION
The cmake/selinux.cmake submodule will set CPACK_RPM_BUILDREQUIRES in PARENT_SCOPE to indicate to the SRPM builders that selinux-policy-devel is required.

Per documentation[1], this isn't set on a per component basis.

[1] https://cmake.org/cmake/help/latest/cpack_gen/rpm.html#variable:CPACK_RPM_BUILDREQUIRES

Corrects: 488fbea4cd