### PR TITLE
MCOL-6332 Fix ORDER BY using numeric positional column reference and DESC order on non-grouped columns in aggregation queries

### DIFF
--- a/dbcon/rbo/rbo_groupby_wrap_columns.cpp
+++ b/dbcon/rbo/rbo_groupby_wrap_columns.cpp
@@ -134,8 +134,19 @@ bool needWrap(execplan::TreeNode* tn, ColumnWrapperContext& lctx)
 template <typename T>
 execplan::AggregateColumn* wrapColumn(const T& rc, ColumnWrapperContext& lctx, RBOptimizerContext& ctx)
 {
+  // Same pattern as above, need to ignore sorting direction for the AggregateColumn and its embedded ReturnedColumn
+  // when comparing for equality. ORDER BY direction (ASC/DESC) is not significant for expression identity.
+  // TODO: Maybe need to consider removing asc/joinInfo from operator== to eliminate this pattern
+  bool savedAsc = rc->asc();
+  rc->asc(true);
+
   auto* ac = optimizer::lib::wrapIntoSelectSomeAgg(rc, ctx.getGwi().timeZone);
   lctx.dedup.assignId(ac);
+
+  // restore sorting direction for both AggregatedColumn and its single ReturnedColumn agg parameter
+  rc->asc(savedAsc);
+  ac->asc(savedAsc);
+
   lctx.applied = true;
   return ac;
 }

--- a/mysql-test/columnstore/bugfixes/MCOL-6332-fix-order-by-by-positional-parameter-for-column-not-under-aggregation.result
+++ b/mysql-test/columnstore/bugfixes/MCOL-6332-fix-order-by-by-positional-parameter-for-column-not-under-aggregation.result
@@ -1,0 +1,77 @@
+DROP DATABASE IF EXISTS mcol_6332;
+CREATE DATABASE mcol_6332;
+USE mcol_6332;
+CREATE TABLE orders (o_custkey INT, o_orderstatus CHAR(1)) ENGINE=Columnstore;
+INSERT INTO orders VALUES (10,'F'),(20,'O'),(10,'P'),(30,'F'),(20,'O'),(40,'P');
+SELECT COUNT(o_orderstatus), o_orderstatus
+FROM orders
+ORDER BY 1, 2 DESC;
+COUNT(o_orderstatus)	o_orderstatus
+6	P
+SELECT COUNT(o_orderstatus), o_orderstatus
+FROM orders
+ORDER BY 1, 2;
+COUNT(o_orderstatus)	o_orderstatus
+6	P
+SELECT COUNT(o_orderstatus), o_orderstatus
+FROM orders
+GROUP BY 2
+ORDER BY 1, 2 DESC;
+COUNT(o_orderstatus)	o_orderstatus
+2	P
+2	O
+2	F
+SELECT COUNT(o_orderstatus), o_orderstatus
+FROM orders
+GROUP BY 2
+ORDER BY 1, 2;
+COUNT(o_orderstatus)	o_orderstatus
+2	F
+2	O
+2	P
+SELECT COUNT(o_orderstatus) cnt, o_orderstatus
+FROM orders
+ORDER BY cnt, o_orderstatus;
+cnt	o_orderstatus
+6	P
+SELECT COUNT(o_orderstatus) cnt, o_orderstatus
+FROM orders
+ORDER BY cnt, o_orderstatus DESC;
+cnt	o_orderstatus
+6	P
+SELECT COUNT(o_orderstatus) cnt, o_orderstatus
+FROM orders
+GROUP BY o_orderstatus
+ORDER BY cnt, o_orderstatus;
+cnt	o_orderstatus
+2	F
+2	O
+2	P
+SELECT COUNT(o_orderstatus) cnt, o_orderstatus
+FROM orders
+GROUP BY o_orderstatus
+ORDER BY cnt, o_orderstatus DESC;
+cnt	o_orderstatus
+2	P
+2	O
+2	F
+CREATE TABLE orders2 (o_custkey INT, o_orderstatus CHAR(1), order_reason INT) ENGINE=Columnstore;
+INSERT INTO orders2 VALUES (10,'F', 1), (20,'O', 1), (20,'O', 2);
+SELECT COUNT(o_orderstatus) cnt, o_orderstatus /* aggregated */, order_reason /* unaggregated */
+FROM orders2
+GROUP BY 2    /* group by o_orderstatus */
+ORDER BY 3;
+cnt	o_orderstatus	order_reason
+1	F	1
+2	O	2
+/* order by order_reason - not in group by */
+SELECT COUNT(o_orderstatus) cnt, o_orderstatus /* aggregated */, order_reason /* unaggregated */
+FROM orders2
+GROUP BY 2         /* group by o_orderstatus */
+ORDER BY 3 DESC;
+cnt	o_orderstatus	order_reason
+2	O	2
+1	F	1
+/* order by order_reason - not in group by */
+# Cleanup
+DROP DATABASE mcol_6332;

