### PR TITLE
chore(infer): MCOL-6423 re-add USE_AFTER_DELETE suppressions for node-based containers

### DIFF
--- a/utils/threadpool/threadpool.h
+++ b/utils/threadpool/threadpool.h
@@ -66,6 +66,8 @@ class ThreadPoolGroup
   {
     for (auto* thread : threads)
     {
+      // False positive: `delete` frees the pointee; the list node stays valid.
+      // @infer-ignore USE_AFTER_DELETE
       delete thread;
     }
   }

--- a/versioning/BRM/lbidresourcegraph.cpp
+++ b/versioning/BRM/lbidresourcegraph.cpp
@@ -275,6 +275,9 @@ void LBIDResourceGraph::releaseResources(VER_t txn)
     ResourceNode* rNode = dynamic_cast<ResourceNode*>(*sit);
     // advance past the current element before removeInEdge() erases it from txnNode->in
     ++sit;
+    // False positive: rNode is freshly read from the set each iteration; the node deleted
+    // below is erased from the set first and never read again.
+    // @infer-ignore USE_AFTER_DELETE
     rNode->wakeAndDetach();
     txnNode->removeInEdge(rNode);
     resources.erase(rNode);

--- a/writeengine/dictionary/we_dctnry.cpp
+++ b/writeengine/dictionary/we_dctnry.cpp
@@ -126,6 +126,8 @@ void Dctnry::freeStringCache()
 {
   for (const auto& sig : m_sigArray)
   {
+    // False positive: `delete[]` frees the signature buffer; the set node stays valid.
+    // @infer-ignore USE_AFTER_DELETE
     delete[] sig.signature;
   }
 

--- a/writeengine/shared/we_chunkmanager.cpp
+++ b/writeengine/shared/we_chunkmanager.cpp
@@ -1531,7 +1531,11 @@ void ChunkManager::cleanUp(const std::map<FID, FID>& columOids)
     if (fIsInsert && it != columOids.end())
     {
       for (auto* chunkData : fileData->fChunkList)
+      {
+        // False positive: `delete` frees the pointee; the list node stays valid.
+        // @infer-ignore USE_AFTER_DELETE
         delete chunkData;
+      }
 
       delete fileData->fFilePtr;
       fFileMap.erase(fileData->fFileID);
@@ -1542,7 +1546,11 @@ void ChunkManager::cleanUp(const std::map<FID, FID>& columOids)
     else if (!fIsInsert || (columOids.size() == 0))
     {
       for (auto* chunkData : fileData->fChunkList)
+      {
+        // False positive: `delete` frees the pointee; the list node stays valid.
+        // @infer-ignore USE_AFTER_DELETE
         delete chunkData;
+      }
 
       delete fileData->fFilePtr;
       fFileMap.erase(fileData->fFileID);


### PR DESCRIPTION
The nightly scan showed the loop refactors fix the false positives for std::vector but not for std::list/std::set, which Infer has no precise model for. Re-add targeted @infer-ignore comments at the five surviving sites (threadpool.h, we_chunkmanager.cpp x2, we_dctnry.cpp, lbidresourcegraph.cpp), keeping the refactored loops.