### PR TITLE
MCOL-6311: Fix UPDATE/DELETE with IN-subqueries  

### DIFF
--- a/dbcon/mysql/ha_mcs.cpp
+++ b/dbcon/mysql/ha_mcs.cpp
@@ -259,7 +259,13 @@ int ha_mcs::open(const char* name, int mode, uint32_t test_if_locked)
   //   CREATE TABLE t1 (a int, b int) engine=columnstore;
   //   PREPARE stmt1 FROM "SELECT * FROM t1";
   //   EXECUTE stmt1;
-  if (isPS)
+  // MCOL-4868 For UPDATE/DELETE, mutate_optimizer_flags must be called early
+  // (during open, before prepare_inner/JOIN::prepare) so that
+  // check_and_do_in_subquery_rewrites sees the correct optimizer flags
+  // (e.g., semijoin=OFF). Without this, IN subqueries are registered as
+  // semijoin candidates instead of being transformed via select_transformer,
+  // leaving Item_in_subselect unwrapped and causing ExeMgr Error 999.
+  if (isPS || ha_mcs_common::isUpdateOrDeleteStatement(current_thd->lex->sql_command))
     mutate_optimizer_flags(current_thd);
 
   int rc;
@@ -281,8 +287,17 @@ int ha_mcs::discover_check_version()
   bool isPS = current_thd->stmt_arena &&
               (current_thd->stmt_arena->is_stmt_prepare() || current_thd->stmt_arena->is_stmt_execute());
 
-  if (isPS)
+  if (isPS || ha_mcs_common::isUpdateOrDeleteStatement(current_thd->lex->sql_command))
+  {
+    // MCOL-4868 For UPDATE/DELETE with subqueries (and for prepared statements),
+    // we need to mutate optimizer flags to disable semijoin and enable
+    // materialization. This ensures:
+    // 1. Item_in_subselect is properly wrapped with Item_in_optimizer via
+    //    check_and_do_in_subquery_rewrites() -> select_transformer().
+    // 2. The subquery uses MATERIALIZATION strategy which works correctly
+    //    with Columnstore's cross-engine join execution.
     mutate_optimizer_flags(current_thd);
+  }
 
   return 0;
 }

--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -6141,22 +6141,28 @@ int processWhere(SELECT_LEX& select_lex, gp_walk_info& gwi, SCSEP& csep, const s
   // Flag to indicate if this is a prepared statement
   bool isPS = gwi.thd->stmt_arena && gwi.thd->stmt_arena->is_stmt_execute();
 
-  if (join != 0 && !isPS)
+  // MCOL-6311: For UPDATE/DELETE at the outer query level (not inside a subquery),
+  // use the isUpdateDelete path (condStack / select_lex.where) instead of join->conds.
+  // After MDEV-25008, the server creates a JOIN for UPDATE/DELETE's select_lex during
+  // prepare phase, making join non-NULL. However, join->conds may have been transformed
+  // by the server's optimizer in ways that Columnstore cannot handle for DML.
+  // Subqueries within UPDATE/DELETE should still use join->conds normally.
+  if (!gwi.subQuery && ha_mcs_common::isUpdateOrDeleteStatement(gwi.thd->lex->sql_command))
+  {
+    isUpdateDelete = true;
+  }
+  else if (join != 0 && !isPS)
     icp = join->conds;
   else if (isPS && select_lex.prep_where)
     icp = select_lex.prep_where;
 
   // if icp is null, try to find the where clause other where
-  if (!join && gwi.thd->lex->derived_tables)
+  if (!icp && !isUpdateDelete && !join && gwi.thd->lex->derived_tables)
   {
     if (select_lex.prep_where)
       icp = select_lex.prep_where;
     else if (select_lex.where)
       icp = select_lex.where;
-  }
-  else if (!join && ha_mcs_common::isUpdateOrDeleteStatement(gwi.thd->lex->sql_command))
-  {
-    isUpdateDelete = true;
   }
 
   if (icp)

--- a/dbcon/mysql/ha_mcs_execplan_walks.cpp
+++ b/dbcon/mysql/ha_mcs_execplan_walks.cpp
@@ -254,7 +254,7 @@ void gp_walk(const Item* item, void* arg)
       Item* ncitem = const_cast<Item*>(item);
       Item_func* ifp = static_cast<Item_func*>(ncitem);
       std::string funcName = ifp->func_name();
-      
+
       if (!gwip->condPush)
       {
         if (!ifp->fixed())

--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -1530,7 +1530,6 @@ uint32_t doUpdateDelete(THD* thd, gp_walk_info& gwi, const std::vector<COND*>& c
     }
   }
 
-  // cout<< "Plan is " << endl << *updateCP << endl;
   // updateCP->traceFlags(1);
   pDMLPackage->HasFilter(true);
   pDMLPackage->uuid(updateCP->uuid());

--- a/dbcon/mysql/ha_mcs_pushdown.cpp
+++ b/dbcon/mysql/ha_mcs_pushdown.cpp
@@ -616,18 +616,6 @@ select_handler* create_columnstore_select_handler_(THD* thd, SELECT_LEX* sel_lex
     return nullptr;
   }
 
-  // MCOL-4868 Disable select_handler for DELETE statements.
-  // Multi-table DELETEs (including self-join DELETEs like
-  // "DELETE FROM t WHERE a IN (SELECT a FROM t)") go through
-  // Sql_cmd_dml::execute_inner which calls find_single_select_handler.
-  // The select_handler's prepare() crashes because the DELETE's
-  // SELECT_LEX doesn't have proper field setup for temp table creation.
-  // DELETE should use the doUpdateDelete path via ha_mcs::rnd_init.
-  if (ha_mcs_common::isDeleteStatement(thd->lex->sql_command))
-  {
-    return nullptr;
-  }
-
   // Flag to indicate if this is a prepared statement
   bool isPS = thd->stmt_arena && thd->stmt_arena->is_stmt_execute();
 
@@ -683,6 +671,17 @@ select_handler* create_columnstore_select_handler_(THD* thd, SELECT_LEX* sel_lex
         return nullptr;
       }
     }