--- a/mysql-test/columnstore/bugfixes/MCOL-6332-fix-order-by-by-positional-parameter-for-column-not-under-aggregation.test
+++ b/mysql-test/columnstore/bugfixes/MCOL-6332-fix-order-by-by-positional-parameter-for-column-not-under-aggregation.test
@@ -1,0 +1,67 @@
+--source ../include/have_columnstore.inc
+--disable_warnings
+DROP DATABASE IF EXISTS mcol_6332;
+--enable_warnings
+CREATE DATABASE mcol_6332;
+USE mcol_6332;
+
+# 1. Original example from the ticket
+CREATE TABLE orders (o_custkey INT, o_orderstatus CHAR(1)) ENGINE=Columnstore;
+INSERT INTO orders VALUES (10,'F'),(20,'O'),(10,'P'),(30,'F'),(20,'O'),(40,'P');
+ 
+SELECT COUNT(o_orderstatus), o_orderstatus
+FROM orders
+ORDER BY 1, 2 DESC;
+
+# 2. Ascending order works as well
+SELECT COUNT(o_orderstatus), o_orderstatus
+FROM orders
+ORDER BY 1, 2;
+
+# 3. Works with group by too
+SELECT COUNT(o_orderstatus), o_orderstatus
+FROM orders
+GROUP BY 2
+ORDER BY 1, 2 DESC;
+
+SELECT COUNT(o_orderstatus), o_orderstatus
+FROM orders
+GROUP BY 2
+ORDER BY 1, 2;
+
+# 4. Still works with named columns
+SELECT COUNT(o_orderstatus) cnt, o_orderstatus
+FROM orders
+ORDER BY cnt, o_orderstatus;
+
+SELECT COUNT(o_orderstatus) cnt, o_orderstatus
+FROM orders
+ORDER BY cnt, o_orderstatus DESC;
+
+SELECT COUNT(o_orderstatus) cnt, o_orderstatus
+FROM orders
+GROUP BY o_orderstatus
+ORDER BY cnt, o_orderstatus;
+
+SELECT COUNT(o_orderstatus) cnt, o_orderstatus
+FROM orders
+GROUP BY o_orderstatus
+ORDER BY cnt, o_orderstatus DESC;
+
+# 5. sort order for a non-group by column referred by position works correctly
+CREATE TABLE orders2 (o_custkey INT, o_orderstatus CHAR(1), order_reason INT) ENGINE=Columnstore;
+
+INSERT INTO orders2 VALUES (10,'F', 1), (20,'O', 1), (20,'O', 2);
+
+SELECT COUNT(o_orderstatus) cnt, o_orderstatus /* aggregated */, order_reason /* unaggregated */
+FROM orders2
+GROUP BY 2    /* group by o_orderstatus */
+ORDER BY 3;   /* order by order_reason - not in group by */
+
+SELECT COUNT(o_orderstatus) cnt, o_orderstatus /* aggregated */, order_reason /* unaggregated */
+FROM orders2
+GROUP BY 2         /* group by o_orderstatus */
+ORDER BY 3 DESC;   /* order by order_reason - not in group by */
+
+# Cleanup
+DROP DATABASE mcol_6332;


### PR DESCRIPTION
This PR addresses [MCOL-6332](https://jira.mariadb.org/browse/MCOL-6332).

Fixes:
- Fix error when using a reference id in an ORDER BY section and specifying a DESC sort order for a non-agg function column that is not under a group by list