### PR TITLE
MCOL-6173: add Func_from_unixtime::getTimestampIntVal

### DIFF
--- a/mysql-test/columnstore/basic/t/mcs247_from_unixtime_funtion2.test
+++ b/mysql-test/columnstore/basic/t/mcs247_from_unixtime_funtion2.test
@@ -2,13 +2,15 @@
 # Test FROM_UNIXTIME function in the machine time zone independent way.
 #
 -- source ../include/have_columnstore.inc
---source ../include/disable_11.8.inc
 
 #
 # Get reference values from MariaDB
 #
 
-let $dt_ts0=`SELECT FROM_UNIXTIME(0)`;
+# FROM_UNIXTIME(0) returns a non-NULL datetime on 11.4 and NULL on 11.8.
+# Wrap with IFNULL so the captured variable is never the empty string,
+# which would make --replace_result fail below.
+let $dt_ts0=`SELECT IFNULL(FROM_UNIXTIME(0), 'NULL')`;
 let $dt_ts1=`SELECT FROM_UNIXTIME(1)`;
 let $dt_ts103=`SELECT FROM_UNIXTIME(103)`;
 let $dt_ts111=`SELECT FROM_UNIXTIME(111)`;
@@ -40,8 +42,12 @@ INSERT INTO t1 VALUES(103, 1234.5699, repeat('o', 5), '1997-12-12', '22:12:02');
 INSERT INTO t1 VALUES(-7299, 111.99, repeat('p', 5), '2001-1-1', '23:59:59');
 INSERT INTO t1 VALUES(9913, 98765.4321, repeat('q', 5), '09-12-11', '01:08:59');
 
+# 11.8+ emits "Truncated incorrect unixtime value: '0.0'" for FROM_UNIXTIME(0);
+# suppress so the stable reference result stays version-agnostic.
+--disable_warnings
 --replace_result $dt_ts0 EXPECTED_DATETIME_0
 SELECT FROM_UNIXTIME(0) FROM t1 LIMIT 1;
+--enable_warnings
 
 SELECT FROM_UNIXTIME(-1) FROM t1 LIMIT 1;
 

--- a/utils/funcexp/func_from_unixtime.cpp
+++ b/utils/funcexp/func_from_unixtime.cpp
@@ -24,6 +24,7 @@
 
 #include <unistd.h>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 using namespace std;
 
@@ -40,10 +41,14 @@ namespace
 {
 using namespace funcexp;
 
-DateTime getDateTime(rowgroup::Row& row, FunctionParm& parm, bool& isNull)
+// Extract the seconds value and fractional microseconds from parm[0].
+// Returns false (and sets isNull=true) when the value is out of range
+// or negative; returns true when val/msec are valid.
+bool getUnixTimestampParts(rowgroup::Row& row, FunctionParm& parm, int64_t& val, uint32_t& msec,
+                           bool& isNull)
 {
-  int64_t val = 0;
-  uint32_t msec = 0;
+  val = 0;
+  msec = 0;
 
   switch (parm[0]->data()->resultType().colDataType)
   {
@@ -54,7 +59,7 @@ DateTime getDateTime(rowgroup::Row& row, FunctionParm& parm, bool& isNull)
       if (value < 0)
       {
         isNull = true;
-        return 0;
+        return false;
       }
 
       double fracpart, intpart;
@@ -71,7 +76,7 @@ DateTime getDateTime(rowgroup::Row& row, FunctionParm& parm, bool& isNull)
       if (dec.value < 0)
       {
         isNull = true;
-        return 0;
+        return false;
       }
 
       if (parm[0]->data()->resultType().colWidth == datatypes::MAXDECIMALWIDTH)
@@ -92,6 +97,17 @@ DateTime getDateTime(rowgroup::Row& row, FunctionParm& parm, bool& isNull)
   }
 
   if (val < 0 || val > helpers::TIMESTAMP_MAX_VALUE)
+    return false;
+
+  return true;
+}
+
+DateTime getDateTime(rowgroup::Row& row, FunctionParm& parm, bool& isNull)
+{
+  int64_t val = 0;
+  uint32_t msec = 0;
+
+  if (!getUnixTimestampParts(row, parm, val, msec, isNull))
     return 0;
 
   DateTime dt;
@@ -177,6 +193,33 @@ int64_t Func_from_unixtime::getTimeIntVal(rowgroup::Row& row, FunctionParm& parm
   }
 
   return *reinterpret_cast<int64_t*>(&dt);
+}
+
+// MCOL-6173: since MariaDB 11.8 Item_func_from_unixtime reports TIMESTAMP as
+// its result type (it inherits from Item_timestampfunc). Without this explicit
+// override the base Func::getTimestampIntVal path would call
+// intToTimestamp(getIntVal()), packing a 14-digit YYYYMMDDHHmmss integer into
+// the Calpont TimeStamp bit layout (msec:20 | seconds:44), producing bogus
+// timestamps. Here we return the correctly packed Calpont TimeStamp where
+// `second` is the raw Unix seconds (no local time conversion) and `msecond`
+// is the fractional microseconds; the server-side handler performs the time
+// zone conversion for display.
+int64_t Func_from_unixtime::getTimestampIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isNull,
+                                               CalpontSystemCatalog::ColType& /*ct*/)
+{
+  int64_t val = 0;
+  uint32_t msec = 0;
+
+  if (!getUnixTimestampParts(row, parm, val, msec, isNull))
+  {
+    isNull = true;
+    return 0;
+  }
+
+  dataconvert::TimeStamp ts(msec, static_cast<unsigned long long>(val));
+  int64_t packed;
+  std::memcpy(&packed, &ts, sizeof(packed));
+  return packed;
 }
 
 int64_t Func_from_unixtime::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& isNull,

