### PR TITLE
MCOL-6221 Fix stack-use-after-scope in TreeNode::getIntVal/getUintVal

### DIFF
--- a/datatypes/numericliteral.h
+++ b/datatypes/numericliteral.h
@@ -55,6 +55,9 @@ class Converter : public Parser, public A
   Converter(const std::string& str, DataCondition& error) : Converter(str.data(), str.length(), error)
   {
   }
+  // A Converter does not own the input string value - it keeps a pointer,
+  // so forbid constructing from a temporary value to avoid dangling pointer errors
+  Converter(std::string&& str, DataCondition& error) = delete;
 };
 
 /*

--- a/dbcon/execplan/treenode.h
+++ b/dbcon/execplan/treenode.h
@@ -691,7 +691,8 @@ inline int64_t TreeNode::getIntVal()
         return fResult.intVal;
       }
       datatypes::DataCondition cnverr;
-      literal::Converter<literal::SignedInteger> cnv(fResult.strVal.safeString(""), cnverr);
+      const std::string str = fResult.strVal.safeString("");
+      literal::Converter<literal::SignedInteger> cnv(str, cnverr);
       return cnv.toSInt<int64_t>(cnverr);
     }
     case CalpontSystemCatalog::VARCHAR:
@@ -703,7 +704,8 @@ inline int64_t TreeNode::getIntVal()
         return fResult.intVal;
 
       datatypes::DataCondition cnverr;
-      literal::Converter<literal::SignedInteger> cnv(fResult.strVal.safeString(""), cnverr);
+      const std::string str = fResult.strVal.safeString("");
+      literal::Converter<literal::SignedInteger> cnv(str, cnverr);
       return cnv.toSInt<int64_t>(cnverr);
     }
 
@@ -751,10 +753,11 @@ inline uint64_t TreeNode::getUintVal()
     case CalpontSystemCatalog::TEXT:
     {
       datatypes::DataCondition cnverr;
-      literal::Converter<literal::UnsignedInteger> cnv(fResult.strVal.safeString(""), cnverr);
+      const std::string str = fResult.strVal.safeString("");
+      literal::Converter<literal::UnsignedInteger> cnv(str, cnverr);
       if (datatypes::DataCondition::Code(cnverr) != 0)
       {
-        std::cerr << "error in unsigned int conversion from '" << fResult.strVal.safeString() << "'";
+        std::cerr << "error in unsigned int conversion from '" << str << "'";
       }
       return cnv.toXIntPositive<uint64_t>(cnverr);
     }


### PR DESCRIPTION
Converter parsed a dangling pointer into the dead safeString() temporary. Caught by ASan in PrimProc via SEC_TO_TIME(varchar) in the MCOL-6221 mtr tests.