### PR TITLE
fix(disk join, oom): MCOL-6435 - improve handling of memory in disk joins

### DIFF
--- a/dbcon/joblist/diskjoinstep.cpp
+++ b/dbcon/joblist/diskjoinstep.cpp
@@ -90,9 +90,10 @@ DiskJoinStep::DiskJoinStep(TupleHashJoinStep* t, int djsIndex, int joinIndex, bo
     largeLimit = numeric_limits<int64_t>::max();
 
   uint64_t totalUMMemory = thjs->resourceManager->getConfiguredUMMemLimit();
+  auto allocator = thjs->resourceManager->getAllocator<rowgroup::RGDataBufType>();
   jp.reset(new JoinPartition(largeRG, smallRG, smallKeyCols, largeKeyCols, typeless,
                              (joinType & ANTI) && (joinType & MATCHNULLS), (bool)fe, totalUMMemory,
-                             partitionSize, maxPartitionTreeDepth));
+                             partitionSize, maxPartitionTreeDepth, allocator));
 
   if (cancelled())
   {

--- a/utils/joiner/joinpartition.cpp
+++ b/utils/joiner/joinpartition.cpp
@@ -45,7 +45,9 @@ JoinPartition::JoinPartition()
 /* This is the ctor used by THJS */
 JoinPartition::JoinPartition(const RowGroup& lRG, const RowGroup& sRG, const vector<uint32_t>& smallKeys,
                              const vector<uint32_t>& largeKeys, bool typeless, bool antiWMN, bool hasFEFilter,
-                             uint64_t totalUMMemory, uint64_t partitionSize, uint32_t maxPartitionTreeDepth)
+                             uint64_t totalUMMemory, uint64_t partitionSize, uint32_t maxPartitionTreeDepth,
+                             allocators::CountingAllocator<rowgroup::RGDataBufType> _allocator
+                            )
  : smallRG(sRG)
  , largeRG(lRG)
  , smallKeyCols(smallKeys)
@@ -67,6 +69,7 @@ JoinPartition::JoinPartition(const RowGroup& lRG, const RowGroup& sRG, const vec
  , nextLargeOffset(0)
  , currentPartitionTreeDepth(0)
  , maxPartitionTreeDepth(maxPartitionTreeDepth)
+ , allocator(_allocator)
 {
   config::Config* config = config::Config::makeConfig();
   string cfgTxt;
@@ -145,6 +148,7 @@ JoinPartition::JoinPartition(const JoinPartition& jp, bool /*splitMode*/, uint32
  , nextLargeOffset(0)
  , currentPartitionTreeDepth(currentPartitionTreeDepth)
  , maxPartitionTreeDepth(jp.maxPartitionTreeDepth)
+ , allocator(jp.allocator)
 {
   ostringstream os;
 
@@ -635,7 +639,7 @@ boost::shared_ptr<RGData> JoinPartition::getNextLargeRGData()
 
   if (bs.length() != 0)
   {
-    ret.reset(new RGData());
+    ret.reset(allocator ? new RGData(*allocator) : new RGData());
     ret->deserialize(bs);
   }
   else

--- a/utils/joiner/joinpartition.h
+++ b/utils/joiner/joinpartition.h
@@ -33,7 +33,9 @@ class JoinPartition
   JoinPartition(const rowgroup::RowGroup& largeRG, const rowgroup::RowGroup& smallRG,
                 const std::vector<uint32_t>& smallkeyCols, const std::vector<uint32_t>& largeKeyCols,
                 bool typeless, bool isAntiWithMatchNulls, bool hasFEFilter, uint64_t totalUMMemory,
-                uint64_t partitionSize, uint32_t maxPartitionTreeDepth);
+                uint64_t partitionSize, uint32_t maxPartitionTreeDepth,
+                allocators::CountingAllocator<rowgroup::RGDataBufType> _allocator
+               );
   JoinPartition(const JoinPartition&, bool splitMode, uint32_t depth);
 
   virtual ~JoinPartition();
@@ -178,5 +180,8 @@ class JoinPartition
   // Options to control partition tree depth.
   uint32_t currentPartitionTreeDepth;
   uint32_t maxPartitionTreeDepth;
+
+  // controlling allocator.
+  std::optional<allocators::CountingAllocator<rowgroup::RGDataBufType>> allocator = {};
 };
 }  // namespace joiner


### PR DESCRIPTION
This simple change provides RGData allocations inside JoinPartitions with the access to CountingAllocator which should prevent excessive memory allocation.

It may introduce regression due to stricter checks.