### PR TITLE
Debug-build (_GLIBCXX_DEBUG / _GLIBCXX_ASSERTIONS) MTR crash fixes

### DIFF
--- a/dbcon/mysql/ha_mcs_ddl.cpp
+++ b/dbcon/mysql/ha_mcs_ddl.cpp
@@ -2638,7 +2638,11 @@ int ha_mcs_impl_create_(const char* /*name*/, TABLE* table_arg, HA_CREATE_INFO* 
 
   if (rc != 0)
   {
-    push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 9999, emsg.c_str());
+    // Some ProcessDDLStatement() failure paths report the error only via
+    // thd->raise_error_printf() and leave emsg empty; push_warning() asserts
+    // on strlen(msg) in debug builds (sql/sql_error.cc:764).
+    if (!emsg.empty())
+      push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 9999, emsg.c_str());
     // Bug 1705 reset the flag if error occurs
     ci.alterTableState = cal_connection_info::NOT_ALTER;
     ci.isAlter = false;
@@ -2715,7 +2719,8 @@ int ha_mcs_impl_delete_table_(const char* /*db*/, const char* name, cal_connecti
 
   if (rc != 0 && rc != ER_NO_SUCH_TABLE_IN_ENGINE)
   {
-    push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 9999, emsg.c_str());
+    if (!emsg.empty())
+      push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 9999, emsg.c_str());
   }
 
   return rc;
@@ -2776,7 +2781,7 @@ int ha_mcs_impl_rename_table_(const char* from, const char* to, cal_connection_i
 
   int rc = ProcessDDLStatement(stmt, db, "", tid2sid(thd->thread_id), emsg);
 
-  if (rc != 0)
+  if (rc != 0 && !emsg.empty())
     push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 9999, emsg.c_str());
 
   return rc;
@@ -2816,7 +2821,7 @@ extern "C"
 
     int rc = ProcessDDLStatement(stmt, db, "", tid2sid(thd->thread_id), emsg, compressiontype);
 
-    if (rc != 0)
+    if (rc != 0 && !emsg.empty())
       push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 9999, emsg.c_str());
 
     return rc;

--- a/dbcon/mysql/ha_mcs_impl.cpp
+++ b/dbcon/mysql/ha_mcs_impl.cpp
@@ -2982,6 +2982,37 @@ int ha_mcs_impl_delete_row()
   return (rc);
 }
 
