### PR TITLE
fix(aggregation): fix dumping RGDatas to disk

### DIFF
--- a/utils/rowgroup/rowstorage.cpp
+++ b/utils/rowgroup/rowstorage.cpp
@@ -1226,7 +1226,7 @@ class RowGroupStorage
   {
     messageqcpp::ByteStream bs;
     fRowGroupOut->setData(rgdata);
-    rgdata->serialize(bs, fRowGroupOut->getSizeWithStrings());
+    rgdata->serialize(bs, fRowGroupOut->getDataSize());
 
     int errNo;
     if ((errNo = fDumper->write(makeRGFilename(rgid), (char*)bs.buf(), bs.length())) != 0)


### PR DESCRIPTION
`amount` parameter of `RGData::serialize` is the raw size of `rowData` buffer without StringStore/UserDataStore/etc