--- a/utils/funcexp/functor_dtm.h
+++ b/utils/funcexp/functor_dtm.h
@@ -386,6 +386,9 @@ class Func_from_unixtime : public Func_Dtm
   int64_t getDatetimeIntVal(rowgroup::Row& row, FunctionParm& fp, bool& isNull,
                             execplan::CalpontSystemCatalog::ColType& op_ct) override;
 
+  int64_t getTimestampIntVal(rowgroup::Row& row, FunctionParm& fp, bool& isNull,
+                             execplan::CalpontSystemCatalog::ColType& op_ct) override;
+
   int64_t getTimeIntVal(rowgroup::Row& row, FunctionParm& fp, bool& isNull,
                         execplan::CalpontSystemCatalog::ColType& op_ct) override;
 };


### PR DESCRIPTION
## Problem
 
On MariaDB 11.8 any `FROM_UNIXTIME(<non-constant expression>)` pushed down to Columnstore produced the same bogus datetime for every row:
 
```sql
SELECT t1_INT, FROM_UNIXTIME(t1_INT) FROM t1 ORDER BY 1;
+--------+-----------------------+
| t1_INT | FROM_UNIXTIME(t1_INT) |
+--------+-----------------------+
|  -7299 | NULL                  |
|    103 | 1970-08-06 10:44:40   |   <-- expected 1970-01-01 00:01:43
|   9913 | 1970-08-06 10:44:40   |   <-- expected 1970-01-01 02:45:13
+--------+-----------------------+
```
 
The same query with `columnstore_select_handler=OFF` (no push-down) returns the correct value, so the bug sits strictly in Columnstore's expression evaluator. `FROM_UNIXTIME` on a literal worked fine — only column-derived arguments were broken. Works on 11.4-enterprise, breaks on 11.8-enterprise.
 
## Root cause
 
In MariaDB 11.8 the server re-parented `Item_func_from_unixtime` to inherit from `Item_timestampfunc`, so its type handler now reports `MYSQL_TYPE_TIMESTAMP` instead of `MYSQL_TYPE_DATETIME`.
 
When `ha_mcs_execplan` builds the `FunctionColumn` for `FROM_UNIXTIME(...)`, it copies that type verbatim, so `FunctionColumn::resultType().colDataType` becomes `TIMESTAMP` (enum=26) instead of `DATETIME` (enum=11).
 
[FuncExp::evaluate](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/funcexp/funcexp.cpp:297:0-560:1) dispatches by `colDataType`:
 
```cpp
case CalpontSystemCatalog::TIMESTAMP:
{
  int64_t val = expression[i]->getTimestampIntVal(row, isNull);
  row.setUintField<8>(val, expression[i]->outputIndex());
  ...
}
```
 
