### PR TITLE
MCOL-5891 Stop rotating Columnstore.xml backups into /etc

### DIFF
--- a/oam/install_scripts/columnstoreLogRotate.in
+++ b/oam/install_scripts/columnstoreLogRotate.in
@@ -13,10 +13,14 @@
     su root root 
 }
 @ENGINE_SYSCONFDIR@/columnstore/Columnstore.xml {
+    missingok
     daily
     dateext
     copy
-    olddir @ENGINE_SYSCONFDIR@/columnstore
+    olddir @ENGINE_LOGDIR@/archive
+    rotate 7
+    maxage 30
+    su root root
 }
 @ENGINE_LOGDIR@/data/bulk/job/*.xml {
     missingok


### PR DESCRIPTION
logrotate wrote daily dated copies of Columnstore.xml into /etc/columnstore, but Ubuntu's logrotate.service runs with ProtectSystem=full (read-only /etc), so the daily run failed with "error creating output file ...: Read-only file system".

Write snapshots to the writable log archive instead, keep at most 7 copies for 30 days (was rotate 0: skipped, or kept forever on older logrotate), and add missingok so a missing file doesn't fail the run.