### PR TITLE
ci(drone): ignore mtr/regression failures for ASan/UBSan nightly

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -715,8 +715,9 @@ local AllPipelines =
     for triggeringEvent in events
     for server in servers[current_branch]
   ] +
+  // sanitizers are non-functional; ignore mtr/regression failures so nightly stays green
   [
-    Pipeline(b, platform, triggeringEvent, a, server, flag, "")
+    Pipeline(b, platform, triggeringEvent, a, server, flag, "", ["regression", "mtr"])
     for a in ["amd64"]
     for b in std.objectFields(platforms)
     for platform in ["ubuntu:24.04"]
@@ -725,7 +726,7 @@ local AllPipelines =
     for server in servers[current_branch]
   ] +
   [
-    Pipeline(b, platform, triggeringEvent, a, server, flag, "", ['test009.sh', 'test011.sh', 'test012.sh'])
+    Pipeline(b, platform, triggeringEvent, a, server, flag, "", ["regression", "mtr"])
     for a in ["amd64"]
     for b in std.objectFields(platforms)
     for platform in ["ubuntu:24.04"]


### PR DESCRIPTION
## Summary
- Sanitizer pipelines (ASan, UBSan) on `ubuntu:24.04` are currently non-functional and frequently fail at runtime.
- Their failures bubble up to the nightly Slack notification, making the whole nightly look red even when everything else is green.
- Reuse the existing `ignoreFailureStepList` mechanism (same `["regression", "mtr"]` pattern already used by the `libcpp` pipeline) so failures in mtr / regression tests of sanitizer builds no longer fail the pipeline.

## Test plan
- [ ] `jsonnet .drone.jsonnet` parses cleanly (verified locally).
- [ ] Confirm in next nightly that ASan/UBSan pipelines report success even when mtr/regression steps fail, while non-sanitizer pipelines still report failures normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)