### PR TITLE
fix(cmapi, aliases): MCO:-6178 Unprivileged users can control cluster via global aliases in /etc/profile.d/

### DIFF
--- a/oam/install_scripts/columnstoreAlias
+++ b/oam/install_scripts/columnstoreAlias
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 # MariaDB Columnstore Alias Commands
 
-mcspm1host=$(mcsGetConfig PMS1 IPaddr)
-mcsapikey=$(grep -r 'x-api-key' /etc/columnstore/cmapi_server.conf 2>/dev/null | cut -d= -f2- | xargs)
+# Only load cluster management aliases for root to prevent
+# unprivileged users from controlling the cluster.
+# See: MCOL-6178
+if [ "$(id -u)" -ne 0 ]; then
+    return 2>/dev/null || exit 0
+fi
 
 alias core='cd /var/log/mariadb/columnstore/corefiles'
 alias tdebug='tail -f /var/log/mariadb/columnstore/debug.log'
@@ -12,8 +16,8 @@ alias twarning='tail -f /var/log/mariadb/columnstore/warning.log'
 alias tcrit='tail -f /var/log/mariadb/columnstore/crit.log'
 alias dbrm='cd /var/lib/columnstore/data1/systemFiles/dbrm'
 alias mcsModule='cat /var/lib/columnstore/local/module'
-alias mcsStatus="curl -s https://$mcspm1host:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header 'x-api-key:$mcsapikey' -k | jq ."
-alias mcsStart="curl -s -X PUT https://$mcspm1host:8640/cmapi/0.4.0/cluster/start --header 'Content-Type:application/json' --header 'x-api-key:$mcsapikey' --data '{\"timeout\":60}' -k | jq ."
-alias mcsShutdown="curl -s -X PUT https://$mcspm1host:8640/cmapi/0.4.0/cluster/shutdown --header 'Content-Type:application/json' --header 'x-api-key:$mcsapikey' --data '{\"timeout\":60}' -k | jq ."
-alias mcsReadOnly="curl -s -X PUT https://$mcspm1host:8640/cmapi/0.4.0/cluster/mode-set --header 'Content-Type:application/json' --header 'x-api-key:$mcsapikey' --data '{\"timeout\":20, \"mode\": \"readonly\"}' -k | jq ."
-alias mcsReadWrite="curl -s -X PUT https://$mcspm1host:8640/cmapi/0.4.0/cluster/mode-set --header 'Content-Type:application/json' --header 'x-api-key:$mcsapikey' --data '{\"timeout\":20, \"mode\": \"readwrite\"}' -k | jq ."
+alias mcsStatus='mcs status'
+alias mcsStart='mcs start'
+alias mcsShutdown='mcs stop'
+alias mcsReadOnly='mcs set mode --mode readonly'
+alias mcsReadWrite='mcs set mode --mode readwrite'


### PR DESCRIPTION
 - remove old API based aliases
 - remove loading api key for old aliases
 - add `mcs` based aliases
 - aliases only for privileged user