### PR TITLE
fix(engine, load_from_s3): MCOL-6146 Add mode 2 and 3 to load_from_s3.

### DIFF
--- a/cmapi/cmapi_server/constants.py
+++ b/cmapi/cmapi_server/constants.py
@@ -14,6 +14,9 @@ DEFAULT_MCS_CONF_PATH = os.path.join(MCS_ETC_PATH, 'Columnstore.xml')
 # default Storage Manager config path
 DEFAULT_SM_CONF_PATH = os.path.join(MCS_ETC_PATH, 'storagemanager.cnf')
 
+# MCSLOGDIR (in mcs engine code) and related paths
+MCS_LOG_PATH = '/var/log/mariadb/columnstore'
+
 # MCSDATADIR (in mcs engine code) and related paths
 MCS_DATA_PATH = '/var/lib/columnstore'
 MCS_MODULE_FILE_PATH = os.path.join(MCS_DATA_PATH, 'local/module')
@@ -109,7 +112,6 @@ ALL_MCS_PROGS: dict[MCSProgs, ProgInfo] = {
 MCS_INSTALL_BIN = '/usr/bin'
 IFLAG = os.path.join(MCS_ETC_PATH, 'container-initialized')
 LIBJEMALLOC_DEFAULT_PATH = os.path.join(MCS_DATA_PATH, 'libjemalloc.so.2')
-MCS_LOG_PATH = '/var/log/mariadb/columnstore'
 
 # BRM shmem lock inspection/reset tool
 SHMEM_LOCKS_PATH = os.path.join(MCS_INSTALL_BIN, 'mcs-shmem-locks')

--- a/cmapi/cmapi_server/controllers/api_clients.py
+++ b/cmapi/cmapi_server/controllers/api_clients.py
@@ -532,6 +532,43 @@ class NodeControllerClient(BaseClient):
         }
         return self._request('GET', 'check-shared-file', data)
 