But [Func_from_unixtime](cci:2://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/funcexp/functor_dtm.h:360:0-393:1) never overrode [getTimestampIntVal](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/funcexp/functor.h:146:2-150:3). The call fell through to the base [Func::getTimestampIntVal](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/funcexp/functor.h:146:2-150:3):
 
```cpp
virtual int64_t getTimestampIntVal(...) {
  return intToTimestamp(getIntVal(...));   // intToTimestamp is identity
}
```
 
And [Func_from_unixtime::getIntVal](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/funcexp/func_from_unixtime.cpp:224:0-238:1) returns the 14-digit `YYYYMMDDHHmmss` representation (e.g. `19700101000143` for unixtime `103`). That 14-digit integer was stored into the 8-byte row field and later read back through the Calpont [TimeStamp](cci:2://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/dataconvert/dataconvert.h:997:0-1015:1) bit layout (`msecond:20 | second:44`). Unpacking:
 
```
19700101000143 >> 20       = 18787480   -> second
19700101000143 & 0xFFFFF   = 371663     -> msec
gmtSecToMySQLTime(18787480) = 1970-08-06 10:44:40
```
 
Explains the constant garbage across all rows, and the tiny `.37167` / `.37355` / `.35554` msec differences on the `DECIMAL` column.
 
On 11.4 this path was never taken: `Item_func_from_unixtime` was a datetime func, the plan used `case DATETIME:` and called the already-correct [Func_from_unixtime::getDatetimeIntVal](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/funcexp/functor.h:140:2-144:3). Adding `Item_timestampfunc` on the server side simply walked into an un-implemented branch in Columnstore's functor.
 
## Fix
 
Purely inside `storage/columnstore/columnstore/` — no server changes.
 
### [utils/funcexp/func_from_unixtime.cpp](cci:7://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/funcexp/func_from_unixtime.cpp:0:0-0:0) + [utils/funcexp/functor_dtm.h](cci:7://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/funcexp/functor_dtm.h:0:0-0:0)
 
- Extract the `(val, msec)` extraction from `parm[0]` (INT / BIGINT / DECIMAL / DOUBLE branches + range check) into a helper [getUnixTimestampParts](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/funcexp/func_from_unixtime.cpp:43:0-102:1). [getDateTime](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/funcexp/func_from_unixtime.cpp:103:0-126:1) is refactored to use it; behaviour unchanged.
- Add [Func_from_unixtime::getTimestampIntVal](cci:1://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/funcexp/functor.h:146:2-150:3) that returns a correctly-packed Calpont [TimeStamp](cci:2://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/utils/dataconvert/dataconvert.h:997:0-1015:1):
  - `second` = raw Unix seconds (no `localtime_r` — the server-side handler applies the session time zone for display),
  - `msecond` = fractional microseconds,
  - out-of-range / negative → `isNull = true`.
 
### [mysql-test/columnstore/basic/t/mcs247_from_unixtime_funtion2.test](cci:7://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/mysql-test/columnstore/basic/t/mcs247_from_unixtime_funtion2.test:0:0-0:0)
 
- Drop `--source ../include/disable_11.8.inc` — the test is now green on 11.8.
- Wrap `$dt_ts0 = SELECT FROM_UNIXTIME(0)` in `IFNULL(..., 'NULL')`: on 11.8 the server itself returns `NULL` for `FROM_UNIXTIME(0)`, otherwise `let` captures the empty string and `--replace_result` aborts with *"Can't initialize replace"*.
- Surround the `SELECT FROM_UNIXTIME(0) FROM t1` row with `--disable_warnings` / `--enable_warnings` to absorb the new 11.8 warning `1292 Truncated incorrect unixtime value: '0.0'` so the `.result` stays version-agnostic.
 
### Left alone
 
[mcs247_from_unixtime_funtion.test](cci:7://file:///home/ubuntu/proj/MDBEnterprise/storage/columnstore/columnstore/mysql-test/columnstore/basic/t/mcs247_from_unixtime_funtion.test:0:0-0:0) (the non-portable sibling) keeps its `disable_11.8.inc` skip. Its hard-coded expected rows (`FROM_UNIXTIME(0)` → `1970-01-01 00:00:00`, `FROM_UNIXTIME(-0.1)` → `NULL` without warning, etc.) reflect pre-11.8 server semantics that changed upstream — nothing to fix on the Columnstore side, and the portable `..._funtion2.test` already covers the same call matrix in a version-agnostic way.
 
`disable_11.8.inc` still carries `MCOL-6174` for two unrelated tests and is left as-is.
 
## Verification
 
Post-fix:
 
```sql
SELECT t1_INT, FROM_UNIXTIME(t1_INT) FROM t1 ORDER BY 1;
|  -7299 | NULL                |
|    103 | 1970-01-01 00:01:43 |
|   9913 | 1970-01-01 02:45:13 |
 
SELECT t1_DECIMAL, FROM_UNIXTIME(t1_DECIMAL) FROM t1 ORDER BY 1;
|   111.99000 | 1970-01-01 00:01:51.99000 |
|  1234.56990 | 1970-01-01 00:20:34.56990 |
| 98765.43210 | 1970-01-02 03:26:05.43210 |
```
 
MTR:
 
```
sudo bash tests/scripts/run_mtr.sh -e -t basic.mcs247_from_unixtime_funtion2
columnstore/basic.mcs247_from_unixtime_funtion2 [ pass ]  23939
```