### PR TITLE
Fix including selinux-policy-devel as a Build Require RPM dep

### DIFF
--- a/cmake/selinux_policy.cmake
+++ b/cmake/selinux_policy.cmake
@@ -23,20 +23,29 @@ if(NOT _is_rhel_like
     return()
 endif()
 
-# Use the common appender macro to handle comma separation.
-# As a SRPM directive, it is global rather than for the component
-columnstore_append_for_cpack(CPACK_RPM_BUILDREQUIRES "selinux-policy-devel")
-
 # Paths
 set(SELINUX_SRC_DIR "${CMAKE_CURRENT_LIST_DIR}/../build/security")
 set(SELINUX_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/selinux")
 set(SELINUX_TE "${SELINUX_SRC_DIR}/columnstore.te")
 set(SELINUX_PP "${SELINUX_BUILD_DIR}/columnstore.pp")
 
+# MariaDB Server's SRPM generator derives BuildRequires from cache FILEPATH
+# entries, so keep this as a find_file() result instead of a plain path.
+find_file(
+    COLUMNSTORE_SELINUX_DEVEL_MAKEFILE
+    NAMES Makefile
+    PATHS /usr/share/selinux/devel
+    NO_DEFAULT_PATH
+    DOC "SELinux policy development Makefile"
+)
+mark_as_advanced(COLUMNSTORE_SELINUX_DEVEL_MAKEFILE)
+
 file(MAKE_DIRECTORY "${SELINUX_BUILD_DIR}")
 
 # Ensure selinux-policy-devel is available
-if(NOT EXISTS "/usr/share/selinux/devel/Makefile")
+if(NOT COLUMNSTORE_SELINUX_DEVEL_MAKEFILE
+   OR NOT EXISTS "${COLUMNSTORE_SELINUX_DEVEL_MAKEFILE}"
+)
     message(
         FATAL_ERROR
             "SELinux policy build requires '/usr/share/selinux/devel/Makefile'. Please install 'selinux-policy-devel' (RHEL/Rocky >= 9) and re-run CMake."
@@ -47,7 +56,7 @@ endif()
 add_custom_command(
     OUTPUT "${SELINUX_PP}"
     COMMAND ${CMAKE_COMMAND} -E copy "${SELINUX_TE}" "${SELINUX_BUILD_DIR}/columnstore.te"
-    COMMAND make -f /usr/share/selinux/devel/Makefile columnstore.pp
+    COMMAND make -f "${COLUMNSTORE_SELINUX_DEVEL_MAKEFILE}" columnstore.pp
     WORKING_DIRECTORY "${SELINUX_BUILD_DIR}"
     DEPENDS "${SELINUX_TE}"
     COMMENT "Building SELinux policy columnstore.pp from columnstore.te"


### PR DESCRIPTION
Server cmake creates build requires by looking at cached cmake variables 
See:https://github.com/MariaDB/server/blob/3f388a1cce36fc0a5eaceb8e9c5ebf12e278c5a1/cmake/build_depends.cmake#L24-L39

`CPACK_RPM_BUILDREQUIRES` is replaced by server cmake with it's own calculated `BUILD_DEPS` values based on cached variables. 
See:https://github.com/MariaDB/server/blob/c8e8d33309606e682c98675d594dbd23ebc2ddf6/cmake/build_depends.cmake#L43

For the above, it means that setting:
```
columnstore_append_for_cpack(CPACK_RPM_BUILDREQUIRES "selinux-policy-devel")
```
**has no effect.**

Using `find_file()` will ensure that the path is cached and then discovered by server's cmake.

---------------------------
**How to test:**
1. Get a Buildbot RHEL 9/10 build environment: `docker run -it --rm quay.io/mariadb-foundation/bb-worker:rhel9 bash`
2. `git clone` any MariaDB Server using CS 23.10 (>=11.4)
3. Update the Columnstore submodule `repo/ref` to this patch
4. Configure: `cmake -S . -DBUILD_CONFIG=mysql_release -DRPM=rhel9`
5. Generate the source RPM: `make package_source`
6. Inspect the build requirements of the source package: `rpm -qp --requires MariaDB-*.src.rpm`
