### PR TITLE
MCOL-6416 Refactoring and fixes for ci pipelines

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -764,9 +764,9 @@ local AllPipelines =
     for triggeringEvent in events
     for server in servers[current_branch]
   ] +
-  // last argument is to ignore mtr and regression failures
+  // last argument (ignoreFailureStepList) ignores only test400
   [
-    Pipeline(b, platform, triggeringEvent, a, server, "", "", ["regression"])
+    Pipeline(b, platform, triggeringEvent, a, server, "", "", ["test400.sh"])
     for a in ["amd64"]
     for b in std.objectFields(platforms)
     for server in extra_servers[current_branch]
@@ -774,16 +774,16 @@ local AllPipelines =
     for triggeringEvent in events
   ] +
   [
-    Pipeline(b, platform, triggeringEvent, a, server, "", "", ["regression"])
+    Pipeline(b, platform, triggeringEvent, a, server, "", "", ["test400.sh"])
     for a in ["amd64"]
     for b in std.objectFields(platforms)
     for server in extra_servers_11_8[current_branch]
     for platform in extra_servers_platforms_11_8[current_branch]
     for triggeringEvent in events
   ] +
-  // // last argument is to ignore mtr and regression failures
+  // // last argument (ignoreFailureStepList) ignores only test400
   [
-    Pipeline(b, platform, triggeringEvent, a, server, flag, envcommand, ["regression", "mtr"])
+    Pipeline(b, platform, triggeringEvent, a, server, flag, envcommand, ["test400.sh"])
     for a in ["amd64"]
     for b in std.objectFields(platforms)
     for platform in ["ubuntu:24.04"]
@@ -797,7 +797,7 @@ local AllPipelines =
   //   <key>      runs smoke + cmapi + mtr + upgrade
   //   <key>Regr  runs the regression chain only
   [
-    Pipeline(b, platform, triggeringEvent, a, server, spec.flag, "", ["smoke", "mtr", "regression", "cmapi test", "upgrade"], spec.testSet)
+    Pipeline(b, platform, triggeringEvent, a, server, spec.flag, "", ["cmapi test", "upgrade", "test400.sh"], spec.testSet)
     for a in ["amd64"]
     for b in std.objectFields(platforms)
     for platform in ["ubuntu:24.04"]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -97,6 +97,16 @@ local upgrade_test_lists = {
 // while the step itself remains red (visible in the UI).
 local normaliseKilledExit = " || { ec=$$?; [ $$ec -ge 128 ] && exit 1; exit $$ec; }";
 
+// Per-step hard time limits (seconds). A hung command then fails red with its
+// logs still collected by the corresponding *log step, instead of stalling
+// the stage until Drone's 8h limit kills it with no diagnostics.
+local prepare_step_timeout = "1800";  // 30m; package installs normally ~10m
+local smoke_step_timeout = "1800";  // 30m; normally minutes
+local mtr_step_timeout = "14400";  // 4h; nightly full-suite under UBSan legitimately takes ~3h
+local cmapi_step_timeout = "3600";  // 1h; ~15m under ASan
+local upgrade_step_timeout = "3600";  // 1h; normally minutes
+local regression_step_timeout = "10800";  // 3h per regression test: slow for sanitizer builds
+
 local make_clickable_link(link) = "echo -e '\\e]8;;" + link + "\\e\\\\" + link + "\\e]8;;\\e\\\\'";
 local echo_running_on = [
   "echo running on ${DRONE_STAGE_MACHINE}",
@@ -211,7 +221,7 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
   local getContainerName(stepname) = stepname + "$${DRONE_BUILD_NUMBER}",
 
   local prepareTestContainer(containerName, result, do_setup, do_install, do_install_builddeps) =
-    'sh -c "apk add bash && ' + get_build_command("prepare_test_container.sh") +
+    'sh -c "apk add bash && timeout ' + prepare_step_timeout + " " + get_build_command("prepare_test_container.sh") +
     " --container-name " + containerName +
     " --docker-image " + img +
     " --result-path " + result +
@@ -246,6 +256,7 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
     volumes: [pipeline._volumes.mdb, pipeline._volumes.docker],
     commands: [
       prepareTestContainer(getContainerName("smoke"), result, true, true, true),
+      "timeout " + smoke_step_timeout + " " +
       get_build_command("run_smoke.sh") +
       " --container-name " + getContainerName("smoke") +
       (if std.member(ignoreFailureStepList, "smoke") then normaliseKilledExit else ""),
@@ -278,6 +289,7 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
     commands: [
       prepareTestContainer(getContainerName("upgrade") + version, result, false, false, false),
 
+      "timeout " + upgrade_step_timeout + " " +
       execInnerDocker(
         'bash -c "./upgrade_setup_' + pkg_format + ".sh "
         + version + " "
@@ -322,7 +334,8 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
     commands: [
       prepareTestContainer(getContainerName("mtr"), result, true, true, true),
 
-      "apk add bash &&" +
+      "apk add bash && " +
+      "timeout " + mtr_step_timeout + " " +
       get_build_command("run_mtr.sh") +
       " --container-name " + getContainerName("mtr") +
       " --distro " + platform +
@@ -374,7 +387,7 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
       'echo "$$REGRESSION_REF"',
 
       "apk add bash && " +
-      (if std.member(ignoreFailureStepList, name) || std.member(ignoreFailureStepList, "regression") then "timeout 5400 " else "") +
+      "timeout " + regression_step_timeout + " " +
       get_build_command("run_regression.sh") +
       " --container-name " + getContainerName("regression") +
       " --test-name " + name +
@@ -450,6 +463,7 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
     commands: [
       prepareTestContainer(getContainerName("cmapi"), result, true, true, true),
       "apk add bash && " +
+      "timeout " + cmapi_step_timeout + " " +
       get_build_command("run_cmapi_test.sh") +
       " --container-name " + getContainerName("cmapi") +
       " --pkg-format " + pkg_format +
@@ -498,6 +512,7 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
     },
     commands: [
       "apk add bash && " +
+      "timeout " + mtr_step_timeout + " " +
       get_build_command("run_multi_node_mtr.sh") +
       " --columnstore-image-name $${MCS_IMAGE_NAME} " +
       " --distro " + platform,

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -392,7 +392,7 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
 
       // REGRESSION_REF can be empty if there is no appropriate branch in regression repository.
       // if REGRESSION_REF is empty, try to see whether regression repository has a branch named as one we PR.
-      'export REGRESSION_REF=$${REGRESSION_REF:-$$(git ls-remote https://github.com/mariadb-corporation/mariadb-columnstore-regression-test --h --sort origin "refs/heads/$$REGRESSION_BRANCH_REF" | grep -E -o "[^/]+$$")}',
+      'export REGRESSION_REF=$${REGRESSION_REF:-$$(git ls-remote https://github.com/mariadb-corporation/mariadb-columnstore-regression-test --h --sort origin "refs/heads/$$REGRESSION_BRANCH_REF" | sed "s#.*refs/heads/##")}',
       "export REGRESSION_REF=$${REGRESSION_REF:-$$REGRESSION_REF_AUX}",
       'echo "$$REGRESSION_REF"',
 

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -60,10 +60,15 @@ local customBootstrapParamsForExisitingPipelines(envkey) =
   (if (std.objectHas(customBootstrapMap, envkey))
    then customBootstrapMap[envkey] else "");
 
+// 'Regr' variants are the regression half of the split sanitizer stages.
+// Distinct keys give them their own result path, so the two halves
+// publish/install independently.
 local customBootstrapParamsForAdditionalPipelinesMap = {
   ASan: "--asan",
+  ASanRegr: "--asan",
   TSAN: "--tsan",
   UBSan: "--ubsan",
+  UBSanRegr: "--ubsan",
   MSan: "--msan",
   libcpp: "--libcpp --skip-unit-tests",
   "gcc-toolset": "--gcc-toolset-for-rocky-8",
@@ -113,7 +118,12 @@ local echo_running_on = [
   make_clickable_link("https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Instances:search=:${DRONE_STAGE_MACHINE};v=3;$case=tags:true%5C,client:false;$regex=tags:false%5C,client:false;sort=desc:launchTime"),
 ];
 
-local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", customBootstrapParamsKey="", customBuildEnvCommandsMapKey="", ignoreFailureStepList=[]) = {
+// testSet selects which test groups the pipeline runs:
+//   "all"        - everything (the default)
+//   "mtr"        - everything except regression chain
+//   "regression" - only the regression chain
+// Used to split sanitizer pipelines in two so each half fits the 8h limit.
+local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", customBootstrapParamsKey="", customBuildEnvCommandsMapKey="", ignoreFailureStepList=[], testSet="all") = {
   local pkg_format = if (std.split(platform, ":")[0] == "rockylinux") then "rpm" else "deb",
   local img = if (platform == "rockylinux:8") then platform else "detravi/" + std.strReplace(platform, "/", "-"),
   local branch_ref = if (branch == any_branch) then current_branch else branch,
@@ -544,6 +554,39 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
     ],
   },
 
+  // --- test step groups --------------------------------------------------
+  local smoke_steps = [pipeline.smoke, pipeline.smokelog, pipeline.publish("smokelog")],
+  local cmapi_steps = [pipeline.cmapitest, pipeline.cmapilog, pipeline.publish("cmapilog")],
+  local docs_check_steps =
+    if (platform == "rockylinux:9" && arch == "amd64" && server == "10.6-enterprise")
+    then [pipeline.mcs_cli_docs_check] else [],
+  local mtr_steps =
+    if (platform == "rockylinux:8" && arch == "amd64" && customBootstrapParamsKey == "gcc-toolset")
+    then [pipeline.dockerfile, pipeline.dockerhub, pipeline.multi_node_mtr, pipeline.multinode_mtrlog, pipeline.publish("multinode-mtrlog")]
+    else [pipeline.mtr, pipeline.mtrlog, pipeline.publish("mtrlog")],
+  // The regression chain is serial: the first test waits for the given
+  // dependencies, every other test waits for the previous one.
+  local regression_steps(first_depends_on) =
+    [pipeline.regression(regression_tests[i], if (i == 0) then first_depends_on else [regression_tests[i - 1]]) for i in indexes(regression_tests)] +
+    [pipeline.regressionlog] +
+    [pipeline.publish("regressionlog")],
+  local upgrade_steps =
+    [pipeline.upgrade(mdb_server_versions[i]) for i in indexes(mdb_server_versions)] +
+    (if (std.length(mdb_server_versions) == 0) then [] else [pipeline.upgradelog] + [pipeline.publish("upgradelog")]),
+  local publish_latest_steps(anchor) =
+    if (event == "cron") then [pipeline.publish(anchor + " latest", "latest")] else [],
+
+  local regression_published_pkgs_prereqs = ["publish pkg", "publish cmapi build"],
+
+  // What each testSet value runs. In "all" the
+  // regression chain additionally waits for mtr, serializing the two heavy
+  // test groups; in "regression" there is no mtr step to wait for.
+  local test_steps_by_set = {
+    all: smoke_steps + cmapi_steps + docs_check_steps + mtr_steps + regression_steps(["mtr"] + regression_published_pkgs_prereqs) + upgrade_steps + publish_latest_steps("regressionlog"),
+    mtr: smoke_steps + cmapi_steps + docs_check_steps + mtr_steps + upgrade_steps + publish_latest_steps("mtrlog"),
+    regression: regression_steps(regression_published_pkgs_prereqs) + publish_latest_steps("regressionlog"),
+  },
+
   kind: "pipeline",
   type: "docker",
   name: std.join(" ", [branch, platform, event, arch, server, customBootstrapParamsKey, customBuildEnvCommandsMapKey]),
@@ -677,20 +720,7 @@ local Pipeline(branch, platform, event, arch="amd64", server="10.6-enterprise", 
          [pipeline.publish("cmapi build")] +
          [pipeline.publish()] +
          (if (event == "cron") then [pipeline.publish("pkg latest", "latest")] else []) +
-         [pipeline.smoke] +
-         [pipeline.smokelog] +
-         [pipeline.publish("smokelog")] +
-         [pipeline.cmapitest] +
-         [pipeline.cmapilog] +
-         [pipeline.publish("cmapilog")] +
-         (if (platform == "rockylinux:9" && arch == "amd64" && server == "10.6-enterprise") then [pipeline.mcs_cli_docs_check] else []) +
-         (if (platform == "rockylinux:8" && arch == "amd64" && customBootstrapParamsKey == "gcc-toolset") then [pipeline.dockerfile] + [pipeline.dockerhub] + [pipeline.multi_node_mtr] + [pipeline.multinode_mtrlog] + [pipeline.publish("multinode-mtrlog")] else [pipeline.mtr] + [pipeline.mtrlog] + [pipeline.publish("mtrlog")]) +
-         [pipeline.regression(regression_tests[i], if (i == 0) then ["mtr", "publish pkg", "publish cmapi build"] else [regression_tests[i - 1]]) for i in indexes(regression_tests)] +
-         [pipeline.regressionlog] +
-         [pipeline.publish("regressionlog")] +
-         [pipeline.upgrade(mdb_server_versions[i]) for i in indexes(mdb_server_versions)] +
-         (if (std.length(mdb_server_versions) == 0) then [] else [pipeline.upgradelog] + [pipeline.publish("upgradelog")]) +
-         (if (event == "cron") then [pipeline.publish("regressionlog latest", "latest")] else []),
+         test_steps_by_set[testSet],
 
   volumes: [pipeline._volumes.mdb { temp: {} }, pipeline._volumes.docker { host: { path: "/var/run/docker.sock" } }],
   trigger: {
@@ -762,22 +792,21 @@ local AllPipelines =
     for triggeringEvent in events
     for server in servers[current_branch]
   ] +
-  // sanitizers: ignore all test step failures so nightly stays green even when tests fail/timeout
+  // sanitizer tests: each sanitizer test is split into two parallel stages so
+  // each half fits the 8h stage limit:
+  //   <key>      runs smoke + cmapi + mtr + upgrade
+  //   <key>Regr  runs the regression chain only
   [
-    Pipeline(b, platform, triggeringEvent, a, server, flag, "", ["smoke", "mtr", "regression", "cmapi test", "upgrade"])
+    Pipeline(b, platform, triggeringEvent, a, server, spec.flag, "", ["smoke", "mtr", "regression", "cmapi test", "upgrade"], spec.testSet)
     for a in ["amd64"]
     for b in std.objectFields(platforms)
     for platform in ["ubuntu:24.04"]
-    for flag in ["UBSan"]
-    for triggeringEvent in events
-    for server in servers[current_branch]
-  ] +
-  [
-    Pipeline(b, platform, triggeringEvent, a, server, flag, "", ["smoke", "mtr", "regression", "cmapi test", "upgrade"])
-    for a in ["amd64"]
-    for b in std.objectFields(platforms)
-    for platform in ["ubuntu:24.04"]
-    for flag in ["ASan"]
+    for spec in [
+      { flag: "UBSan", testSet: "mtr" },
+      { flag: "UBSanRegr", testSet: "regression" },
+      { flag: "ASan", testSet: "mtr" },
+      { flag: "ASanRegr", testSet: "regression" },
+    ]
     for triggeringEvent in events
     for server in servers[current_branch]
   ] +


### PR DESCRIPTION
- Split each sanitizer stage (heavy, nightly only) into two parallel stages to make them fit in their time quotas
- Fix failing regression test test500.sh on Debian 13 and Ubuntu 26.04 (see PR in https://github.com/mariadb-corporation/mariadb-columnstore-regression-test repo)
- Add more granular explicit timeouts per stage step
- Remove from ignored tests all tests except: test400.sh (regression test, fails sporadically), cmapi, upgrade