+  }
+
+  // MCOL-4868 Reject select_handler when SELECT_LEX has no result columns.
+  // This happens for DML statements with IN-subqueries that are routed
+  // through Sql_cmd_dml::execute_inner (e.g. "DELETE FROM t WHERE a IN
+  // (SELECT a FROM t)"). The select_handler's create_tmp_table() would
+  // crash with m_alloced_field_count==0 assertion because item_list is empty.
+  for (size_t i = 0; i < select_lex_vec.size(); i++)
+  {
+    if (select_lex_vec[i]->item_list.elements == 0)
+      return nullptr;
   }
 
   // We apply dedicated rewrites from MDB here so MDB's data structures

--- a/dbcon/mysql/ha_mcs_pushdown.cpp
+++ b/dbcon/mysql/ha_mcs_pushdown.cpp
@@ -616,6 +616,18 @@ select_handler* create_columnstore_select_handler_(THD* thd, SELECT_LEX* sel_lex
     return nullptr;
   }
 
+  // MCOL-4868 Disable select_handler for DELETE statements.
+  // Multi-table DELETEs (including self-join DELETEs like
+  // "DELETE FROM t WHERE a IN (SELECT a FROM t)") go through
+  // Sql_cmd_dml::execute_inner which calls find_single_select_handler.
+  // The select_handler's prepare() crashes because the DELETE's
+  // SELECT_LEX doesn't have proper field setup for temp table creation.
+  // DELETE should use the doUpdateDelete path via ha_mcs::rnd_init.
+  if (ha_mcs_common::isDeleteStatement(thd->lex->sql_command))
+  {
+    return nullptr;
+  }
+
   // Flag to indicate if this is a prepared statement
   bool isPS = thd->stmt_arena && thd->stmt_arena->is_stmt_execute();
 

--- a/mysql-test/columnstore/bugfixes/disabled.def
+++ b/mysql-test/columnstore/bugfixes/disabled.def
@@ -1,2 +1,1 @@
 MCOL-6198-segfault-crossengine-join : oom probably due to filltablecol function
-mcol-4868 : MCOL-6311 2025-09-26 roman.nozdrin@mariadb.com 

