### PR TITLE
ci(drone): ignore mtr/regression failures on sanitizer nightly

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -83,6 +83,11 @@ local upgrade_test_lists = {
   "ubuntu24.04": default_arch_versions,
 };
 
+// Normalise signal-killed exits (≥128) to 1 so Drone records status=`failure`
+// instead of status=`killed`; `failure: ignore` then suppresses pipeline failure
+// while the step itself remains red (visible in the UI).
+local normaliseKilledExit = " || { ec=$$?; [ $$ec -ge 128 ] && exit 1; exit $$ec; }";
+
 local make_clickable_link(link) = "echo -e '\\e]8;;" + link + "\\e\\\\" + link + "\\e]8;;\\e\\\\'";
 local echo_running_on = [
   "echo running on ${DRONE_STAGE_MACHINE}",
@@ -310,7 +315,8 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
       " --distro " + platform +
       " --triggering-event " + event +
       " --full-mtr $${MTR_FULL_SUITE}" +
-      if std.endsWith(result, "ASan") then " --run-as-extern" else "",
+      (if std.endsWith(result, "ASan") then " --run-as-extern" else "") +
+      (if std.member(ignoreFailureStepList, "mtr") then normaliseKilledExit else ""),
     ],
     [if (std.member(ignoreFailureStepList, "mtr")) then "failure"]: "ignore",
 
@@ -360,7 +366,8 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
       " --test-name " + name +
       " --distro " + platform +
       " --regression-branch $$REGRESSION_REF" +
-      " --regression-timeout $${REGRESSION_TIMEOUT}",
+      " --regression-timeout $${REGRESSION_TIMEOUT}" +
+      (if std.member(ignoreFailureStepList, name) || std.member(ignoreFailureStepList, "regression") then normaliseKilledExit else ""),
     ],
 
   },


### PR DESCRIPTION
Sanitizer pipelines (ASan/UBSan) are non-functional and shouldn't red the nightly. Step-level `failure: ignore` was already there, but it only catches `status=failure` — OOM/timeout-killed mtr surfaces as `status=killed` and bypasses it (was the cause of build #3616).

**Fix:**
- Pass `["regression", "mtr"]` as `ignoreFailureStepList` for ASan/UBSan pipelines
- Normalise signal-killed exits (≥128) to 1 in mtr/regression so they become `status=failure` instead of `status=killed`

Step stays **red and visible**, pipeline goes **green**.

Validated on build [#3635](https://ci.columnstore.mariadb.net/mariadb-corporation/mariadb-columnstore-engine/3635) with a deliberate `exit 137` in `run_mtr.sh`: mtr step red, sanitizer pipelines green, overall build green.