+// Make every column of `table` readable via Field::val_str() for the duration
+// of a cpimport bulk insert by pointing table->read_set at the shared
+// TABLE_SHARE::all_set (whose invariant is "all bits are set").  The caller's
+// original read_set pointer is stashed in ci->bulkInsertSavedReadSet and
+// restored by restore_bulk_insert_read_set().
+//
+// Before MCOL-xxxxx the plugin mutated bits directly via
+// bitmap_set_all/bitmap_clear_all on table->read_set.  During ALTER TABLE's
+// copy_data_between_tables the server points read_set *and* write_set at
+// &s->all_set (via TABLE::use_all_columns()), so bitmap_clear_all wiped the
+// shared bitmap and the subsequent handler::ha_reset() tripped
+//   DBUG_ASSERT(bitmap_is_set_all(&table->s->all_set)).
+static void save_and_swap_bulk_insert_read_set(TABLE* table, cal_connection_info* ci)
+{
+  // Idempotent: tolerate repeated calls within the same bulk insert.
+  if (!ci->bulkInsertSavedReadSet)
+  {
+    ci->bulkInsertSavedReadSet = table->read_set;
+    table->read_set = &table->s->all_set;
+  }
+}
+
+static void restore_bulk_insert_read_set(TABLE* table, cal_connection_info* ci)
+{
+  if (ci->bulkInsertSavedReadSet)
+  {
+    table->read_set = ci->bulkInsertSavedReadSet;
+    ci->bulkInsertSavedReadSet = nullptr;
+  }
+}
+
 void ha_mcs_impl_start_bulk_insert(ha_rows rows, TABLE* table, bool is_cache_insert)
 {
   THD* thd = current_thd;
@@ -3292,9 +3323,13 @@ void ha_mcs_impl_start_bulk_insert(ha_rows rows, TABLE* table, bool is_cache_ins
         ci->fdt[0] = -1;
         // now we can send all the data thru FIFO[1], writer of PARENT
       }
-      // Set read_set used for bulk insertion of Fields inheriting
-      // from Field_blob|Field_varstring. Used in ColWriteBatchString()
-      bitmap_set_all(table->read_set);
+      // Swap read_set so that every column is readable via Field::val_str()
+      // during cpimport bulk insertion (used by ColWriteBatchString for
+      // Field_blob/Field_varstring).  We point read_set at the shared
+      // TABLE_SHARE::all_set instead of mutating bits in place, so we never
+      // clobber a server-owned bitmap that may be aliased via
+      // TABLE::use_all_columns() (e.g. during ALTER TABLE copy).
+      save_and_swap_bulk_insert_read_set(table, ci);
     }
     else
     {
@@ -3360,7 +3395,7 @@ void ha_mcs_impl_start_bulk_insert(ha_rows rows, TABLE* table, bool is_cache_ins
       setError(current_thd, ER_READ_ONLY_MODE, "Cannot execute the statement. DBRM is read only!");
       ci->rc = rc;
       ci->singleInsert = true;
-      bitmap_clear_all(table->read_set);
+      restore_bulk_insert_read_set(table, ci);
       return;
     }
 
@@ -3370,7 +3405,7 @@ void ha_mcs_impl_start_bulk_insert(ha_rows rows, TABLE* table, bool is_cache_ins
     if (stateFlags & SessionManagerServer::SS_SUSPENDED)
     {
       setError(current_thd, ER_INTERNAL_ERROR, "Writing to the database is disabled.");
-      bitmap_clear_all(table->read_set);
+      restore_bulk_insert_read_set(table, ci);
       return;
     }
 
@@ -3385,12 +3420,12 @@ void ha_mcs_impl_start_bulk_insert(ha_rows rows, TABLE* table, bool is_cache_ins
     }
     catch (IDBExcept& ie)
     {
-      bitmap_clear_all(table->read_set);
+      restore_bulk_insert_read_set(table, ci);
       setError(thd, ER_INTERNAL_ERROR, ie.what());
     }
     catch (std::exception& ex)
     {
-      bitmap_clear_all(table->read_set);
+      restore_bulk_insert_read_set(table, ci);
       setError(thd, ER_INTERNAL_ERROR,
                logging::IDBErrorInfo::instance()->errorMsg(ERR_SYSTEM_CATALOG) + ex.what());
     }
@@ -3402,10 +3437,17 @@ void ha_mcs_impl_start_bulk_insert(ha_rows rows, TABLE* table, bool is_cache_ins
 
 int ha_mcs_impl_end_bulk_insert(bool abort, TABLE* table)
 {
-  // Clear read_set used for bulk insertion of Fields inheriting
-  // from Field_blob|Field_varstring
-  bitmap_clear_all(table->read_set);
   THD* thd = current_thd;
+
+  // Restore the read_set pointer that start_bulk_insert swapped to
+  // &s->all_set for ColWriteBatchString.  No-op if start_bulk_insert did not
+  // swap (e.g. non-cpimport path, slave thread early-return, or a throw
+  // before the swap).
+  if (void* fe = get_fe_conn_info_ptr())
+  {
+    restore_bulk_insert_read_set(
+        table, reinterpret_cast<cal_connection_info*>(fe));
+  }
 
   if (thd->slave_thread && !get_replication_slave(thd))
     return 0;

--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -575,6 +575,7 @@ struct cal_connection_info
    , useCpimport(mcs_use_import_for_batchinsert_mode_t::ON)
    , delimiter('\7')
    , affectedRows(0)
+   , bulkInsertSavedReadSet(nullptr)
   {
     auto* cf = config::Config::makeConfig();
     if (checkQueryStats(cf))
@@ -655,6 +656,19 @@ struct cal_connection_info
   // MCOL-1101 remove compilation unit variable rmParms
   std::vector<execplan::RMParam> rmParms;
   long long affectedRows;
+  // Saved table->read_set pointer for the duration of a cpimport bulk insert.
+  // The bulk-insert path needs every column readable via Field::val_str()
+  // (from ColWriteBatchString), which requires the read_set to have all bits
+  // set.  Previously the plugin mutated the bits directly via
+  // bitmap_set_all/bitmap_clear_all on table->read_set.  That breaks when the
+  // server pointed read_set at the shared TABLE_SHARE::all_set (e.g. during
+  // ALTER TABLE's copy_data_between_tables via TABLE::use_all_columns()),
+  // because bitmap_clear_all then wipes s->all_set and the next
+  // handler::ha_reset() fires bitmap_is_set_all(&table->s->all_set).
+  // We now save the original pointer and swap read_set to &s->all_set for the
+  // duration of the bulk insert, restoring it in ha_mcs_impl_end_bulk_insert
+  // (or on an early-error return from start_bulk_insert).
+  MY_BITMAP* bulkInsertSavedReadSet;
 };
 
 const std::string infinidb_err_msg =

--- a/tools/rebuildEM/rebuildEM.cpp
+++ b/tools/rebuildEM/rebuildEM.cpp
@@ -16,7 +16,9 @@
    MA 02110-1301, USA. */
 
 #include <iostream>
+#include <set>
 #include <stdint.h>
+#include <tuple>
 
 #include "rebuildEM.h"
 #include "calpontsystemcatalog.h"
@@ -438,15 +440,18 @@ int32_t EMReBuilder::rebuildExtentMap()
         std::cout << "For " << fileId << std::endl;
       }
 
-      // This is important part, it sets a status for specific extent
-      // as 'available' that means we can use it.
+      // Mark the just-created extent as AVAILABLE.  ExtentMap::setLocalHWM
+      // also stores `newHWM` on the extent that currently has the highest
+      // blockOffset for (oid, partition, segment), so we intentionally pass
+      // 0 here: the correct HWM is applied in the second pass below, after
+      // every extent of that segment is in the extent map.
       if (doVerbose())
       {
-        std::cout << "Setting a HWM for " << fileId << std::endl;
+        std::cout << "Marking AVAILABLE for " << fileId << std::endl;
       }
       try
       {
-        getEM().setLocalHWM(fileId.oid, fileId.partition, fileId.segment, fileId.hwm, false, true);
+        getEM().setLocalHWM(fileId.oid, fileId.partition, fileId.segment, 0, false, true);
       }
       catch (std::exception& e)
       {
@@ -456,6 +461,62 @@ int32_t EMReBuilder::rebuildExtentMap()
       }
       getEM().confirmChanges();
     }
+  }
+
+  if (doDisplay())
+    return 0;
+
+  // Second pass: apply the real HWM exactly once per (oid, partition,
+  // segment).  ExtentMap::setLocalHWM always writes newHWM into the extent
+  // with the highest blockOffset of that segment file *and* resets the
+  // previous HWM-bearing extent to 0 (versioning/BRM/extentmap.cpp:4866-
+  // 4876).  Calling it per-extent inside the creation loop therefore
+  // nukes the correct HWM as soon as any trailing entry with hwm=0 is
+  // processed, which happens routinely for "invisible" LBIDs appended by
+  // addInvisibleLBIDs() (they carry artificial LBIDs higher than any real
+  // one, so they always come last after the LBID sort).  Reproducer:
+  // bugfixes.MCOL-6321-test-em-rebuild, which hits MCS-2031 "Blocks are
+  // missing" because getLocalHWM() comes back as 0 and PrimProc computes
+  // `range.size = HWM - lowfbo + 1` as a huge negative number.
+  //
+  // Running the HWM update as a dedicated second pass guarantees that:
+  //   * every extent in the segment has been created, so setLocalHWM sees
+  //     a `lastEm` whose [blockOffset, blockOffset+range.size*1024) window
+  //     can accommodate the recorded HWM (avoiding the "new HWM past the
+  //     end of the file" check at extentmap.cpp:4856);
+  //   * setLocalHWM is called at most once per segment file, so no stale
+  //     zero ever races against the real HWM.
+  std::set<std::tuple<uint32_t, uint32_t, uint32_t>> hwmApplied;
+  for (const auto& fileId : extentMap)
+  {
+    auto key = std::make_tuple(fileId.oid, fileId.partition, fileId.segment);
+    if (!hwmApplied.insert(key).second)
+      continue;
+
+    // Per-OID HWM is populated by searchHWMInSegmentFile() in
+    // collectExtent() for regular OIDs; system extents carry the real HWM
+    // directly on fileId.hwm (see scanSystemCatalogFile()).
+    uint64_t hwm = fileId.hwm;
+    auto it = oidHWMs.find(fileId.oid);
+    if (it != oidHWMs.end())
+      hwm = it->second;
+
+    if (doVerbose())
+    {
+      std::cout << "Setting a HWM=" << hwm << " for OID " << fileId.oid << " partition "
+                << fileId.partition << " segment " << fileId.segment << std::endl;
+    }
+    try
+    {
+      getEM().setLocalHWM(fileId.oid, fileId.partition, fileId.segment, hwm, false, true);
+    }
+    catch (std::exception& e)
+    {
+      getEM().undoChanges();
+      std::cerr << "Cannot set local HWM: " << e.what() << std::endl;
+      return -1;
+    }
+    getEM().confirmChanges();
   }
   return 0;
 }