--- a/utils/common/utils_utf8.cpp
+++ b/utils/common/utils_utf8.cpp
@@ -21,6 +21,8 @@ namespace datatypes
 {
 static inline CHARSET_INFO& get_charset_or_bin(int32_t charsetNumber)
 {
+  if (charsetNumber == 0)
+    return my_charset_bin;
   CHARSET_INFO* cs = get_charset(charsetNumber, MYF(MY_WME));
   return cs ? *cs : my_charset_bin;
 }


### PR DESCRIPTION
UPDATE and DELETE statements with IN-subqueries fail in three different ways
depending on the query shape:
 
1. **Cross-engine UPDATE/DELETE** (`UPDATE cs_table SET ... WHERE a IN (SELECT a FROM innodb_table)`)
   fails with `ExeMgr Error 999` because the IN-subquery is not properly
   transformed by the server optimizer — [Item_in_subselect](cci:1://file:///home/ubuntu/proj/MDBEnterprise/sql/item_subselect.cc:1644:0-1704:1) remains unwrapped
   by `Item_in_optimizer`, and Columnstore cannot serialize it.
 
2. **Cross-engine DELETE** additionally triggers `"Character set '#0' is not a
   compiled character set"` when the execution plan is deserialized in DMLProc,
   because integer column predicates have `charsetNumber=0` (unset) and
   `get_charset(0)` calls `my_error()`.
 
3. **Self-join DELETE** (`DELETE FROM t WHERE a IN (SELECT a FROM t)`) crashes
   the server with `Assertion 'm_alloced_field_count' failed` in
   [Create_tmp_table::start](cci:1://file:///home/ubuntu/proj/MDBEnterprise/sql/sql_select.cc:21896:0-22054:1). The server calls [find_single_select_handler()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/sql/sql_select.cc:5278:0-5287:1)
   for multi-table DELETEs, which invokes Columnstore's `select_handler`.
   The handler's [prepare()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/sql/sql_select.cc:1423:0-1902:1) tries to create a temp table but the DELETE's
   `SELECT_LEX` has no fields configured for this.
 
### Root Cause
 
- **Issue 1**: Columnstore was not calling [mutate_optimizer_flags()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_pushdown.cpp:63:0-77:1) for
  UPDATE/DELETE statements (only for prepared statements). Without flag
  mutation, the server's [check_and_do_in_subquery_rewrites()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/sql/item_subselect.cc:49:0-49:50) registers
  IN-subqueries as semijoin candidates instead of transforming them via
  [select_transformer()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/sql/item_subselect.cc:232:0-238:1), which is the path that creates `Item_in_optimizer`.
 
- **Issue 2**: `PredicateOperator::setOpType()` only sets `charsetNumber`
  for CHAR/VARCHAR types. For INT columns, `charsetNumber` remains 0.
  `get_charset_or_bin(0)` calls `get_charset(0, MYF(MY_WME))`, which
  pushes an error to the THD error stack.
 
- **Issue 3**: After MDEV-25008, the server creates a JOIN for UPDATE/DELETE
  during the prepare phase and routes multi-table DELETEs through
  [Sql_cmd_dml::execute_inner()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/sql/sql_select.cc:34708:0-34740:1), which calls [find_single_select_handler()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/sql/sql_select.cc:5278:0-5287:1).
  Columnstore's [create_columnstore_select_handler_()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_pushdown.cpp:584:0-899:1) had no guard against
  DELETE statements.
 
### Fix
 
1. **[ha_mcs.cpp](cci:7://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs.cpp:0:0-0:0)**: Call [mutate_optimizer_flags()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_pushdown.cpp:63:0-77:1) for UPDATE/DELETE
   statements in [ha_mcs::open()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs.cpp:247:0-282:1) and [ha_mcs::discover_check_version()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs.cpp:284:0-302:1),
   matching the existing behavior for prepared statements. This disables
   SEMIJOIN and enables MATERIALIZATION, ensuring proper `Item_in_optimizer`
   wrapping.
 
2. **[utils_utf8.cpp](cci:7://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/common/utils_utf8.cpp:0:0-0:0)**: Return `my_charset_bin` when `charsetNumber == 0`
   in `get_charset_or_bin()`, avoiding the `my_error()` call.
 
3. **[ha_mcs_pushdown.cpp](cci:7://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_pushdown.cpp:0:0-0:0)**: Return `nullptr` from
   [create_columnstore_select_handler_()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_pushdown.cpp:584:0-899:1) for DELETE statements, so they
   use the `doUpdateDelete` path via [ha_mcs::rnd_init()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs.cpp:617:0-649:1).
 
4. **[ha_mcs_execplan.cpp](cci:7://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:0:0-0:0)**: Reorder [processWhere()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_execplan.cpp:6115:0-6418:1) to check for
   UPDATE/DELETE at the outer query level *before* checking `join->conds`.
   After MDEV-25008, `join` is non-NULL for DML, but `join->conds` may
   contain optimizer transformations that Columnstore cannot process.
   Subqueries within UPDATE/DELETE continue to use `join->conds` normally.