### PR TITLE
fix(cpimport): MCOL-6326 - cpimport should invalidate partially rolled back extents [develop-23.02]

### DIFF
--- a/tests/custom/README.md
+++ b/tests/custom/README.md
@@ -1,0 +1,9 @@
+# Custom tests
+
+Many tests should be performed on specific distros and/or with specific actions done over Columnstore's processes and their data.
+
+While MTR formally allows that, the implementation there is difficult, MTR renders full functionality of Perl inaccessible.
+
+Thus, this directory is born.
+
+Place here tests that need to check what is hard to check under MTR.

--- a/tests/custom/cpimport-rollback.sh
+++ b/tests/custom/cpimport-rollback.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+echo "PATH: $PATH"
+
+export PATH=$PATH:/usr/bin:/usr/sbin
+
+DB_NAME="test_cp_rb"
+TB_NAME="date_crash"
+
+echo "1. Setting up test schema..."
+mariadb -e "DROP DATABASE IF EXISTS ${DB_NAME};"
+mariadb -e "CREATE DATABASE IF NOT EXISTS ${DB_NAME};"
+mariadb -e "CREATE TABLE ${DB_NAME}.${TB_NAME} (id INT, dt DATE) ENGINE=ColumnStore;"
+
+echo "2. Generating test data..."
+seq 1 5000000 | awk '{print $1",2025-03-01"}' > /tmp/test_data0.csv
+echo '100000000,\N' >>/tmp/test_data0.csv
+seq 1 50000000 | awk '{print $1",2026-03-01"}' > /tmp/test_data.csv
+echo '110000000,\N' >>/tmp/test_data.csv
+
+echo "3.a. Loading data before the bigger bulk"
+cpimport -s ',' ${DB_NAME} ${TB_NAME} /tmp/test_data0.csv
+echo "3.b. Starting cpimport in background..."
+cpimport -s ',' ${DB_NAME} ${TB_NAME} /tmp/test_data.csv &
+CP_PID=$!
+
+echo "4. Waiting 1 second for extents to allocate..."
+sleep 1
+
+echo "5. Sending SIGSEGV to force BulkRollbackMgr execution..."
+kill -11 $CP_PID
+
+wait $CP_PID
+
+echo "6. Testing MAX(dt) - Will incorrectly return 0000-00-00:"
+RESULT=`mariadb -N -e "SELECT MAX(dt) FROM ${DB_NAME}.${TB_NAME};"`
+
+echo "MAX(dt): $RESULT"
+
+mariadb -e "DROP DATABASE ${DB_NAME};" # cleanup
+
+if [ "$RESULT" != "2026-03-01" ];
+then
+	exit 1
+fi

--- a/versioning/BRM/extentmap.cpp
+++ b/versioning/BRM/extentmap.cpp
@@ -226,6 +226,14 @@ bool EMEntry::operator<(const EMEntry& e) const
   return false;
 }
 
+void EMEntry::setHWMAndInvalidate(HWM_t newHWM)
+{
+  HWM = newHWM;
+
+  partition.cprange.isValid = CP_INVALID;
+}
+
+
 /*static*/
 boost::mutex ExtentMap::mutex;
 boost::mutex ExtentMap::emIndexMutex;
@@ -3827,7 +3835,7 @@ void ExtentMap::rollbackColumnExtents_DBroot(int oid, bool bDeleteAll, uint16_t 
             if (emEntry.HWM != (fboLo - 1))
             {
               makeUndoRecordRBTree(UndoRecordType::DEFAULT, emEntry);
-              emEntry.HWM = fboLo - 1;  // case 3A
+              emEntry.setHWMAndInvalidate(fboLo - 1);  // case 3A
               emEntry.status = EXTENTAVAILABLE;
             }
           }
@@ -3845,7 +3853,7 @@ void ExtentMap::rollbackColumnExtents_DBroot(int oid, bool bDeleteAll, uint16_t 
           if (emEntry.HWM != fboHi)
           {
             makeUndoRecordRBTree(UndoRecordType::DEFAULT, emEntry);
-            emEntry.HWM = fboHi;  // case 4B
+            emEntry.setHWMAndInvalidate(fboHi);  // case 4B
             emEntry.status = EXTENTAVAILABLE;
           }
         }
@@ -3854,7 +3862,7 @@ void ExtentMap::rollbackColumnExtents_DBroot(int oid, bool bDeleteAll, uint16_t 
           if (emEntry.HWM != hwm)
           {
             makeUndoRecordRBTree(UndoRecordType::DEFAULT, emEntry);
-            emEntry.HWM = hwm;  // case 4C
+            emEntry.setHWMAndInvalidate(hwm);  // case 4C
             emEntry.status = EXTENTAVAILABLE;
           }
         }

--- a/versioning/BRM/extentmap.h
+++ b/versioning/BRM/extentmap.h
@@ -195,6 +195,7 @@ struct EMEntry
   EXPORT EMEntry(const EMEntry&);
   EXPORT EMEntry& operator=(const EMEntry&);
   EXPORT bool operator<(const EMEntry&) const;
+  EXPORT void setHWMAndInvalidate(HWM_t newHWM); // used in cpimport failure rollback
 };
 
 // Bug 2989, moved from joblist


### PR DESCRIPTION


This patch adds invalidation logic for partially rolled back extents during rollback after a failure. Previously only HWMs were set, now ranges are specifically invalidated too.