### PR TITLE
MCOL-4258: feat(sp)  Support stored functions in Columnstore SELECT projection (connector-side evaluation)

### DIFF
--- a/dbcon/mysql/ha_mcs_execplan.cpp
+++ b/dbcon/mysql/ha_mcs_execplan.cpp
@@ -6717,13 +6717,23 @@ int processSelect(SELECT_LEX& select_lex, gp_walk_info& gwi, SCSEP& csep, vector
       {
         Item_func* ifp = static_cast<Item_func*>(item);
 
-        // @bug4383. error out non-support stored function
+        // Stored functions are evaluated on the connector side after ExeMgr
+        // returns rows. Push a ConstantColumn placeholder so ExeMgr reserves a
+        // slot in the output row, and record the Item_func_sp* for post-processing.
         if (ifp->functype() == Item_func::FUNC_SP)
         {
-          gwi.fatalParseError = true;
-          gwi.parseErrorText = IDBErrorInfo::instance()->errorMsg(ERR_SP_FUNCTION_NOT_SUPPORT);
-          setError(gwi.thd, ER_CHECK_NOT_IMPLEMENTED, gwi.parseErrorText, gwi);
-          return ER_CHECK_NOT_IMPLEMENTED;
+          uint32_t outputIdx = gwi.returnedCols.size();
+          ConstantColumn* cc = new ConstantColumn((int64_t)0, ConstantColumn::NUM);
+          cc->timeZone(gwi.timeZone);
+          cc->resultType(colType_MysqlToIDB(ifp));
+          if (ifp->name.length)
+            cc->alias(ifp->name.str);
+          else if (!itemAlias.empty())
+            cc->alias(itemAlias);
+          SRCP srcp(cc);
+          gwi.returnedCols.push_back(srcp);
+          gwi.storedFuncCols.push_back(std::make_pair(static_cast<Item*>(ifp), outputIdx));
+          break;
         }
 
         if (string(ifp->func_name()) == "xor")
@@ -7716,6 +7726,24 @@ int cs_get_select_plan(ha_columnstore_select_handler* handler, THD* thd, SCSEP& 
     return ER_INTERNAL_ERROR;
   else if (status < 0)
     return status;
+
+  // Transfer stored function info to the handler for connector-side evaluation.
+  for (auto& sf : gwi.storedFuncCols)
+  {
+    StoredFuncColumnInfo info;
+    info.sp_item = static_cast<Item_func_sp*>(sf.first);
+    info.output_field_idx = sf.second;
+    handler->stored_func_cols.push_back(info);
+  }
+
+  // DISTINCT with stored function columns is unsupported: ExeMgr cannot
+  // correctly deduplicate because SP columns are ConstantColumn(0) placeholders.
+  if (!handler->stored_func_cols.empty() && csep->distinct())
+  {
+    setError(gwi.thd, ER_CHECK_NOT_IMPLEMENTED,
+             "DISTINCT with stored functions is not supported by Columnstore in ON mode.", gwi);
+    return ER_CHECK_NOT_IMPLEMENTED;
+  }
 
   if (csep->traceOn())
   {

--- a/dbcon/mysql/ha_mcs_impl_if.h
+++ b/dbcon/mysql/ha_mcs_impl_if.h
@@ -464,6 +464,10 @@ struct gp_walk_info
   // the chain using sorta kinda RAII.
   SubQuery** subQueriesChain;
 
+  // Stored function columns in the SELECT list: (Item_func_sp*, output_field_idx).
+  // These are evaluated on the connector side after ExeMgr returns rows.
+  std::vector<std::pair<Item*, uint32_t>> storedFuncCols;
+
   gp_walk_info(long timeZone_, SubQuery** subQueriesChain_)
    : tableStatistics({})
    , sessionid(0)

--- a/dbcon/mysql/ha_mcs_pushdown.cpp
+++ b/dbcon/mysql/ha_mcs_pushdown.cpp
@@ -1039,6 +1039,102 @@ int ha_columnstore_select_handler::next_row()
 
   int rc = ha_mcs_impl_select_next(table->record[0], table, time_zone);
 
+  if (rc == 0 && !stored_func_cols.empty() && select_lex)
+  {
+    // Copy source table field values from tmp table so that
+    // Item_func_sp arguments (Item_field pointing to source tables) read correctly.
+    uint32_t field_idx = 0;
+    List_iterator_fast<Item> it(select_lex->item_list);
+    Item* item;
+    while ((item = it++))
+    {
+      if (item->type() == Item::FIELD_ITEM)
+      {
+        Item_field* item_field = static_cast<Item_field*>(item);
+        Field* src_field = item_field->field;
+        Field* tmp_field = table->field[field_idx];
+        if (src_field && tmp_field && src_field->table)
+        {
+          // Enable writing to source table field (needed for debug builds)
+          MY_BITMAP* old_map = dbug_tmp_use_all_columns(src_field->table,
+                                                        &src_field->table->write_set);
+          if (tmp_field->is_null())
+            src_field->set_null();
+          else
+          {
+            src_field->set_notnull();
+            // Copy value via string representation (type-safe)
+            StringBuffer<256> buf;
+            tmp_field->val_str(&buf);
+            src_field->store(buf.ptr(), buf.length(), buf.charset());
+          }
+          dbug_tmp_restore_column_map(&src_field->table->write_set, old_map);
+        }
+      }
+      field_idx++;
+    }
+
+    // Evaluate each stored function and write results to the tmp table.
+    for (const auto& sf : stored_func_cols)
+    {
+      Field* out_field = table->field[sf.output_field_idx];
+      switch (sf.sp_item->result_type())
+      {
+        case INT_RESULT:
+        {
+          longlong val = sf.sp_item->val_int();
+          if (sf.sp_item->null_value)
+            out_field->set_null();
+          else
+          {
+            out_field->set_notnull();
+            out_field->store(val, sf.sp_item->unsigned_flag);
+          }
+          break;
+        }
+        case REAL_RESULT:
+        {
+          double val = sf.sp_item->val_real();
+          if (sf.sp_item->null_value)
+            out_field->set_null();
+          else
+          {
+            out_field->set_notnull();
+            out_field->store(val);
+          }
+          break;
+        }
+        case DECIMAL_RESULT:
+        {
+          my_decimal val;
+          my_decimal* res = sf.sp_item->val_decimal(&val);
+          if (sf.sp_item->null_value || !res)
+            out_field->set_null();
+          else
+          {
+            out_field->set_notnull();
+            out_field->store_decimal(res);
+          }
+          break;
+        }
+        case STRING_RESULT:
+        default:
+        {
+          String val;
+          String* res = sf.sp_item->val_str(&val);
+          if (sf.sp_item->null_value || !res)
+            out_field->set_null();
+          else
+          {
+            out_field->set_notnull();
+            out_field->store(res->ptr(), res->length(), res->charset());
+          }
+          break;
+        }
+      }
+    }
+  }
+
   DBUG_RETURN(rc);
 }
 

--- a/dbcon/mysql/ha_mcs_pushdown.h
+++ b/dbcon/mysql/ha_mcs_pushdown.h
@@ -26,6 +26,9 @@
 #include "ha_mcs_impl_if.h"
 #include "ha_mcs_opt_rewrites.h"
 
+#include <vector>
+#include <utility>
+
 void mutate_optimizer_flags(THD* thd_);
 void restore_optimizer_flags(THD* thd_);
 
@@ -135,6 +138,14 @@ class ha_columnstore_derived_handler : public derived_handler
  * next_row - get a row back from sm.
  * end_scan - finish and clean the things up.
  ***********************************************************/
+// Info about a stored function column in the SELECT list that needs
+// connector-side evaluation after ExeMgr returns rows.
+struct StoredFuncColumnInfo
+{
+  Item_func_sp* sp_item;   // The MariaDB stored function Item
+  uint32_t output_field_idx;  // Index in the result tmp table's field array
+};
+
 class ha_columnstore_select_handler : public select_handler
 {
  private:
@@ -145,6 +156,8 @@ class ha_columnstore_select_handler : public select_handler
  public:
   bool scan_initialized;
   int pushdown_init_rc;
+  // Stored function columns that need connector-side evaluation
+  std::vector<StoredFuncColumnInfo> stored_func_cols;
   // MCOL-4525 Store the original TABLE_LIST::outer_join value in a hash map.
   // This will be used to restore to the original state later in case
   // query execution fails using the select_handler.

--- a/mysql-test/columnstore/basic/r/mcs39_select_function_calls.result
+++ b/mysql-test/columnstore/basic/r/mcs39_select_function_calls.result
@@ -44,7 +44,17 @@ col	@a
 9	121
 10	121
 SELECT col AS 'num', func(col) as 'square of num' from t1;
-ERROR 42000: The storage engine for the table doesn't support MCS-1017: Stored function is currently not supported in Columnstore.
+num	square of num
+1	1
+2	4
+3	9
+4	16
+5	25
+6	36
+7	49
+8	64
+9	81
+10	100
 SELECT f1(@b) AS 'square of 99', * FROM t1;
 ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '* FROM t1' at line 1
 SELECT func(@b/0);

--- a/mysql-test/columnstore/basic/r/mcs_stored_function_support.result
+++ b/mysql-test/columnstore/basic/r/mcs_stored_function_support.result
@@ -1,0 +1,339 @@
+SET GLOBAL log_bin_trust_function_creators = 1;
+DROP DATABASE IF EXISTS mcs_sf_db;
+CREATE DATABASE mcs_sf_db;
+USE mcs_sf_db;
+#
+# Setup: tables and stored functions
+#
+CREATE TABLE t1(a INT, b VARCHAR(50)) Engine=Columnstore;
+INSERT INTO t1 VALUES(1,'alpha'),(2,'beta'),(3,'gamma'),(4,'delta'),(5,'epsilon'),(NULL,NULL);
+CREATE TABLE t2(x INT, y INT) Engine=Columnstore;
+INSERT INTO t2 VALUES(1,10),(2,20),(3,30),(4,40);
+CREATE TABLE t3(id INT, dt DATE, amount DECIMAL(10,2)) Engine=Columnstore;
+INSERT INTO t3 VALUES(1,'2024-01-15',100.50),(2,'2024-06-20',250.75),(3,'2024-12-31',999.99);
+CREATE FUNCTION sf_square(n INT) RETURNS BIGINT
+DETERMINISTIC
+RETURN n * n|
+CREATE FUNCTION sf_double(n INT) RETURNS INT
+DETERMINISTIC
+RETURN n * 2|
+CREATE FUNCTION sf_upper(s VARCHAR(50)) RETURNS VARCHAR(50)
+DETERMINISTIC
+RETURN UPPER(s)|
+CREATE FUNCTION sf_add(x INT, y INT) RETURNS INT
+DETERMINISTIC
+RETURN x + y|
+CREATE FUNCTION sf_concat_dash(a VARCHAR(50), b VARCHAR(50)) RETURNS VARCHAR(110)
+DETERMINISTIC
+RETURN CONCAT(a, '-', b)|
+CREATE FUNCTION sf_is_even(n INT) RETURNS BOOLEAN
+DETERMINISTIC
+RETURN n % 2 = 0|
+CREATE FUNCTION sf_pct(n DECIMAL(10,2), total DECIMAL(10,2)) RETURNS DECIMAL(10,2)
+DETERMINISTIC
+RETURN n * 100.0 / total|
+CREATE FUNCTION sf_add_days(d DATE, n INT) RETURNS DATE
+DETERMINISTIC
+RETURN DATE_ADD(d, INTERVAL n DAY)|
+CREATE FUNCTION sf_strlen(s VARCHAR(100)) RETURNS INT
+DETERMINISTIC
+RETURN LENGTH(s)|
+CREATE FUNCTION sf_coalesce_int(a INT, b INT) RETURNS INT
+DETERMINISTIC
+RETURN COALESCE(a, b)|
+#
+# 1. Basic projection: SP with single column argument
+#
+SELECT a, sf_square(a) FROM t1;
+a	sf_square(a)
+1	1
+2	4
+3	9
+4	16
+5	25
+NULL	NULL
+#
+# 2. Basic projection: SP with VARCHAR result
+#
+SELECT a, b, sf_upper(b) FROM t1;
+a	b	sf_upper(b)
+1	alpha	ALPHA
+2	beta	BETA
+3	gamma	GAMMA
+4	delta	DELTA
+5	epsilon	EPSILON
+NULL	NULL	NULL
+#
+# 3. Multiple SPs in one SELECT
+#
+SELECT a, b, sf_square(a), sf_upper(b) FROM t1;
+a	b	sf_square(a)	sf_upper(b)
+1	alpha	1	ALPHA
+2	beta	4	BETA
+3	gamma	9	GAMMA
+4	delta	16	DELTA
+5	epsilon	25	EPSILON
+NULL	NULL	NULL	NULL
+#
+# 4. Multi-argument SP: column + CAST expression
+#
+SELECT a, b, sf_concat_dash(b, CAST(a AS CHAR)) FROM t1;
+a	b	sf_concat_dash(b, CAST(a AS CHAR))
+1	alpha	alpha-1
+2	beta	beta-2
+3	gamma	gamma-3
+4	delta	delta-4
+5	epsilon	epsilon-5
+NULL	NULL	NULL
+#
+# 5. SP with expression argument: a + 1
+#
+SELECT a, sf_square(a + 1) FROM t1 WHERE a IS NOT NULL;
+a	sf_square(a + 1)
+1	4
+2	9
+3	16
+4	25
+5	36
+#
+# 6. SP with complex expression argument: a * 2 + 1
+#
+SELECT a, sf_square(a * 2 + 1) FROM t1 WHERE a IS NOT NULL;
+a	sf_square(a * 2 + 1)
+1	9
+2	25
+3	49
+4	81
+5	121
+#
+# 7. Nested SPs: sf_square(sf_double(a))
+#
+SELECT a, sf_square(sf_double(a)) FROM t1 WHERE a IS NOT NULL;
+a	sf_square(sf_double(a))
+1	4
+2	16
+3	36
+4	64
+5	100
+#
+# 8. SP with constant argument (evaluated per row)
+#
+SELECT a, sf_square(10) FROM t1 WHERE a IS NOT NULL;
+a	sf_square(10)
+1	100
+2	100
+3	100
+4	100
+5	100
+#
+# 9. NULL handling: NULLs propagate through SPs
+#
+SELECT a, b, sf_square(a), sf_upper(b) FROM t1 WHERE a IS NULL OR b IS NULL;
+a	b	sf_square(a)	sf_upper(b)
+NULL	NULL	NULL	NULL
+#
+# 10. SP that handles NULLs internally via COALESCE
+#
+SELECT a, sf_coalesce_int(a, -1) FROM t1;
+a	sf_coalesce_int(a, -1)
+1	1
+2	2
+3	3
+4	4
+5	5
+NULL	-1
+#
+# 11. INNER JOIN: SP on columns from both tables
+#
+SELECT t1.a, t2.y, sf_add(t1.a, t2.y)
+FROM t1 JOIN t2 ON t1.a = t2.x;
+a	y	sf_add(t1.a, t2.y)
+1	10	11
+2	20	22
+3	30	33
+4	40	44
+#
+# 12. INNER JOIN: separate SP on each table
+#
+SELECT t1.a, sf_square(t1.a), t2.x, sf_double(t2.x)
+FROM t1 JOIN t2 ON t1.a = t2.x;
+a	sf_square(t1.a)	x	sf_double(t2.x)
+1	1	1	2
+2	4	2	4
+3	9	3	6
+4	16	4	8
+#
+# 13. LEFT JOIN with SP (NULLs from unmatched rows)
+#
+SELECT t1.a, t2.x, sf_add(t1.a, COALESCE(t2.x, 0))
+FROM t1 LEFT JOIN t2 ON t1.a = t2.x
+WHERE t1.a IS NOT NULL;
+a	x	sf_add(t1.a, COALESCE(t2.x, 0))
+1	1	2
+2	2	4
+3	3	6
+4	4	8
+5	NULL	5
+#
+# 14. Self-join with SP
+#
+SELECT a1.a, a2.a, sf_add(a1.a, a2.a)
+FROM t1 a1 JOIN t1 a2 ON a1.a = a2.a
+WHERE a1.a IS NOT NULL;
+a	a	sf_add(a1.a, a2.a)
+1	1	2
+2	2	4
+3	3	6
+4	4	8
+5	5	10
+#
+# 15. DISTINCT with SP is unsupported (error expected)
+#
+SELECT DISTINCT a, sf_square(a) FROM t1 WHERE a IS NOT NULL;
+ERROR 42000: The storage engine for the table doesn't support DISTINCT with stored functions is not supported by Columnstore in ON mode.
+#
+# 16. LIMIT with SP
+#
+SELECT a, sf_square(a) FROM t1 WHERE a IS NOT NULL ORDER BY a LIMIT 3;
+a	sf_square(a)
+1	1
+2	4
+3	9
+#
+# 17. DECIMAL return type
+#
+SELECT id, amount, sf_pct(amount, 1000.00) FROM t3;
+id	amount	sf_pct(amount, 1000.00)
+1	100.50	10.05
+2	250.75	25.08
+3	999.99	100.00
+Warnings:
+Note	1265	Data truncated for column 'sf_pct(amount, 1000.00)' at row 0
+Note	1265	Data truncated for column 'sf_pct(amount, 1000.00)' at row 0
+#
+# 18. DATE return type
+#
+SELECT id, dt, sf_add_days(dt, 30) FROM t3;
+id	dt	sf_add_days(dt, 30)
+1	2024-01-15	2024-02-14
+2	2024-06-20	2024-07-20
+3	2024-12-31	2025-01-30
+#
+# 19. INT from VARCHAR argument (sf_strlen)
+#
+SELECT a, b, sf_strlen(b) FROM t1 WHERE b IS NOT NULL;
+a	b	sf_strlen(b)
+1	alpha	5
+2	beta	4
+3	gamma	5
+4	delta	5
+5	epsilon	7
+#
+# 20. Boolean return type in projection
+#
+SELECT a, sf_is_even(a) FROM t1 WHERE a IS NOT NULL;
+a	sf_is_even(a)
+1	0
+2	1
+3	0
+4	1
+5	0
+#
+# 21. INSERT INTO ... SELECT with SP
+#
+CREATE TABLE t_result(val INT, sq BIGINT) Engine=Columnstore;
+INSERT INTO t_result SELECT a, sf_square(a) FROM t1 WHERE a IS NOT NULL;
+SELECT * FROM t_result;
+val	sq
+1	1
+2	4
+3	9
+4	16
+5	25
+DROP TABLE t_result;
+#
+# 22. CREATE TABLE AS SELECT with SP
+#
+CREATE TABLE t_ctas Engine=Columnstore AS
+SELECT a, sf_square(a) AS sq FROM t1 WHERE a IS NOT NULL;
+SELECT * FROM t_ctas;
+a	sq
+1	1
+2	4
+3	9
+4	16
+5	25
+DROP TABLE t_ctas;
+#
+# 23. Multiple SPs stress: 5 SPs in one query
+#
+SELECT a, b,
+sf_square(a),
+sf_double(a),
+sf_upper(b),
+sf_strlen(b),
+sf_concat_dash(b, sf_upper(b))
+FROM t1 WHERE a IS NOT NULL;
+a	b	sf_square(a)	sf_double(a)	sf_upper(b)	sf_strlen(b)	sf_concat_dash(b, sf_upper(b))
+1	alpha	1	2	ALPHA	5	alpha-ALPHA
+2	beta	4	4	BETA	4	beta-BETA
+3	gamma	9	6	GAMMA	5	gamma-GAMMA
+4	delta	16	8	DELTA	5	delta-DELTA
+5	epsilon	25	10	EPSILON	7	epsilon-EPSILON
+#
+# 24. SP with mixed column and literal arguments
+#
+SELECT a, sf_add(a, 100) FROM t1 WHERE a IS NOT NULL;
+a	sf_add(a, 100)
+1	101
+2	102
+3	103
+4	104
+5	105
+#
+# 25. SP on a single-column table
+#
+CREATE TABLE t_single(v INT) Engine=Columnstore;
+INSERT INTO t_single VALUES(7),(14),(21);
+SELECT v, sf_square(v) FROM t_single;
+v	sf_square(v)
+14	196
+21	441
+7	49
+DROP TABLE t_single;
+#
+# 26. Two-table join: multiple SPs including cross-table multi-arg
+#
+SELECT t1.a, t2.x, t2.y,
+sf_square(t1.a),
+sf_double(t2.y),
+sf_add(t1.a, t2.y)
+FROM t1 JOIN t2 ON t1.a = t2.x;
+a	x	y	sf_square(t1.a)	sf_double(t2.y)	sf_add(t1.a, t2.y)
+1	1	10	1	20	11
+2	2	20	4	40	22
+3	3	30	9	60	33
+4	4	40	16	80	44
+#
+# 27. SP with WHERE filter on non-SP column
+#
+SELECT a, sf_square(a) FROM t1 WHERE a > 2 AND a < 5;
+a	sf_square(a)
+3	9
+4	16
+#
+# 28. Error: wrong number of arguments
+#
+SELECT sf_square();
+ERROR 42000: Incorrect number of arguments for FUNCTION mcs_sf_db.sf_square; expected 1, got 0
+SELECT sf_square(1, 2);
+ERROR 42000: Incorrect number of arguments for FUNCTION mcs_sf_db.sf_square; expected 1, got 2
+#
+# 29. Error: non-existent function
+#
+SELECT nonexistent_func(a) FROM t1;
+ERROR 42000: FUNCTION mcs_sf_db.nonexistent_func does not exist
+#
+# Cleanup
+#
+DROP DATABASE mcs_sf_db;

--- a/mysql-test/columnstore/basic/t/mcs39_select_function_calls.test
+++ b/mysql-test/columnstore/basic/t/mcs39_select_function_calls.test
@@ -30,8 +30,7 @@ SELECT func(11/22);
 
 SELECT col,@a FROM t1;
 
-# Bug
---error ER_CHECK_NOT_IMPLEMENTED
+# Stored functions should work with Columnstore tables
 SELECT col AS 'num', func(col) as 'square of num' from t1;
 
 --error ER_PARSE_ERROR

--- a/mysql-test/columnstore/basic/t/mcs_stored_function_support.test
+++ b/mysql-test/columnstore/basic/t/mcs_stored_function_support.test
@@ -1,0 +1,288 @@
+#
+# Comprehensive tests for stored function support in Columnstore (ON mode).
+# Tests SP evaluation on the connector side after ExeMgr returns rows.
+#
+# Stored functions are evaluated per-row on the connector (MariaDB server)
+# side AFTER ExeMgr returns rows. This means SPs work in SELECT projection
+# when their argument columns are also present in the SELECT list.
+#
+# Known limitations in ON mode (not tested here):
+# - SP in WHERE clause: requires filter pushdown support
+# - SP in ORDER BY: requires ORDER BY expression support
+# - SP in GROUP BY / HAVING: requires grouping expression support
+# - DISTINCT with SP: ExeMgr cannot deduplicate on SP placeholder values
+# - Arithmetic on SP result in projection (e.g. sf(a) + 1): hits expression tree
+# - Aggregate on SP result (e.g. MIN(sf(a))): requires expression support
+# - SP-only projection without source column: source field not populated
+#
+-- source ../include/have_columnstore.inc
+SET GLOBAL log_bin_trust_function_creators = 1;
+
+--disable_warnings
+DROP DATABASE IF EXISTS mcs_sf_db;
+--enable_warnings
+
+CREATE DATABASE mcs_sf_db;
+USE mcs_sf_db;
+
+--echo #
+--echo # Setup: tables and stored functions
+--echo #
+
+CREATE TABLE t1(a INT, b VARCHAR(50)) Engine=Columnstore;
+INSERT INTO t1 VALUES(1,'alpha'),(2,'beta'),(3,'gamma'),(4,'delta'),(5,'epsilon'),(NULL,NULL);
+
+CREATE TABLE t2(x INT, y INT) Engine=Columnstore;
+INSERT INTO t2 VALUES(1,10),(2,20),(3,30),(4,40);
+
+CREATE TABLE t3(id INT, dt DATE, amount DECIMAL(10,2)) Engine=Columnstore;
+INSERT INTO t3 VALUES(1,'2024-01-15',100.50),(2,'2024-06-20',250.75),(3,'2024-12-31',999.99);
+
+DELIMITER |;
+
+CREATE FUNCTION sf_square(n INT) RETURNS BIGINT
+  DETERMINISTIC
+  RETURN n * n|
+
+CREATE FUNCTION sf_double(n INT) RETURNS INT
+  DETERMINISTIC
+  RETURN n * 2|
+
+CREATE FUNCTION sf_upper(s VARCHAR(50)) RETURNS VARCHAR(50)
+  DETERMINISTIC
+  RETURN UPPER(s)|
+
+CREATE FUNCTION sf_add(x INT, y INT) RETURNS INT
+  DETERMINISTIC
+  RETURN x + y|
+
+CREATE FUNCTION sf_concat_dash(a VARCHAR(50), b VARCHAR(50)) RETURNS VARCHAR(110)
+  DETERMINISTIC
+  RETURN CONCAT(a, '-', b)|
+
+CREATE FUNCTION sf_is_even(n INT) RETURNS BOOLEAN
+  DETERMINISTIC
+  RETURN n % 2 = 0|
+
+CREATE FUNCTION sf_pct(n DECIMAL(10,2), total DECIMAL(10,2)) RETURNS DECIMAL(10,2)
+  DETERMINISTIC
+  RETURN n * 100.0 / total|
+
+CREATE FUNCTION sf_add_days(d DATE, n INT) RETURNS DATE
+  DETERMINISTIC
+  RETURN DATE_ADD(d, INTERVAL n DAY)|
+
+CREATE FUNCTION sf_strlen(s VARCHAR(100)) RETURNS INT
+  DETERMINISTIC
+  RETURN LENGTH(s)|
+
+CREATE FUNCTION sf_coalesce_int(a INT, b INT) RETURNS INT
+  DETERMINISTIC
+  RETURN COALESCE(a, b)|
+
+DELIMITER ;|
+
+--echo #
+--echo # 1. Basic projection: SP with single column argument
+--echo #
+--sorted_result
+SELECT a, sf_square(a) FROM t1;
+
+--echo #
+--echo # 2. Basic projection: SP with VARCHAR result
+--echo #
+--sorted_result
+SELECT a, b, sf_upper(b) FROM t1;
+
+--echo #
+--echo # 3. Multiple SPs in one SELECT
+--echo #
+--sorted_result
+SELECT a, b, sf_square(a), sf_upper(b) FROM t1;
+
+--echo #
+--echo # 4. Multi-argument SP: column + CAST expression
+--echo #
+--sorted_result
+SELECT a, b, sf_concat_dash(b, CAST(a AS CHAR)) FROM t1;
+
+--echo #
+--echo # 5. SP with expression argument: a + 1
+--echo #
+--sorted_result
+SELECT a, sf_square(a + 1) FROM t1 WHERE a IS NOT NULL;
+
+--echo #
+--echo # 6. SP with complex expression argument: a * 2 + 1
+--echo #
+--sorted_result
+SELECT a, sf_square(a * 2 + 1) FROM t1 WHERE a IS NOT NULL;
+
+--echo #
+--echo # 7. Nested SPs: sf_square(sf_double(a))
+--echo #
+--sorted_result
+SELECT a, sf_square(sf_double(a)) FROM t1 WHERE a IS NOT NULL;
+
+--echo #
+--echo # 8. SP with constant argument (evaluated per row)
+--echo #
+--sorted_result
+SELECT a, sf_square(10) FROM t1 WHERE a IS NOT NULL;
+
+--echo #
+--echo # 9. NULL handling: NULLs propagate through SPs
+--echo #
+SELECT a, b, sf_square(a), sf_upper(b) FROM t1 WHERE a IS NULL OR b IS NULL;
+
+--echo #
+--echo # 10. SP that handles NULLs internally via COALESCE
+--echo #
+--sorted_result
+SELECT a, sf_coalesce_int(a, -1) FROM t1;
+
+--echo #
+--echo # 11. INNER JOIN: SP on columns from both tables
+--echo #
+--sorted_result
+SELECT t1.a, t2.y, sf_add(t1.a, t2.y)
+  FROM t1 JOIN t2 ON t1.a = t2.x;
+
+--echo #
+--echo # 12. INNER JOIN: separate SP on each table
+--echo #
+--sorted_result
+SELECT t1.a, sf_square(t1.a), t2.x, sf_double(t2.x)
+  FROM t1 JOIN t2 ON t1.a = t2.x;
+
+--echo #
+--echo # 13. LEFT JOIN with SP (NULLs from unmatched rows)
+--echo #
+--sorted_result
+SELECT t1.a, t2.x, sf_add(t1.a, COALESCE(t2.x, 0))
+  FROM t1 LEFT JOIN t2 ON t1.a = t2.x
+  WHERE t1.a IS NOT NULL;
+
+--echo #
+--echo # 14. Self-join with SP
+--echo #
+--sorted_result
+SELECT a1.a, a2.a, sf_add(a1.a, a2.a)
+  FROM t1 a1 JOIN t1 a2 ON a1.a = a2.a
+  WHERE a1.a IS NOT NULL;
+
+--echo #
+--echo # 15. DISTINCT with SP is unsupported (error expected)
+--echo #
+--error ER_CHECK_NOT_IMPLEMENTED
+SELECT DISTINCT a, sf_square(a) FROM t1 WHERE a IS NOT NULL;
+
+--echo #
+--echo # 16. LIMIT with SP
+--echo #
+SELECT a, sf_square(a) FROM t1 WHERE a IS NOT NULL ORDER BY a LIMIT 3;
+
+--echo #
+--echo # 17. DECIMAL return type
+--echo #
+--sorted_result
+SELECT id, amount, sf_pct(amount, 1000.00) FROM t3;
+
+--echo #
+--echo # 18. DATE return type
+--echo #
+--sorted_result
+SELECT id, dt, sf_add_days(dt, 30) FROM t3;
+
+--echo #
+--echo # 19. INT from VARCHAR argument (sf_strlen)
+--echo #
+--sorted_result
+SELECT a, b, sf_strlen(b) FROM t1 WHERE b IS NOT NULL;
+
+--echo #
+--echo # 20. Boolean return type in projection
+--echo #
+--sorted_result
+SELECT a, sf_is_even(a) FROM t1 WHERE a IS NOT NULL;
+
+--echo #
+--echo # 21. INSERT INTO ... SELECT with SP
+--echo #
+CREATE TABLE t_result(val INT, sq BIGINT) Engine=Columnstore;
+INSERT INTO t_result SELECT a, sf_square(a) FROM t1 WHERE a IS NOT NULL;
+--sorted_result
+SELECT * FROM t_result;
+DROP TABLE t_result;
+
+--echo #
+--echo # 22. CREATE TABLE AS SELECT with SP
+--echo #
+CREATE TABLE t_ctas Engine=Columnstore AS
+  SELECT a, sf_square(a) AS sq FROM t1 WHERE a IS NOT NULL;
+--sorted_result
+SELECT * FROM t_ctas;
+DROP TABLE t_ctas;
+
+--echo #
+--echo # 23. Multiple SPs stress: 5 SPs in one query
+--echo #
+--sorted_result
+SELECT a, b,
+       sf_square(a),
+       sf_double(a),
+       sf_upper(b),
+       sf_strlen(b),
+       sf_concat_dash(b, sf_upper(b))
+  FROM t1 WHERE a IS NOT NULL;
+
+--echo #
+--echo # 24. SP with mixed column and literal arguments
+--echo #
+--sorted_result
+SELECT a, sf_add(a, 100) FROM t1 WHERE a IS NOT NULL;
+
+--echo #
+--echo # 25. SP on a single-column table
+--echo #
+CREATE TABLE t_single(v INT) Engine=Columnstore;
+INSERT INTO t_single VALUES(7),(14),(21);
+--sorted_result
+SELECT v, sf_square(v) FROM t_single;
+DROP TABLE t_single;
+
+--echo #
+--echo # 26. Two-table join: multiple SPs including cross-table multi-arg
+--echo #
+--sorted_result
+SELECT t1.a, t2.x, t2.y,
+       sf_square(t1.a),
+       sf_double(t2.y),
+       sf_add(t1.a, t2.y)
+  FROM t1 JOIN t2 ON t1.a = t2.x;
+
+--echo #
+--echo # 27. SP with WHERE filter on non-SP column
+--echo #
+--sorted_result
+SELECT a, sf_square(a) FROM t1 WHERE a > 2 AND a < 5;
+
+--echo #
+--echo # 28. Error: wrong number of arguments
+--echo #
+--error ER_SP_WRONG_NO_OF_ARGS
+SELECT sf_square();
+
+--error ER_SP_WRONG_NO_OF_ARGS
+SELECT sf_square(1, 2);
+
+--echo #
+--echo # 29. Error: non-existent function
+--echo #
+--error ER_SP_DOES_NOT_EXIST
+SELECT nonexistent_func(a) FROM t1;
+
+--echo #
+--echo # Cleanup
+--echo #
+DROP DATABASE mcs_sf_db;


### PR DESCRIPTION
Implement support for MariaDB stored functions (CREATE FUNCTION ... RETURN) in SELECT queries against Columnstore tables without falling back to the MariaDB server's default execution path.

Previously, any query with a stored function (Item_func::FUNC_SP) against a Columnstore table was rejected with error MCS-1001 / ERR_SP_FUNCTION_NOT_SUPPORT (@bug4383). This patch removes that restriction for the SELECT projection case and evaluates stored functions on the connector side.

== Architecture / Approach ==

Stored functions (Item_func_sp) require the MariaDB server context (THD, SP framework, etc.) for evaluation. This context is not available inside the remote ExeMgr/PrimProc processes where Columnstore normally evaluates FunctionColumn expressions. Therefore, a "connector-side post-processing" approach is used:

1. PLAN BUILDING (ha_mcs_execplan.cpp, getSelectPlan):
   - When a FUNC_SP item is encountered in the SELECT list, instead of raising an error, a ConstantColumn(0) placeholder is pushed into CSEP::returnedCols at the corresponding position. This reserves a slot in the ExeMgr output row.
   - The Item_func_sp pointer and its output field index are recorded in gp_walk_info::storedFuncCols.
   - After getSelectPlan() completes, cs_get_select_plan() transfers this metadata into ha_columnstore_select_handler::stored_func_cols.

2. ROW DELIVERY (ha_mcs_pushdown.cpp, next_row):
   - After fetchNextRow() fills table->record[0] from ExeMgr data, the connector performs post-processing for each row:

     a) SOURCE FIELD POPULATION: iterates select_lex->item_list to find Item_field items. For each one, copies the value from the corresponding tmp table field (filled by ExeMgr) into the source table field (t1->record[0]) that the Item_field points to. This is necessary because Item_func_sp's arguments are Item_field objects bound to source table fields, which are not populated in select_handler mode. Uses dbug_tmp_use_all_columns() to allow writing to source table fields in debug builds.

     b) SP EVALUATION: for each stored function column, calls the appropriate Item_func_sp->val_*() method (val_int, val_real, val_decimal, val_str depending on result_type()), then writes the result into the output field in table->record[0], replacing the placeholder value.

3. DATA STRUCTURES:
   - StoredFuncColumnInfo: holds Item_func_sp* and output_field_idx
   - ha_columnstore_select_handler::stored_func_cols: vector of above
   - gp_walk_info::storedFuncCols: temporary storage during plan building

== What works (columnstore_select_handler=ON) ==

- SP in SELECT projection with source columns present
- Multiple SPs in one query
- Multi-argument SPs (columns from same or different tables)
- Nested SPs: sf(sf(col))
- SP with expression arguments: sf(col + 1), sf(col * 2 + 1)
- SP with constant arguments: sf(10)
- NULL propagation
- All return types: INT, BIGINT, VARCHAR, DECIMAL, DATE, BOOLEAN
- INNER JOIN, LEFT JOIN, self-join
- LIMIT
- INSERT INTO ... SELECT, CREATE TABLE AS SELECT
- WHERE filter on non-SP columns

== Known limitations ==

- SP in WHERE/ORDER BY/GROUP BY/HAVING: these clauses go through Columnstore's filter/sort/group expression evaluation in ExeMgr, which cannot call Item_func_sp. Falls back in AUTO mode.
- DISTINCT with SP: ExeMgr cannot deduplicate on SP placeholder values
- Arithmetic on SP result in projection (e.g. sf(a) + 1): the outer '+' operator is processed by buildFunctionColumn which tries to push it to ExeMgr.
- Aggregate on SP result (e.g. MIN(sf(a))): same issue.
- SP-only projection without source column in SELECT list: the source table field is not populated because ExeMgr doesn't return the column.