### PR TITLE
fix(json): MCOL-6563 - fix crashes with CS 13.1

### DIFF
--- a/utils/funcexp/functor_json.h
+++ b/utils/funcexp/functor_json.h
@@ -41,6 +41,7 @@ class Func_json
     {
 #if MYSQL_VERSION_ID >= 120200
       path_inited= false;
+      jsEg.killed_ptr = nullptr; // enough initialization for json_scan_next() not to SEGV.
       initJsonArray(NULL, &jsEg.stack, sizeof(int), &jsEg_stack[0],
                     MY_INIT_BUFFER_USED | MY_BUFFER_NO_RESIZE);
 #endif


### PR DESCRIPTION
This oneliner introduces enough initialization of JSON engine so that crashes do not happen.