### PR TITLE
MCOL-6337: Fix Window function with TEXT/BLOB column in PARTITION BY fails with MCS-9019 "Unknown column type"

### DIFF
--- a/mysql-test/columnstore/bugfixes/mcol_6337.result
+++ b/mysql-test/columnstore/bugfixes/mcol_6337.result
@@ -1,0 +1,52 @@
+DROP DATABASE IF EXISTS mcol_6337;
+CREATE DATABASE mcol_6337;
+USE mcol_6337;
+DROP TABLE IF EXISTS t_text;
+DROP TABLE IF EXISTS t_blob;
+CREATE TABLE t_text (id INT, txt TEXT) ENGINE=Columnstore;
+INSERT INTO t_text VALUES (1,'aaa'),(2,'bbb'),(3,'aaa'),(4,'ccc'),(5,'bbb');
+CREATE TABLE t_blob (id INT, blb BLOB) ENGINE=Columnstore;
+INSERT INTO t_blob VALUES (1,'aaa'),(2,'bbb'),(3,'aaa'),(4,'ccc'),(5,'bbb');
+SELECT id, txt, RANK() OVER (PARTITION BY txt ORDER BY id) FROM t_text;
+id	txt	RANK() OVER (PARTITION BY txt ORDER BY id)
+1	aaa	1
+3	aaa	2
+2	bbb	1
+5	bbb	2
+4	ccc	1
+SELECT id, txt, ROW_NUMBER() OVER (PARTITION BY txt ORDER BY id) FROM t_text;
+id	txt	ROW_NUMBER() OVER (PARTITION BY txt ORDER BY id)
+1	aaa	1
+3	aaa	2
+2	bbb	1
+5	bbb	2
+4	ccc	1
+SELECT id, txt, DENSE_RANK() OVER (PARTITION BY txt ORDER BY id) FROM t_text;
+id	txt	DENSE_RANK() OVER (PARTITION BY txt ORDER BY id)
+1	aaa	1
+3	aaa	2
+2	bbb	1
+5	bbb	2
+4	ccc	1
+SELECT id, txt, COUNT(*) OVER (PARTITION BY txt ORDER BY id) FROM t_text;
+id	txt	COUNT(*) OVER (PARTITION BY txt ORDER BY id)
+1	aaa	1
+3	aaa	2
+2	bbb	1
+5	bbb	2
+4	ccc	1
+SELECT id, blb, RANK() OVER (PARTITION BY blb ORDER BY id) FROM t_blob;
+id	blb	RANK() OVER (PARTITION BY blb ORDER BY id)
+1	aaa	1
+2	bbb	1
+3	aaa	1
+4	ccc	1
+5	bbb	1
+SELECT id, blb, ROW_NUMBER() OVER (PARTITION BY blb ORDER BY id) FROM t_blob;
+id	blb	ROW_NUMBER() OVER (PARTITION BY blb ORDER BY id)
+1	aaa	1
+2	bbb	1
+3	aaa	1
+4	ccc	1
+5	bbb	1
+DROP DATABASE mcol_6337;

--- a/mysql-test/columnstore/bugfixes/mcol_6337.result
+++ b/mysql-test/columnstore/bugfixes/mcol_6337.result
@@ -38,15 +38,29 @@ id	txt	COUNT(*) OVER (PARTITION BY txt ORDER BY id)
 SELECT id, blb, RANK() OVER (PARTITION BY blb ORDER BY id) FROM t_blob;
 id	blb	RANK() OVER (PARTITION BY blb ORDER BY id)
 1	aaa	1
+3	aaa	2
 2	bbb	1
-3	aaa	1
+5	bbb	2
 4	ccc	1
-5	bbb	1
 SELECT id, blb, ROW_NUMBER() OVER (PARTITION BY blb ORDER BY id) FROM t_blob;
 id	blb	ROW_NUMBER() OVER (PARTITION BY blb ORDER BY id)
 1	aaa	1
+3	aaa	2
 2	bbb	1
-3	aaa	1
+5	bbb	2
 4	ccc	1
-5	bbb	1
+SELECT id, blb, DENSE_RANK() OVER (PARTITION BY blb ORDER BY id) FROM t_blob;
+id	blb	DENSE_RANK() OVER (PARTITION BY blb ORDER BY id)
+1	aaa	1
+3	aaa	2
+2	bbb	1
+5	bbb	2
+4	ccc	1
+SELECT id, blb, COUNT(*) OVER (PARTITION BY blb ORDER BY id) FROM t_blob;
+id	blb	COUNT(*) OVER (PARTITION BY blb ORDER BY id)
+1	aaa	1
+3	aaa	2
+2	bbb	1
+5	bbb	2
+4	ccc	1
 DROP DATABASE mcol_6337;