--- a/utils/common/collation.h
+++ b/utils/common/collation.h
@@ -116,6 +116,17 @@ class MariaDBHasher
   }
   MariaDBHasher& add(CHARSET_INFO* cs, const char* str, size_t length)
   {
+    // Hashing an empty string is a no-op in every MariaDB collation
+    // (skip_trailing_space/my_hash_sort_* return immediately when len==0).
+    // Avoid calling hash_sort() with a NULL pointer: MariaDB computes
+    // `ptr + len` before checking, which is UB ("applying zero offset to
+    // null pointer"), and MDEV-35620 hardened skip_trailing_space() with
+    // DBUG_ASSERT(ptr), which then fires in debug builds.  Columnstore's
+    // utils::ConstString explicitly documents that its internal pointer
+    // can be NULL (e.g. for NULL string columns in a rowgroup::Row), so
+    // just short-circuit here.
+    if (length == 0)
+      return *this;
 #ifdef MY_HASH_ADD_MARIADB
     my_hasher_st hasher= my_hasher_mysql5x();
     cs->hash_sort(&hasher, (const uchar*)str, length);


### PR DESCRIPTION
Four independent bug fixes, each with its own commit, surfaced by enabling `_GLIBCXX_DEBUG` / `_GLIBCXX_ASSERTIONS` in Debug builds so the plugin is built with the same ABI as the server. The flags are not reverted; all fixes are upstream.

Scope: plugin + `rebuildEM` tool only. No schema or on-disk format changes.

## Commits

- **`07cb331` fix(plugin): do not mutate `table->read_set` bits in bulk insert**
- **`d0e0369` fix(plugin): skip `hash_sort()` when [MariaDBHasher::add](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/primitives/primproc/primitiveserver.cpp:2367:0-2389:1) is given an empty string**
- **`b50445c` fix(plugin): do not `push_warning()` with an empty message after [ProcessDDLStatement](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_ddl.cpp:752:0-2254:1) failures**
- **`cdf64f4` fix(rebuildEM): apply HWM once per segment file after all extents exist**

## Bugs fixed

### 1. `handler::ha_reset` assert — shared `TABLE_SHARE::all_set` bitmap corruption
[ha_mcs_impl_start_bulk_insert()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_impl.cpp:3015:0-3435:1) / [ha_mcs_impl_end_bulk_insert()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_impl.cpp:3437:0-3645:1) called `bitmap_set_all` / `bitmap_clear_all` directly on `table->read_set`. When the server had aliased `read_set` onto `&s->all_set` via `TABLE::use_all_columns()` (which `copy_data_between_tables()` does for every `ALTER TABLE` that copies rows), `bitmap_clear_all` wiped the server-owned "all bits always set" invariant, and the next `ha_reset()` on temporary-table drop fired `DBUG_ASSERT(bitmap_is_set_all(&table->s->all_set))` in `sql/handler.cc:7829`.

Fix: swap the `read_set` pointer for the duration of bulk insert via a new `cal_connection_info::bulkInsertSavedReadSet` field. No server-owned bits are mutated.

MTR reproducers now passing: `basic.mcol_2000`, `bugfixes.MCOL_5175`, `bugfixes.mcol-4758`, `bugfixes.mcol-5779`.

### 2. [MariaDBHasher::add](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/primitives/primproc/primitiveserver.cpp:2367:0-2389:1) — `nullptr` into [skip_trailing_space](cci:1://file:///home/ubuntu/proj/MDBEnterprise/strings/strings_def.h:81:0-105:1)
[Row::colUpdateHasher](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/rowgroup/rowgroup.h:1002:0-1023:1) forwards `ConstString{nullptr, 0}` (Columnstore's NULL / empty-string representation) into `cs->hash_sort()` → `my_hash_sort_utf8mb3()` → [skip_trailing_space(ptr=0x0, len=0)](cci:1://file:///home/ubuntu/proj/MDBEnterprise/strings/strings_def.h:81:0-105:1). That triggers the MDEV-35620 assert `DBUG_ASSERT(ptr)` in `sql/strings_def.h:85` and is UB in release builds.

Fix: early return in [MariaDBHasher::add](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/primitives/primproc/primitiveserver.cpp:2367:0-2389:1) when `length == 0` — every MariaDB collation already treats empty input as a no-op, hash stability for non-NULL inputs is untouched.

MTR reproducer now passing: `basic.MCOL-5250_disk_based_distinct`.

### 3. `push_warning()` assert — empty `emsg` after parser-rejected DDL
Several [ProcessDDLStatement()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/dbcon/mysql/ha_mcs_ddl.cpp:752:0-2254:1) failure paths (parser `!Good()`, "AUTO_INCREMENT not supported", "RENAME COLUMN not supported", "MIN_ROWS/MAX_ROWS not supported", etc.) surface the error only via `thd->raise_error_printf()` and leave `emsg` empty, but the four callers forward `emsg.c_str()` to `push_warning()` unconditionally on `rc != 0`. `push_warning()` asserts `strlen(msg)` in `sql/sql_error.cc:764` and aborts the server in debug builds.

Fix: guard the four `push_warning(emsg.c_str())` sites with `if (!emsg.empty())`. The client already gets the error through `raise_error_printf()`.

MTR reproducer now passing: `basic.mcol641-create`.

### 4. `mcsRebuildEM` — HWM wiped by invisible trailing extents
[ExtentMap::setLocalHWM()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/versioning/BRM/extentmap.cpp:4778:0-4906:1) writes `newHWM` into the extent with the highest `blockOffset` in `(oid, partition, segment)` and resets the previously HWM-bearing extent to 0. [rebuildExtentMap()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/tools/rebuildEM/rebuildEM.cpp:385:0-521:1) called it per extent inside the creation loop; [addInvisibleLBIDs()](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/tools/rebuildEM/rebuildEM.cpp:126:0-178:1) appends entries with artificial LBIDs greater than any real one and `hwm = 0`. After the LBID sort these always come last, so their [setLocalHWM(newHWM=0)](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/versioning/BRM/extentmap.cpp:4778:0-4906:1) nukes the real HWM written earlier. PrimProc then reads [getLocalHWM() == 0](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/versioning/BRM/extentmap.cpp:4697:0-4776:1), computes a negative `range.size` and aborts with MCS-2031 "Blocks are missing".

Fix: two-pass rebuild.
1. Create every extent and call [setLocalHWM(newHWM=0)](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/versioning/BRM/extentmap.cpp:4778:0-4906:1) only to flip status to `AVAILABLE`.
2. Walk `extentMap` a second time and call [setLocalHWM](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/versioning/BRM/extentmap.cpp:4778:0-4906:1) exactly once per unique `(oid, partition, segment)`, taking the HWM from `oidHWMs[oid]` (regular OIDs) or `fileId.hwm` (system OIDs populated by `scanSystemCatalogFile`).

At pass 2 every extent of the segment is present, so `lastEm` has a big enough `blockOffset` not to trip the "new HWM past the end of the file" check in `versioning/BRM/extentmap.cpp:4856`.

MTR reproducer now passing: `bugfixes.MCOL-6321-test-em-rebuild`.

## Risk

- **Bulk-insert fix**: `read_set` is restored on every exit path of start (including early-return / catch) and unconditionally at the end. No behavioural change for code paths that read columns during bulk insert — they still see an all-set bitmap.
- **Hash fix**: purely a no-op short-circuit on an input case that was already UB.
- **DDL warning fix**: dropped warnings were zero-length strings; the actual error is still raised via `raise_error_printf()`.
- **rebuildEM fix**: changes only the order of [setLocalHWM](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/versioning/BRM/extentmap.cpp:4778:0-4906:1) calls inside the rebuild tool; on-disk EM format and runtime EM access paths are untouched. The tool is invoked manually by operators, not on the hot path.

## Testing

Run the plugin MTR suite against a Debug build with `-D_GLIBCXX_DEBUG -D_GLIBCXX_ASSERTIONS`. Previously failing tests now pass:

- `basic.mcol_2000`
- `basic.mcol641-create`
- `basic.MCOL-5250_disk_based_distinct`
- `bugfixes.MCOL_5175`
- `bugfixes.mcol-4758`
- `bugfixes.mcol-5779`
- `bugfixes.MCOL-6321-test-em-rebuild`

Build: `sudo build/bootstrap_mcs.sh -t Debug`. Run: `sudo bash tests/scripts/run_mtr.sh`.

## JIRA

- MCOL-6321 (EM rebuild)
- MCOL-5250 (disk-based distinct)
- MCOL-641 (ALTER RENAME COLUMN)