+    def download_s3_file(
+        self, bucket: str, filename: str, key: str, secret: str,
+        region: str, storage: str, target_path: str
+    ) -> Union[Dict[str, Any], Dict[str, str]]:
+        """Download an S3/GCS file to a local path on a node.
+
+        :param bucket: S3/GCS bucket URL
+        :param filename: filename in bucket
+        :param key: access key
+        :param secret: access secret
+        :param region: region (for AWS)
+        :param storage: storage type ('aws' or 'gs')
+        :param target_path: local path to save the file
+        :return: The response from the API.
+        """
+        data = {
+            'bucket': bucket,
+            'filename': filename,
+            'key': key,
+            'secret': secret,
+            'region': region,
+            'storage': storage,
+            'target_path': target_path,
+        }
+        return self._request('PUT', 'download-s3-file', data)
+
+    def delete_load_file(
+        self, target_path: str
+    ) -> Union[Dict[str, Any], Dict[str, str]]:
+        """Delete a previously downloaded load file on a node.
+
+        :param target_path: path of the file to delete
+        :return: The response from the API.
+        """
+        return self._request(
+            'PUT', 'delete-load-file', {'target_path': target_path}
+        )
 
 class AppControllerClient(BaseClient):
     """Client for the AppController API.

--- a/cmapi/cmapi_server/controllers/dispatcher.py
+++ b/cmapi/cmapi_server/controllers/dispatcher.py
@@ -484,6 +484,26 @@ dispatcher.connect(
 )
 
 
+# /_version/node/download-s3-file/ (PUT)
+dispatcher.connect(
+    name = 'node_download_s3_file',
+    route = f'/cmapi/{_version}/node/download-s3-file',
+    action = 'download_s3_file',
+    controller = NodeController(),
+    conditions = {'method': ['PUT']}
+)
+
+
+# /_version/node/delete-load-file/ (PUT)
+dispatcher.connect(
+    name = 'node_delete_load_file',
+    route = f'/cmapi/{_version}/node/delete-load-file',
+    action = 'delete_load_file',
+    controller = NodeController(),
+    conditions = {'method': ['PUT']}
+)
+
+
 # /_version/cluster/check-shared-storage/ (PUT)
 dispatcher.connect(
     name = 'cluster_check_shared_storage',

--- a/cmapi/cmapi_server/controllers/endpoints.py
+++ b/cmapi/cmapi_server/controllers/endpoints.py
@@ -1,14 +1,18 @@
-import logging
+import furl
 import hashlib
+import logging
 import os
 import shlex
 import socket
 import subprocess
+import tempfile
 import threading
 import time
+import uuid
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
+from subprocess import CalledProcessError, PIPE, Popen, run
 from typing import Optional
 
 import cherrypy
@@ -25,6 +29,7 @@ from cmapi_server.constants import (
     CMAPI_PORT,
     CMAPI_PYTHON_BIN,
     CMAPI_PYTHON_DEPS_PATH,
+    CMAPI_PYTHON_BINARY_DEPS_PATH,
     DEFAULT_MCS_CONF_PATH,
     DMLPROC_SHUTDOWN_TIMEOUT,
     EM_PATH_SUFFIX,
@@ -2209,6 +2214,154 @@ class NodeController:
         }
         logger.debug(f'{func_name} returns {str(response)}')
         return response
+
+    @cherrypy.tools.timeit()
+    @cherrypy.tools.json_in()
+    @cherrypy.tools.json_out()
+    @cherrypy.tools.validate_api_key()  # pylint: disable=no-member
+    def download_s3_file(self):
+        """Handler for /node/download-s3-file (PUT) endpoint.
+
+        Downloads a file from S3/GCS to a specified local path on this node.
+        Used by load_s3data mode 2 to distribute data files to all PMs.
+        """
+        func_name = 'download_s3_file'
+        log_begin(module_logger, func_name)
+
+        request_body = cherrypy.request.json
+        bucket = request_body.get('bucket')
+        filename = request_body.get('filename')
+        key = request_body.get('key')
+        secret = request_body.get('secret')
+        region = request_body.get('region', '')
+        storage = request_body.get('storage')
+        target_path = request_body.get('target_path')
+
+        if not all([bucket, filename, key, secret, storage, target_path]):
+            raise_422_error(
+                module_logger, func_name,
+                'Missing required parameters: bucket, filename, key, secret, '
+                'storage, target_path'
+            )
+
+        ACCEPTED_DIRS = ('/tmp/',)
+        if not target_path.startswith(ACCEPTED_DIRS):
+            raise_422_error(
+                module_logger, func_name,
+                f'Target_path must start with one of {ACCEPTED_DIRS}'
+            )
+
+        target_dir = os.path.dirname(target_path)
+        os.makedirs(target_dir, exist_ok=True)
+
+        try:
+            if storage == 'aws':
+                my_env = os.environ.copy()
+                my_env['AWS_ACCESS_KEY_ID'] = key
+                my_env['AWS_SECRET_ACCESS_KEY'] = secret
+                my_env['PYTHONPATH'] = CMAPI_PYTHON_DEPS_PATH
+
+                aws_cli_binary = os.path.join(
+                    CMAPI_PYTHON_BINARY_DEPS_PATH, 'aws'
+                )
+                s3_url = furl.furl(bucket).add(path=filename).url
+                aws_command_line = [
+                    CMAPI_PYTHON_BIN, aws_cli_binary,
+                    's3', 'cp', '--source-region', region, s3_url, target_path
+                ]
+                module_logger.debug(
+                    f'download_s3_file AWS cmd: {" ".join(aws_command_line)}'
+                )
+                result = run(
+                    aws_command_line, env=my_env, capture_output=True,
+                    encoding='utf-8', check=True
+                )
+            elif storage == 'gs':
+                my_env = os.environ.copy()
+                my_env['PYTHONPATH'] = CMAPI_PYTHON_DEPS_PATH
+                gs_cli_binary = os.path.join(
+                    CMAPI_PYTHON_BINARY_DEPS_PATH, 'gsutil'
+                )
+                temporary_config = os.path.join(
+                    tempfile.gettempdir(),
+                    '.boto.' + str(uuid.uuid4())
+                )
+                my_env['BOTO_CONFIG'] = temporary_config
+                project_id = 'project_id'
+                config_cmd = (
+                    f'/usr/bin/bash -c '
+                    f'\'echo -e "{key}\n{secret}\n{project_id}"\' | '
+                    f'{CMAPI_PYTHON_BIN} {gs_cli_binary} '
+                    f'config -a -o {temporary_config}'
+                )
+                run(config_cmd, capture_output=True, shell=True,
+                    encoding='utf-8', check=True, env=my_env)
+
+                gs_url = furl.furl(bucket).add(path=filename).url
+                gs_command_line = [
+                    CMAPI_PYTHON_BIN, gs_cli_binary, 'cp', gs_url, target_path
+                ]
+                module_logger.debug(
+                    f'download_s3_file GS cmd: {" ".join(gs_command_line)}'
+                )
+                result = run(
+                    gs_command_line, env=my_env, capture_output=True,
+                    encoding='utf-8', check=True
+                )
+                if os.path.exists(temporary_config):
+                    os.remove(temporary_config)
+            else:
+                raise_422_error(
+                    module_logger, func_name,
+                    f'Unknown storage type: {storage}'
+                )
+        except CalledProcessError as exc:
+            raise_422_error(
+                module_logger, func_name,
+                f'S3 download failed: {exc.stderr or exc.stdout}'
+            )
+
+        response = {
+            'timestamp': str(datetime.now()),
+            'success': True,
+            'target_path': target_path
+        }
+        module_logger.debug(f'{func_name} returns {str(response)}')
+        return response
+
+    @cherrypy.tools.timeit()
+    @cherrypy.tools.json_in()
+    @cherrypy.tools.json_out()
+    @cherrypy.tools.validate_api_key()  # pylint: disable=no-member
+    def delete_load_file(self):
+        """Handler for /node/delete-load-file (PUT) endpoint.
+
+        Deletes a previously downloaded load file from this node.
+        Used for cleanup after mode 2 cpimport finishes.
+        """
+        func_name = 'delete_load_file'
+        log_begin(module_logger, func_name)
+
+        request_body = cherrypy.request.json
+        target_path = request_body.get('target_path')
+
+        if not target_path:
+            raise_422_error(
+                module_logger, func_name, 'Missing target_path parameter'
+            )
+
+        ACCEPTED_DIRS = ('/tmp/', '/var/lib/columnstore/', '/var/tmp/')
+        if not target_path.startswith(ACCEPTED_DIRS):
+            raise_422_error(
+                module_logger, func_name,
+                f'target_path must start with one of {ACCEPTED_DIRS}'
+            )
+
+        if os.path.exists(target_path):
+            os.remove(target_path)
+            module_logger.debug(f'Deleted load file: {target_path}')
+
+        return {'timestamp': str(datetime.now()), 'success': True}
 
     @cherrypy.tools.timeit()
     @cherrypy.tools.json_in()

--- a/cmapi/cmapi_server/controllers/s3dataload.py
+++ b/cmapi/cmapi_server/controllers/s3dataload.py
@@ -9,10 +9,16 @@ from subprocess import PIPE, Popen, run, CalledProcessError
 import cherrypy
 import furl
 from cmapi_server.constants import (
-    CMAPI_PYTHON_BIN, CMAPI_PYTHON_BINARY_DEPS_PATH, CMAPI_PYTHON_DEPS_PATH
+    CMAPI_PYTHON_BIN,
+    CMAPI_PYTHON_BINARY_DEPS_PATH,
+    CMAPI_PYTHON_DEPS_PATH,
+    CMAPI_PORT,
+    LONG_REQUEST_TIMEOUT,
 )
 
+from cmapi_server.controllers.api_clients import NodeControllerClient
 from cmapi_server.controllers.endpoints import raise_422_error
+from cmapi_server.helpers import get_active_nodes
 
 
 module_logger = logging.getLogger('cmapi_server')
@@ -207,12 +213,13 @@ class S3DataLoadController:
 
             return gs_process
 
-        module_logger.debug(f'LOAD S3 Data')
+        module_logger.debug('LOAD S3 Data')
         request = cherrypy.request
         request_body = request.json
 
         bucket = getKey('bucket', request_body)
 
+        storage: str = ''
         if bucket.startswith(r's3://'):
             storage = 'aws'
         elif bucket.startswith(r'gs://'):
@@ -228,7 +235,8 @@ class S3DataLoadController:
         filename = getKey('filename', request_body)
         key = getKey('key', request_body)
         secret = getKey('secret', request_body)
-        region = getKey('region', request_body, required=storage=='aws')
+        is_aws_storage = bool(storage=='aws')
+        region = getKey('region', request_body, required=is_aws_storage)
         database = getKey('database', request_body)
         terminated_by = getKey('terminated_by', request_body, skip_check=True)
         enclosed_by = getKey(
@@ -237,19 +245,7 @@ class S3DataLoadController:
         escaped_by = getKey(
             'escaped_by', request_body, skip_check=True, required=False
         )
-
-        if storage == 'aws':
-            download_proc = prepare_aws(bucket, filename, secret, key, region)
-        elif storage == 'gs':
-            temporary_config = os.path.join(
-                tempfile.gettempdir(), '.boto.' + str(uuid.uuid4())
-            )
-
-            download_proc = prepare_google_storage(
-                bucket, filename, secret, key, temporary_config
-            )
-        else:
-            response_error('Unknown storage detected. Internal error')
+        mode = request_body.get('mode', 1)
 
         cpimport_command_line = [
             'cpimport', database, table, '-s', terminated_by
@@ -258,65 +254,164 @@ class S3DataLoadController:
             cpimport_command_line += ['-C', escaped_by]
         if enclosed_by:
             cpimport_command_line += ['-E', enclosed_by]
+        try:
+            mode_val = int(mode)
+        except (ValueError, TypeError):
+            response_error(f'Invalid mode value: {mode}')
+        if mode_val not in (1, 2, 3):
+            response_error(
+                f'Invalid mode: {mode_val}. Must be 1, 2, or 3'
+            )
+
+        cpimport_command_line += ['-m', str(mode_val)]
+
+        temporary_config = None
+        download_proc = None
+        temporary_load_file = None
+        active_nodes = []
+
+        if mode_val == 2:
+            # Mode 2 requires a local file path (-f/-l) on every PM.
+            # Tell each node in the cluster to download the file from S3
+            # into the same local path.
+            load_filename = 'cs_s3load_' + str(uuid.uuid4()) + '.dat'
+            temporary_load_file = os.path.join(
+                tempfile.gettempdir(), load_filename
+            )
+
+            active_nodes = get_active_nodes()
+            if not active_nodes:
+                response_error(
+                    'Mode 2 requires an active cluster with nodes'
+                )
+
+            module_logger.info(
+                f'Mode 2: distributing S3 file to {len(active_nodes)} '
+                f'nodes at {temporary_load_file}'
+            )
+
+            for node in active_nodes:
+                module_logger.debug(
+                    f'Mode 2: requesting download on node {node}'
+                )
+                # we need to download possibly big files from s3, so longer timeout needed.
+                client = NodeControllerClient(
+                    request_timeout=LONG_REQUEST_TIMEOUT,
+                    base_url=f'https://{node}:{CMAPI_PORT}'
+                )
+                try:
+                    client.download_s3_file(
+                        bucket=bucket,
+                        filename=filename,
+                        key=key,
+                        secret=secret,
+                        region=region,
+                        storage=storage,
+                        target_path=temporary_load_file
+                    )
+                except Exception as e:
+                    response_error(
+                        f'Failed to download file on node {node}: {e}'
+                    )
+
+            cpimport_command_line += [
+                '-f', os.path.dirname(temporary_load_file),
+                '-l', os.path.basename(temporary_load_file)
+            ]
+        else:
+            # Modes 1/3: stream S3 data via download process stdout.
+            if storage == 'aws':
+                download_proc = prepare_aws(
+                    bucket, filename, secret, key, region
+                )
+            elif storage == 'gs':
+                temporary_config = os.path.join(
+                    tempfile.gettempdir(), '.boto.' + str(uuid.uuid4())
+                )
+                download_proc = prepare_google_storage(
+                    bucket, filename, secret, key, temporary_config
+                )
+            else:
+                response_error('Unknown storage detected. Internal error')
 
         module_logger.debug(
             f'cpimport command line: {" ".join(cpimport_command_line)}'
         )
 
-        cpimport_proc = Popen(
-            cpimport_command_line, shell=False, stdin=download_proc.stdout,
-            stdout=PIPE, stderr=PIPE, encoding='utf-8'
-        )
+        if mode_val == 2:
+            # Mode 2: file already on disk, no stdin piping needed.
+            cpimport_proc = Popen(
+                cpimport_command_line, shell=False, stdin=PIPE,
+                stdout=PIPE, stderr=PIPE, encoding='utf-8'
+            )
+            cpimport_proc.stdin.close()
 
-        selector = selectors.DefaultSelector()
-        for stream in [
-            download_proc.stderr, cpimport_proc.stderr, cpimport_proc.stdout
-        ]:
-            os.set_blocking(stream.fileno(), False)
+            cpimport_output, cpimport_error = cpimport_proc.communicate()
+            downloader_error = ''
+        else:
+            # Mode 1/3: pipe S3 download stdout directly to cpimport stdin.
+            cpimport_proc = Popen(
+                cpimport_command_line, shell=False, stdin=download_proc.stdout,
+                stdout=PIPE, stderr=PIPE, encoding='utf-8'
+            )
 
-        selector.register(
-            download_proc.stderr, selectors.EVENT_READ, data='downloader_error'
-        )
-        selector.register(
-            cpimport_proc.stderr, selectors.EVENT_READ, data='cpimport_error'
-        )
-        selector.register(
-            cpimport_proc.stdout, selectors.EVENT_READ, data='cpimport_output'
-        )
+            selector = selectors.DefaultSelector()
+            for stream in [download_proc.stderr, cpimport_proc.stderr, cpimport_proc.stdout]:
+                os.set_blocking(stream.fileno(), False)
 
-        downloader_error = ''
-        cpimport_error = ''
-        cpimport_output = ''
+            selector.register(download_proc.stderr, selectors.EVENT_READ, data='downloader_error')
+            selector.register(cpimport_proc.stderr, selectors.EVENT_READ, data='cpimport_error')
+            selector.register(cpimport_proc.stdout, selectors.EVENT_READ, data='cpimport_output')
 
-        while True:
-            events = selector.select()
-            for key, mask in events:
-                name = key.data
-                line = key.fileobj.readline().rstrip()
-                if name == 'downloader_error' and line:
-                    downloader_error += line + '\n'
-                if name == 'cpimport_error' and line:
-                    cpimport_error += line + '\n'
-                if name == 'cpimport_output' and line:
-                    cpimport_output += line + '\n'
+            downloader_error = ''
+            cpimport_error = ''
+            cpimport_output = ''
 
-            if downloader_error:
-                response_error(downloader_error)
+            while True:
+                events = selector.select()
+                for key, mask in events:
+                    name = key.data
+                    line = key.fileobj.readline().rstrip()
+                    if name == 'downloader_error' and line:
+                        downloader_error += line + '\n'
+                    if name == 'cpimport_error' and line:
+                        cpimport_error += line + '\n'
+                    if name == 'cpimport_output' and line:
+                        cpimport_output += line + '\n'
 
-            if cpimport_error:
-                response_error(cpimport_error)
+                if downloader_error:
+                    response_error(downloader_error)
 
-            cpimport_status = cpimport_proc.poll()
-            download_status = download_proc.poll()
+                if cpimport_error:
+                    response_error(cpimport_error)
 
-            if cpimport_status is not None \
-              and download_status is not None:
-                break
+                cpimport_status = cpimport_proc.poll()
+                download_status = download_proc.poll()
 
+                if cpimport_status is not None \
+                  and download_status is not None:
+                    break
 
         # clean after Prepare Google
-        if storage == 'gs' and os.path.exists(temporary_config):
+        if temporary_config and os.path.exists(temporary_config):
             os.remove(temporary_config)
+
+        # clean temp data file on all nodes for mode 2
+        if temporary_load_file:
+            if mode_val == 2:
+                for node in active_nodes:
+                    try:
+                        client = NodeControllerClient(
+                            request_timeout=REQUEST_TIMEOUT,
+                            base_url=f'https://{node}:{CMAPI_PORT}'
+                        )
+                        client.delete_load_file(temporary_load_file)
+                    except Exception as e:
+                        module_logger.warning(
+                            f'Failed to cleanup file on node {node}: {e}'
+                        )
+            elif os.path.exists(temporary_load_file):
+                os.remove(temporary_load_file)
 
         if downloader_error:
             response_error(downloader_error)

--- a/dbcon/mysql/columnstore_dataload.cpp
+++ b/dbcon/mysql/columnstore_dataload.cpp
@@ -91,7 +91,8 @@ extern "C"
                                         std::string_view region, std::string_view cmapi_host,
                                         ulong cmapi_port, std::string_view cmapi_version,
                                         std::string_view cmapi_key, std::string_view terminated_by,
-                                        std::string_view enclosed_by, std::string_view escaped_by)
+                                        std::string_view enclosed_by, std::string_view escaped_by,
+                                        long long mode)
 
   {
     CURLcode res;
@@ -109,7 +110,7 @@ extern "C"
     j["terminated_by"] = terminated_by;
     j["enclosed_by"] = enclosed_by;
     j["escaped_by"] = escaped_by;
-
+    j["mode"] = mode;
 
     std::string param = j.dump();
 
@@ -168,7 +169,15 @@ extern "C"
     const char* terminated_by = args->args[4];
     const char* enclosed_by = args->args[5];
     const char* escaped_by = args->args[6];
+    long long mode = (args->arg_count > 7 && args->args[7]) ? *((long long*)args->args[7]) : 1;
 
+    if (mode != 1 && mode != 2 && mode != 3)
+    {
+      std::string msg("Invalid mode: must be 1, 2, or 3");
+      memcpy(result, msg.c_str(), msg.length());
+      *length = msg.length();
+      return result;
+    }
 
     ulong cmapi_port = get_cmapi_port(_current_thd());
     const char* cmapi_host = get_cmapi_host(_current_thd());
@@ -184,14 +193,14 @@ extern "C"
     return columnstore_dataload_impl(initData->curl, initData->result, length, bucket, table, filename,
                                      database, secret, key, region, cmapi_host, cmapi_port, cmapi_version,
                                      ::strlen(cmapi_key) == 0 ? parseCMAPIkey().c_str() : cmapi_key,
-                                     terminated_by, enclosed_by, escaped_by);
+                                     terminated_by, enclosed_by, escaped_by, mode);
   }
 
   my_bool columnstore_dataload_init(UDF_INIT* initid, UDF_ARGS* args, char* message)
   {
-    if (args->arg_count != 7)
+    if (args->arg_count < 7 || args->arg_count > 8)
     {
-      strcpy(message, "columnstore_dataload needs 7 arguments: (bucket, file_name, db_name, table, terminated_by, enclosed_by, escaped_by)");
+      strcpy(message, "columnstore_dataload needs 7 or 8 arguments: (bucket, file_name, db_name, table, terminated_by, enclosed_by, escaped_by [, mode])");
       return 1;
     }
 

--- a/dbcon/mysql/columnstore_info.sql
+++ b/dbcon/mysql/columnstore_info.sql
@@ -120,6 +120,9 @@ create or replace procedure columnstore_upgrade() SQL SECURITY INVOKER
     END LOOP;
 END //
 
+-- DEPRECATED: load_from_s3 is discontinued. Use load_from_s3_ex with explicit
+-- mode parameter instead. This procedure is kept for backward compatibility
+-- and always uses mode 1.
 CREATE OR REPLACE PROCEDURE load_from_s3 (in bucket varchar(256) CHARACTER SET utf8,
                                           in filename varchar(256) CHARACTER SET utf8,
                                           in dbname varchar(256) CHARACTER SET utf8,
@@ -133,7 +136,29 @@ NOT DETERMINISTIC
 MODIFIES SQL DATA
 SQL SECURITY INVOKER
 BEGIN
+    SIGNAL SQLSTATE '01000' SET MESSAGE_TEXT = 'load_from_s3 is deprecated and uses mode 1 only. Use load_from_s3_ex with explicit mode parameter.';
     select columnstore_dataload(bucket, filename, dbname, table_name, terminated_by, enclosed_by, escaped_by);
+END //
+
+
+CREATE OR REPLACE PROCEDURE load_from_s3_ex (in bucket varchar(256) CHARACTER SET utf8,
+                                             in filename varchar(256) CHARACTER SET utf8,
+                                             in dbname varchar(256) CHARACTER SET utf8,
+                                             in table_name varchar(256) CHARACTER SET utf8,
+                                             in terminated_by varchar(256) CHARACTER SET utf8,
+                                             in enclosed_by varchar(1) CHARACTER SET utf8,
+                                             in escaped_by varchar(1) CHARACTER SET utf8,
+                                             in mode int
+                                             )
+LANGUAGE SQL
+NOT DETERMINISTIC
+MODIFIES SQL DATA
+SQL SECURITY INVOKER
+BEGIN
+    IF mode IS NULL OR mode NOT IN (1, 2, 3) THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Invalid mode: must be 1, 2, or 3';
+    END IF;
+    select columnstore_dataload(bucket, filename, dbname, table_name, terminated_by, enclosed_by, escaped_by, mode);
 END //
 
 


### PR DESCRIPTION
- fix cmapi s3 data load
- fix engine load_from_s3 implementation
- mode number validation added at all three layers(columnstore_info.sql, columnstore_dataload.cpp, s3dataload.py). Each rejects invalid modes (anything other than 0, 2, 3) with a clear error