### PR TITLE
fix(simd): MCOL-6511 disambiguate TypeToVecWrapperType<__int128> on aarch64 with GCC 16

### DIFF
--- a/utils/common/simd_arm.h
+++ b/utils/common/simd_arm.h
@@ -187,7 +187,8 @@ struct TypeToVecWrapperType<T, typename std::enable_if<std::is_unsigned_v<T>>::t
 };
 
 template <typename T>
-struct TypeToVecWrapperType<T, typename std::enable_if<std::is_signed_v<T> && !std::is_floating_point_v<T>>::type>
+struct TypeToVecWrapperType<T, typename std::enable_if<std::is_signed_v<T> && !std::is_floating_point_v<T> &&
+                                                        !std::is_same_v<T, __int128>>::type>
  : WidthToSVecWrapperType<sizeof(T)>
 {
 };


### PR DESCRIPTION
https://jira.mariadb.org/browse/MCOL-6511

## Problem

`aarch64-fedora-44-rpm-autobake` fails to compile Community Server builds embedding ColumnStore (first seen on 11.8.9, [build 227](https://buildbot.mariadb.org/#/builders/1259/builds/227)):

```
utils/common/simd_arm.h:215:9: error: ambiguous template instantiation for 'struct simd::TypeToVecWrapperType<__int128, void>'
```

## Root cause

Fedora 44 ships GCC 16.1.1, whose libstdc++ implements the type traits via compiler built-ins that treat `__int128` as a signed integral type **even in strict `-std=c++NN` mode** (ColumnStore builds with `CMAKE_CXX_EXTENSIONS FALSE`). `std::is_signed_v<__int128>` therefore flipped from `false` to `true`, and two partial specializations of `simd::TypeToVecWrapperType` now both match `__int128`:

- `simd_arm.h:167` — `enable_if<is_same<T, __int128>>`
- `simd_arm.h:190` — `enable_if<is_signed_v<T> && !is_floating_point_v<T>>`

Neither is more specialized than the other → ambiguous. The first instantiation to hit it is `column.cpp:1695` (`IntegralToSIMD<__int128, KIND_DEFAULT>` in `vectorizedFilteringDispatcher`). x86 is unaffected: `simd_sse.h` maps types by width and has no overlapping specialization pair (`amd64-fedora-44-rpm-autobake` is green with the same source).

## Fix

Exclude `__int128` from the generic signed-integral specialization so only the dedicated `is_same<T, __int128>` one matches. Both candidates derive from the same `WidthToSVecWrapperType<16>`, so type resolution is identical before and after, on every toolchain; on pre-GCC-16 toolchains (where `is_signed_v<__int128>` is `false` in strict mode) the change is a no-op.

## Verification

Compiled the real `simd_arm.h` (standalone, with two minimal stubs for its includes), instantiating `simd::IntegralToSIMD` for exactly the set of types `column.cpp`'s explicit `columnScanAndFilter` instantiations reach, with `static_assert`s pinning every wrapper-type resolution:

| toolchain (all aarch64) | unpatched | patched |
|---|---|---|
| GCC 16.1.1, Fedora 44, `-std=c++20` and `-std=gnu++20` | fails with exactly the buildbot error (lines 215/167/190) | compiles clean, all static_asserts pass |
| GCC 14.2.1, Fedora 40, `-std=c++20` | compiles clean (why this never failed before) | compiles clean — no-op on older toolchains |

Reproducible without ARM hardware: `docker run --platform linux/arm64 fedora:44` (native on ARM hosts, qemu-emulated on x86).

**Backport PR** to `develop-23.02` (also an active release series, same latent failure): #4076. The same block also exists in `develop`.