### PR TITLE
MCOL-6336: fix DATE_SUB/DATE_ADD with INTERVAL NULL crashes with BatchPrimitiveProcessor error instead of returning NULL

### DIFF
--- a/mysql-test/columnstore/bugfixes/mcol_6336.result
+++ b/mysql-test/columnstore/bugfixes/mcol_6336.result
@@ -1,0 +1,11 @@
+DROP DATABASE IF EXISTS mcol_6336;
+CREATE DATABASE mcol_6336;
+USE mcol_6336;
+DROP TABLE IF EXISTS t1;
+create table t1 (dt DATETIME) ENGINE=Columnstore;
+insert into t1 values ('2020-01-01 12:00:00');
+select date_sub(dt, INTERVAL NULL DAY) FROM t1;
+date_sub(dt, INTERVAL NULL DAY)
+NULL
+DROP TABLE IF EXISTS t1;
+DROP DATABASE mcol_6336;

--- a/mysql-test/columnstore/bugfixes/mcol_6336.test
+++ b/mysql-test/columnstore/bugfixes/mcol_6336.test
@@ -1,0 +1,21 @@
+-- source ../include/have_columnstore.inc
+--disable_warnings
+DROP DATABASE IF EXISTS mcol_6336;
+--enable_warnings
+CREATE DATABASE mcol_6336;
+USE mcol_6336;
+
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+--enable_warnings
+create table t1 (dt DATETIME) ENGINE=Columnstore;
+insert into t1 values ('2020-01-01 12:00:00');
+select date_sub(dt, INTERVAL NULL DAY) FROM t1;
+
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+--enable_warnings
+
+--disable_warnings
+DROP DATABASE mcol_6336;
+--enable_warnings

--- a/utils/funcexp/func_date_add.cpp
+++ b/utils/funcexp/func_date_add.cpp
@@ -822,8 +822,15 @@ int64_t Func_date_add::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& i
   else
     funcType = static_cast<OpType>(parm[3]->data()->getIntVal(row, isNull));
 
-  uint64_t value =
-      helpers::dateAdd(val, parm[1]->data()->getStrVal(row, isNull).safeString(""), unit, dateType, funcType);
+  const auto expr = parm[1]->data()->getStrVal(row, isNull).safeString("");
+
+  if (isNull)
+  {
+    isNull = true;
+    return 0;
+  }
+
+  uint64_t value = helpers::dateAdd(val, expr, unit, dateType, funcType);
 
   if (value == 0)
     isNull = true;

--- a/utils/funcexp/func_date_add.cpp
+++ b/utils/funcexp/func_date_add.cpp
@@ -825,10 +825,7 @@ int64_t Func_date_add::getIntVal(rowgroup::Row& row, FunctionParm& parm, bool& i
   const auto expr = parm[1]->data()->getStrVal(row, isNull).safeString("");
 
   if (isNull)
-  {
-    isNull = true;
     return 0;
-  }
 
   uint64_t value = helpers::dateAdd(val, expr, unit, dateType, funcType);
 


### PR DESCRIPTION
Fixes: [MCOL-6336](https://jira.mariadb.org/browse/MCOL-6336)
Added a null check before date add processing.