### PR TITLE
MCOL-6408 Fix MariaDBHasher losing hash state on server 12.3

### DIFF
--- a/utils/common/collation.h
+++ b/utils/common/collation.h
@@ -107,13 +107,27 @@ namespace datatypes
 {
 class MariaDBHasher
 {
+#ifdef MY_HASH_ADD_MARIADB
+  /*
+    Server 12.3+ (MDEV-9826): hash state is accumulated in a my_hasher_st
+    object passed to hash_sort().
+  */
+  my_hasher_st mHasher;
+#else
   ulong mPart1;
   ulong mPart2;
+#endif
 
  public:
+#ifdef MY_HASH_ADD_MARIADB
+  MariaDBHasher() : mHasher(my_hasher_mysql5x())
+  {
+  }
+#else
   MariaDBHasher() : mPart1(1), mPart2(4)
   {
   }
+#endif
   MariaDBHasher& add(CHARSET_INFO* cs, const char* str, size_t length)
   {
     // Hashing an empty string is a no-op in every MariaDB collation
@@ -128,8 +142,7 @@ class MariaDBHasher
     if (length == 0)
       return *this;
 #ifdef MY_HASH_ADD_MARIADB
-    my_hasher_st hasher= my_hasher_mysql5x();
-    cs->hash_sort(&hasher, (const uchar*)str, length);
+    cs->hash_sort(&mHasher, (const uchar*)str, length);
 #else
     cs->hash_sort((const uchar*)str, length, &mPart1, &mPart2);
 #endif
@@ -141,7 +154,11 @@ class MariaDBHasher
   }
   uint32_t finalize() const
   {
+#ifdef MY_HASH_ADD_MARIADB
+    return (uint32_t)mHasher.m_nr1;
+#else
     return (uint32_t)mPart1;
+#endif
   }
 };
 


### PR DESCRIPTION
Server 12.3 (MDEV-9826) changed the collation hash_sort() API from two caller-owned accumulators (ulong *nr1, *nr2) to a single my_hasher_st object that carries both the accumulator and the chosen algorithm. ColumnStore's port of MariaDBHasher::add() created that my_hasher_st as a local variable, so every add() call hashed into a throwaway object and the accumulated state was discarded. finalize() then always returned the seed value (1), making every typeless hash key collide into a single bucket. Joins and aggregations on string/compound keys still produced correct results but degraded to O(n^2) and appeared to hang (e.g. mcol-5279, dbt3 q9).

Keep the my_hasher_st as a member of MariaDBHasher so it persists across add() calls and finalize() returns the real hash. The legacy (pre-12.3) two-accumulator path is unchanged under #else.