--- a/mysql-test/columnstore/bugfixes/mcol_6337.test
+++ b/mysql-test/columnstore/bugfixes/mcol_6337.test
@@ -1,0 +1,26 @@
+--source ../include/have_columnstore.inc  
+--disable_warnings  
+DROP DATABASE IF EXISTS mcol_6337;
+--enable_warnings  
+  
+CREATE DATABASE mcol_6337;
+USE mcol_6337;
+
+--disable_warnings
+DROP TABLE IF EXISTS t_text;
+DROP TABLE IF EXISTS t_blob;
+--enable_warnings
+CREATE TABLE t_text (id INT, txt TEXT) ENGINE=Columnstore;
+INSERT INTO t_text VALUES (1,'aaa'),(2,'bbb'),(3,'aaa'),(4,'ccc'),(5,'bbb');
+CREATE TABLE t_blob (id INT, blb BLOB) ENGINE=Columnstore;
+INSERT INTO t_blob VALUES (1,'aaa'),(2,'bbb'),(3,'aaa'),(4,'ccc'),(5,'bbb');
+SELECT id, txt, RANK() OVER (PARTITION BY txt ORDER BY id) FROM t_text;
+SELECT id, txt, ROW_NUMBER() OVER (PARTITION BY txt ORDER BY id) FROM t_text; 
+SELECT id, txt, DENSE_RANK() OVER (PARTITION BY txt ORDER BY id) FROM t_text;
+SELECT id, txt, COUNT(*) OVER (PARTITION BY txt ORDER BY id) FROM t_text;
+SELECT id, blb, RANK() OVER (PARTITION BY blb ORDER BY id) FROM t_blob;
+SELECT id, blb, ROW_NUMBER() OVER (PARTITION BY blb ORDER BY id) FROM t_blob;
+
+--disable_warnings
+DROP DATABASE mcol_6337;
+--enable_warnings

--- a/mysql-test/columnstore/bugfixes/mcol_6337.test
+++ b/mysql-test/columnstore/bugfixes/mcol_6337.test
@@ -20,6 +20,8 @@ SELECT id, txt, DENSE_RANK() OVER (PARTITION BY txt ORDER BY id) FROM t_text;
 SELECT id, txt, COUNT(*) OVER (PARTITION BY txt ORDER BY id) FROM t_text;
 SELECT id, blb, RANK() OVER (PARTITION BY blb ORDER BY id) FROM t_blob;
 SELECT id, blb, ROW_NUMBER() OVER (PARTITION BY blb ORDER BY id) FROM t_blob;
+SELECT id, blb, DENSE_RANK() OVER (PARTITION BY blb ORDER BY id) FROM t_blob;
+SELECT id, blb, COUNT(*) OVER (PARTITION BY blb ORDER BY id) FROM t_blob;
 
 --disable_warnings
 DROP DATABASE mcol_6337;

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -632,7 +632,9 @@ void CompareRule::compileRules(const std::vector<IdbSortSpec>& spec, const rowgr
 
       case CalpontSystemCatalog::CHAR:
       case CalpontSystemCatalog::VARCHAR:
+      case CalpontSystemCatalog::VARBINARY:
       case CalpontSystemCatalog::TEXT:
+      case CalpontSystemCatalog::BLOB:
       {
         Compare* c = new StringCompare(spec_el);
         fCompares.push_back(c);

--- a/utils/windowfunction/idborderby.cpp
+++ b/utils/windowfunction/idborderby.cpp
@@ -845,6 +845,9 @@ bool EqualCompData::operator()(Row::Pointer a, Row::Pointer b)
 
       case CalpontSystemCatalog::CHAR:
       case CalpontSystemCatalog::VARCHAR:
+      case CalpontSystemCatalog::VARBINARY:
+      case CalpontSystemCatalog::TEXT:
+      case CalpontSystemCatalog::BLOB:
       {
         eq = (fRow1.getStringField(*i) == fRow2.getStringField(*i));
         break;


### PR DESCRIPTION
Fixes: [MCOL-6337](https://jira.mariadb.org/browse/MCOL-6337)

Added the missing cases into switch statement.