### PR TITLE
fix(json_append): Fix JSON_APPEND crash under 12.3 CS

### DIFF
--- a/utils/dataconvert/dataconvert.h
+++ b/utils/dataconvert/dataconvert.h
@@ -67,7 +67,9 @@ inline uint64_t htonll(uint64_t n);
 #endif
 
 #define LEAPS_THRU_END_OF(y) ((y) / 4 - (y) / 100 + (y) / 400)
+#ifndef isleap
 #define isleap(y) (((y) % 4) == 0 && (((y) % 100) != 0 || ((y) % 400) == 0))
+#endif
 
 // this method evalutes the uint64 that stores a char[] to expected value
 inline uint64_t uint64ToStr(uint64_t n)

--- a/utils/funcexp/functor_json.h
+++ b/utils/funcexp/functor_json.h
@@ -105,7 +105,7 @@ class Func_json_multipath : public Func_json
       for (size_t i=0; i<paths.size(); i++)
       {
         JSONPath& path = paths[i];
-        initJsonArray(NULL, &path.p.steps, sizeof(json_path_step_t), &p_steps_arr[i],  MY_INIT_BUFFER_USED | MY_BUFFER_NO_RESIZE);
+        initJsonArray(NULL, &path.p.steps, sizeof(json_path_step_t), &p_steps_arr[i][0],  MY_INIT_BUFFER_USED | MY_BUFFER_NO_RESIZE);
       }
       path_inited= true;
     }


### PR DESCRIPTION
This patch prevents redefinition of isleap macro to allow building under 12.3 CS and fixes heap buffer overrun in the JSON_APPEND function implementation.